### PR TITLE
New infra - setting maven options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,6 +182,11 @@ spec:
         name: maven-repo-shared-storage
       - mountPath: "/home/jenkins/.m2/repository/org/glassfish/main"
         name: maven-repo-local-storage
+    env:
+      - name: "MAVEN_OPTS"
+        value: "-Duser.home=/home/jenkins"
+      - name: "MVN_EXTRA"
+        value: "--batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
     resources:
       limits:
         memory: "7Gi"

--- a/gfbuild.sh
+++ b/gfbuild.sh
@@ -63,7 +63,7 @@ archive_bundles(){
 }
 
 dev_build(){
-  mvn -U clean install -Dmaven.test.failure.ignore=true -Pstaging
+  mvn -U clean install -Dmaven.test.failure.ignore=true -Pstaging ${MVN_EXTRA}
 }
 
 build_re_dev(){


### PR DESCRIPTION
This sets the maven home and runs the build in batch mode without progress logging.

Setting the home is needed since the custom docker image for GF is being as non-root.
See also https://github.com/carlossg/docker-maven#running-as-non-root.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>