### PR TITLE
Replace Jakarta Jekyll theme with Eclipse Foundation Jekyll theme

### DIFF
--- a/docs/website/src/main/resources/_config.yml
+++ b/docs/website/src/main/resources/_config.yml
@@ -1,4 +1,6 @@
-remote_theme: jakartaee/jekyll-theme-jakarta-ee
+github: [metadata]
+
+remote_theme: eclipsefdn/jekyll-theme-eclipsefdn
 
 title: [Eclipse GlassFish]
 description: [Open Source Jakarta EE Platform Implementation]


### PR DESCRIPTION
Signed-off-by: Ivar Grimstad <ivar.grimstad@eclipse-foundation.org>

This time making the change in the correct location and not directly under gh-pages...