### PR TITLE
GLassFish self signed certificates now use Eclipse for the organisation in the CN

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/KeystoreManager.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/KeystoreManager.java
@@ -44,7 +44,7 @@ public class KeystoreManager {
     private static final String KEYTOOL_EXE_NAME = OS.isWindows() ? "keytool.exe" : "keytool";
     private static String CERTIFICATE_DN_PREFIX = "CN=";
     private static String CERTIFICATE_DN_SUFFIX =
-            ",OU=GlassFish,O=Oracle Corporation,L=Santa Clara,ST=California,C=US";
+            ",OU=GlassFish,O=Eclipse.org Foundation Inc,L=Ottawa,ST=Ontario,C=CA";
     public static final String CERTIFICATE_ALIAS = "s1as";
     public static final String INSTANCE_SECURE_ADMIN_ALIAS = "glassfish-instance";
     public static final String DEFAULT_MASTER_PASSWORD = "changeit";

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/admin/cli/SecureAdminConfigUpgrade.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/admin/cli/SecureAdminConfigUpgrade.java
@@ -439,7 +439,7 @@ public class SecureAdminConfigUpgrade extends SecureAdminUpgradeHelper implement
     private static String CERTIFICATE_DN_PREFIX = "CN=";
 
     private static String CERTIFICATE_DN_SUFFIX =
-        ",OU=GlassFish,O=Oracle Corporation,L=Santa Clara,ST=California,C=US";
+        ",OU=GlassFish,O=Eclipse.org Foundation Inc,L=Ottawa,ST=Ontario,C=CA";
 
     private static final String INSTANCE_CN_SUFFIX = "-instance";
 


### PR DESCRIPTION
Fixes #22978 
Signed-off-by: smillidge <steve.millidge@payara.fish>

