### PR TITLE
Add missing versions for embedded modules

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -290,6 +290,7 @@
      <dependency>
          <groupId>org.shoal</groupId>
          <artifactId>shoal-cache</artifactId>
+         <version>{shoal.version}</version>
          <optional>true</optional>
      </dependency>
      <dependency>
@@ -598,11 +599,13 @@
         <dependency>
             <groupId>org.shoal</groupId>
             <artifactId>shoal-gms-api</artifactId>
+            <version>{shoal.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.shoal</groupId>
             <artifactId>shoal-gms-impl</artifactId>
+            <version>{shoal.version}</version>
             <optional>true</optional>
         </dependency>
         <!-- glassfish-jmx -->
@@ -735,6 +738,7 @@
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>javax.inject</artifactId>
+            <version>${hk2.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/extras/embedded/nucleus/pom.xml
+++ b/appserver/extras/embedded/nucleus/pom.xml
@@ -170,6 +170,7 @@
       <dependency>
           <groupId>org.glassfish.hk2.external</groupId>
           <artifactId>javax.inject</artifactId>
+          <version>${hk2.version}</version>
           <optional>true</optional>
       </dependency>
       <dependency>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -172,6 +172,7 @@
     <dependency>
         <groupId>org.glassfish.hk2.external</groupId>
         <artifactId>javax.inject</artifactId>
+        <version>${hk2.version}</version>
         <optional>true</optional>
     </dependency>
     <dependency>
@@ -593,6 +594,7 @@
     <dependency>
         <groupId>org.shoal</groupId>
         <artifactId>shoal-cache</artifactId>
+        <version>${hk2.version}</version>
         <optional>true</optional>
     </dependency>
     <dependency>
@@ -1364,11 +1366,13 @@
     <dependency>
         <groupId>org.shoal</groupId>
         <artifactId>shoal-gms-api</artifactId>
+        <version>${hk2.version}</version>
         <optional>true</optional>
     </dependency>
     <dependency>
         <groupId>org.shoal</groupId>
         <artifactId>shoal-gms-impl</artifactId>
+        <version>${hk2.version}</version>
         <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
If embedded profile is activated, version number to these dependencies needs to be provided.