### PR TITLE
Fix for ear redeploy fails(eclipse-ee4j#22383)

### DIFF
--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationInfo.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationInfo.java
@@ -424,7 +424,11 @@ public class ApplicationInfo extends ModuleInfo {
         // clean up the app level classloader
         if (appClassLoader != null) {
             try {
-                appServiceLocator.preDestroy(appClassLoader);
+                if (appServiceLocator != null) {
+                    appServiceLocator.preDestroy(appClassLoader);
+                } else {
+                    PreDestroy.class.cast(appClassLoader).preDestroy();
+                }
             }
             catch (Exception e) {
                 // Ignore, some failure in preDestroy


### PR DESCRIPTION
Enables class loader release processing when an application is undeployed.

Signed-off-by: endtak <endo.takafumi@jp.fujitsu.com>