### PR TITLE
increase java version and reference jaxb explicitly

### DIFF
--- a/appserver/ldapbp/pom.xml
+++ b/appserver/ldapbp/pom.xml
@@ -40,4 +40,11 @@
             </resource>
         </resources>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>glassfish-corba-omgapi</artifactId>
+            <version>${glassfish-corba.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -84,12 +84,16 @@
             <groupId>org.glassfish.external</groupId>
             <artifactId>management-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>glassfish-corba-omgapi</artifactId>
+            <version>${glassfish-corba.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
             <optional>true</optional>
-      </dependency>        
+      </dependency>
     </dependencies>
 </project>

--- a/nucleus/deployment/common/src/test/java/org/glassfish/deployment/versioning/VersioningUtilsTest.java
+++ b/nucleus/deployment/common/src/test/java/org/glassfish/deployment/versioning/VersioningUtilsTest.java
@@ -29,7 +29,13 @@ import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.TransactionFailure;
 import org.jvnet.hk2.config.types.Property;
 import org.glassfish.api.deployment.DeployCommandParameters;
-import com.sun.enterprise.config.serverbeans.*;
+import com.sun.enterprise.config.serverbeans.Module;
+import com.sun.enterprise.config.serverbeans.Application;
+import com.sun.enterprise.config.serverbeans.ApplicationExtension;
+import com.sun.enterprise.config.serverbeans.ApplicationRef;
+import com.sun.enterprise.config.serverbeans.AppTenants;
+import com.sun.enterprise.config.serverbeans.Engine;
+import com.sun.enterprise.config.serverbeans.Resources;
 
 /**
  *

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/PolicyLoader.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/PolicyLoader.java
@@ -131,14 +131,14 @@ public class PolicyLoader{
                 Object obj = javaPolicyClass.newInstance();
                 if (j2ee13) {
                     // Use JDK 1.3 classes if j2ee1 3 property being used
-                    if (!(obj instanceof javax.security.auth.Policy)) {
+                    if (!(obj instanceof java.security.Policy)) {
                         String msg = 
                             sm.getString("enterprise.security.plcyload.not13");
                         throw new RuntimeException(msg);
                     }
-                    javax.security.auth.Policy policy =
-                        (javax.security.auth.Policy)obj;
-                    javax.security.auth.Policy.setPolicy(policy);
+                    java.security.Policy policy =
+                        (java.security.Policy)obj;
+                    java.security.Policy.setPolicy(policy);
                     policy.refresh();
                     
                 } else {

--- a/nucleus/test-utils/utils/src/main/java/org/glassfish/tests/utils/ProxyModule.java
+++ b/nucleus/test-utils/utils/src/main/java/org/glassfish/tests/utils/ProxyModule.java
@@ -16,7 +16,14 @@
 
 package org.glassfish.tests.utils;
 
-import com.sun.enterprise.module.*;
+import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.ModuleDefinition;
+import com.sun.enterprise.module.ModuleDependency;
+import com.sun.enterprise.module.ModulesRegistry;
+import com.sun.enterprise.module.ModuleState;
+import com.sun.enterprise.module.ModuleMetadata;
+import com.sun.enterprise.module.ModuleChangeListener;
+import com.sun.enterprise.module.ResolveError;
 
 import java.util.List;
 import java.io.PrintStream;


### PR DESCRIPTION
Signed-off-by: rlfnb <github@rlfnb.de>

My change wont compile, as the referenced version of the command-security-plugin might be not available. As the needed change to ompile with java11 is already done there, @arjantijms @Cousjava might do a release (https://github.com/eclipse-ee4j/glassfish-security-plugin/issues/9) and I can change the version accordingly. 