### PR TITLE
Minimal changes including the following changes to run with JDK 11.

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -163,14 +163,12 @@
         <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
         <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
         <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
 		<jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
@@ -206,6 +204,9 @@
         <jvm-options>-XX:NewRatio=2</jvm-options>
         <!-- Woodstox property needed to pass StAX TCK -->
         <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap.jar</jvm-options>
+        <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -347,13 +348,11 @@
              <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
              <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
              <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-             <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
              <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
              <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
              <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
              <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-             <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
              <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
              <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
@@ -387,6 +386,9 @@
              -->
              <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
              <!-- End of OSGi bundle configurations -->
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap.jar</jvm-options>
+             <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+             <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
         </java-config>
          <availability-service>
              <web-container-availability/>

--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -255,20 +255,9 @@
                 <include>javaee.jar</include>
                 <include>appserv-rt.jar</include>
                 <include>gf-client.jar</include>
-            </includes>
-            <outputDirectory>${install.dir.name}/glassfish/lib</outputDirectory>
-        </fileSet>
-
-        <!-- modules/endorsed -->
-        <fileSet>
-            <directory>${temp.dir}</directory>
-            <includes>
-                <include>jakarta.annotation-api.jar</include>
-                <include>jakarta.xml.bind-api.jar</include>
-                <include>webservices-api-osgi.jar</include>
                 <include>grizzly-npn-bootstrap.jar</include>
             </includes>
-            <outputDirectory>${install.dir.name}/glassfish/modules/endorsed</outputDirectory>
+            <outputDirectory>${install.dir.name}/glassfish/lib</outputDirectory>
         </fileSet>
 
         <!-- felix -->
@@ -336,7 +325,6 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
-                <exclude>jakarta.annotation-api.jar</exclude>
                 <exclude>grizzly-npn-bootstrap.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>
@@ -352,8 +340,6 @@
                 <exclude>mejb.jar</exclude>
                 <exclude>weld-se-core.jar</exclude>
                 <exclude>weld-se-shaded.jar</exclude>
-                <exclude>jakarta.xml.bind-api.jar</exclude>
-                <exclude>webservices-api-osgi.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/glassfish/modules</outputDirectory>
         </fileSet>

--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -836,5 +836,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -976,6 +976,16 @@
                 <version>${derby.version}</version>
                 <type>zip</type>
            </dependency>
