### PR TITLE
Update various dependencies to newer ones.

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -134,8 +134,8 @@
 
         <!-- Jakarta Batch -->
         <jakarta.batch-api.version>2.0.0-M2</jakarta.batch-api.version>
-        <com.ibm.jbatch.container.version>2.0.0-M1</com.ibm.jbatch.container.version>
-        <com.ibm.jbatch.spi.version>2.0.0-M1</com.ibm.jbatch.spi.version>
+        <com.ibm.jbatch.container.version>2.0.0-M2</com.ibm.jbatch.container.version>
+        <com.ibm.jbatch.spi.version>2.0.0-M2</com.ibm.jbatch.spi.version>
 
         <!-- Jakarta Enterprise beans -->
         <jakarta.ejb-api.version>4.0.0-RC2</jakarta.ejb-api.version>
@@ -152,8 +152,8 @@
         <jsp-impl.version>3.0.0-RC1</jsp-impl.version>
 
         <!-- Used for Jakarta XML Web Services -->
-        <woodstox.version>5.1.0</woodstox.version>
-        <stax2-api.version>4.1</stax2-api.version>
+        <woodstox.version>5.3.0</woodstox.version>
+        <stax2-api.version>4.2.1</stax2-api.version>
 
         <!-- Jakarta Standard Tag Library -->
         <jstl-api.version>2.0.0-RC1</jstl-api.version>
@@ -556,7 +556,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>

--- a/nucleus/hk2/config-generator/pom.xml
+++ b/nucleus/hk2/config-generator/pom.xml
@@ -64,17 +64,17 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>codemodel</artifactId>
-            <version>2.3.0</version>
+            <version>3.0.0-M4</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -90,7 +90,7 @@
 
         <!-- Jakarta Validation -->
         <jakarta.validation.version>3.0.0-M1</jakarta.validation.version>        
-        <hibernate-validator.version>7.0.0.Alpha2</hibernate-validator.version>
+        <hibernate-validator.version>7.0.0.Alpha3</hibernate-validator.version>
 
         <!-- Jakarta Web Services -->
         <webservices.version>3.0.0-M2</webservices.version>
@@ -117,7 +117,7 @@
         <jakarta.annotation-api.version>2.0.0-RC1</jakarta.annotation-api.version>
 
         <!-- GlassFish Components -->                                   
-        <glassfish-corba.version>4.2.0</glassfish-corba.version>
+        <glassfish-corba.version>4.2.1</glassfish-corba.version>
         <grizzly.version>3.0.0-M1</grizzly.version>
         <grizzly.npn.version>1.9</grizzly.npn.version>
         <glassfish-management-api.version>3.2.3</glassfish-management-api.version>
@@ -137,14 +137,14 @@
         <stax-api.version>1.0-2</stax-api.version>
         <slf4j.version>1.7.21</slf4j.version>
         <jboss.logging.annotation.version>2.2.1.Final</jboss.logging.annotation.version>
-        <javassist.version>3.26.0-GA</javassist.version>
+        <javassist.version>3.27.0-GA</javassist.version>
         <jboss.logging.version>3.4.1.Final</jboss.logging.version>
         <fasterxml.classmate.version>1.5.1</fasterxml.classmate.version>
         <jsch.version>0.1.56</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.2</ant.version>
-        <jackson.version>2.10.2</jackson.version>
-        <jettison.version>1.4.0</jettison.version>
+        <jackson.version>2.11.0</jackson.version>
+        <jettison.version>1.4.1</jettison.version>
         <mimepull.version>1.9.13</mimepull.version>
         <asm.version>7.3.1</asm.version>
 
@@ -747,7 +747,7 @@
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.webconsole</artifactId>
-                <version>4.3.16</version>
+                <version>4.5.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -915,7 +915,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.6</version>
+                <version>2.7</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>
@@ -925,7 +925,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-launcher</artifactId>
-                <version>1.10.7</version>
+                <version>1.10.8</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>
@@ -985,7 +985,7 @@
             <dependency>
                <groupId>org.apache.felix</groupId>
                <artifactId>org.apache.felix.fileinstall</artifactId>
-               <version>3.6.4</version>
+               <version>3.6.6</version>
             </dependency>
             <dependency>
                <groupId>org.apache.felix</groupId>
@@ -999,7 +999,7 @@
             <dependency>
                <groupId>org.apache.felix</groupId>
                <artifactId>org.apache.felix.scr</artifactId>
-               <version>2.1.16</version>
+               <version>2.1.20</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
@@ -1026,7 +1026,7 @@
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
After update, GF builds, starts up, and still displays the admin console as per the current state of master.

Risky/troublesome updates such as `asm 8` have been omitted from updating. If we want to update these a separate effort would be needed.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>

