### PR TITLE
Add missing dependency (#22772)

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -1438,6 +1438,11 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
             <optional>true</optional>
         </dependency>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -1267,6 +1267,11 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
             <optional>true</optional>
         </dependency>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -1218,6 +1218,11 @@
     </dependency>
     <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
+        <artifactId>jersey-container-servlet</artifactId>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.glassfish.jersey.containers</groupId>
         <artifactId>jersey-container-servlet-core</artifactId>
         <optional>true</optional>
     </dependency>


### PR DESCRIPTION
Embedded glassfish doesn't have a dependency for jersey-container-servlet which handles Servelet3.x.
Added the dependency so that JAX-RS application with no web.xml can be deployed.

Signed-off-by: Katsuhiro Kunisada <katsuhiro@jp.fujitsu.com>