### PR TITLE
Add stale issue action

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -13,6 +13,6 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been marked as inactive and old and will be closed in 7 days if there is no further activity'
+        stale-issue-message: 'This issue has been marked as inactive and old and will be closed in 7 days if there is no further activity. If you want the issue to remain open please add a comment'
         days-before-stale: 365
         days-before-close: 7

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,18 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as inactive and old and will be closed in 7 days if there is no further activity'
+        days-before-stale: 365
+        days-before-close: 7


### PR DESCRIPTION
Adds automation to comment on issues over 1 year with no activity and then closes them after another week of inactivity. This should close down a lot of the old issues.