### PR TITLE
Glassfish Requires JDK8 & Branding Updates

### DIFF
--- a/appserver/admingui/common/src/main/resources/commonTask.jsf
+++ b/appserver/admingui/common/src/main/resources/commonTask.jsf
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/appserver/admingui/community-theme/src/main/resources/org/glassfish/admingui/community-theme/Strings.properties
+++ b/appserver/admingui/community-theme/src/main/resources/org/glassfish/admingui/community-theme/Strings.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,4 +24,4 @@ msg.JS.confirmLogout=Log Out of GlassFish Administration Console ?
 productName=GlassFish Server Open Source Edition
 promotionLink=java.sun.com/glassfish/productmsg.html
 
-copyright.fullPage=Copyright \u00a9 2005,2018, Oracle and/or its affiliates. All rights reserved.  <br><br>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0, which is available at http://www.eclipse.org/legal/epl-2.0. <br><br>This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability setforth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception, which is available at https://www.gnu.org/software/classpath/license.html. <br><br>SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+copyright.fullPage=Copyright \u00a9 2005,2020, Oracle and/or its affiliates. All rights reserved.  <br><br>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0, which is available at http://www.eclipse.org/legal/epl-2.0. <br><br>This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability setforth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception, which is available at https://www.gnu.org/software/classpath/license.html. <br><br>SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0

--- a/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
+++ b/appserver/admingui/core/src/main/resources/org/glassfish/admingui/core/Strings.properties
@@ -25,9 +25,9 @@ login.productImage.height=42
 login.productImage.width=380
 
 ## this is the copyright message in the bottom of the login page.
-copyright.shortMessage=Copyright \u00a9 2005, 2018, Oracle and/or its affiliates. All rights reserved. 
+copyright.shortMessage=Copyright \u00a9 2005, 2020, Oracle and/or its affiliates. All rights reserved. 
 
-copyright.fullPage=Copyright \u00a9 2005,2018, Oracle and/or its affiliates. All rights reserved.  <br><br>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0, which is available at http://www.eclipse.org/legal/epl-2.0. <br><br>This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability setforth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception, which is available at https://www.gnu.org/software/classpath/license.html. <br><br>SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+copyright.fullPage=Copyright \u00a9 2005,2020, Oracle and/or its affiliates. All rights reserved.  <br><br>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0, which is available at http://www.eclipse.org/legal/epl-2.0. <br><br>This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability setforth in the Eclipse Public License v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception, which is available at https://www.gnu.org/software/classpath/license.html. <br><br>SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 shutdown.pageTitle=Shutting down DAS
 shutdown.RestartContinue=Click <a href="../../">here</a> to return to the login page after the server has started.
@@ -395,7 +395,7 @@ commonTasks.task.glassfishNews=GlassFish News
 
 commonTasks.task.aquarium=GlassFish News
 commonTasks.task.aquarium.toolTip=News from the GlassFish Community
-commonTasks.task.aquariumLink=http://blogs.oracle.com/theaquarium
+commonTasks.task.aquariumLink=https://eclipse-ee4j.github.io/glassfish/
 
 commonTasks.task.support=Support
 commonTasks.task.support.toolTip=GlassFish Support
@@ -431,11 +431,11 @@ commonTasks.task.docpage=Open Source Edition Documentation Set
 commonTasks.task.docpage.toolTip=Open Source Edition documentation set
 
 # change the doc link to the localized copy if there is any
-commonTasks.doc.qstart=http://glassfish.java.net/docs/4.0/quick-start-guide.pdf
-commonTasks.doc.adminGuide=http://glassfish.java.net/docs/4.0/administration-guide.pdf
-commonTasks.doc.devGuide=http://glassfish.java.net/docs/4.0/application-development-guide.pdf
-commonTasks.doc.deployGuide=http://glassfish.java.net/docs/4.0/application-deployment-guide.pdf
-commonTasks.doc.docpage=http://glassfish.java.net/docs/index.html
+commonTasks.doc.qstart=https://eclipse-ee4j.github.io/glassfish/docs/latest/quick-start-guide.pdf	
+commonTasks.doc.adminGuide=https://eclipse-ee4j.github.io/glassfish/docs/latest/administration-guide.pdf
+commonTasks.doc.devGuide=https://eclipse-ee4j.github.io/glassfish/docs/latest/application-development-guide.pdf
+commonTasks.doc.deployGuide=https://eclipse-ee4j.github.io/glassfish/docs/latest/application-deployment-guide.pdf
+commonTasks.doc.docpage=https://eclipse-ee4j.github.io/glassfish/docs/
 
 
 commonTasks.task.adminPassword=Change Administrator Password

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/AdminMain.java
@@ -193,7 +193,7 @@ public class AdminMain {
         //JDK9 the major verion would be the real major version e.g in case
         // of JDK9 major version is 9.So in that case checking the major version only.
         if (major<9) {
-            if (minor < 6) {
+            if (minor < 8) {
                 System.err.println(strings.get( "OldJdk", "" + minor));
                 return ERROR;
             }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/LocalStrings.properties
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/LocalStrings.properties
@@ -172,7 +172,7 @@ badEnvVarUnset=CLI163: Could not unset environment variable: {0}\nVariable names
 cantRemoveEnvVar=CLI149: Environment variable is not set: {0}
 operandPrompt=Enter the value for the {0} operand> 
 optionPrompt=Enter the value for the {0} option> 
-OldJdk=GlassFish requires Java SE version 6.  Your JDK is version {0}
+OldJdk=GlassFish requires Java SE version 8.  Your JDK is version {0}
 DeprecatedSyntax=Deprecated syntax, instead use:
 ## Parser
 parser.noValueAllowed=Option may not have value: {0}


### PR DESCRIPTION
Hi
Because JakartaEE9 requires at least JDK8, I corrected the JDK control in AdminMain.
Also, this PR updates branding info links in Admin UI common tasks section.