### PR TITLE
Update jsonp version to use jakarta package

### DIFF
--- a/appserver/appclient/client/acc-standalone/pom.xml
+++ b/appserver/appclient/client/acc-standalone/pom.xml
@@ -109,7 +109,7 @@
                           <fileSeparator>/</fileSeparator>
                           <prefix>../modules</prefix>
                           <stripVersion>true</stripVersion>
-                          <excludeArtifactIds>javax.json</excludeArtifactIds>
+                          <excludeArtifactIds>jakarta.json</excludeArtifactIds>
                           <excludeArtifactIds>javax.inject</excludeArtifactIds>
                       </configuration>
                   </execution>

--- a/appserver/core/api-exporter-fragment/pom.xml
+++ b/appserver/core/api-exporter-fragment/pom.xml
@@ -140,7 +140,7 @@ javax.imageio.spi; \
 javax.imageio.stream; \
 javax.interceptor; \
 javax.jms; \
-javax.json; \
+jakarta.json; \
 javax.json.bind; \
 javax.json.bind.adapter; \
 javax.json.bind.annotation; \

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -64,7 +64,7 @@
                           <fileSeparator>/</fileSeparator>
                           <prefix>../../modules</prefix>
                           <stripVersion>true</stripVersion>
-                          <excludeArtifactIds>jsftemplating, javax.json, jakarta.json-api</excludeArtifactIds>
+                          <excludeArtifactIds>jsftemplating, jakarta.json, jakarta.json-api</excludeArtifactIds>
                       </configuration>
                   </execution>
               </executions>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -94,8 +94,8 @@
         <wsdl4j.version>1.5.0</wsdl4j.version>
         <websocket-api.version>1.1.1</websocket-api.version>
         <tyrus.version>1.15</tyrus.version>
-        <jsonp-api.version>1.1.6</jsonp-api.version>
-        <jsonp-ri.version>1.1.6</jsonp-ri.version>
+        <jsonp-api.version>2.0.0-RC2</jsonp-api.version>
+        <jsonp-ri.version>2.0.0-RC2</jsonp-ri.version>
         <jsonp-jaxrs.version>1.1.6</jsonp-jaxrs.version>
         <json.bind-api.version>1.0.2</json.bind-api.version>
 
@@ -191,7 +191,7 @@
                             <jarType>impl</jarType>
                             <specVersion>1.1</specVersion>
                             <implVersion>${jsonp-ri.version}</implVersion>
-                            <apiPackage>javax.json</apiPackage>
+                            <apiPackage>jakarta.json</apiPackage>
                             <implNamespace>org.glassfish</implNamespace>
                         </spec>
                         <spec>


### PR DESCRIPTION
It works to compile, execute the quick look tests, start the domain, running TCK tests of this other PR https://github.com/eclipse-ee4j/jakartaee-tck/pull/147 . Sig tests works too if you use an updated sigtest.jar

I attach some logs of previous executions.
[gfQuickLook.log](https://github.com/eclipse-ee4j/glassfish/files/4339186/gfQuickLook.log)
[tck.log](https://github.com/eclipse-ee4j/glassfish/files/4339287/tck.log)

It seems that glassfish is not making use directly jsonp, and that is why previous executions worked.

But I expect to have run time errors. For example if you run an app that is using Jersey (because Jersey depends on Jsonp).

There is a discussion going on about this jakarta integration topic:
https://github.com/eclipse-ee4j/glassfish/issues/22892#issuecomment-596568926




 