### PR TITLE
The response sender and receiver use the same encoding

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/reader/MultipartProprietaryReader.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/reader/MultipartProprietaryReader.java
@@ -97,6 +97,7 @@ public class MultipartProprietaryReader implements ProprietaryReader<ParamsWithP
                 String name = "noname";
                 if (cdParams.containsKey("name")) {
                     name = cdParams.getProperty("name");
+                    name = new String(name.getBytes("ISO8859-1"), "UTF-8");
                 } else if (cdParams.containsKey("filename")) {
                     name = cdParams.getProperty("filename");
                 }

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/writer/MultipartProprietaryWriter.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/writer/MultipartProprietaryWriter.java
@@ -193,7 +193,7 @@ public class MultipartProprietaryWriter implements ProprietaryWriter {
         }
         contentTypeWriter.writeContentType("multipart", ctType, boundary);
         // Write content
-        final Writer writer = new BufferedWriter(new OutputStreamWriter(os));
+        final Writer writer = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
 //        boolean isFirst = true;
         //Parameters
         if (parameters != null) {


### PR DESCRIPTION
Unify the encoding used by the response sender and receiver to UTF-8.
The response sender specifies the file name in UTF-8 in the multipart header in the HTTP response body.
The response receiver converts the file name described in the multipart header back to a byte string in ISO8859-1 once and converts it to a string in UTF-8.

Signed-off-by: endtak <endo.takafumi@jp.fujitsu.com>