+           <dependency>
+               <groupId>jakarta.activation</groupId>
+               <artifactId>jakarta.activation-api</artifactId>
+               <version>${jakarta.activation-api.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>com.sun.activation</groupId>
+               <artifactId>jakarta.activation</artifactId>
+               <version>${jakarta.activation.version}</version>
+           </dependency>
       </dependencies>
     </dependencyManagement>
 

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -168,5 +168,15 @@
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
      </dependencies>
 </project>

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
@@ -134,8 +134,6 @@ com.sun.enterprise.hk2.cacheDir=${org.osgi.framework.storage}
 # to control what gets installed in which order, what gets started and what should be the bundle's start level.
 # glassfish.osgi.auto.install is used to configure a list of locations from where bundles will be installed.
 # The order is important as bundle installation order is an input to package resolution process in OSGi.
-# Since we want packages from endorsed bundles to be preferred over those exported by system bundle for
-# overlapping packages, we need to install and start endorsed bundles first.
 # Then we start osgi-resource-locator bundle as osgi-adapter depends on it being active.
 # Since Felix starts bundles with same start level in the order in which bundles are installed,
 # and osgi-adapter and osgi-resource-locator both have same start level of 1, to make sure
@@ -146,7 +144,6 @@ com.sun.enterprise.hk2.cacheDir=${org.osgi.framework.storage}
 # Then we autostart GlassFish core bundles followed by optional services.
 # The reason for using installRootURI is to make sure any char like white space is properly encoded.
 glassfish.osgi.auto.install=\
- ${com.sun.aas.installRootURI}modules/endorsed/ \
  ${com.sun.aas.installRootURI}modules/osgi-resource-locator.jar \
  ${com.sun.aas.installRootURI}modules/ \
  ${com.sun.aas.installRootURI}modules/autostart/
@@ -173,7 +170,6 @@ hk2.bundles=\
  ${com.sun.aas.installRootURI}modules/osgi-adapter.jar
 
 core.bundles=\
- ${com.sun.aas.installRootURI}modules/endorsed/ \
  ${obr.bundles} \
  ${hk2.bundles} \
  ${com.sun.aas.installRootURI}modules/glassfish.jar
@@ -366,31 +362,118 @@ jre-1.6=\
  org.w3c.dom.ls, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers, ${endorsed-standard-packages}
-
-endorsed-standard-packages=\
- javax.annotation, \
- javax.xml.bind, \
- javax.xml.bind.annotation, \
- javax.xml.bind.annotation.adapters, \
- javax.xml.bind.attachment, \
- javax.xml.bind.helpers, \
- javax.xml.bind.util, \
- javax.jws, \
- javax.jws.soap, \
- javax.xml.ws, \
- javax.xml.ws.handler, \
- javax.xml.ws.handler.soap, \
- javax.xml.ws.http, \
- javax.xml.ws.soap, \
- javax.xml.ws.spi, \
- javax.xml.ws.wsaddressing
+ org.xml.sax.helpers
 
 #dtrace support
 # TODO: We still need to add appropriate SE packages for 7 & 8.
 jre-1.7=${jre-1.6},com.sun.tracing
 jre-1.8=${jre-1.7}
 jre-9=${jre-1.8}
+jre-10=${jre-9}
+jre-11=\
+ javax.accessibility, \
+ javax.annotation.processing, \
+ javax.crypto, \
+ javax.crypto.interfaces, \
+ javax.crypto.spec, \
+ javax.imageio, \
+ javax.imageio.event, \
+ javax.imageio.metadata, \
+ javax.imageio.plugins.bmp, \
+ javax.imageio.plugins.jpeg, \
+ javax.imageio.spi, \
+ javax.imageio.stream, \
+ javax.lang.model, \
+ javax.lang.model.element, \
+ javax.lang.model.type, \
+ javax.lang.model.util, \
+ javax.management, \
+ javax.management.loading, \
+ javax.management.modelmbean, \
+ javax.management.monitor, \
+ javax.management.openmbean, \
+ javax.management.relation, \
+ javax.management.remote, \
+ javax.management.remote.rmi, \
+ javax.management.timer, \
+ javax.naming, \
+ javax.naming.directory, \
+ javax.naming.event, \
+ javax.naming.ldap, \
+ javax.naming.spi, \
+ javax.net, \
+ javax.net.ssl, \
+ javax.print, \
+ javax.print.attribute, \
+ javax.print.attribute.standard, \
+ javax.print.event, \
+ javax.rmi, \
+ javax.rmi.ssl, \
+ javax.script, \
+ javax.security.auth, \
+ javax.security.auth.callback, \
+ javax.security.auth.kerberos, \
+ javax.security.auth.login, \
+ javax.security.auth.spi, \
+ javax.security.auth.x500, \
+ javax.security.cert, \
+ javax.security.sasl, \
+ javax.sound.midi, \
+ javax.sound.midi.spi, \
+ javax.sound.sampled, \
+ javax.sound.sampled.spi, \
+ javax.sql, \
+ javax.sql.rowset, \
+ javax.sql.rowset.serial, \
+ javax.sql.rowset.spi, \
+ javax.swing, \
+ javax.swing.border, \
+ javax.swing.colorchooser, \
+ javax.swing.event, \
+ javax.swing.filechooser, \
+ javax.swing.plaf, \
+ javax.swing.plaf.basic, \
+ javax.swing.plaf.metal, \
+ javax.swing.plaf.multi, \
+ javax.swing.plaf.nimbus, \
+ javax.swing.plaf.synth, \
+ javax.swing.table, \
+ javax.swing.text, \
+ javax.swing.text.html, \
+ javax.swing.text.html.parser, \
+ javax.swing.text.rtf, \
+ javax.swing.tree, \
+ javax.swing.undo, \
+ javax.tools, \
+ javax.transaction.xa, \
+ javax.xml, \
+ javax.xml.catalog, \
+ javax.xml.crypto, \
+ javax.xml.crypto.dom, \
+ javax.xml.crypto.dsig, \
+ javax.xml.crypto.dsig.dom, \
+ javax.xml.crypto.dsig.keyinfo, \
+ javax.xml.crypto.dsig.spec, \
+ javax.xml.datatype, \
+ javax.xml.namespace, \
+ javax.xml.parsers, \
+ javax.xml.stream; javax.xml.stream.events; javax.xml.stream.util, \
+ javax.xml.transform, \
+ javax.xml.transform.dom, \
+ javax.xml.transform.sax, \
+ javax.xml.transform.stax, \
+ javax.xml.transform.stream, \
+ javax.xml.validation, \
+ javax.xml.xpath, \
+ org.ietf.jgss, \
+ org.w3c.dom, \
+ org.w3c.dom.bootstrap, \
+ org.w3c.dom.events, \
+ org.w3c.dom.ls, \
+ org.xml.sax, \
+ org.xml.sax.ext, \
+ org.xml.sax.helpers, \
+ com.sun.tracing
 
 # Bundle information optimization to improve performance
 felix.cache.singlebundlefile=true
@@ -420,6 +503,10 @@ gosh.args=--nointeractive
 org.osgi.framework.system.capabilities= \
  ${eecap-${java.specification.version}}
  #we are adding eecap entries upto 1.7 as GF is not supported for JDK<1.7
+eecap-11= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10,11"
+eecap-10= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9,10"
 eecap-9= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
  osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9"
 eecap-1.8= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -107,6 +107,7 @@
         <jackson.version>2.9.4</jackson.version>
         <jettison.version>1.3.7</jettison.version>
         <jaxb-api.version>2.3.2</jaxb-api.version>
+        <jaxb.version>2.3.2</jaxb.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1.3</jax-rs-api.impl.version>
         <mimepull.version>1.9.11</mimepull.version>
@@ -131,6 +132,8 @@
         <javaee.version.new>8</javaee.version.new>
         <jmockit.version>1.36</jmockit.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
+        <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>
+        <jakarta.activation.version>1.2.1</jakarta.activation.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Minimal changes including the following changes to run with JDK 11.
 - Remove JVM options (java.ext.dirs and java.endorsed.dirs) from domain template and osgi.properties.
 - Move the packages from modules/endorsed/ to modules/ or lib/.
 - Add -Xbootclasspath option to load grizzly-npn-bootstrap.jar.
 - Add JVM options for reference to internal APIs and enable to add long JVM options (such as --add-opens).

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>