### PR TITLE
Kill domain

### DIFF
--- a/appserver/tests/appserv-tests/config/run.xml
+++ b/appserver/tests/appserv-tests/config/run.xml
@@ -116,7 +116,7 @@
 <target name="stopDomain" depends="init-common">
     <echo message="run.xml:stopping domain..."/>
     <exec executable="${ASADMIN}" failonerror="true">
-        <arg line="stop-domain"/>
+        <arg line="stop-domain --kill=true"/>
     </exec>
 </target>
 

--- a/appserver/tests/cts_smoke/run_test.sh
+++ b/appserver/tests/cts_smoke/run_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -223,6 +223,7 @@ run_test_id(){
 }
 
 post_test_run(){
+  break
 }
 
 list_test_ids(){


### PR DESCRIPTION
Use OS to kill domain to avoid on Jenkins:
```shell
stopDomain:
     [echo] run.xml:stopping domain...
     [exec] Picked up JAVA_TOOL_OPTIONS: -Xmx2G
     [exec] Timed out (60 seconds) waiting for the domain to stop.
     [exec] Waiting for the domain to stop ...........................................................
     [exec] Command stop-domain failed.

BUILD FAILED
.../appserver/tests/appserv-tests/devtests/web/build.xml:50: The following error occurred while executing this line:
.../appserver/tests/appserv-tests/devtests/web/jspCachingInstanceLevel/build.xml:90: The following error occurred while executing this line:
.../appserver/tests/appserv-tests/config/run.xml:48: The following error occurred while executing this line:
.../appserver/tests/appserv-tests/config/run.xml:118: exec returned: 1
```
