### PR TITLE
Reenable servlet API sensitive calls

### DIFF
--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/Ejb3MessageDispatcher.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/Ejb3MessageDispatcher.java
@@ -81,8 +81,7 @@ public class Ejb3MessageDispatcher implements EjbMessageDispatcher {
                 adapterInfo = (AdapterInvocationInfo) endpointInfo.prepareInvocation(true);
                 adapter = adapterInfo.getAdapter();
                 if (adapter != null) {
-                    logger.log(SEVERE, "!!! TODO: UNCOMMENT LINE BELLOW !!! ({0})", Ejb3MessageDispatcher.class.getName());
-//                    adapter.handle(null, req, resp);
+                    adapter.handle(null, req, resp);
                 } else {
                     logger.log(SEVERE, UNABLE_FIND_ADAPTER, endpointInfo.getEndpoint().getName());
                 }
@@ -109,8 +108,7 @@ public class Ejb3MessageDispatcher implements EjbMessageDispatcher {
             adapterInfo = (AdapterInvocationInfo) endpointInfo.prepareInvocation(true);
             adapter = adapterInfo.getAdapter();
             if (adapter != null) {
-                logger.log(SEVERE, "!!! TODO: UNCOMMENT LINE BELLOW !!! ({0})", Ejb3MessageDispatcher.class.getName());
-//                adapter.publishWSDL(ctxt, req, resp);
+                adapter.publishWSDL(ctxt, req, resp);
             } else {
                 String message = "Invalid wsdl request " + req.getRequestURL();
                 (new WsUtil()).writeInvalidMethodType(resp, message);

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/JAXWSServlet.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/JAXWSServlet.java
@@ -137,8 +137,7 @@ public class JAXWSServlet extends HttpServlet {
         try {
             ServletAdapter targetEndpoint = (ServletAdapter) getEndpointFor(request);
             if (targetEndpoint != null) {
-                logger.log(Level.SEVERE, "!!! TODO: UNCOMMENT LINE BELLOW !!! ({0})", JAXWSServlet.class.getName());
-//                targetEndpoint.handle(getServletContext(), request, response);
+                targetEndpoint.handle(getServletContext(), request, response);
             } else {
                 throw new ServletException("Service not found");
             }
@@ -191,8 +190,7 @@ public class JAXWSServlet extends HttpServlet {
         try {
             ServletAdapter targetEndpoint = (ServletAdapter) getEndpointFor(request);
             if (targetEndpoint != null && wsdlExposed) {
-                logger.log(Level.SEVERE, "!!! TODO: UNCOMMENT LINE BELLOW !!! ({0})", JAXWSServlet.class.getName());
-//                targetEndpoint.publishWSDL(getServletContext(), request, response);
+                targetEndpoint.publishWSDL(getServletContext(), request, response);
             } else {
                 String message = "Invalid wsdl request " + request.getRequestURL();
                 (new WsUtil()).writeInvalidMethodType(response, message);


### PR DESCRIPTION
the code was disabled due to javax.servlet vs jakarta.servlet conflicts. Since there is grizzly 3 now, the code can be re-enabled