### PR TITLE
remove endorsed from QL, add missing jars to default web cp

### DIFF
--- a/appserver/admin/template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/template/src/main/resources/config/default-web.xml
@@ -306,6 +306,7 @@
         validation.jar
         jakarta.ejb.jar
         jakarta.jms-api.jar
+        jakarta.activation.jar
         jakarta.mail.jar
         jakarta.management.j2ee-api.jar
         jakarta.persistence.jar
@@ -313,6 +314,8 @@
         jakarta.security.auth.message-api.jar
         jakarta.authorization-api.jar
         jakarta.transaction-api.jar
+        jakarta.xml.bind-api.jar
+        webservices-api-osgi.jar
         webservices-osgi.jar
         weld-osgi-bundle.jar
         jersey-mvc-jsp.jar

--- a/appserver/tests/quicklook/build.xml
+++ b/appserver/tests/quicklook/build.xml
@@ -308,7 +308,6 @@
             <jvmarg value="-Djava.compiler=NONE"/>
             <jvmarg value="-Dhttp.host=${glassfish.http.host}"/>
             <jvmarg value="-Dhttp.port=${glassfish.http.port}"/>
-	    <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
 	    <jvmarg value="-DASADMIN=${ASADMIN}" />
 	    <jvmarg value="-DAPPCLIENT=${APPCLIENT}"/>
             <sysproperty key="glassfish.home" value="${glassfish.home}"/>

--- a/appserver/tests/quicklook/gfproject/build-impl.xml
+++ b/appserver/tests/quicklook/gfproject/build-impl.xml
@@ -58,13 +58,6 @@
         <pathelement location="${test.class.output}"/>
     </path>
 
-    <path id = "boot.classpath">
-        <fileset dir="${glassfish.home}/modules/endorsed">
-            <include name="**/*.jar"/>
-        </fileset>        
-    </path>
-
-
     <!-- classpath at QL build time for building testing apps -->
     <path id="class.path">
         <fileset dir="${glassfish.home}/modules">
@@ -340,7 +333,6 @@
         <classfileset dir="${test.class.output}" includes="**/${testng.testclient}.class"/>
         <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
         <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-	<jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
 	<jvmarg value="-DASADMIN=${ASADMIN}" />
     </testng>
 </target>
@@ -355,7 +347,6 @@
         <xmlfileset dir="." includes="testng.xml"/>
         <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
         <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-	<jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
 	<jvmarg value="-DASADMIN=${ASADMIN}" />
 	<jvmarg value="-DAPPCLIENT=${APPCLIENT}" />
     </testng>
@@ -374,7 +365,6 @@
         <classfileset dir="${test.class.output}" includes="**/${testng.testclient}.class"/>
         <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
         <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-        <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
         <jvmarg value="-DASADMIN=${ASADMIN}" />
     </testng>
 </target>
@@ -427,11 +417,7 @@
             <classfileset dir="${build.classes.home}" includes="**/${testng.testclient}.class"/>
             <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
             <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-            <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
             <bootclasspath classpathref="boot.class.path"/>
-<sysproperty key="-Djava.endorsed.dirs" value="${glassfish.home}/modules/endorsed"/>
-
-
         </testng>
     </target>
 
@@ -445,11 +431,7 @@
             <xmlfileset dir="." includes="testng.xml"/>
             <jvmarg value="-Dhttp.host=${glassfish.http.host}" />
             <jvmarg value="-Dhttp.port=${glassfish.http.port}" />
-            <jvmarg value="-Djava.endorsed.dirs=${glassfish.home}/modules/endorsed" />
             <bootclasspath classpathref="boot.class.path"/>
-<sysproperty key="-Djava.endorsed.dirs" value="${glassfish.home}/modules/endorsed"/>
-
-
         </testng>
     </target>
 

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/monitoring/WebServiceTesterServlet.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/monitoring/WebServiceTesterServlet.java
@@ -578,15 +578,14 @@ public class WebServiceTesterServlet extends HttpServlet {
             logger.log(Level.SEVERE, LogUtils.CREATE_DIR_FAILED, classesDir);
         }
 
-        String[] wsimportArgs = new String[8];
+        String[] wsimportArgs = new String[7];
         wsimportArgs[0]="-d";
         wsimportArgs[1]=classesDir.getAbsolutePath();
         wsimportArgs[2]="-keep";
         wsimportArgs[3]=wsdlLocation.toExternalForm();
-        wsimportArgs[4]="-Xendorsed";
-        wsimportArgs[5]="-target";
-        wsimportArgs[6]="2.1";
-        wsimportArgs[7]="-extension";
+        wsimportArgs[4]="-target";
+        wsimportArgs[5]="2.1";
+        wsimportArgs[6]="-extension";
         WSToolsObjectFactory tools = WSToolsObjectFactory.newInstance();
         logger.log(Level.INFO, LogUtils.WSIMPORT_INVOKE, wsdlLocation);
         boolean success = tools.wsimport(System.out, wsimportArgs);


### PR DESCRIPTION
* removing endorsed from QL paths
* removing `-Xendorsed` from ws tester
* adding APIs removed from JDK to the default web system classpath