### PR TITLE
Modifications to make devtests work on JDK 11

### DIFF
--- a/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
+++ b/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
@@ -198,7 +198,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/appserver/admin/template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/template/src/main/resources/config/default-web.xml
@@ -288,6 +288,14 @@
       <param-value>GET,POST,HEAD</param-value>
     </init-param>
     <init-param>
+      <param-name>compilerSourceVM</param-name>
+      <param-value>1.8</param-value>
+    </init-param>
+    <init-param>
+      <param-name>compilerTargetVM</param-name>
+      <param-value>1.8</param-value>
+    </init-param>
+    <init-param>
       <param-name>system-jar-includes</param-name>
       <param-value>
         /lib/

--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -204,7 +204,10 @@
         <jvm-options>-XX:NewRatio=2</jvm-options>
         <!-- Woodstox property needed to pass StAX TCK -->
         <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.annotation-api.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.xml.bind-api.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/webservices-api-osgi.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
       </java-config>
@@ -386,7 +389,10 @@
              -->
              <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
              <!-- End of OSGi bundle configurations -->
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-bootstrap.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.annotation-api.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.xml.bind-api.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/webservices-api-osgi.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
         </java-config>

--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -154,7 +154,7 @@
         </message-security-config>
 	<property value="SHA-256" name="default-digest-algorithm" />
       </security-service>
-      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%%%JAVA_DEBUGGER_PORT%%%">
+      <java-config classpath-suffix="" system-classpath="" debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:%%%JAVA_DEBUGGER_PORT%%%">
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
@@ -341,7 +341,7 @@
          </security-service>
          <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" automatic-recovery="true" />
          <diagnostic-service />
-         <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
+         <java-config debug-options="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:${JAVA_DEBUGGER_PORT}" system-classpath="" classpath-suffix="">
              <jvm-options>-XX:MaxPermSize=192m</jvm-options>
              <jvm-options>-server</jvm-options>
              <jvm-options>-Djava.awt.headless=true</jvm-options>

--- a/appserver/admingui/devtests/hudson.xml
+++ b/appserver/admingui/devtests/hudson.xml
@@ -58,7 +58,7 @@
     <property name="ant.contrib.url"
               value="http://mirrors.ibiblio.org/pub/mirrors/maven2/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"/>
     <property name="maven.ant.tasks.url"
-              value="http://repo2.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.1/maven-ant-tasks-2.1.1.jar"/>
+              value="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.1/maven-ant-tasks-2.1.1.jar"/>
     <property name="glassfish.dist.url"
               value="http://hudson.glassfish.org/job/gf-trunk-build-continuous/lastSuccessfulBuild/artifact/bundles/glassfish.zip"/>
 

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -925,7 +925,11 @@ public class CLIBootstrap {
 
         command.append(' ').append(INSTALL_ROOT_PROPERTY_EXPR).append(quote(gfInfo.home().getAbsolutePath()));
         command.append(' ').append(SECURITY_POLICY_PROPERTY_EXPR).append(quote(gfInfo.securityPolicy().getAbsolutePath()));
-        command.append(' ').append(SYSTEM_CLASS_LOADER_PROPERTY_EXPR);
+        //In JDK 9 and later ACCAgentClassLoader is not required.
+        int major = JDK.getMajor();
+        if(major < 9) {
+            command.append(' ').append(SYSTEM_CLASS_LOADER_PROPERTY_EXPR);
+        }
         command.append(' ').append(SECURITY_AUTH_LOGIN_CONFIG_PROPERTY_EXPR).append(quote(gfInfo.loginConfig().getAbsolutePath()));
         
     }

--- a/appserver/connectors/admin/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/admin/src/test/resources/DomainTest.xml
@@ -134,7 +134,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
@@ -128,7 +128,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
@@ -137,7 +137,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -260,6 +260,18 @@
             <outputDirectory>${install.dir.name}/glassfish/lib</outputDirectory>
         </fileSet>
 
+        <!-- modules/endorsed -->
+        <fileSet>
+            <directory>${temp.dir}</directory>
+            <includes>
+                <include>jakarta.annotation-api.jar</include>
+                <include>jakarta.xml.bind-api.jar</include>
+                <include>webservices-api-osgi.jar</include>
+                <include>grizzly-npn-bootstrap.jar</include>
+            </includes>
+            <outputDirectory>${install.dir.name}/glassfish/modules/endorsed</outputDirectory>
+        </fileSet>
+
         <!-- felix -->
         <fileSet>
             <directory>${temp.dir}</directory>
@@ -325,6 +337,7 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
+                <exclude>jakarta.annotation-api.jar</exclude>
                 <exclude>grizzly-npn-bootstrap.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>
@@ -340,6 +353,8 @@
                 <exclude>mejb.jar</exclude>
                 <exclude>weld-se-core.jar</exclude>
                 <exclude>weld-se-shaded.jar</exclude>
+                <exclude>jakarta.xml.bind-api.jar</exclude>
+                <exclude>webservices-api-osgi.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/glassfish/modules</outputDirectory>
         </fileSet>

--- a/appserver/ejb/ejb-container/osgi.bundle
+++ b/appserver/ejb/ejb-container/osgi.bundle
@@ -38,6 +38,7 @@ Import-Package: \
                         javax.jws;resolution:=optional, \
                         org.glassfish.apf.context, \
                         org.glassfish.ejb.deployment.archive, \
+                        org.glassfish.rmic, \
                         *
 
 Bundle-SymbolicName: \

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -225,5 +225,9 @@
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>rmic</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/StaticRmiStubGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/StaticRmiStubGenerator.java
@@ -34,6 +34,7 @@ import com.sun.enterprise.deployment.Application;
 import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.deployment.EjbBundleDescriptor;
 import com.sun.enterprise.deployment.util.TypeUtil;
+import com.sun.enterprise.util.JDK;
 import com.sun.enterprise.util.OS;
 import org.glassfish.api.admin.ServerEnvironment;
 
@@ -242,7 +243,7 @@ public class StaticRmiStubGenerator {
             return;
         }
 
