### PR TITLE
remove dependency on pfl-asm

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -534,11 +534,6 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.pfl</groupId>
-            <artifactId>pfl-asm</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.pfl</groupId>
             <artifactId>pfl-basic</artifactId>
             <optional>true</optional>
         </dependency>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -388,11 +388,6 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.pfl</groupId>
-            <artifactId>pfl-asm</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.pfl</groupId>
             <artifactId>pfl-basic</artifactId>
             <optional>true</optional>
         </dependency>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -894,11 +894,6 @@
     </dependency>
     <dependency>
         <groupId>org.glassfish.pfl</groupId>
-        <artifactId>pfl-asm</artifactId>
-        <optional>true</optional>
-    </dependency>
-    <dependency>
-        <groupId>org.glassfish.pfl</groupId>
         <artifactId>pfl-basic</artifactId>
         <optional>true</optional>
     </dependency>

--- a/nucleus/featuresets/nucleus/pom.xml
+++ b/nucleus/featuresets/nucleus/pom.xml
@@ -236,16 +236,6 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.pfl</groupId>
-            <artifactId>pfl-asm</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.pfl</groupId>
             <artifactId>pfl-basic</artifactId>
             <exclusions>
                 <exclusion>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -819,11 +819,6 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish.pfl</groupId>
-                <artifactId>pfl-asm</artifactId>
-                <version>${pfl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.pfl</groupId>
                 <artifactId>pfl-tf</artifactId>
                 <version>${pfl.version}</version>
             </dependency>


### PR DESCRIPTION
Signed-off-by: Russell Gold <russ@gold-family.us>

pfl-asm is not needed directly by Glassfish. This change will allow the pfl project to remove the dependency