### PR TITLE
Upgrade hk2 and asm - import from JDK 11 branch

### DIFF
--- a/appserver/admingui/plugin-service/src/main/java/org/glassfish/admingui/plugin/ConsolePluginService.java
+++ b/appserver/admingui/plugin-service/src/main/java/org/glassfish/admingui/plugin/ConsolePluginService.java
@@ -36,7 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sun.enterprise.module.ModulesRegistry;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 
 import org.glassfish.admingui.connector.TOC;
 import org.glassfish.admingui.connector.TOCItem;
@@ -61,7 +61,7 @@ public class ConsolePluginService {
 
 /*
     @Inject ModulesRegistry modulesRegistry;
-        for(Module m : modulesRegistry.getModules()) {
+        for(HK2Module m : modulesRegistry.getModules()) {
             url = m.getClassLoader().getResource(ConsoleProvider.DEFAULT_CONFIG_FILENAME);
             if(url!=null)
                 ; // TODO: parse url

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientDeployer.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientDeployer.java
@@ -18,7 +18,7 @@ package org.glassfish.appclient.server.core;
 
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.Applications;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import java.io.IOException;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.deployment.Application;
@@ -187,7 +187,7 @@ public class AppClientDeployer
     public void postConstruct() {
         logger = Logger.getLogger(JavaWebStartInfo.APPCLIENT_SERVER_MAIN_LOGGER, 
                 JavaWebStartInfo.APPCLIENT_SERVER_LOGMESSAGE_RESOURCE);
-        for (Module module : modulesRegistry.getModules(GF_CLIENT_MODULE_NAME)) {
+        for (HK2Module module : modulesRegistry.getModules(GF_CLIENT_MODULE_NAME)) {
             gfClientModuleClassLoader = module.getClassLoader();
         }
     }

--- a/appserver/connectors/connectors-connector/src/main/java/com/sun/enterprise/connectors/connector/module/ConnectorSniffer.java
+++ b/appserver/connectors/connectors-connector/src/main/java/com/sun/enterprise/connectors/connector/module/ConnectorSniffer.java
@@ -18,7 +18,7 @@ package com.sun.enterprise.connectors.connector.module;
 
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.deployment.GenericSniffer;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.deployment.annotation.introspection.EjbComponentAnnotationScanner;
 import com.sun.enterprise.deployment.annotation.introspection.ResourceAdapterAnnotationScanner;
 import com.sun.appserv.connectors.internal.api.ConnectorConstants;
@@ -73,7 +73,7 @@ public class ConnectorSniffer extends GenericSniffer {
      * @throws java.io.IOException exception if something goes sour
      */
     @Override
-    public Module[] setup(String containerHome, Logger logger) throws IOException {
+    public HK2Module[] setup(String containerHome, Logger logger) throws IOException {
         // do nothing, we are embedded in GFv3 for now
         return null;
     }
@@ -91,7 +91,7 @@ public class ConnectorSniffer extends GenericSniffer {
     }
 
     /**
-     * Returns the Module type
+     * Returns the HK2Module type
      *
      * @return the container name
      */

--- a/appserver/ejb/ejb-client/pom.xml
+++ b/appserver/ejb/ejb-client/pom.xml
@@ -176,8 +176,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.pfl</groupId>

--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/deployment/archive/EjbSniffer.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/deployment/archive/EjbSniffer.java
@@ -17,7 +17,7 @@
 package org.glassfish.ejb.deployment.archive;
 
 import org.glassfish.internal.deployment.GenericSniffer;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleDefinition;
 import com.sun.enterprise.module.common_impl.DirectoryBasedRepository;
 import com.sun.enterprise.module.common_impl.AbstractModulesRegistryImpl;

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -198,8 +198,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.pfl</groupId>

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
@@ -236,9 +236,9 @@ public class EjbDeployer
         if (ejbBundle.containsCMPEntity()) {
             CMPService cmpService = cmpServiceProvider.get();
             if (cmpService == null) {
-                throw new RuntimeException("CMP Module is not available");
+                throw new RuntimeException("CMP HK2Module is not available");
             } else if (!cmpService.isReady()) {
-                throw new RuntimeException("CMP Module is not initialized");
+                throw new RuntimeException("CMP HK2Module is not initialized");
             }
         }
 

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -651,14 +651,33 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>asm-repackaged</artifactId>
-            <version>${hk2.version}</version>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
+            <version>${asm.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>${asm.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>${asm.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>${asm.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/extras/embedded/nucleus/pom.xml
+++ b/appserver/extras/embedded/nucleus/pom.xml
@@ -86,14 +86,33 @@
           <optional>true</optional>
       </dependency>
       <dependency>
-          <groupId>org.glassfish.hk2.external</groupId>
-          <artifactId>asm-repackaged</artifactId>
-          <version>${hk2.version}</version>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+          <version>${asm.version}</version>
           <optional>true</optional>
       </dependency>
       <dependency>
-          <groupId>org.glassfish.external</groupId>
-          <artifactId>asm-all</artifactId>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-analysis</artifactId>
+          <version>${asm.version}</version>
+          <optional>true</optional>
+      </dependency>
+      <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+          <version>${asm.version}</version>
+          <optional>true</optional>
+      </dependency>
+      <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-tree</artifactId>
+          <version>${asm.version}</version>
+          <optional>true</optional>
+      </dependency>
+      <dependency>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-util</artifactId>
+          <version>${asm.version}</version>
           <optional>true</optional>
       </dependency>
       <dependency>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -481,14 +481,33 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>asm-repackaged</artifactId>
-            <version>${hk2.version}</version>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
+            <version>${asm.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>${asm.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>${asm.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>${asm.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -88,14 +88,33 @@
         <optional>true</optional>
     </dependency>
     <dependency>
-        <groupId>org.glassfish.hk2.external</groupId>
-        <artifactId>asm-repackaged</artifactId>
-        <version>${hk2.version}</version>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${asm.version}</version>
         <optional>true</optional>
     </dependency>
     <dependency>
-        <groupId>org.glassfish.external</groupId>
-        <artifactId>asm-all</artifactId>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-analysis</artifactId>
+        <version>${asm.version}</version>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-commons</artifactId>
+        <version>${asm.version}</version>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-tree</artifactId>
+        <version>${asm.version}</version>
+        <optional>true</optional>
+    </dependency>
+    <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-util</artifactId>
+        <version>${asm.version}</version>
         <optional>true</optional>
     </dependency>
     <dependency>

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/GlassFishORBManager.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/GlassFishORBManager.java
@@ -54,7 +54,7 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 
 import org.jvnet.hk2.config.types.Property;
@@ -535,12 +535,12 @@ public final class GlassFishORBManager {
 
                 if( processType.isServer()) {
 
-                    Module corbaOrbModule = null;
+                    HK2Module corbaOrbModule = null;
 
                     // start glassfish-corba-orb bundle
                     ModulesRegistry modulesRegistry = services.getService(ModulesRegistry.class);
 
-                    for(Module m : modulesRegistry.getModules()) {
+                    for(HK2Module m : modulesRegistry.getModules()) {
                         if( m.getName().equals("glassfish-corba-orb") ) {
                             corbaOrbModule = m;
                             break;

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecuritySniffer.java
@@ -32,7 +32,7 @@ import javax.enterprise.deploy.shared.ModuleType;
 import java.util.logging.Logger;
 import java.io.IOException;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import java.lang.annotation.Annotation;
 
 import javax.inject.Inject;
@@ -105,7 +105,7 @@ public class SecuritySniffer extends GenericSniffer {
      * @throws java.io.IOException exception if something goes sour
      */
     @Override
-     public Module[] setup(String containerHome, Logger logger) throws IOException {
+     public HK2Module[] setup(String containerHome, Logger logger) throws IOException {
         lifecycle = habitat.getServiceHandle(SecurityLifecycle.class);
         lifecycle.getService();
         return null;

--- a/appserver/verifier/verifier-impl/src/main/java/com/sun/enterprise/tools/verifier/apiscan/classfile/ASMClassFile.java
+++ b/appserver/verifier/verifier-impl/src/main/java/com/sun/enterprise/tools/verifier/apiscan/classfile/ASMClassFile.java
@@ -133,7 +133,7 @@ class ASMClassFile implements ClassFile {
         ASMClassFile cf;
 
         public MyVisitor(ASMClassFile cf) {
-            super(ASM6);
+            super(ASM7);
             this.cf = cf;
         }
 

--- a/appserver/verifier/verifier-impl/src/main/java/com/sun/enterprise/tools/verifier/apiscan/classfile/ASMMethod.java
+++ b/appserver/verifier/verifier-impl/src/main/java/com/sun/enterprise/tools/verifier/apiscan/classfile/ASMMethod.java
@@ -53,7 +53,7 @@ class ASMMethod extends MethodVisitor implements Method{
     public ASMMethod(
             ClassFile owningClass, String name, String descriptor, int access,
             String signature, String[] exceptions) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM7);
         this.owningClass = new SoftReference<ClassFile>(owningClass);
         this.name = name;
         this.descriptor = descriptor;

--- a/appserver/web/jersey-mvc-connector/src/main/java/org/glassfish/main/web/jersey/server/mvc/jsp/integration/JerseyMvcTldProvider.java
+++ b/appserver/web/jersey-mvc-connector/src/main/java/org/glassfish/main/web/jersey/server/mvc/jsp/integration/JerseyMvcTldProvider.java
@@ -39,7 +39,7 @@ import org.jvnet.hk2.annotations.Service;
 import org.glassfish.api.web.TldProvider;
 import org.glassfish.web.loader.LogFacade;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.util.net.JarURIPattern;
 
@@ -80,7 +80,7 @@ public class JerseyMvcTldProvider implements TldProvider, PostConstruct {
         final Class jerseyIncludeClass = org.glassfish.jersey.server.mvc.jsp.Include.class;
 
         URI[] uris = null;
-        Module m = null;
+        HK2Module m = null;
         if (jerseyIncludeClass != null) {
             m = registry.find(jerseyIncludeClass);
         }

--- a/appserver/web/jsf-connector/src/main/java/org/glassfish/faces/integration/GlassFishTldProvider.java
+++ b/appserver/web/jsf-connector/src/main/java/org/glassfish/faces/integration/GlassFishTldProvider.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.faces.integration;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.util.net.JarURIPattern;
 import org.jvnet.hk2.annotations.Service;
@@ -107,7 +107,7 @@ public class GlassFishTldProvider implements TldProvider, PostConstruct {
         }
 
         URI[] uris = null;
-        Module m = null;
+        HK2Module m = null;
         if (jsfImplClass != null) {
             m = registry.find(jsfImplClass);
         }

--- a/appserver/web/jspcaching-connector/src/main/java/org/glassfish/jspcaching/integration/GlassFishTldProvider.java
+++ b/appserver/web/jspcaching-connector/src/main/java/org/glassfish/jspcaching/integration/GlassFishTldProvider.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 import com.sun.appserv.web.taglibs.cache.CacheTag;
 import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.util.net.JarURIPattern;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -101,7 +101,7 @@ public class GlassFishTldProvider
          */
         Class jspCachingImplClass = CacheTag.class;
         URI[] uris = null;
-        Module m = null;
+        HK2Module m = null;
         if (jspCachingImplClass != null) {
             m = registry.find(jspCachingImplClass);
         }

--- a/appserver/web/jstl-connector/src/main/java/org/glassfish/jstl/integration/GlassFishTldProvider.java
+++ b/appserver/web/jstl-connector/src/main/java/org/glassfish/jstl/integration/GlassFishTldProvider.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.util.net.JarURIPattern;
 import org.glassfish.api.web.TldProvider;
@@ -88,7 +88,7 @@ public class GlassFishTldProvider implements TldProvider, PostConstruct {
         Class jstlImplClass = org.apache.taglibs.standard.Version.class;
 
         URI[] uris = null;
-        Module m = null;
+        HK2Module m = null;
         if (jstlImplClass != null) {
             m = registry.find(jstlImplClass);
         }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/AttributeMethodVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/AttributeMethodVisitor.java
@@ -29,7 +29,7 @@ public class AttributeMethodVisitor extends EmptyVisitor {
     private boolean duckTyped;
 
     public AttributeMethodVisitor(ClassDef classDef, String method, String aggType) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM7);
         def = classDef;
         name = method;
         type = aggType;

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
@@ -28,7 +28,7 @@ public class DocClassVisitor extends ClassVisitor {
     private boolean showDeprecated;
 
     public DocClassVisitor(final boolean showDep) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM7);
         showDeprecated = showDep;
     }
 
@@ -106,7 +106,6 @@ public class DocClassVisitor extends ClassVisitor {
     public void visitEnd() {
     }
 
-    @Override
     public ModuleVisitor visitModule() {
         return null;
     }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/CustomizationTokensProvider.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/CustomizationTokensProvider.java
@@ -155,7 +155,7 @@ public class CustomizationTokensProvider {
             }
         });
         if (fjars == null)
-            throw new IOException("No Jar Files in the Modules Directory!");
+            throw new IOException("No Jar Files in the HK2Modules Directory!");
         URL[] jars = new URL[fjars.length];
         for (int i = 0; i < fjars.length; i++)
             jars[i] = fjars[i].toURI().toURL();

--- a/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/MonitoringBootstrap.java
+++ b/nucleus/admin/monitor/src/main/java/org/glassfish/admin/monitor/MonitoringBootstrap.java
@@ -44,7 +44,7 @@ import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.ConfigListener;
 import org.jvnet.hk2.config.UnprocessedChangeEvents;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleState;
 import com.sun.enterprise.module.ModuleDefinition;
 import com.sun.enterprise.module.ModulesRegistry;
@@ -125,7 +125,7 @@ public class MonitoringBootstrap implements PostConstruct, PreDestroy, EventList
     private Domain domain;
 
 
-    Map<String,Module> map = Collections.synchronizedMap(new WeakHashMap<String,Module>());
+    Map<String,HK2Module> map = Collections.synchronizedMap(new WeakHashMap<String,HK2Module>());
     List<String> appList = Collections.synchronizedList(new ArrayList<String>());
 
     private static final String INSTALL_ROOT_URI_PROPERTY_NAME = "com.sun.aas.installRootURI";
@@ -176,7 +176,7 @@ public class MonitoringBootstrap implements PostConstruct, PreDestroy, EventList
         // Iterate thru existing modules
         if (logger.isLoggable(Level.FINE))
             logger.log(Level.FINE, "Discovering the ProbeProviders");
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if ((m.getState() == ModuleState.READY) || (m.getState() == ModuleState.RESOLVED)) {
                 if (logger.isLoggable(Level.FINE))
                     logger.fine(" In (discoverProbeProviders) ModuleState - " + m.getState() + " : " + m.getName());
@@ -223,17 +223,17 @@ public class MonitoringBootstrap implements PostConstruct, PreDestroy, EventList
         amxg.listenForDomainRoot(ManagementFactory.getPlatformMBeanServer(), spmd);
     }
 
-    public void moduleResolved(Module module) {
+    public void moduleResolved(HK2Module module) {
         if (module == null) return;
         verifyModule(module);
     }
 
-    public synchronized void moduleStarted(Module module) {
+    public synchronized void moduleStarted(HK2Module module) {
         if (module == null) return;
         verifyModule(module);
     }
 
-    private synchronized void verifyModule(Module module) {
+    private synchronized void verifyModule(HK2Module module) {
         if (module == null) return;
         String str = module.getName();
         if (!map.containsKey(str)) {
@@ -264,20 +264,20 @@ public class MonitoringBootstrap implements PostConstruct, PreDestroy, EventList
 
     // noop to satisfy interface
     @Override
-    public synchronized void moduleStopped(Module module) {
+    public synchronized void moduleStopped(HK2Module module) {
     }
 
     // noop to satisfy interface
     @Override
-    public void moduleInstalled(Module module) {
+    public void moduleInstalled(HK2Module module) {
     }
 
     // noop to satisfy interface
     @Override
-    public void moduleUpdated(Module module) {
+    public void moduleUpdated(HK2Module module) {
     }
 
-    private void addProvider(Module module) {
+    private void addProvider(HK2Module module) {
         if (logger.isLoggable(Level.FINE))
             logger.fine(" Adding the Provider - verified the module");
         ClassLoader mcl = module.getClassLoader();
@@ -420,8 +420,8 @@ public class MonitoringBootstrap implements PostConstruct, PreDestroy, EventList
                     continue;
                 }
                 if (logger.isLoggable(Level.FINE))
-                    logger.fine (" Module found (containsKey)");
-                Module module = map.get(moduleName);
+                    logger.fine (" HK2Module found (containsKey)");
+                HK2Module module = map.get(moduleName);
 
                 if (module == null) {
                     logger.log(Level.SEVERE,
@@ -620,7 +620,7 @@ public class MonitoringBootstrap implements PostConstruct, PreDestroy, EventList
     private void enableMonitoringForProbeProviders(boolean isDiscoverXMLProviders) {
         //Process all ProbeProviders from modules loaded
         discoverProbeProviders();
-        //Start listening to any new Modules that are coming in now
+        //Start listening to any new HK2Modules that are coming in now
         registry.register(this);
         //Don't do this the first time, since we need to wait till the server starts
         // We should try to do this in a seperate thread, as we dont want to get held up in server start

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/RuntimeRootImpl.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/RuntimeRootImpl.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.logging.Level;
 
 import com.sun.enterprise.module.ModulesRegistry;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 
 import com.sun.enterprise.security.ssl.SSLUtils;
 import javax.management.JMException;
@@ -104,10 +104,10 @@ public final class RuntimeRootImpl extends AMXImplBase
     public void stopDomain()
     {
         final ModulesRegistry registry = InjectedValues.getInstance().getModulesRegistry();
-        final Collection<Module> modules = registry.getModules("com.sun.enterprise.osgi-adapter");
+        final Collection<HK2Module> modules = registry.getModules("com.sun.enterprise.osgi-adapter");
         if (modules.size() == 1)
         {
-            final Module mgmtAgentModule = modules.iterator().next();
+            final HK2Module mgmtAgentModule = modules.iterator().next();
             mgmtAgentModule.stop();
         }
         else

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/container/Sniffer.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/container/Sniffer.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.logging.Logger;
 import java.lang.annotation.Annotation;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import java.util.Map;
 
 /**
@@ -98,7 +98,7 @@ public interface Sniffer {
      * Sets up the container libraries so that any imported bundle from the
      * connector jar file will now be known to the module subsystem
      *
-     * This method returns a {@link Module}s for the module containing
+     * This method returns a {@link HK2Module}s for the module containing
      * the core implementation of the container. That means that this module
      * will be locked as long as there is at least one module loaded in the
      * associated container.
@@ -109,7 +109,7 @@ public interface Sniffer {
      *
      * @throws java.io.IOException exception if something goes sour
      */
-    public Module[] setup(String containerHome, Logger logger) throws IOException;
+    public HK2Module[] setup(String containerHome, Logger logger) throws IOException;
 
    /**
      * Tears down a container, remove all imported libraries from the module

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/DeploymentTracing.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/DeploymentTracing.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.internal.deployment;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleState;
 import com.sun.enterprise.module.ModulesRegistry;
 
@@ -128,7 +128,7 @@ public class DeploymentTracing {
             this.moduleName = moduleName;
         }
         void print(PrintStream ps) {
-            ps.println("Module " +  moduleName + " Mark " + mark.toString() + " at " + elapsedInMs());
+            ps.println("HK2Module " +  moduleName + " Mark " + mark.toString() + " at " + elapsedInMs());
         }
     }
 
@@ -166,10 +166,10 @@ public class DeploymentTracing {
         }
         int counter=0;
 
-        StringBuilder sb = new StringBuilder("Module Status Report Begins\n");
+        StringBuilder sb = new StringBuilder("HK2Module Status Report Begins\n");
         // first started :
 
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()== ModuleState.READY) {
                 sb.append(m).append("\n");
                 counter++;
@@ -179,7 +179,7 @@ public class DeploymentTracing {
         sb.append("\n");
         counter=0;
         // then resolved
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()== ModuleState.RESOLVED) {
                 sb.append(m).append("\n");
                 counter++;
@@ -189,14 +189,14 @@ public class DeploymentTracing {
         sb.append("\n");
         counter=0;
         // finally installed
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()!= ModuleState.READY && m.getState()!=ModuleState.RESOLVED) {
                 sb.append(m).append("\n");
                 counter++;
             }
         }
         sb.append("there were " + counter + " modules in INSTALLED state");
-        sb.append("Module Status Report Ends");
+        sb.append("HK2Module Status Report Ends");
         logger.log(level, sb.toString());
     }    
 }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericDeployer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericDeployer.java
@@ -19,7 +19,7 @@ package org.glassfish.internal.deployment;
 import org.glassfish.api.deployment.*;
 import org.glassfish.api.container.Container;
 import org.jvnet.hk2.annotations.Service;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 
 /**
  * Generic implementation of the deployer contract, enough to get started with adding a container to

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/deployment/GenericSniffer.java
@@ -18,7 +18,7 @@ package org.glassfish.internal.deployment;
 
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.ModuleDefinition;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import java.io.ByteArrayOutputStream;
 import javax.inject.Inject;
 import javax.xml.stream.XMLEventReader;
@@ -59,7 +59,7 @@ public abstract class GenericSniffer implements Sniffer {
     final private String urlPattern;
     
     final private static XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
-    private Module[] modules;
+    private HK2Module[] modules;
 
     public GenericSniffer(String containerName, String appStigma, String urlPattern) {
         this.containerName = containerName;
@@ -158,23 +158,23 @@ public abstract class GenericSniffer implements Sniffer {
      *
      * @throws java.io.IOException exception if something goes sour
      */
-    public synchronized Module[] setup(String containerHome, Logger logger) throws IOException {   // TODO(Sahoo): Change signature to not accept containerHome or logger
+    public synchronized HK2Module[] setup(String containerHome, Logger logger) throws IOException {   // TODO(Sahoo): Change signature to not accept containerHome or logger
         if (modules != null) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.logp(Level.FINE, "GenericSniffer", "setup", "{0} has already setup {1} container, so just returning.", new Object[]{this, containerName});
             }
             return modules;
         }
-        List<Module> tmp = new ArrayList<Module>();
+        List<HK2Module> tmp = new ArrayList<HK2Module>();
         for (String moduleName : getContainerModuleNames()) {
-            Module m = modulesRegistry.makeModuleFor(moduleName, null);
+            HK2Module m = modulesRegistry.makeModuleFor(moduleName, null);
             if (m != null) {
                 tmp.add(m);
             } else {
                 throw new RuntimeException("Unable to set up module " + moduleName);
             }
         }
-        modules = tmp.toArray(new Module[tmp.size()]);
+        modules = tmp.toArray(new HK2Module[tmp.size()]);
         return modules;
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/ListContainersCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/ListContainersCommand.java
@@ -21,7 +21,7 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.data.EngineInfo;
 import org.glassfish.internal.data.ContainerRegistry;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.config.serverbeans.Application;
 import com.sun.enterprise.config.serverbeans.Applications;
@@ -93,7 +93,7 @@ public class ListContainersCommand implements AdminCommand {
                     container.addProperty(
                             localStrings.getLocalString("status", "Status"),
                             localStrings.getLocalString("started", "Started"));
-                    Module connectorModule = modulesRegistry.find(engineInfo.getSniffer().getClass());
+                    HK2Module connectorModule = modulesRegistry.find(engineInfo.getSniffer().getClass());
                     container.addProperty(localStrings.getLocalString("connector", "Connector"),
                             connectorModule.getModuleDefinition().getName() +
                             ":" + connectorModule.getModuleDefinition().getVersion());

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/ListModulesCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/ListModulesCommand.java
@@ -27,7 +27,7 @@ import org.glassfish.api.admin.CommandLock;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import com.sun.enterprise.module.ModulesRegistry;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleState;
 
 import java.net.URI;
@@ -62,29 +62,29 @@ public class ListModulesCommand implements AdminCommand {
         top.setMessage("List Of Modules");
         top.setChildrenType("Module");
 
-        StringBuilder sb = new StringBuilder("Module Status Report Begins\n");
+        StringBuilder sb = new StringBuilder("HK2Module Status Report Begins\n");
         // first started :
 
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()== ModuleState.READY) {
                 sb.append(m).append("\n");
             }
         }
         sb.append("\n");
         // then resolved
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()== ModuleState.RESOLVED) {
                 sb.append(m).append("\n");
             }
         }
         sb.append("\n");
         // finally installed
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()!= ModuleState.READY && m.getState()!=ModuleState.RESOLVED) {
                 sb.append(m).append("\n");
             }
         }
-        sb.append("Module Status Report Ends");
+        sb.append("HK2Module Status Report Ends");
         ActionReport.MessagePart childPart = top.addChild();
         childPart.setMessage(sb.toString());
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/DerbyLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/bootstrap/DerbyLifecycle.java
@@ -26,7 +26,7 @@
 package com.sun.enterprise.v3.bootstrap;
 
 import com.sun.enterprise.module.LifecyclePolicy;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleState;
 import com.sun.enterprise.module.common_impl.LogHelper;
 import java.util.logging.Level;
@@ -47,10 +47,10 @@ public class DerbyLifecycle implements LifecyclePolicy {
      * or set up access to resources
      * @param module the module instance
      */
-    public void start(Module module) {
+    public void start(HK2Module module) {
    
         try {
-            final Module myModule = module;
+            final HK2Module myModule = module;
             Thread thread = new Thread() {
                 public void run() {
                     try {
@@ -84,7 +84,7 @@ public class DerbyLifecycle implements LifecyclePolicy {
      * free all the module resources and returned to a {@link ModuleState#NEW NEW} state.
      * @param module the module instance
      */
-    public void stop(Module module) {
+    public void stop(HK2Module module) {
     
     }
     

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java
@@ -16,7 +16,7 @@
 
 package com.sun.enterprise.v3.server;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleLifecycleListener;
 import com.sun.enterprise.module.ModuleState;
 import com.sun.enterprise.module.ModulesRegistry;
@@ -98,7 +98,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
         }
     };
     final static Logger logger = KernelLoggerInfo.getLogger();
-    private Module APIModule;
+    private HK2Module APIModule;
 
     public void postConstruct() {
         try {
@@ -173,20 +173,20 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
 
             // add a listener to manage blacklist in APIClassLoader
             mr.register(new ModuleLifecycleListener() {
-                public void moduleInstalled(Module module) {
+                public void moduleInstalled(HK2Module module) {
                     clearBlackList();
                 }
 
-                public void moduleResolved(Module module) {
+                public void moduleResolved(HK2Module module) {
                 }
 
-                public void moduleStarted(Module module) {
+                public void moduleStarted(HK2Module module) {
                 }
 
-                public void moduleStopped(Module module) {
+                public void moduleStopped(HK2Module module) {
                 }
 
-                public void moduleUpdated(Module module) {
+                public void moduleUpdated(HK2Module module) {
                     clearBlackList();
                 }
             });
@@ -214,7 +214,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
                         c = apiModuleLoader.loadClass(name); // we ignore the resolution flag
                     } catch (ClassNotFoundException cnfe) {
                         // punch in. find the provider class, no matter where we are.
-                        Module m = mr.getProvidingModule(name);
+                        HK2Module m = mr.getProvidingModule(name);
                         if (m != null) {
                             if(select(m)) {
                                 return m.getClassLoader().loadClass(name); // abort search if we fail to load.
@@ -248,7 +248,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
          * @param m
          * @return
          */
-        private boolean select(Module m) {
+        private boolean select(HK2Module m) {
             ModuleState state = m.getState();
             return state.compareTo(punchInModuleState) >= 0 && state != ModuleState.ERROR;
         }
@@ -267,7 +267,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
                 if (name.equals(MAILCAP)) {
                     // punch in for META-INF/mailcap files.
                     // see issue #8426
-                    for (Module m : mr.getModules()) {
+                    for (HK2Module m : mr.getModules()) {
                         if (!select(m)) continue;
                         if ((url = m.getClassLoader().getResource(name)) != null) {
                             return url;
@@ -280,7 +280,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
                     String serviceName = name.substring(
                             META_INF_SERVICES.length());
 
-                    for( Module m : mr.getModules() ) {
+                    for( HK2Module m : mr.getModules() ) {
                         if (!select(m)) continue;
                         List<URL> list = m.getMetadata().getDescriptors(
                                 serviceName);
@@ -341,7 +341,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
                 // now punch-ins for various cases that require special handling
                 if (name.equals(MAILCAP)) {
                      // punch in for META-INF/mailcap files. see issue #8426
-                    for (Module m : mr.getModules()) {
+                    for (HK2Module m : mr.getModules()) {
                         if (!select(m)) continue; // We don't look in unresolved modules
                         if (m == APIModule) continue; // we have already looked up resources in apiModuleLoader
                         enumerations.add(m.getClassLoader().getResources(name));
@@ -350,7 +350,7 @@ public class APIClassLoaderServiceImpl implements PostConstruct {
                     // punch in. find the service loader from any module
                     String serviceName = name.substring(META_INF_SERVICES.length());
                     List<URL> punchedInURLs = new ArrayList<URL>();
-                    for (Module m : mr.getModules()) {
+                    for (HK2Module m : mr.getModules()) {
                         if (!select(m)) continue; // We don't look in modules that don't meet punch in criteria
                         if (m == APIModule) continue; // we have already looked up resources in apiModuleLoader
                         punchedInURLs.addAll(m.getMetadata().getDescriptors(serviceName));

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -18,7 +18,7 @@ package com.sun.enterprise.v3.server;
 
 
 import com.sun.appserv.server.util.Version;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleState;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.bootstrap.ModuleStartup;
@@ -394,29 +394,29 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
             return;
         }
         
-        StringBuilder sb = new StringBuilder("Module Status Report Begins\n");
+        StringBuilder sb = new StringBuilder("HK2Module Status Report Begins\n");
         // first started :
 
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()== ModuleState.READY) {
                 sb.append(m).append("\n");
             }
         }
         sb.append("\n");
         // then resolved
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()== ModuleState.RESOLVED) {
                 sb.append(m).append("\n");
             }
         }
         sb.append("\n");
         // finally installed
-        for (Module m : registry.getModules()) {
+        for (HK2Module m : registry.getModules()) {
             if (m.getState()!= ModuleState.READY && m.getState()!=ModuleState.RESOLVED) {
                 sb.append(m).append("\n");
             }
         }
-        sb.append("Module Status Report Ends");
+        sb.append("HK2Module Status Report Ends");
         logger.log(level, sb.toString());
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
@@ -142,7 +142,7 @@ public class ClassLoaderHierarchyImpl implements ClassLoaderHierarchy {
             String importedBundles = m.getMainAttributes().getValue(ManifestConstants.BUNDLE_IMPORT_NAME);
             if (importedBundles!=null) {
                 for( String token : new Tokenizer(importedBundles,",")) {
-                    Collection<Module> modules = modulesRegistry.getModules(token);
+                    Collection<HK2Module> modules = modulesRegistry.getModules(token);
                     if (modules.size() ==1) {
                         defs.add(modules.iterator().next().getModuleDefinition());
                     } else {
@@ -177,7 +177,7 @@ public class ClassLoaderHierarchyImpl implements ClassLoaderHierarchy {
             if (requestedWiring!=null) {
                 for (String token : new Tokenizer(requestedWiring, ",")) {
                     for (Object impl : habitat.getAllServices(BuilderHelper.createContractFilter(token))) {
-                        Module wiredBundle = modulesRegistry.find(impl.getClass());
+                        HK2Module wiredBundle = modulesRegistry.find(impl.getClass());
                         if (wiredBundle!=null) {
                             defs.add(wiredBundle.getModuleDefinition());
                         }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ClassLoaderHierarchyImpl.java
@@ -29,7 +29,7 @@ import org.glassfish.internal.api.DelegatingClassLoader;
 import org.glassfish.internal.api.ConnectorClassLoaderService;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.api.deployment.DeploymentContext;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 
 import java.net.URI;
 import java.net.MalformedURLException;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ContainerStarter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ContainerStarter.java
@@ -36,7 +36,7 @@ import org.glassfish.internal.data.EngineInfo;
 import org.glassfish.server.ServerEnvironmentImpl;
 import org.jvnet.hk2.annotations.Service;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 
 /**
  * This class is responsible for starting containers.
@@ -70,7 +70,7 @@ public class ContainerStarter {
         // repositories which would allow access to the container module.
         try {
 
-            Module[] modules = sniffer.setup(null, logger);
+            HK2Module[] modules = sniffer.setup(null, logger);
             logger.logp(Level.FINE, "ContainerStarter", "startContainer", "Sniffer {0} set up following modules: {1}",
                     new Object[]{sniffer, modules != null ? Arrays.toString(modules): ""});
         } catch(FileNotFoundException fnf) {

--- a/nucleus/core/kernel/src/test/java/org/glassfish/tests/kernel/deployment/container/FakeSniffer.java
+++ b/nucleus/core/kernel/src/test/java/org/glassfish/tests/kernel/deployment/container/FakeSniffer.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 import java.util.Map;
 import java.io.IOException;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 
 /**
  * Created by IntelliJ IDEA.
@@ -65,7 +65,7 @@ public class FakeSniffer implements Sniffer {
         return "fake";
     }
 
-    public Module[] setup(String containerHome, Logger logger) throws IOException {
+    public HK2Module[] setup(String containerHome, Logger logger) throws IOException {
         return null;
     }
 

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LoggerInfoMetadataService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LoggerInfoMetadataService.java
@@ -42,9 +42,9 @@ import javax.inject.Singleton;
 import org.jvnet.hk2.annotations.Service;
 
 import com.sun.enterprise.module.ModulesRegistry;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleDefinition;
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModuleChangeListener;
 
 @Service
@@ -64,7 +64,7 @@ public class LoggerInfoMetadataService implements LoggerInfoMetadata, ModuleChan
     // Reset valid flag if teh set of modules changes, so meta-data will be recomputed
     private Set<String> currentModuleNames() {
         Set<String> currentNames = new HashSet<String>();
-        for (Module module : modulesRegistry.getModules()) {
+        for (HK2Module module : modulesRegistry.getModules()) {
             currentNames.add(module.getName());
         }
         // If new modules set changes, force recomputation of logger meta-datas
@@ -135,7 +135,7 @@ public class LoggerInfoMetadataService implements LoggerInfoMetadata, ModuleChan
     
     // If a module changed in any way, reset the valid flag so meta-data will be
     // recomputed when subsequently requested.
-    public synchronized void changed(Module sender)  {
+    public synchronized void changed(HK2Module sender)  {
         valid = false;
     }
     
@@ -170,7 +170,7 @@ public class LoggerInfoMetadataService implements LoggerInfoMetadata, ModuleChan
         
         private void initialize() {
             ClassLoader nullClassLoader = new NullClassLoader();
-            for (Module module : modulesRegistry.getModules()) {
+            for (HK2Module module : modulesRegistry.getModules()) {
                 ModuleDefinition moduleDef = module.getModuleDefinition();
                 // FIXME: We may optimize this by creating a manifest entry in the 
                 // jar file(s) to indicate that the jar contains logger infos. Jar files

--- a/nucleus/deployment/common/osgi.bundle
+++ b/nucleus/deployment/common/osgi.bundle
@@ -25,6 +25,7 @@
                         
 Import-Package: \
                         javax.rmi.CORBA, \
+                        org.objectweb.asm, \
                         *
                         
 DynamicImport-Package: \

--- a/nucleus/deployment/common/pom.xml
+++ b/nucleus/deployment/common/pom.xml
@@ -103,8 +103,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.tests</groupId>

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
@@ -62,7 +62,7 @@ public class GenericAnnotationDetector extends AnnotationScanner {
     List<String> annotations = new ArrayList<String>();; 
 
     public GenericAnnotationDetector(Class[] annotationClasses) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM7);
         if (annotationClasses != null) {
             for (Class annClass : annotationClasses) {
                 annotations.add(Type.getDescriptor(annClass));

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/NodeInfo.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/NodeInfo.java
@@ -69,7 +69,7 @@ class NodeInfo
     }
 
     NodeInfo(byte[] classData) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM7);
         ClassReader cr = new ClassReader(classData);
 
         cr.accept(this, ClassReader.SKIP_CODE);
@@ -117,7 +117,7 @@ class NodeInfo
     }
 
     NodeInfo(String className) {
-        super(Opcodes.ASM6);
+        super(Opcodes.ASM7);
         this.className = className;
     }
 

--- a/nucleus/deployment/common/src/main/java/org/glassfish/loader/util/ASClassLoaderUtil.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/loader/util/ASClassLoaderUtil.java
@@ -16,7 +16,7 @@
 
 package org.glassfish.loader.util;
 
-import com.sun.enterprise.module.Module;
+import com.sun.enterprise.module.HK2Module;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.util.io.FileUtils;
 import org.glassfish.api.deployment.DeployCommandParameters;
@@ -70,7 +70,7 @@ public class ASClassLoaderUtil {
      * defined [if any] for the application
      *
      * @param habitat the habitat the application resides in.
-     * @param moduleId Module id of the module
+     * @param moduleId HK2Module id of the module
      * @param deploymentLibs libraries option passed through deployment
      * @return A <code>File.pathSeparator</code> separated list of classpaths
      *         for the passed in module, including the module specified
@@ -213,7 +213,7 @@ public class ASClassLoaderUtil {
                 final StringBuilder tmpString = new StringBuilder();
                 ModulesRegistry mr = habitat.getService(ModulesRegistry.class);
                 if (mr != null) {
-                    for (Module module : mr.getModules()) {
+                    for (HK2Module module : mr.getModules()) {
                         for (URI uri : module.getModuleDefinition().getLocations()) {
                             tmpString.append(uri.getPath());
                             tmpString.append(File.pathSeparator);

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
@@ -169,7 +169,11 @@ hk2.bundles=\
  ${com.sun.aas.installRootURI}modules/config-types.jar \
  ${com.sun.aas.installRootURI}modules/bean-validator.jar \
  ${com.sun.aas.installRootURI}modules/class-model.jar \
- ${com.sun.aas.installRootURI}modules/asm-repackaged.jar \
+ ${com.sun.aas.installRootURI}modules/asm.jar \
+ ${com.sun.aas.installRootURI}modules/asm-analysis.jar \
+ ${com.sun.aas.installRootURI}modules/asm-commons.jar \
+ ${com.sun.aas.installRootURI}modules/asm-tree.jar \
+ ${com.sun.aas.installRootURI}modules/asm-util.jar \
  ${com.sun.aas.installRootURI}modules/osgi-adapter.jar
 
 core.bundles=\

--- a/nucleus/featuresets/atomic/pom.xml
+++ b/nucleus/featuresets/atomic/pom.xml
@@ -257,8 +257,48 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -342,16 +382,6 @@
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>
             <artifactId>aopalliance-repackaged</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>asm-repackaged</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/nucleus/flashlight/framework/pom.xml
+++ b/nucleus/flashlight/framework/pom.xml
@@ -86,8 +86,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
-            <artifactId>asm-all</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
@@ -286,7 +286,7 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
             extends ClassVisitor {
 
         ProbeProviderClassVisitor(ClassVisitor cv) {
-            super(Opcodes.ASM6, cv);
+            super(Opcodes.ASM7, cv);
             if (Log.getLogger().isLoggable(Level.FINER)) {
                 for (String methodDesc : probes.keySet()) {
                     Log.finer("visit" + methodDesc);
@@ -315,7 +315,7 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
         private Label startFinally;
 
         ProbeProviderMethodVisitor(MethodVisitor mv, int access, String name, String desc, FlashlightProbe probe) {
-            super(Opcodes.ASM6, mv, access, name, desc);
+            super(Opcodes.ASM7, mv, access, name, desc);
             this.probe = probe;
         }
 

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
@@ -136,7 +136,7 @@ public class ProviderSubClassImplGenerator {
         String id;
 
         ProbeProviderSubClassGenerator(ClassVisitor cv, String token, String id) {
-            super(Opcodes.ASM6, cv);
+            super(Opcodes.ASM7, cv);
             this.id = id;
             this.token = token;
         }
@@ -184,7 +184,7 @@ public class ProviderSubClassImplGenerator {
         private String token;
 
         ProbeProviderAnnotationVisitor(AnnotationVisitor delegate, String token) {
-            super(Opcodes.ASM6);
+            super(Opcodes.ASM7);
             this.delegate = delegate;
             this.token = token;
         }

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -169,7 +169,11 @@ hk2.bundles=\
  ${com.sun.aas.installRootURI}modules/config-types.jar \
  ${com.sun.aas.installRootURI}modules/bean-validator.jar \
  ${com.sun.aas.installRootURI}modules/class-model.jar \
- ${com.sun.aas.installRootURI}modules/asm-repackaged.jar \
+ ${com.sun.aas.installRootURI}modules/asm.jar \
+ ${com.sun.aas.installRootURI}modules/asm-analysis.jar \
+ ${com.sun.aas.installRootURI}modules/asm-commons.jar \
+ ${com.sun.aas.installRootURI}modules/asm-tree.jar \
+ ${com.sun.aas.installRootURI}modules/asm-util.jar \
  ${com.sun.aas.installRootURI}modules/osgi-adapter.jar
 
 core.bundles=\

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -95,7 +95,7 @@
         <javassist.version>3.22.0-GA</javassist.version>
         <jakarta.el.version>3.0.3</jakarta.el.version>
         <jakarta.el-api.version>3.0.2</jakarta.el-api.version>
-        <hk2.version>2.5.0</hk2.version>
+        <hk2.version>2.6.1</hk2.version>
         <hk2.plugin.version>2.5.0</hk2.plugin.version>
         <jboss.logging.version>3.3.1.Final</jboss.logging.version>
         <fasterxml.classmate.version>1.5.1</fasterxml.classmate.version>
@@ -112,7 +112,7 @@
         <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
         <mimepull.version>1.9.11</mimepull.version>
         <glassfish-management-api.version>3.2.1</glassfish-management-api.version>
-        <asm.version>6.1_ALPHA</asm.version>
+        <asm.version>7.1</asm.version>
         <shoal.version>1.6.53</shoal.version>
         <ha-api.version>3.1.12</ha-api.version>
         <glassfishbuild.version>3.2.27</glassfishbuild.version>
@@ -972,8 +972,28 @@
                 <version>2.8</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.external</groupId>
-                <artifactId>asm-all</artifactId>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
                 <version>${asm.version}</version>
             </dependency>
             <dependency>

--- a/nucleus/test-utils/utils/src/main/java/org/glassfish/tests/utils/ProxyModule.java
+++ b/nucleus/test-utils/utils/src/main/java/org/glassfish/tests/utils/ProxyModule.java
@@ -28,7 +28,7 @@ import java.io.PrintStream;
  * Time: 11:29:13 PM
  * To change this template use File | Settings | File Templates.
  */
-public class ProxyModule implements Module {
+public class ProxyModule implements HK2Module {
 
     final ClassLoader classLoader;
     final ModuleDefinition moduleDef;
@@ -90,15 +90,15 @@ public class ProxyModule implements Module {
         return classLoader;
     }
 
-    public List<Module> getImports() {
+    public List<HK2Module> getImports() {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
-    public void addImport(Module module) {
+    public void addImport(HK2Module module) {
         //To change body of implemented methods use File | Settings | File Templates.
     }
 
-    public Module addImport(ModuleDependency dependency) {
+    public HK2Module addImport(ModuleDependency dependency) {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 


### PR DESCRIPTION
Cherry pick the "Upgrade hk2 and asm." commit from the https://github.com/eclipse-ee4j/glassfish/tree/5.1.0-run-with-JDK11 branch.

Fixed one wrong import. QuickLook and spot checks run locally.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>