### PR TITLE
Modifications to make devtests work on JDK 11

### DIFF
--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -47,7 +47,7 @@
                             <archive>
                                 <manifestEntries>
                                     <Glassfish-require-services>org.glassfish.api.admingui.ConsoleProvider</Glassfish-require-services>
-                                    <HK2-Import-Bundles>org.glassfish.main.admingui.console-common,org.glassfish.hk2.hk2,org.glassfish.main.admingui.console-plugin-service, org.glassfish.main.deployment.deployment-client, jakarta.servlet-api, jakarta.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, org.glassfish.main.admingui.dataprovider</HK2-Import-Bundles>
+                                    <HK2-Import-Bundles>org.glassfish.main.admingui.console-common,org.glassfish.hk2.hk2,org.glassfish.main.admingui.console-plugin-service, org.glassfish.main.deployment.deployment-client, jakarta.servlet-api, com.sun.el.javax.el, com.sun.jsftemplating, org.glassfish.main.admingui.dataprovider</HK2-Import-Bundles>
                                 </manifestEntries>
                             </archive>
                         </configuration>
@@ -78,7 +78,7 @@
                                <jar jarfile="target/admingui.war" basedir="target/temp">
                                     <manifest>
                                       <attribute name="Glassfish-require-services" value="org.glassfish.api.admingui.ConsoleProvider" />
-                                      <attribute name="HK2-Import-Bundles" value="org.glassfish.main.admingui.console-common,org.glassfish.hk2.hk2,org.glassfish.main.admingui.console-plugin-service, org.glassfish.main.deployment.deployment-client, jakarta.servlet-api, jakarta.servlet.jsp-api, com.sun.el.javax.el, com.sun.jsftemplating, org.glassfish.main.admingui.dataprovider" />
+                                      <attribute name="HK2-Import-Bundles" value="org.glassfish.main.admingui.console-common,org.glassfish.hk2.hk2,org.glassfish.main.admingui.console-plugin-service, org.glassfish.main.deployment.deployment-client, jakarta.servlet-api, com.sun.el.javax.el, com.sun.jsftemplating, org.glassfish.main.admingui.dataprovider" />
                                     </manifest>
                                 </jar>
                                 <delete dir="target/temp" />

--- a/appserver/admingui/war/src/main/webapp/META-INF/MANIFEST.MF
+++ b/appserver/admingui/war/src/main/webapp/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Build-Jdk: 1.5.0_13
 Glassfish-require-repository: console-plugins=${com.sun.aas.installRoo
  t}/lib/console-plugins
 Glassfish-require-services: org.glassfish.api.admingui.ConsoleProvider
-HK2-Import-Bundles: org.glassfish.admingui.console-common,com.sun.enterprise.hk2,org.glassfish.admingui.console-plugin-service, org.glassfish.deployment.deployment-client, org.glassfish.javax.servlet, jakarta.servlet.jsp, org.glassfish.jsftemplating, org.glassfish.admingui.dataprovider
+HK2-Import-Bundles: org.glassfish.admingui.console-common,com.sun.enterprise.hk2,org.glassfish.admingui.console-plugin-service, org.glassfish.deployment.deployment-client, org.glassfish.javax.servlet, org.glassfish.jsftemplating, org.glassfish.admingui.dataprovider
 s

--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -520,6 +520,16 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
+            <artifactId>webservices-rt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-extra-jdk-packages</artifactId>
             <exclusions>
                 <exclusion>

