### PR TITLE
Fix connection leak reclaim (#19427)

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -128,13 +128,11 @@ public class RWLockDataStructure implements DataStructure {
         boolean removed = false;
         writeLock.lock();
         try {
-            removed = resources.remove(resource);
+            resources.remove(resource);
         } finally {
             writeLock.unlock();
         }
-        if(removed) {
-            handler.deleteResource(resource);
-        }
+        handler.deleteResource(resource);
     }
 
     /**


### PR DESCRIPTION
Because there is no connection in the pool when the state of pool is unpooling, `handler.deleteResource(resource)` must unconditionally execute (not only when `resources.remove(resource)` returns true)

Signed-off-by: Craig Andrews <candrews@integralblue.com>