### PR TITLE
Fix for context root(eclipse-ee4j#22860)

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/DeploymentHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/DeploymentHandler.java
@@ -213,7 +213,7 @@ public class DeploymentHandler {
             Map payload = new HashMap();
 
              //If we are redeploying a web app, we want to preserve context root.
-             String ctxRoot = valueMap.get("contextroot");
+             String ctxRoot = valueMap.get("contextRoot");
              if (ctxRoot != null){
                  payload.put("contextroot", ctxRoot);
              }


### PR DESCRIPTION
Signed-off-by: takeda0121 <takeda.rikuho@jp.fujitsu.com>  

I changed key of valueMap to which context root is preserved when we redeploy a web application by value of valueMap corresponding from "contextroot" to "contextRoot" because correct key of valueMap is "contextRoot".