### PR TITLE
Add removed constructor to restore backward compatibility

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AuthenticationInfo.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/AuthenticationInfo.java
@@ -28,7 +28,14 @@ public final class AuthenticationInfo {
     private final char[] password;
 
     /**
-     * The only way to construct the instances of this class.
+     * @param user      the user name for the connection
+     * @param password  the clear text password for the connection
+     */
+    public AuthenticationInfo(String user, String password) {
+        this(user, password.toCharArray());
+    }
+
+    /**
      * @param user      the user name for the connection
      * @param password  the clear text password for the connection
      */


### PR DESCRIPTION
Add removed constructor to `com.sun.enterprise.admin.util.AuthenticationInfo` to restore backward compatibility. This fixes https://youtrack.jetbrains.com/issue/IDEA-194181 .