### PR TITLE
Integrate Glassfish Security Plugin 1.0.10

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -116,7 +116,7 @@
         <ha-api.version>3.1.12</ha-api.version>
         <glassfishbuild.version>3.2.27</glassfishbuild.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
-        <command-security-plugin.version>1.0.9</command-security-plugin.version>
+        <command-security-plugin.version>1.0.10</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
         <mail.version>1.6.3</mail.version>
         <jakarta.annotation-api.version>1.3.4</jakarta.annotation-api.version>


### PR DESCRIPTION
Integrates `org.glassfish.build:command-security-maven-plugin:1.0.10`

Quicklook tests run successful.