### PR TITLE
#22983 Update jsftemplating to m2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -167,7 +167,7 @@
 
 
         <!-- Admin console components -->
-        <jsftemplating.version>3.0.0-M1</jsftemplating.version>
+        <jsftemplating.version>3.0.0-M2</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>5.0.0-M1</woodstock.version>
 


### PR DESCRIPTION
#22983 jsftemplating updated to m2. Fixes OSGi error.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>


