### PR TITLE
Upgrade Felix to 6.0.3

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -711,7 +711,7 @@
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.main</artifactId>
-                <version>5.6.10</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Some components (such as eclipse-ee4j/orb-gmbal-pfl) are provided in the form of multi-release jar, but Felix (the OSGi Framework) supports multi-release jars since 6.0.0.
(http://svn.apache.org/repos/asf/felix/releases/org.apache.felix.main.distribution-6.0.0/doc/changelog_framework.txt)
```
Changes from 5.6.10 to 6.0.0
----------------------------

** New Feature
    * [FELIX-5791] - Support OSGi R7 framework features

** Sub-task
    * [FELIX-5792] - Implement java.* import and exports
    * [FELIX-5796] - Implement multi-release jar support ★★
    * [FELIX-5797] - Implement extension bundle imports
    * [FELIX-5798] - Implement FrameworkWiringDTO
    * [FELIX-5811] - Prevent bundles from providing ee capabilities
```
so upgrade Felix to the latest version (6.0.3).

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>