-        if( toolsJarPath == null && !OS.isDarwin()) {
+        if( toolsJarPath == null && !OS.isDarwin() && JDK.getMajor() < 9) {
             _logger.log(Level.INFO,  "[RMIC] tools.jar location was not found");
             return;
         }
@@ -271,7 +272,7 @@ public class StaticRmiStubGenerator {
         _logger.info("[RMIC] options: " + cmds);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        sun.rmi.rmic.Main compiler = new sun.rmi.rmic.Main(baos, "rmic");
+        org.glassfish.rmic.Main compiler = new org.glassfish.rmic.Main(baos, "rmic");
         boolean success = compiler.compile(cmds.toArray(new String[cmds.size()]));
         //success = true;  // it ALWAYS returns an "error" if -Xnocompile is used!!
 

--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -856,5 +856,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/jdbc/admin/src/test/resources/DomainTest.xml
+++ b/appserver/jdbc/admin/src/test/resources/DomainTest.xml
@@ -118,7 +118,6 @@
       <diagnostic-service></diagnostic-service>
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
+++ b/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
@@ -142,7 +142,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
+++ b/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
@@ -128,7 +128,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -986,6 +986,16 @@
                <artifactId>jakarta.activation</artifactId>
                <version>${jakarta.activation.version}</version>
            </dependency>
+           <dependency>
+               <groupId>javax.xml.ws</groupId>
+               <artifactId>jaxws-api</artifactId>
+               <version>${jaxws-api.version}</version>
+           </dependency>
+           <dependency>
+               <groupId>jakarta.jws</groupId>
+               <artifactId>jakarta.jws-api</artifactId>
+               <version>${jakarta.jws-api.version}</version>
+           </dependency>
       </dependencies>
     </dependencyManagement>
 

--- a/appserver/resources/javamail/javamail-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/javamail/javamail-connector/src/test/resources/DomainTest.xml
@@ -134,7 +134,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/appserver/resources/resources-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/resources-connector/src/test/resources/DomainTest.xml
@@ -134,7 +134,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/appserver/tests/appserv-tests/config/common.xml
+++ b/appserver/tests/appserv-tests/config/common.xml
@@ -76,7 +76,6 @@ Variables used:
     debug="on"
     includeantruntime="false"
     failonerror="true">
-    <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed"/>
    </javac>
 </target>
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v2domain.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v2domain.xml
@@ -188,7 +188,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.ee.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-Dcom.sun.appserv.pluggable.features=com.sun.enterprise.ee.server.pluggable.EEPluggableFeatureImpl</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
@@ -335,7 +334,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.ee.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-Dcom.sun.appserv.pluggable.features=com.sun.enterprise.ee.server.pluggable.EEPluggableFeatureImpl</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
@@ -487,7 +485,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.ee.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-Dcom.sun.appserv.pluggable.features=com.sun.enterprise.ee.server.pluggable.EEPluggableFeatureImpl</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
@@ -639,7 +636,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.ee.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-Dcom.sun.appserv.pluggable.features=com.sun.enterprise.ee.server.pluggable.EEPluggableFeatureImpl</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v3_0_1domain.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v3_0_1domain.xml
@@ -154,7 +154,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/appserver/tests/appserv-tests/devtests/batch/batch-dev-tests/build.xml
+++ b/appserver/tests/appserv-tests/devtests/batch/batch-dev-tests/build.xml
@@ -31,7 +31,7 @@
     &commonRun;
 
 <property environment="env" />
-<get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+<get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
 <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
 <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection-with-resource-declaration-in-another-jar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection-with-resource-declaration-in-another-jar/build.xml
@@ -50,7 +50,6 @@
         </antcall>
 
 	    <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed"/>
         </javac>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/bean-in-lib-dir-used-by-ejb-in-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/bean-in-lib-dir-used-by-ejb-in-ear/build.xml
@@ -53,7 +53,6 @@
 
 
 		<javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-			<compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed" />
 		</javac>
 	</target>
 

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/normal-bean-injection-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/normal-bean-injection-ear/build.xml
@@ -47,7 +47,6 @@
         </antcall>
 
 	<javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed"/>
 	 
         </javac>
 <!--

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/programmatic-lookup-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/programmatic-lookup-ear/build.xml
@@ -47,7 +47,6 @@
         </antcall>
 
 	<javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed"/>
 	 
         </javac>
 <!--

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ear/build.xml
@@ -47,7 +47,6 @@
         </antcall>
 
 	<javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed"/>
 	 
         </javac>
 <!--

--- a/appserver/tests/appserv-tests/devtests/connector/v3/securitymapweb/client/WebTest.java
+++ b/appserver/tests/appserv-tests/devtests/connector/v3/securitymapweb/client/WebTest.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.Base64;
 
 import com.sun.ejte.ccl.reporter.*;
 
@@ -165,8 +166,7 @@ public class WebTest {
     }
 
     public static String encode(String userpass) {
-        sun.misc.BASE64Encoder enc = new sun.misc.BASE64Encoder();
-        return new String(enc.encodeBuffer(userpass.getBytes()));
+        return new String(Base64.getEncoder().encodeToString(userpass.getBytes()));
     }
 
 }

--- a/appserver/tests/appserv-tests/devtests/deployment/autodeploy/slowCopy/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/autodeploy/slowCopy/build.xml
@@ -118,7 +118,6 @@
                 resultproperty="slow.autodeploy.deployResult"
                 output="${build}/1.output.log"
             >
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
             <arg value="timed"/>
             <arg value="${inputArchive}"/>
             <arg value="${outputArchive}"/>
@@ -187,7 +186,6 @@
                 resultproperty="autodeployResult"
                 output="${build}/${log.id}.output.log"
             >
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
             <jvmarg value="-Dmonitor.debug=true"/>
 
             <classpath refid="autodeploy.compile.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/autodeploy/util/util.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/autodeploy/util/util.xml
@@ -53,7 +53,6 @@
                 resultproperty="autodeployResult"
                 output="${build}/${log.id}.output.log"
             >
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
             <jvmarg value="-Dmonitor.debug=true"/>
 
             <classpath refid="autodeploy.compile.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/autodeploy/withEJB/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/autodeploy/withEJB/build.xml
@@ -109,7 +109,6 @@
                 resultproperty="autodeployResult"
                 output="${build}/${log.id}.output.log"
             >
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
             <jvmarg value="-Dmonitor.debug=true"/>
 
             <classpath>

--- a/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
@@ -824,7 +824,6 @@ AS_ADMIN_MASTERPASSWORD=changeit
         <sysproperty key="server" value="${appserver.instance.name}"/>
         <sysproperty key="java.library.path" value="${inst}/lib"/>
         <sysproperty key="com.sun.aas.configRoot" value="${inst}/config"/>
-        <sysproperty key="java.endorsed.dirs" value="${inst}/lib/endorsed"/>
 <!--
         <jvmarg value="-Xdebug"/>
         <jvmarg value="-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9999"/>
@@ -1268,7 +1267,6 @@ AS_ADMIN_MASTERPASSWORD=changeit
         <jvmarg value="-Dcom.sun.aas.installRoot=${inst}"/>
         <jvmarg value="-Djava.library.path=${inst}/lib"/>
         <jvmarg value="-Dcom.sun.aas.configRoot=${inst}/config"/>
-        <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/> 
         <classpath>
             <pathelement path="${build}:${inst}/lib/j2ee.jar:${inst}/lib/appserv-rt.jar:${inst}/lib/appserv-admin.jar:${inst}/lib/dom.jar:${inst}/lib/xalan.jar:${inst}/lib/xercesImpl.jar"/>
         </classpath>

--- a/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
@@ -79,7 +79,7 @@
 
         
 <target name="init" depends="init.os,init.tools,setAsadminArgs">
-    <get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" dest="${env.APS_HOME}/devtests/deployment/junit-4.12.jar" usetimestamp="true"/>
+    <get src="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" dest="${env.APS_HOME}/devtests/deployment/junit-4.12.jar" usetimestamp="true"/>
     <property name="root" value="${basedir}"/>
 
     <available property="cluster.exists" file="${s1as.home}/domains/${testDomain}"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/ear/build.xml
@@ -144,7 +144,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
                                                                                 
             <classpath>
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/earwithsuffix/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/earwithsuffix/build.xml
@@ -145,7 +145,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
                                                                                 
             <classpath>                
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/ejb/build.xml
@@ -114,7 +114,6 @@
                                                                                 
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${tgtPort}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
                                                                                 
             <classpath>
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/ejbwithsuffix/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/ejbwithsuffix/build.xml
@@ -115,7 +115,6 @@
                                                                                 
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${tgtPort}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
                                                                                 
             <classpath>
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/war/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/war/build.xml
@@ -114,7 +114,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
                                                                                 
             <classpath>
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/warwithsuffix/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/directorydeploy/warwithsuffix/build.xml
@@ -114,7 +114,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
                                                                                 
             <classpath>
                  <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/dol/override/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/dol/override/build.xml
@@ -41,7 +41,6 @@
                destdir="${build}"
                debug="on"
                failonerror="true">
-           <compilerarg line="-endorseddirs ${inst}/modules/endorsed"/>
            <classpath>
                 <path refid="gfv3.classpath"/>
             </classpath>
@@ -71,7 +70,6 @@
 -->
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
             <jvmarg value="-Dcom.sun.aas.installRoot=${inst}"/>
             <jvmarg value="-Dwriteout.xml=true"/>
             <jvmarg value="-Djavax.enterprise.system.tools.deployment.org.glassfish.deployment.common=FINE"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/dol/validation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/dol/validation/build.xml
@@ -164,7 +164,6 @@
 -->
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
             <jvmarg value="-Dcom.sun.aas.installRoot=${inst}"/>
             <jvmarg value="-Dwriteout.xml=true"/>
             <jvmarg value="-Djavax.enterprise.system.tools.deployment.org.glassfish.deployment.common=FINE"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/appmgt/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/appmgt/build.xml
@@ -172,7 +172,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/earwithall/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/earwithall/build.xml
@@ -181,7 +181,6 @@
             output="${build}/${log.id}.output.log"
             resultproperty="result">
 
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/earwithall2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/earwithall2/build.xml
@@ -301,7 +301,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/earwithejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/earwithejb/build.xml
@@ -196,7 +196,6 @@
 
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${tgtPort}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/earwithwar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/earwithwar/build.xml
@@ -177,7 +177,6 @@
 
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/libClassPath/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/libClassPath/build.xml
@@ -92,7 +92,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/manifestClassPath/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/manifestClassPath/build.xml
@@ -92,7 +92,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/uniquecr/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/uniquecr/build.xml
@@ -113,7 +113,6 @@
 
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ejb/statelesshello/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ejb/statelesshello/build.xml
@@ -167,7 +167,6 @@
 
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${tgtPort}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ejb/webservice/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ejb/webservice/build.xml
@@ -154,7 +154,6 @@
             output="${build}/${log.id}.output.log"
             resultproperty="result">
 
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ejb30/ear/mdb/webclient/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ejb30/ear/mdb/webclient/build.xml
@@ -88,7 +88,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${depltest.orbport}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ejb30/ear/xmloverride/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ejb30/ear/xmloverride/build.xml
@@ -38,7 +38,6 @@
 
     <target name="compile" depends="prepare">
         <javac srcdir="ejb" destdir="${build}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${inst}/modules/endorsed"/>
           <classpath refid="gfv3.classpath"/>
          </javac>
         <javac srcdir="client" destdir="${build}" debug="on" failonerror="true">

--- a/appserver/tests/appserv-tests/devtests/deployment/jsr88/apitests/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/jsr88/apitests/build.xml
@@ -117,7 +117,6 @@
             <sysproperty key="server" value="${appserver.instance.name}"/>
             <sysproperty key="java.library.path" value="${inst}/lib"/>
             <sysproperty key="com.sun.aas.configRoot" value="${inst}/config"/>
-            <sysproperty key="java.endorsed.dirs" value="${inst}/lib/endorsed"/>
 
             <arg line="${arg.list}" />
         </javaWithResult>
@@ -149,7 +148,6 @@
             <sysproperty key="server" value="${appserver.instance.name}"/>
             <sysproperty key="java.library.path" value="${inst}/lib"/>
             <sysproperty key="com.sun.aas.configRoot" value="${inst}/config"/>
-            <sysproperty key="java.endorsed.dirs" value="${inst}/lib/endorsed"/>
 -->
             <arg line="${arg.list}" />
         </java>

--- a/appserver/tests/appserv-tests/devtests/deployment/jsr88/misc/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/jsr88/misc/build.xml
@@ -195,7 +195,6 @@
             <sysproperty key="jsr88client.host" value="${admin.host}"/>
             <sysproperty key="jsr88client.port" value="${admin.port}"/>
             <sysproperty key="com.sun.aas.installRoot" value="${inst}"/>
-            <sysproperty key="java.endorsed.dirs" value="${inst}/lib/endorsed"/>
 
             <classpath>
                 <pathelement location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/osgi/simple/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/osgi/simple/build.xml
@@ -111,7 +111,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/versioning/simple-versioned-appclient/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/versioning/simple-versioned-appclient/build.xml
@@ -58,9 +58,8 @@
 
   <!-- the jvm args used in the runclient target -->
   <property name="jvm.arg1" value="-Djava.security.policy=${inst}/lib/appclient/client.policy"/>
-  <property name="jvm.arg2" value="-Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader"/>
-  <property name="jvm.arg3" value="-javaagent:${gfClientJar}=mode=ascript,arg=-configxml,arg=${sunAccXml},client=jar=${appClientStubsFile}"/>
-  <property name="jvm.arguments" value="${jvm.arg1} ${jvm.arg2} ${jvm.arg3}"/>
+  <property name="jvm.arg2" value="-javaagent:${gfClientJar}=mode=ascript,arg=-configxml,arg=${sunAccXml},client=jar=${appClientStubsFile}"/>
+  <property name="jvm.arguments" value="${jvm.arg1} ${jvm.arg2}"/>
 
   <!-- the classpath used in the runclient target -->
   <property name="runClientClassPath" value="${appClientStubsFile}"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/appmgt/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/appmgt/build.xml
@@ -169,7 +169,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/deploydir/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/deploydir/build.xml
@@ -127,7 +127,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/htmlonly/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/htmlonly/build.xml
@@ -155,7 +155,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/jsponly/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/jsponly/build.xml
@@ -139,7 +139,6 @@
                 resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
 	       <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/nojarexpansion/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/nojarexpansion/build.xml
@@ -167,7 +167,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path refid="gfv3.classpath"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/servletonly/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/servletonly/build.xml
@@ -202,7 +202,6 @@ public class ChangeableClass {
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/virtualserver/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/virtualserver/build.xml
@@ -130,7 +130,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/webinflib/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/webinflib/build.xml
@@ -165,7 +165,6 @@
             resultproperty="result">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialHost=${http.host}"/>
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/war/webservices/helloservice/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/webservices/helloservice/build.xml
@@ -150,7 +150,6 @@
             output="${build}/${log.id}.output.log"
             resultproperty="result">
 
-            <jvmarg value="-Djava.endorsed.dirs=${inst}/lib/endorsed"/>
 
             <classpath>
                 <path location="${inst}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/cli/negative/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/cli/negative/build.xml
@@ -69,7 +69,7 @@
                srcdir="${env.APS_HOME}/devtests/admin/cli/src" includes="**/*BaseDevTest.java">
         </javac>
         <javac fork="true" includeAntRuntime="false" 
-               classpath="${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+               classpath="${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${s1astest.classpath}"
                destdir="${build.classes.dir}" debug="true" srcdir="client" includes="**/*.java">
             <classpath path="${classpath}"/>
         </javac>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/ear/build.xml
@@ -47,7 +47,6 @@
         </antcall>
 
 	<javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed${path.separator}${env.S1AS_HOME}/modules"/>
 	 
         </javac>
 <!--

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/jcdifull/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/jcdifull/build.xml
@@ -38,7 +38,6 @@
     <target name="compile" depends="clean">
       <mkdir dir="${build.classes.dir}"/>
       <javac classpath="${env.S1AS_HOME}/modules/weld-osgi-bundle.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="ejb" destdir="${build.classes.dir}" debug="on" failonerror="true" includeantruntime="false" >
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed${path.separator}${env.S1AS_HOME}/modules"/>
         </javac>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/security/simple/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/security/simple/build.xml
@@ -41,7 +41,6 @@
             <param name="src" value="ejb"/>
         </antcall>
 	<javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
-          <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed${path.separator}${env.S1AS_HOME}/modules"/>
 	 
         </javac>
     </target>

--- a/appserver/tests/appserv-tests/devtests/ejb/webservice/ksink/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/webservice/ksink/build.xml
@@ -233,7 +233,6 @@
      <antcall target="build-standalone"/>
      <java fork="true" classname="com.sun.s1asdev.ejb.webservice.ksink.standalone.StandAloneClient"
           failonerror="true">
-      <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/lib/endorsed"/>
       <arg line="spellng http://${http.host}:${http.port}/ejb_webservice_ksink_GoogleServlet/GoogleSearch"/>
       <classpath>
         <pathelement location="${env.S1AS_HOME}/lib/j2ee.jar"/>

--- a/appserver/tests/appserv-tests/devtests/jdbc/v3/v3_jdbc_dev_tests/nbproject/build-impl.xml
+++ b/appserver/tests/appserv-tests/devtests/jdbc/v3/v3_jdbc_dev_tests/nbproject/build-impl.xml
@@ -163,12 +163,6 @@
             </and>
         </condition>
         <property name="javadoc.encoding.used" value="${source.encoding}"/>
-        <condition else="" property="javac.compilerargs.jaxws" value="-Djava.endorsed.dirs='${jaxws.endorsed.dir}'">
-            <and>
-                <isset property="jaxws.endorsed.dir"/>
-                <available file="nbproject/jaxws-build.xml"/>
-            </and>
-        </condition>
     </target>
     <target name="-post-init">
         <!-- Empty placeholder for easier customization. -->

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/build.xml
@@ -44,7 +44,6 @@
             debug="on"
             includeantruntime="false"
             failonerror="true">
-            <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
         </javac>
         <antcall target="compile-common">
             <param name="src" value="client"/>

--- a/appserver/tests/appserv-tests/devtests/jms/defaultCF/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/defaultCF/build.xml
@@ -44,7 +44,6 @@
             debug="on"
             includeantruntime="false"
             failonerror="true">
-            <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
         </javac>
         <antcall target="compile-common">
             <param name="src" value="client"/>

--- a/appserver/tests/appserv-tests/devtests/naming/naming2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/naming/naming2/build.xml
@@ -31,7 +31,7 @@
     &commonRun;
 
 <property environment="env" />
-<get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+<get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
 <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
 <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/naming/naming2/context/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/naming/naming2/context/pom.xml
@@ -65,7 +65,6 @@
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
-                    <compilerArgument>-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed</compilerArgument>
                 </configuration>
             </plugin>
             <plugin>
@@ -73,7 +72,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.9</version>
                 <configuration>
-                    <argLine>-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed</argLine>
                     <enableAssertions>false</enableAssertions>
                 </configuration>
             </plugin>

--- a/appserver/tests/appserv-tests/devtests/security/container-auth/testConfig/domain.xml
+++ b/appserver/tests/appserv-tests/devtests/security/container-auth/testConfig/domain.xml
@@ -200,7 +200,6 @@ XXX CHARLIE
       <java-config classpath-suffix="${com.sun.aas.installRoot}/pointbase/lib/pbclient.jar${path.separator}${com.sun.aas.installRoot}/pointbase/lib/pbembedded.jar" debug-enabled="false" debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044" env-classpath-ignored="true" java-home="${com.sun.aas.javaRoot}" javac-options="-g" rmic-options="-iiop -poa -alwaysgenerate -keepgenerated -g" server-classpath="${com.sun.aas.javaRoot}/lib/tools.jar${path.separator}${com.sun.aas.installRoot}/lib/install/applications/jmsra/imqjmsra.jar${path.separator}${com.sun.aas.imqLib}/jaxm-api.jar${path.separator}${com.sun.aas.imqLib}/fscontext.jar${path.separator}${com.sun.aas.installRoot}/lib/ant/lib/ant.jar">
         <!-- various required jvm-options -->
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/tests/appserv-tests/devtests/security/ejb-auth-async/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/ejb-auth-async/build.xml
@@ -34,7 +34,7 @@
    &testProperties;
    &commonSecurity;
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/build.xml
@@ -31,7 +31,7 @@
    &commonRun;
    &testProperties;  
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/soteria/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/build.xml
@@ -34,7 +34,7 @@
    &testProperties;
    &commonSecurity;
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/addJspFile/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/addJspFile/build.xml
@@ -73,7 +73,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/compositeTrailerSupplier/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/compositeTrailerSupplier/build.xml
@@ -70,7 +70,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/contextCharEncoding/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/contextCharEncoding/build.xml
@@ -70,7 +70,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/defaultContextPath/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/defaultContextPath/build.xml
@@ -69,7 +69,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/defaultContextPathEar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/defaultContextPathEar/build.xml
@@ -73,7 +73,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/mappingDiscovery/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/mappingDiscovery/build.xml
@@ -69,7 +69,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <arg value="${http.host}"/>
             <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushArbitraryMethod/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushArbitraryMethod/build.xml
@@ -65,7 +65,6 @@
 
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <sysproperty key="debug" value="true"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushAuthorization/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushAuthorization/build.xml
@@ -79,7 +79,6 @@
 
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <sysproperty key="debug" value="true"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushCacheable/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushCacheable/build.xml
@@ -65,7 +65,6 @@
 
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <sysproperty key="debug" value="true"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushDynamic/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushDynamic/build.xml
@@ -65,7 +65,6 @@
 
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <sysproperty key="debug" value="true"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushQueryString/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushQueryString/build.xml
@@ -65,7 +65,6 @@
 
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <sysproperty key="debug" value="true"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushStatic/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/pushStatic/build.xml
@@ -65,7 +65,6 @@
 
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-            <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
             <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
             <sysproperty key="debug" value="true"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/reqResEncoding/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/reqResEncoding/build.xml
@@ -70,7 +70,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/setSessionTimeout/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/setSessionTimeout/build.xml
@@ -72,7 +72,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/servlet-4.0/trailer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/servlet-4.0/trailer/build.xml
@@ -70,7 +70,6 @@
     
     <target name="run" depends="init-common">
         <java classname="WebTest" fork="true">
-          <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
           <sysproperty key="S1AS_HOME" value="${env.S1AS_HOME}"/>
           <arg value="${http.host}"/>
           <arg value="${https.port}"/>

--- a/appserver/tests/appserv-tests/devtests/web/useBundledJsfWithTagCompilation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/useBundledJsfWithTagCompilation/build.xml
@@ -46,7 +46,7 @@
 
     <target name="deploy" depends="init-common">
       <get
-        src="http://repo1.maven.org/maven2/com/sun/faces/extensions/jsf-cardemo/0.2/jsf-cardemo-0.2.war"
+        src="https://repo1.maven.org/maven2/com/sun/faces/extensions/jsf-cardemo/0.2/jsf-cardemo-0.2.war"
         dest="jsf-cardemo.war"/>
       <antcall target="deploy-war-name"/>
     </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/mappedname/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/mappedname/build.xml
@@ -152,7 +152,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/msgctxt/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/msgctxt/build.xml
@@ -98,7 +98,6 @@
           <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
                 includes="webclient/**">
              <classpath refid="classpath"/>
-             <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
           </javac>
           <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/noname/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/noname/build.xml
@@ -92,7 +92,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/noname2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/noname2/build.xml
@@ -98,7 +98,6 @@
           <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
                 includes="webclient/**">
              <classpath refid="classpath"/>
-             <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
           </javac>
           <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/oneway/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/oneway/build.xml
@@ -97,7 +97,6 @@
           <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
                 includes="webclient/**">
              <classpath refid="classpath"/>
-             <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
           </javac>
           <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/postconstruct/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/postconstruct/build.xml
@@ -99,7 +99,6 @@
           <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
                 includes="webclient/**">
              <classpath refid="classpath"/>
-             <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
           </javac>
           <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webserviceref-cobundle/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webserviceref-cobundle/build.xml
@@ -62,7 +62,6 @@
         classpath="${s1astest.classpath}"
         debug="on"
         failonerror="true">
-            <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
         </javac>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webserviceref-lookup/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webserviceref-lookup/build.xml
@@ -83,7 +83,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
  
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-addressing-2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-addressing-2/build.xml
@@ -83,7 +83,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
  
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-addressing-appclient/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-addressing-appclient/build.xml
@@ -75,7 +75,6 @@
 <javac srcdir="." destdir="${build.classes.dir}/appclient"
             includes="appclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
       </javac>
 

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-addressing/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-addressing/build.xml
@@ -83,7 +83,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
  
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-clientdds/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-clientdds/build.xml
@@ -83,7 +83,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
  
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-respectbinding/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webservices13-respectbinding/build.xml
@@ -86,7 +86,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
  
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/wsctxt/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/wsctxt/build.xml
@@ -72,7 +72,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
 
       </javac>
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/wsRef-webservice-features/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/wsRef-webservice-features/build.xml
@@ -97,7 +97,6 @@
       <javac srcdir="." destdir="${build.classes.dir}/webclient/WEB-INF/classes"
             includes="webclient/**">
          <classpath refid="classpath"/>
-         <compilerarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/modules/endorsed"/>
       </javac>
 
       <copy file="client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/googleserver/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/googleserver/build.xml
@@ -234,7 +234,6 @@
      <antcall target="build-standalone"/>
      <java fork="true" classname="standalone.StandAloneClient"
           failonerror="true">
-      <jvmarg value="-Djava.endorsed.dirs=${env.S1AS_HOME}/lib/endorsed"/>
       <arg line="spellng http://${http.host}:${http.port}/google/GoogleSearch"/>
       <classpath>
         <pathelement location="${env.S1AS_HOME}/lib/j2ee.jar"/>

--- a/appserver/tests/quicklook/build.xml
+++ b/appserver/tests/quicklook/build.xml
@@ -308,7 +308,6 @@
             <jvmarg value="-Djava.compiler=NONE"/>
             <jvmarg value="-Dhttp.host=${glassfish.http.host}"/>
             <jvmarg value="-Dhttp.port=${glassfish.http.port}"/>
-	    <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
 	    <jvmarg value="-DASADMIN=${ASADMIN}" />
 	    <jvmarg value="-DAPPCLIENT=${APPCLIENT}"/>
             <sysproperty key="glassfish.home" value="${glassfish.home}"/>

--- a/appserver/tests/quicklook/gfproject/build-impl.xml
+++ b/appserver/tests/quicklook/gfproject/build-impl.xml
@@ -340,7 +340,6 @@
         <classfileset dir="${test.class.output}" includes="**/${testng.testclient}.class"/>
         <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
         <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-	<jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
 	<jvmarg value="-DASADMIN=${ASADMIN}" />
     </testng>
 </target>
@@ -355,7 +354,6 @@
         <xmlfileset dir="." includes="testng.xml"/>
         <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
         <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-	<jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
 	<jvmarg value="-DASADMIN=${ASADMIN}" />
 	<jvmarg value="-DAPPCLIENT=${APPCLIENT}" />
     </testng>
@@ -374,7 +372,6 @@
         <classfileset dir="${test.class.output}" includes="**/${testng.testclient}.class"/>
         <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
         <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-        <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
         <jvmarg value="-DASADMIN=${ASADMIN}" />
     </testng>
 </target>
@@ -422,7 +419,6 @@
             <classfileset dir="${build.classes.home}" includes="**/${testng.testclient}.class"/>
             <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
             <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-            <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
             <bootclasspath classpathref="boot.class.path"/>
 <sysproperty key="-Djava.endorsed.dirs" value="${glassfish.home}/modules/endorsed"/>
 
@@ -440,7 +436,6 @@
             <xmlfileset dir="." includes="testng.xml"/>
             <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
             <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-            <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
             <bootclasspath classpathref="boot.class.path"/>
 <sysproperty key="-Djava.endorsed.dirs" value="${glassfish.home}/modules/endorsed"/>
 

--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-		<version>1.7</version>
+		<version>1.8</version>
                 <executions>
                     <execution>
                         <id>default-test</id>

--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -184,13 +184,6 @@
                         <version>1.10.1</version>
                         <scope>runtime</scope>
                     </dependency>
-                    <dependency>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools-jar</artifactId>
-                        <version>1</version>
-                        <scope>system</scope>
-                        <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                    </dependency>
 		    <dependency>
 			<groupId>com.beust</groupId>
 			<artifactId>jcommander</artifactId>

--- a/appserver/tests/quicklook/wsit/JaxwsFromWsdl/build.xml
+++ b/appserver/tests/quicklook/wsit/JaxwsFromWsdl/build.xml
@@ -52,7 +52,7 @@
         <javac
             srcdir="${basedir}/src"
             destdir="${build.classes.home}"
-            includes="**/server/**,**/common/**">
+            includes="**/server/**,**/common/**" classpathref="class.path">
             <classpath refid="wsit.classpath"/>
         </javac>
     </target>

--- a/appserver/tests/quicklook/wsit/jsr109tester/build.xml
+++ b/appserver/tests/quicklook/wsit/jsr109tester/build.xml
@@ -43,7 +43,7 @@
         <javac
                 srcdir="${basedir}/src"
                 destdir="${build.classes.home}"
-                includes="**/server/**,**/common/**">
+                includes="**/server/**,**/common/**" classpathref="class.path">
             <classpath refid="wsit.classpath"/>
         </javac>
     </target>

--- a/appserver/tests/v2-tests/appserv-tests/config/common.xml
+++ b/appserver/tests/v2-tests/appserv-tests/config/common.xml
@@ -76,7 +76,6 @@ Variables used:
     debug="on"
     includeantruntime="false"
     failonerror="true">
-    <compilerarg line="-endorseddirs ${env.S1AS_HOME}/modules/endorsed"/>
    </javac>
 </target>
 

--- a/appserver/tests/v2-tests/appserv-tests/devtests/admin/framework/testfiles/test.xml
+++ b/appserver/tests/v2-tests/appserv-tests/devtests/admin/framework/testfiles/test.xml
@@ -182,7 +182,6 @@
       <diagnostic-service capture-app-dd="true" capture-hadb-info="true" capture-install-log="true" capture-system-info="true" compute-checksum="true" max-log-entries="500" min-log-level="INFO" verify-config="true"/>
       <java-config classpath-suffix="" debug-enabled="false" debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" env-classpath-ignored="true" java-home="${com.sun.aas.javaRoot}" javac-options="-g" rmic-options="-iiop -poa -alwaysgenerate -keepgenerated -g" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar">
         <!-- various required jvm-options -->
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
@@ -330,7 +329,6 @@
       <diagnostic-service capture-app-dd="true" capture-hadb-info="true" capture-install-log="true" capture-system-info="true" compute-checksum="true" max-log-entries="500" min-log-level="INFO" verify-config="true"/>
       <java-config classpath-suffix="" debug-enabled="false" debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" env-classpath-ignored="true" java-home="${com.sun.aas.javaRoot}" javac-options="-g" rmic-options="-iiop -poa -alwaysgenerate -keepgenerated -g" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar">
         <!-- various required jvm-options -->
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>

--- a/appserver/tests/v2-tests/appserv-tests/devtests/admin/offlineconfig/testfiles/domain.xml
+++ b/appserver/tests/v2-tests/appserv-tests/devtests/admin/offlineconfig/testfiles/domain.xml
@@ -166,7 +166,6 @@
       <diagnostic-service capture-app-dd="true" capture-hadb-info="true" capture-install-log="true" capture-system-info="true" compute-checksum="true" max-log-entries="500" min-log-level="INFO" verify-config="true"/>
       <java-config debug-enabled="false" debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" env-classpath-ignored="true" java-home="${com.sun.aas.javaRoot}" javac-options="-g" rmic-options="-iiop -poa -alwaysgenerate -keepgenerated -g" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar">
         <!-- various required jvm-options -->
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/tests/v2-tests/appserv-tests/devtests/appserv-commons/com/sun/enterprise/config/domain.orig.xml
+++ b/appserver/tests/v2-tests/appserv-tests/devtests/appserv-commons/com/sun/enterprise/config/domain.orig.xml
@@ -130,7 +130,6 @@
 	<!-- various required jvm-options -->
 	<jvm-options>-client</jvm-options>
 	<jvm-options>-Dcom.sun.enterprise.web.connector.useCoyoteConnector=true</jvm-options> 
-	<jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
 	<jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
 	<jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
 	<jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
@@ -234,7 +233,6 @@
       <java-config java-home="${com.sun.aas.javaRoot}" debug-enabled="false" debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044" rmic-options="-iiop -poa -alwaysgenerate -keepgenerated -g" javac-options="-g" server-classpath="${com.sun.aas.javaRoot}/lib/tools.jar${path.separator}${com.sun.aas.installRoot}/lib/install/applications/jmsra/imqjmsra.jar${path.separator}${com.sun.aas.imqLib}/jaxm-api.jar${path.separator}${com.sun.aas.imqLib}/fscontext.jar${path.separator}${com.sun.aas.installRoot}/lib/ant/lib/ant.jar${path.separator}${com.sun.aas.hadbRoot}/lib/hadbjdbc4.jar${path.separator}/usr/lib/audit/Audit.jar${path.separator}${com.sun.aas.jdmkHome}/lib/jdmkrt.jar" classpath-suffix="${com.sun.aas.installRoot}/pointbase/lib/pbclient.jar${path.separator}${com.sun.aas.installRoot}/pointbase/lib/pbembedded.jar" env-classpath-ignored="true">
 	<!-- various required jvm-options -->
 	<jvm-options>-client</jvm-options>
-	<jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
 	<jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
 	<jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
 	<jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
@@ -30,4 +30,4 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+exec "$JAVA" -cp "$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/endorsed/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/endorsed/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
@@ -33,4 +33,4 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+%JAVA% -cp "%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\endorsed\jakarta.xml.bind-api.jar;%~dp0..\modules\endorsed\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile
@@ -31,4 +31,4 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" $WSCOMPILE_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"
+exec "$JAVA" $WSCOMPILE_OPTS -cp "$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/endorsed/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/endorsed/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar:$AS_INSTALL_LIB/aixporting-repackaged.jar" com.sun.xml.rpc.tools.wscompile.Main "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wscompile.bat
@@ -33,4 +33,4 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% %WSCOMPILE_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*
+%JAVA% %WSCOMPILE_OPTS% -cp "%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\endorsed\jakarta.xml.bind-api.jar;%~dp0..\modules\endorsed\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wscompile.Main %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy
@@ -31,4 +31,4 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"
+exec "$JAVA" -cp "$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/endorsed/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/endorsed/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$JAVAX_MAIL_JAR:$JAVA_HOME/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsdeploy.bat
@@ -33,4 +33,4 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*
+%JAVA% -cp "%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\endorsed\jakarta.xml.bind-api.jar;%~dp0..\modules\endorsed\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.mail.jar;%JAVA_HOME%/lib/tools.jar" com.sun.xml.rpc.tools.wsdeploy.Main %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
@@ -30,4 +30,4 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" $WSGEN_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsGen "$@"
+exec "$JAVA" $WSGEN_OPTS -cp "$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/endorsed/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/endorsed/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsGen "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
@@ -33,4 +33,4 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% %WSGEN_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*
+%JAVA% %WSGEN_OPTS% -cp "%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\endorsed\jakarta.xml.bind-api.jar;%~dp0..\modules\endorsed\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsGen %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -30,4 +30,4 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" $WSIMPORT_OPTS -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"
+exec "$JAVA" $WSIMPORT_OPTS $VMARGS -cp "$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/endorsed/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/endorsed/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.ws.WsImport "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
@@ -33,4 +33,4 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% %WSIMPORT_OPTS% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*
+%JAVA% %WSIMPORT_OPTS% %VMARGS% -cp "%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\endorsed\jakarta.xml.bind-api.jar;%~dp0..\modules\endorsed\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.ws.WsImport %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
@@ -30,4 +30,4 @@ if [ ${AS_JAVA} ]; then
     JAVA=${AS_JAVA}/bin/java
 fi
 
-exec "$JAVA" -Djava.endorsed.dirs="$AS_INSTALL_LIB/endorsed" -cp "$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"
+exec "$JAVA" -cp "$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/endorsed/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/endorsed/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.rpc-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar" com.sun.tools.xjc.Driver "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
@@ -33,4 +33,4 @@ goto run
 set JAVA=java
 
 :run
-%JAVA% -Djava.endorsed.dirs="%~dp0..\modules\endorsed" -cp "%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*
+%JAVA% -cp "%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\endorsed\jakarta.xml.bind-api.jar;%~dp0..\modules\endorsed\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.rpc-api.jar;%~dp0..\modules\jaxb-osgi.jar" com.sun.tools.xjc.Driver %*

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -25,9 +25,9 @@ RUN chmod +x /etc/entrypoint.sh && \
     #
     # install takari extensions
     #
-    curl -O http://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.2/takari-local-repository-0.11.2.jar && \
+    curl -O https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.2/takari-local-repository-0.11.2.jar && \
     mv takari-local-repository-*.jar /usr/share/maven/lib/ext/ && \
-    curl -O http://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar && \
+    curl -O https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar && \
     mv takari-filemanager-*.jar /usr/share/maven/lib/ext/ && \
     #
     # install ant

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -100,7 +100,7 @@
                             <!-- adding bean-validator as explicit dependency
                                  for admin cli as bean-validator repackaged module
                                  is now part of nucleus/packager/external/bean-validator -->
-                            <Class-Path>bean-validator.jar</Class-Path>
+                            <Class-Path>bean-validator.jar endorsed/jakarta.annotation-api.jar endorsed/jakarta.xml.bind-api.jar</Class-Path>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
+++ b/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
@@ -101,7 +101,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -229,7 +228,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -357,7 +355,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/DomainTest.xml
+++ b/nucleus/admin/config-api/src/test/resources/DomainTest.xml
@@ -126,7 +126,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
@@ -145,7 +145,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -271,7 +270,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -403,7 +401,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -535,7 +532,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -667,7 +663,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -799,7 +794,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -931,7 +925,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
@@ -156,7 +156,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -282,7 +281,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -414,7 +412,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -546,7 +543,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -678,7 +674,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -810,7 +805,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -942,7 +936,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1.xml
@@ -123,7 +123,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -249,7 +248,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -381,7 +379,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
@@ -134,7 +134,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -260,7 +259,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -392,7 +390,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -524,7 +521,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
@@ -123,7 +123,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -249,7 +248,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -381,7 +379,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/stock.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/stock.xml
@@ -135,7 +135,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -294,7 +293,6 @@
              <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
              <jvm-options>-XX:+LogVMOutput</jvm-options>
              <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-             <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
              <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
              <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/admin/launcher/src/test/resources/domains/baddomain/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/baddomain/config/domain.xml
@@ -145,7 +145,6 @@
       <diagnostic-service></diagnostic-service>
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
@@ -147,7 +147,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/launcher/src/test/resources/domains/domain2/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain2/config/domain.xml
@@ -146,7 +146,6 @@
       <diagnostic-service></diagnostic-service>
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/launcher/src/test/resources/domains/domain3/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain3/config/domain.xml
@@ -144,7 +144,6 @@
       <diagnostic-service></diagnostic-service>
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
@@ -144,7 +144,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -135,14 +135,12 @@
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
         <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
 	<jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
         <!-- Configure post startup bundle list here. This is a comma separated list of bundle sybolic names. -->
         <!-- Configuration of various third-party OSGi bundles like
@@ -173,6 +171,11 @@
         <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
         <!-- End of OSGi bundle configurations -->
         <jvm-options>-XX:NewRatio=2</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.annotation-api.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.xml.bind-api.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
+        <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -281,13 +284,11 @@
              <jvm-options>-Djava.awt.headless=true</jvm-options>
              <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
              <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-             <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
              <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
              <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
              <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
              <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
-             <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext</jvm-options>
              <jvm-options>-DANTLR_USE_DIRECT_CLASS_LOADING=true</jvm-options>
              <jvm-options>-XX:NewRatio=2</jvm-options>
              <jvm-options>-Xmx512m</jvm-options>
@@ -318,6 +319,11 @@
              -->
              <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
              <!-- End of OSGi bundle configurations -->
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.annotation-api.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/jakarta.xml.bind-api.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
+             <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
+             <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
          </java-config>
          <availability-service/>
          <network-config>

--- a/nucleus/common/common-util/src/test/resources/big.xml
+++ b/nucleus/common/common-util/src/test/resources/big.xml
@@ -140,7 +140,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/clusters1.xml
+++ b/nucleus/common/common-util/src/test/resources/clusters1.xml
@@ -176,7 +176,6 @@
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -327,7 +326,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -494,7 +492,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -661,7 +658,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -828,7 +824,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -995,7 +990,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/manysysprops.xml
+++ b/nucleus/common/common-util/src/test/resources/manysysprops.xml
@@ -181,7 +181,6 @@
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -332,7 +331,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -502,7 +500,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -669,7 +666,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -836,7 +832,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
@@ -1003,7 +998,6 @@
         <jvm-options>-server</jvm-options>
         <jvm-options>-Djava.awt.headless=true</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/modules/endorsed${path.separator}${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
@@ -140,7 +140,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/monitoringNone.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringNone.xml
@@ -140,7 +140,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
@@ -140,7 +140,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/olddomain.xml
+++ b/nucleus/common/common-util/src/test/resources/olddomain.xml
@@ -122,7 +122,6 @@
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-XX:+LogVMOutput</jvm-options>
         <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/v2domain.xml
+++ b/nucleus/common/common-util/src/test/resources/v2domain.xml
@@ -183,7 +183,6 @@
         <!-- various required jvm-options -->
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
@@ -538,7 +538,9 @@ public class MainHelper {
             ClassLoaderBuilder clb = new ClassLoaderBuilder(ctx, delegate);
             clb.addFrameworkJars();
             clb.addBootstrapApiJar(); // simple-glassfish-api.jar
-            clb.addJDKToolsJar();
+            if (getMajorJdkVersion() < 9) {
+                clb.addJDKToolsJar();
+            }
             return clb.build();
         } catch (IOException e) {
             throw new Error(e);

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/list-jvm-options.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/list-jvm-options.1
@@ -69,7 +69,6 @@ EXAMPLES
                /lib/ext${path.separator}${com.sun.aas.derbyRoot}/lib
                -Xmx512m
                -XX:MaxPermSize=192m
-               -Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed
                -XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log
                Command list-jvm-options executed successfully.
 

--- a/nucleus/core/kernel/src/test/resources/DomainTest.xml
+++ b/nucleus/core/kernel/src/test/resources/DomainTest.xml
@@ -86,7 +86,6 @@
       <diagnostic-service></diagnostic-service>
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
-        <jvm-options>-Djava.endorsed.dirs=${com.sun.aas.installRoot}/lib/endorsed</jvm-options>
         <jvm-options>-Djava.security.policy=${com.sun.aas.instanceRoot}/config/server.policy</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
@@ -144,6 +144,7 @@ com.sun.enterprise.hk2.cacheDir=${org.osgi.framework.storage}
 # Then we autostart GlassFish core bundles followed by optional services.
 # The reason for using installRootURI is to make sure any char like white space is properly encoded.
 glassfish.osgi.auto.install=\
+ ${com.sun.aas.installRootURI}modules/endorsed/ \
  ${com.sun.aas.installRootURI}modules/osgi-resource-locator.jar \
  ${com.sun.aas.installRootURI}modules/ \
  ${com.sun.aas.installRootURI}modules/autostart/
@@ -174,6 +175,7 @@ hk2.bundles=\
  ${com.sun.aas.installRootURI}modules/osgi-adapter.jar
 
 core.bundles=\
+ ${com.sun.aas.installRootURI}modules/endorsed/ \
  ${obr.bundles} \
  ${hk2.bundles} \
  ${com.sun.aas.installRootURI}modules/glassfish.jar
@@ -366,7 +368,25 @@ jre-1.6=\
  org.w3c.dom.ls, \
  org.xml.sax, \
  org.xml.sax.ext, \
- org.xml.sax.helpers
+ org.xml.sax.helpers, ${endorsed-standard-packages}
+
+endorsed-standard-packages=\
+ javax.annotation, \
+ javax.xml.bind, \
+ javax.xml.bind.annotation, \
+ javax.xml.bind.annotation.adapters, \
+ javax.xml.bind.attachment, \
+ javax.xml.bind.helpers, \
+ javax.xml.bind.util, \
+ javax.jws, \
+ javax.jws.soap, \
+ javax.xml.ws, \
+ javax.xml.ws.handler, \
+ javax.xml.ws.handler.soap, \
+ javax.xml.ws.http, \
+ javax.xml.ws.soap, \
+ javax.xml.ws.spi, \
+ javax.xml.ws.wsaddressing
 
 #dtrace support
 # TODO: We still need to add appropriate SE packages for 7 & 8.

--- a/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
+++ b/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
@@ -100,6 +100,7 @@
             <directory>${temp.dir}</directory>
             <includes>
                 <include>jakarta.annotation-api.jar</include>
+                <include>jakarta.xml.bind-api.jar</include>
                 <include>grizzly-npn-bootstrap.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/modules/endorsed</outputDirectory>
@@ -144,6 +145,7 @@
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>jakarta.annotation-api.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>
+                <exclude>jakarta.xml.bind-api.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/modules</outputDirectory>
         </fileSet>

--- a/nucleus/featuresets/atomic/pom.xml
+++ b/nucleus/featuresets/atomic/pom.xml
@@ -996,5 +996,49 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb-api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
+            <version>${jaxb.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>${jakarta.activation-api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <version>${jakarta.activation.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/nucleus/featuresets/nucleus/pom.xml
+++ b/nucleus/featuresets/nucleus/pom.xml
@@ -235,6 +235,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.corba</groupId>
+            <artifactId>rmic</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.pfl</groupId>
             <artifactId>pfl-asm</artifactId>
             <exclusions>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -134,6 +134,8 @@
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
         <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>
         <jakarta.activation.version>1.2.1</jakarta.activation.version>
+        <jaxws-api.version>2.3.1</jaxws-api.version>
+        <jakarta.jws-api.version>1.1.1</jakarta.jws-api.version>
     </properties>
 
     <build>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -175,7 +175,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.7</version>
+                    <version>1.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -187,7 +187,6 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.6.1</version>
                     <configuration>
-                        <compilerArgument>-Djava.endorsed.dirs=${project.build.directory}/endorsed</compilerArgument>
                         <source>1.8</source>
                         <target>1.8</target>
                         <excludes>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -797,6 +797,11 @@
                 <version>${glassfish-corba.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.corba</groupId>
+                <artifactId>rmic</artifactId>
+                <version>${glassfish-corba.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.mail</groupId>
                 <artifactId>jakarta.mail-api</artifactId>
                 <version>${mail.version}</version>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -160,6 +160,16 @@ of COPY_LIB map constant.)
             <scope>test</scope>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
     </dependencies>
 </project>
 


### PR DESCRIPTION
( FOR 5.1.0-run-with-JDK11 BRANCH )

These modifications will make most tests work on JDK 11.  I’ve not changed any of the test expectations.
Please do not hesitate to ask me if you have any questions about each modification.

|package|TestCases|Before(Pass)|After(Pass)|
|------|------|------|------|
|batch_all|26|0|26|
|cdi_all|119|Error|Error|
|connector_group_1|65|Error|65|
|connector_group_2|22|Error|22|
|connector_group_3|5|Error|5|
|connector_group_4|200|Error|200|
|deployment_all|283|Error|272|
|ejb_group_1|111|Error|110|
|ejb_group_2|59|Error|59|
|ejb_group_3|134|Error|Error|
|ejb_web_all|30|Error|23|
|jdbc_all|209|Error|165|
|nucleus_admin_all|81|Error|61|
|persistence_all|16|0|16|
|ql_gf_full_profile_all|325|Error|286|
|ql_gf_nucleus_all|15|Error|10|
|ql_gf_web_profile_all|268|Error|121|
|web_jsp|89|14|89|


■To confirm the modifications work locally
you need to address all of the other project issues listed in this ticket (https://github.com/eclipse-ee4j/glassfish/issues/22893).
Or,
1. clone and build orb-gmbal-pfl on JDK11 (to enable multi-release jar)
  ```git clone https://github.com/eclipse-ee4j/orb-gmbal-pfl.git```
2. clone and build orb on JDK8
  ```git clone -b 4.2.1-with-JDK11 https://github.com/hs536/orb.git```
3. clone and build glassfish-security-plugin on JDK8
  ```git clone https://github.com/eclipse-ee4j/glassfish-security-plugin.git```
4. clone and build glassfish on JDK8
  ```git clone -b revise-check https://github.com/hs536/glassfish.git```
5. run devtests on JDK11