### PR TITLE
Update maven URLs to use https

### DIFF
--- a/appserver/admingui/devtests/hudson.xml
+++ b/appserver/admingui/devtests/hudson.xml
@@ -58,7 +58,7 @@
     <property name="ant.contrib.url"
               value="http://mirrors.ibiblio.org/pub/mirrors/maven2/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3.jar"/>
     <property name="maven.ant.tasks.url"
-              value="http://repo2.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.1/maven-ant-tasks-2.1.1.jar"/>
+              value="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.1/maven-ant-tasks-2.1.1.jar"/>
     <property name="glassfish.dist.url"
               value="http://hudson.glassfish.org/job/gf-trunk-build-continuous/lastSuccessfulBuild/artifact/bundles/glassfish.zip"/>
 

--- a/appserver/tests/appserv-tests/devtests/batch/batch-dev-tests/build.xml
+++ b/appserver/tests/appserv-tests/devtests/batch/batch-dev-tests/build.xml
@@ -31,7 +31,7 @@
     &commonRun;
 
 <property environment="env" />
-<get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+<get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
 <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
 <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
@@ -79,7 +79,7 @@
 
         
 <target name="init" depends="init.os,init.tools,setAsadminArgs">
-    <get src="http://central.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" dest="${env.APS_HOME}/devtests/deployment/junit-4.12.jar" usetimestamp="true"/>
+    <get src="https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar" dest="${env.APS_HOME}/devtests/deployment/junit-4.12.jar" usetimestamp="true"/>
     <property name="root" value="${basedir}"/>
 
     <available property="cluster.exists" file="${s1as.home}/domains/${testDomain}"/>

--- a/appserver/tests/appserv-tests/devtests/naming/naming2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/naming/naming2/build.xml
@@ -31,7 +31,7 @@
     &commonRun;
 
 <property environment="env" />
-<get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+<get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
 <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
 <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/ejb-auth-async/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/ejb-auth-async/build.xml
@@ -34,7 +34,7 @@
    &testProperties;
    &commonSecurity;
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/build.xml
@@ -31,7 +31,7 @@
    &commonRun;
    &testProperties;  
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/security/soteria/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/soteria/build.xml
@@ -34,7 +34,7 @@
    &testProperties;
    &commonSecurity;
     <property environment="env"/>
-    <get src="http://central.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
+    <get src="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/2.1.3/maven-ant-tasks-2.1.3.jar" dest="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar"/>
     <path id="maven-ant-tasks.classpath" path="${env.APS_HOME}/lib/maven-ant-tasks-2.1.3.jar" />
     <typedef resource="org/apache/maven/artifact/ant/antlib.xml"
            uri="antlib:org.apache.maven.artifact.ant"

--- a/appserver/tests/appserv-tests/devtests/web/useBundledJsfWithTagCompilation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/web/useBundledJsfWithTagCompilation/build.xml
@@ -46,7 +46,7 @@
 
     <target name="deploy" depends="init-common">
       <get
-        src="http://repo1.maven.org/maven2/com/sun/faces/extensions/jsf-cardemo/0.2/jsf-cardemo-0.2.war"
+        src="https://repo1.maven.org/maven2/com/sun/faces/extensions/jsf-cardemo/0.2/jsf-cardemo-0.2.war"
         dest="jsf-cardemo.war"/>
       <antcall target="deploy-war-name"/>
     </target>

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -25,9 +25,9 @@ RUN chmod +x /etc/entrypoint.sh && \
     #
     # install takari extensions
     #
-    curl -O http://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.2/takari-local-repository-0.11.2.jar && \
+    curl -O https://repo1.maven.org/maven2/io/takari/aether/takari-local-repository/0.11.2/takari-local-repository-0.11.2.jar && \
     mv takari-local-repository-*.jar /usr/share/maven/lib/ext/ && \
-    curl -O http://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar && \
+    curl -O https://repo1.maven.org/maven2/io/takari/takari-filemanager/0.8.3/takari-filemanager-0.8.3.jar && \
     mv takari-filemanager-*.jar /usr/share/maven/lib/ext/ && \
     #
     # install ant


### PR DESCRIPTION
(For 5.1.0-BRANCH)

The jenkins job of 5.1.0-BRANCH still has errors because of the old maven central url.
I merged the commit from master branch.