### PR TITLE
Integrate mail 2.0.0-RC6

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -108,7 +108,7 @@
         <jersey.version>3.0.0-M4</jersey.version>
         
         <!-- Jakarta Mail -->
-        <mail.version>2.0.0-RC5</mail.version>
+        <mail.version>2.0.0-RC6</mail.version>
         
         <!-- Jakarta Activation -->
         <activation.version>2.0.0-RC3</activation.version>


### PR DESCRIPTION
javadoc jar in RC5 is empty, RC6 fixes this; there should be no change in functionality between RC5 and RC6

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>