--- a/appserver/libpam4j/src/main/java/org/jvnet/libpam/PAM.java
+++ b/appserver/libpam4j/src/main/java/org/jvnet/libpam/PAM.java
@@ -65,7 +65,7 @@ public class PAM {
      */
     public PAM(String serviceName) throws PAMException {
         pam_conv conv = new pam_conv(new PamCallback() {
-            public int callback(int num_msg, Pointer msg, Pointer resp, Pointer _) {
+            public int callback(int num_msg, Pointer msg, Pointer resp, Pointer pointer) {
                 if(LOGGER.isLoggable(Level.FINE))
                     LOGGER.fine("pam_conv num_msg="+num_msg);
                 if(password==null)

--- a/appserver/libpam4j/src/main/java/org/jvnet/libpam/impl/PAMLibrary.java
+++ b/appserver/libpam4j/src/main/java/org/jvnet/libpam/impl/PAMLibrary.java
@@ -122,17 +122,17 @@ public interface PAMLibrary extends Library {
              * resp and its member string both needs to be allocated by malloc,
              * to be freed by the caller.
              */
-            int callback(int num_msg, Pointer msg, Pointer resp, Pointer _);
+            int callback(int num_msg, Pointer msg, Pointer resp, Pointer pointer);
         }
         public PamCallback conv;
-        public Pointer _;
+        public Pointer pointer;
 
         public pam_conv(PamCallback conv) {
             this.conv = conv;
         }
 
         protected List getFieldOrder() {
-            return Arrays.asList("conv", "_");
+            return Arrays.asList("conv", "pointer");
         }
         protected PamCallback getConv(){
             return conv;

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -652,6 +652,11 @@
                 <version>${webservices.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.metro</groupId>
+                <artifactId>webservices-rt</artifactId>
+                <version>${webservices.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-osgi</artifactId>
                 <version>${jaxb.version}</version>

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/perms/SMGlobalPolicyUtil.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/perms/SMGlobalPolicyUtil.java
@@ -26,8 +26,11 @@ import java.security.cert.Certificate;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -159,7 +162,12 @@ public class SMGlobalPolicyUtil {
     
     private static final AllPermission ALL_PERM = new AllPermission();
 
-    
+    //JDK-8173082: JDK required permissions needed by applications using java.desktop module
+    private static final List<String> JDK_REQUIRED_PERMISSIONS = Stream.of(
+        "accessClassInPackage.com.sun.beans",
+        "accessClassInPackage.com.sun.beans.*",
+        "accessClassInPackage.com.sun.java.swing.plaf.*",
+        "accessClassInPackage.com.apple.*").collect(Collectors.toList());
 
     //convert a string type to the CommponentType
     public static CommponentType convertComponentType(String type) {        
@@ -389,7 +397,7 @@ public class SMGlobalPolicyUtil {
         Enumeration<Permission> checkEnum = toBeCheckedPC.elements();
         while (checkEnum.hasMoreElements()) {
             Permission p = checkEnum.nextElement();
-            if (containPC.implies(p)) {
+            if (!JDK_REQUIRED_PERMISSIONS.contains(p.getName()) && containPC.implies(p)) {
                 throw new SecurityException("Restricted permission " + p 
                         + " is declared or implied in the " + containPC);
             }

--- a/appserver/tests/quicklook/gfproject/build-impl.xml
+++ b/appserver/tests/quicklook/gfproject/build-impl.xml
@@ -50,6 +50,16 @@
             <include name="**/amx-core.jar"/>
             <include name="**/amx-javaee.jar"/>
             <include name="**/gf-client.jar"/>
+            <include name="**/jaxws-api.jar"/>
+            <include name="**/webservices-osgi.jar"/>
+            <include name="**/webservices-rt.jar"/>
+            <include name="**/jaxb-osgi.jar"/>
+            <include name="**/jakarta.activation-api.jar"/>
+        </fileset>
+        <fileset dir="${glassfish.home}/modules/endorsed">
+            <include name="**/webservices-api-osgi.jar"/>
+            <include name="**/jakarta.xml.bind-api.jar"/>
+            <include name="**/jakarta.annotation-api.jar"/>
         </fileset>
 	<fileset dir="${maven.repo.local}/com/beust/jcommander">
 	    <include name="**/1.72/jcommander-1.72.jar"/>

--- a/appserver/tests/quicklook/weld/extensions/build.xml
+++ b/appserver/tests/quicklook/weld/extensions/build.xml
@@ -61,8 +61,8 @@
         <mkdir dir="${class.output}"/>
         <mkdir dir="${dist.dir}/lib"/>
         <javac   debug="true"
-    source="1.5"
-    target="1.5"
+    source="1.8"
+    target="1.8"
     classpathref="class.path"
     srcdir="src/java"
     failonerror="false"

--- a/appserver/tests/quicklook/weld/extensions/src/java/extensions/ExtensionBean.java
+++ b/appserver/tests/quicklook/weld/extensions/src/java/extensions/ExtensionBean.java
@@ -53,7 +53,7 @@ public class ExtensionBean implements Extension {
         adv = true;
     }
 
-    void processAnnotatedType(@Observes ProcessAnnotatedType<?> _) {
+    void processAnnotatedType(@Observes ProcessAnnotatedType<?> type) {
         pat = true;
     }
 

--- a/appserver/tests/quicklook/weld/extensions/src/java/jar/ExtensionBean.java
+++ b/appserver/tests/quicklook/weld/extensions/src/java/jar/ExtensionBean.java
@@ -53,7 +53,7 @@ public class ExtensionBean implements Extension {
         adv = true;
     }
 
-    void processAnnotatedType(@Observes ProcessAnnotatedType<?> _) {
+    void processAnnotatedType(@Observes ProcessAnnotatedType<?> type) {
         pat = true;
     }
 

--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -130,3 +130,8 @@
       permission java.io.FilePermission       "<<ALL FILES>>", "write,read";
 
  };
+//Added for creating stub on JDK 11
+grant codeBase "jrt:/jdk.compiler" {
+      permission java.lang.RuntimePermission "getenv.JDK_JAVAC_OPTIONS";
+      permission java.lang.RuntimePermission "createClassLoader";
+};

--- a/nucleus/core/kernel/osgi.bundle
+++ b/nucleus/core/kernel/osgi.bundle
@@ -27,8 +27,8 @@
 
 # dependent flashlight package resolved at runtime
 DynamicImport-Package: org.glassfish.flashlight.provider, \
-                       org.objectweb.asm;password=GlassFish, \
-                       org.objectweb.asm.commons;password=GlassFish
+                       org.objectweb.asm, \
+                       org.objectweb.asm.commons
 
 # Only in non-OSGi embedded mode, kernel depends on logging package, so
 # optionally depend on that pkg. This way, when GF is embedded in

--- a/nucleus/deployment/common/osgi.bundle
+++ b/nucleus/deployment/common/osgi.bundle
@@ -30,5 +30,5 @@ Import-Package: \
                         
 DynamicImport-Package: \
                         org.glassfish.flashlight.provider, \
-                        org.objectweb.asm;password=GlassFish, \
-                        org.objectweb.asm.commons;password=GlassFish
+                        org.objectweb.asm, \
+                        org.objectweb.asm.commons

--- a/nucleus/flashlight/framework/osgi.bundle
+++ b/nucleus/flashlight/framework/osgi.bundle
@@ -21,8 +21,8 @@
                             org.glassfish.flashlight.provider; version=${project.osgi.version}
 
 DynamicImport-Package: \
-                        org.objectweb.asm;password=GlassFish, \
-                        org.objectweb.asm.commons;password=GlassFish \
+                        org.objectweb.asm, \
+                        org.objectweb.asm.commons \
 
 
 Bundle-Activator: org.glassfish.flashlight.impl.core.FlashlightBundleActivator

--- a/nucleus/hk2/tiger-types/src/main/java/org/jvnet/tiger_types/Types.java
+++ b/nucleus/hk2/tiger-types/src/main/java/org/jvnet/tiger_types/Types.java
@@ -240,26 +240,26 @@ public class Types {
      * Implements the logic for {@link #erasure(Type)}.
      */
     private static final TypeVisitor<Class,Void> eraser = new TypeVisitor<Class,Void>() {
-        public Class onClass(Class c,Void _) {
+        public Class onClass(Class c,Void v) {
             return c;
         }
 
-        public Class onParameterizdType(ParameterizedType p,Void _) {
+        public Class onParameterizdType(ParameterizedType p,Void v) {
             // TODO: why getRawType returns Type? not Class?
             return visit(p.getRawType(),null);
         }
 
-        public Class onGenericArray(GenericArrayType g,Void _) {
+        public Class onGenericArray(GenericArrayType g,Void v) {
             return Array.newInstance(
                 visit(g.getGenericComponentType(),null),
                 0 ).getClass();
         }
 
-        public Class onVariable(TypeVariable v,Void _) {
-            return visit(v.getBounds()[0],null);
+        public Class onVariable(TypeVariable t,Void v) {
+            return visit(t.getBounds()[0],null);
         }
 
-        public Class onWildcard(WildcardType w,Void _) {
+        public Class onWildcard(WildcardType w,Void v) {
             return visit(w.getUpperBounds()[0],null);
         }
     };


### PR DESCRIPTION
( FOR 5.1.0-run-with-JDK11 BRANCH )
This is a continuation of #22935 and #22979.

These fixes make almost all tests pass on JDK 11.
If this PR is approved, this branch could be merged into the master though there are still some issues with some non-GlassFish components (such as orb. refs #22893).

■Current status:

|package|fail|skip|pass|total|
|-----|-----|-----|-----|-----|
|batch_all|0|0|26|26|
|build-unit-tests|0|67|693|760|
|cdi_all|0|0|112|112|
|connector_group_1|0|0|65|65|
|connector_group_2|0|0|22|22|
|connector_group_3|0|0|5|5|
|connector_group_4|0|0|200|200|
|deployment_all|0|0|283|283|
|ejb_group_1|0|0|111|111|
|ejb_group_2|0|0|59|59|
|ejb_group_3|0|0|133|133|
|ejb_web_all|0|0|30|30|
|jdbc_all|0|0|209|209|
|nucleus_admin_all|0|9|81|90|
|persistence_all|0|0|16|16|
|ql_gf_full_profile_all|6※|2+10※|322|327|
|ql_gf_nucleus_all|0|0|15|15|
|ql_gf_web_profile_all|0|2|268|270|
|web_jsp|0|0|89|89|

※There are a few remaining Fails and unexpected Skips, both of which are due to the following 2 issues caused by ```appserver/webservices/jsr109-impl```.
* The system classpath is not referenced when wsimport is called internally.
* References to some classes fail.
  related to: https://github.com/eclipse-ee4j/metro-wsit/issues/54

These issues are difficult to solve simply, and I'd like to investigate them after incorporating the latest modules (after migrating namespaces javax->jakarta).


■To confirm the modifications work locally
you need to address all of the other project issues listed in this ticket (#22893).
Or,
```
1. clone and build orb-gmbal-pfl <b>on JDK11 (to enable multi-release jar)</b>
git clone https://github.com/eclipse-ee4j/orb-gmbal-pfl.git
cd orb-gmbal-pfl
git checkout 4001073
mvn clean install

2. clone and build orb on JDK8
git clone -b 4.2.1-with-JDK11 https://github.com/hs536/orb.git
cd orb
mvn clean install

3. clone and build glassfish-security-plugin on JDK8
git clone https://github.com/eclipse-ee4j/glassfish-security-plugin.git
cd glassfish-security-plugin
mvn clean install

4. clone and build weld-core on JDK8
git clone -b 3.0.0.Final.jdk11 https://github.com/hs536/core.git
cd core
mvn clean install -Dmaven.test.skip=true
cd bundles/osgi
mvn clean install

5. clone and build jsp-api on JDK8
git clone -b 2.3.6-jdk11 https://github.com/hs536/jsp-api.git
cd jsp-api
mvn clean install

6. clone and build glassfish on JDK8
git clone -b devtests https://github.com/hs536/glassfish.git
cd glassfish
mvn clean install

7. run devtests on JDK11 (with "export CLASSPATH=<glassfish src root dir>/glassfish5/javadb")
```

■AdditionalInfo
```
# java -version
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)

# mvn -version
Apache Maven 3.6.3 (cecedd343002696d0abb50b32b541b8a6ba2883f)
Maven home: /work/tools/apache-maven-3.6.3
Java version: 11.0.2, vendor: Oracle Corporation, runtime: /work/JDK/jdk-11.0.2
Default locale: en_US, platform encoding: ANSI_X3.4-1968
OS name: "linux", version: "3.10.0-327.el7.x86_64", arch: "amd64", family: "unix"

# ant -version
Apache Ant(TM) version 1.10.7 compiled on September 1 2019
```
