### PR TITLE
potential M1 updates for API versions

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -130,10 +130,10 @@
         <jakarta.transaction-api.version>2.0.0-RC2</jakarta.transaction-api.version>
 
         <!-- Jakarta Connectors -->
-        <jakarta.resource-api.version>2.0.0-RC1</jakarta.resource-api.version>
+        <jakarta.resource-api.version>2.0.0-RC2</jakarta.resource-api.version>
 
         <!-- Jakarta Batch -->
-        <jakarta.batch-api.version>2.0.0-M2</jakarta.batch-api.version>
+        <jakarta.batch-api.version>2.0.0-M3</jakarta.batch-api.version>
         <com.ibm.jbatch.container.version>2.0.0-M3</com.ibm.jbatch.container.version>
         <com.ibm.jbatch.spi.version>2.0.0-M3</com.ibm.jbatch.spi.version>
 
@@ -148,7 +148,7 @@
         <yasson.version>2.0.0-M2</yasson.version>
 
         <!-- Jakarta Server Pages -->
-        <jsp-api.version>3.0.0-M1</jsp-api.version>
+        <jsp-api.version>3.0.0-RC2</jsp-api.version>
         <jsp-impl.version>3.0.0-RC1</jsp-impl.version>
 
         <!-- Used for Jakarta XML Web Services -->


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

As I prepare the Platform and Web Profile API jar files, I see the following updates in the Staging repository.  These are what I plan to use as input for the Milestone 1 API jar files (Platform and Web Profile).  This PR updates the Glassfish pom for the items I could find... I didn't update the Impl jar file versions.  And, I couldn't find Mail nor EL in this pom.  I'll leave these as an exercise for the Glassfish team.  The main point of this PR is to make you aware of these updates.

        <jakarta.servlet.jsp-api.version>3.0.0-RC2</jakarta.servlet.jsp-api.version>
        <jakarta.el-api.version>4.0.0-RC2</jakarta.el-api.version>
        <jakarta.mail-api.version>2.0.0-RC6</jakarta.mail-api.version>
        <jakarta.resource-api.version>2.0.0-RC2</jakarta.resource-api.version>
        <jakarta.batch-api.version>2.0.0-M3</jakarta.batch-api.version>
