### PR TITLE
Package Web Service apis in Web Feature Set

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -55,6 +55,14 @@
         <!-- glassfish-jmx -->
         <!-- glassfish-management -->
         <!-- glassfish-corba-base -->
+        
+        <!-- Web Services APIs in Jakarta Namespace -->
+        <dependency>
+        <!-- Contains jakarta.jws, jakarta.xml.soap, jakarta.xml.ws -->
+            <groupId>org.glassfish.metro</groupId>
+            <artifactId>webservices-api-osgi</artifactId>
+            <version>${webservices.version}</version>
+        </dependency>
 
         <!-- glassfish-common -->
         <dependency>


### PR DESCRIPTION
Required to fix OSGI errors on deployment in web profile 

Signed-off-by: smillidge <steve.millidge@payara.fish>

`Unable to resolve org.glassfish.main.web.weld-integration [128](R 128.0): missing requirement   [org.glassfish.main.web.weld-integration [128](R 128.0)] osgi.wiring.package; (&(osgi.wiring.package=jakarta.xml.ws)(version>=3.0.0)(!(version>=4.0.0))) Unresolved requirements: [[org.glassfish.main.web.weld-integration [128](R 128.0)] osgi.wiring.package; (&(osgi.wiring.package=jakarta.xml.ws)(version>=3.0.0)(!(version>=4.0.0)))]`