### PR TITLE
Fix jakarta-annotation-api.jar location

### DIFF
--- a/appserver/distributions/web/src/main/assembly/web.xml
+++ b/appserver/distributions/web/src/main/assembly/web.xml
@@ -180,7 +180,7 @@
         <fileSet>
             <directory>${temp.dir}</directory>
             <includes>
-                <include>javax.annotation-api.jar</include>
+                <include>jakarta.annotation-api.jar</include>
                 <include>grizzly-npn-bootstrap.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/modules/endorsed</outputDirectory>
@@ -251,7 +251,7 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
-                <exclude>javax.annotation-api.jar</exclude>
+                <exclude>jakarta.annotation-api.jar</exclude>
                 <exclude>grizzly-npn-bootstrap.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>

--- a/nucleus/distributions/atomic/src/main/assembly/atomic.xml
+++ b/nucleus/distributions/atomic/src/main/assembly/atomic.xml
@@ -96,7 +96,7 @@
         <fileSet>
             <directory>${temp.dir}</directory>
             <includes>
-                <include>javax.annotation-api.jar</include>
+                <include>jakarta.annotation-api.jar</include>
                 <include>grizzly-npn-bootstrap.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/modules/endorsed</outputDirectory>
@@ -139,7 +139,7 @@
                 <exclude>org.apache.felix.scr.jar</exclude>
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
-                <exclude>javax.annotation-api.jar</exclude>
+                <exclude>jakarta.annotation-api.jar</exclude>
                 <exclude>grizzly-npn-bootstrap.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/modules</outputDirectory>

--- a/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
+++ b/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
@@ -99,7 +99,7 @@
         <fileSet>
             <directory>${temp.dir}</directory>
             <includes>
-                <include>javax.annotation-api.jar</include>
+                <include>jakarta.annotation-api.jar</include>
                 <include>grizzly-npn-bootstrap.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/modules/endorsed</outputDirectory>
@@ -142,7 +142,7 @@
                 <exclude>org.apache.felix.scr.jar</exclude>
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
-                <exclude>javax.annotation-api.jar</exclude>
+                <exclude>jakarta.annotation-api.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/modules</outputDirectory>


### PR DESCRIPTION
In web profile, `jakarta-annotation-api.jar` is expected to be available
under `glassfish/modules/endorsed`, however, at present, it appears under
`glassfish/modules`. This PR fixes the location of `jakarta-annotation-api.jar`.