### PR TITLE
#22925 Update to Metro without RPC after removing RPC in GF

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -79,7 +79,7 @@
         <findbugs.version>3.0.3</findbugs.version>
         <findbugs.glassfish.logging.validLoggerPrefixes>javax.enterprise</findbugs.glassfish.logging.validLoggerPrefixes>
 
-        <webservices.version>2.4.3</webservices.version>
+        <webservices.version>3.0.0-M1</webservices.version>
         <glassfish-corba.version>4.2.0</glassfish-corba.version>
         <stax-api.version>1.0-2</stax-api.version>
         <slf4j.version>1.7.21</slf4j.version>
@@ -107,7 +107,7 @@
         <jersey.version>2.30.1</jersey.version>
         <jackson.version>2.10.2</jackson.version>
         <jettison.version>1.4.0</jettison.version>
-        <jaxb-api.version>2.3.2</jaxb-api.version>
+        <jaxb-api.version>2.3.3</jaxb-api.version>
         <jax-rs-api.spec.version>2.1</jax-rs-api.spec.version>
         <jax-rs-api.impl.version>2.1.5</jax-rs-api.impl.version>
         <mimepull.version>1.9.12</mimepull.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -79,7 +79,7 @@
         <findbugs.version>3.0.3</findbugs.version>
         <findbugs.glassfish.logging.validLoggerPrefixes>javax.enterprise</findbugs.glassfish.logging.validLoggerPrefixes>
 
-        <webservices.version>3.0.0-M1</webservices.version>
+        <webservices.version>3.0.0-alpha1</webservices.version>
         <glassfish-corba.version>4.2.0</glassfish-corba.version>
         <stax-api.version>1.0-2</stax-api.version>
         <slf4j.version>1.7.21</slf4j.version>


### PR DESCRIPTION
Followup to #22925 and PR https://github.com/eclipse-ee4j/glassfish/pull/22963 where JAX-RPC was removed, but the Metro version used still declared its usage. Added 3.0.0-M1 metro which is not yet the Jakarta-ized version, but the version without the JAX-RPC requirement.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>
