### PR TITLE
Fixed NullPointerException in LogCleanerUtil#neutralizeForLog

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/logging/LogCleanerUtil.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/logging/LogCleanerUtil.java
@@ -66,6 +66,9 @@ public final class LogCleanerUtil {
 
 
     public static String neutralizeForLog(String message){
+        if (message == null) {
+            return null;
+        }
         StringBuilder sb = new StringBuilder();
         for(int offset  = 0; offset < message.length(); ){
             final int point = message.codePointAt(offset);


### PR DESCRIPTION
This PR fixes a NullPointerException in LogCleanerUtil#neutralizeForLog.

This Exception occurred when ApplicationDispatcher had a null value as a name.
With Log level FINE it would then log the name and thrown a NullPointerException in LogCleanerUtil#neutralizeForLog.

This PR should fix #22866 

Signed-off-by: SplotyCode davidscandurra@gmail.com