### PR TITLE
Update Jackson version to 2.9.9

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -104,7 +104,7 @@
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.2</ant.version>
         <jersey.version>2.28</jersey.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <jettison.version>1.3.7</jettison.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>


### PR DESCRIPTION
Fixes CVE-2019-12086; see https://github.com/FasterXML/jackson-databind/issues/2326