### PR TITLE
Site updates for M1

### DIFF
--- a/docs/website/src/main/resources/README.md
+++ b/docs/website/src/main/resources/README.md
@@ -8,6 +8,15 @@ Eclipse GlassFish 5.1 is also Java EE 8 Compatible.
 
 ## Latest News
 
+
+### June 23, 2020 -- Eclipse GlassFish 6.0 Milestone 1 is released
+
+This release contains new Jakarta EE 9 compatible APIs. This is an early alpha release of Eclipse GlassFish 6. See the download page to get your copy.
+
+### September 23, 2019 -- Eclipse GlassFish 5.1 is certified compatible with Eclipse Jakarta EE 8
+
+Eclipse GlassFish 5.1 was certified as part of the release of the Jakarta EE 8 specification. This certification was completed without requiring any changes to Eclipse GlassFish 5.1, released in January of this same year.
+
 ### January 28, 2019 -- Eclipse GlassFish 5.1 is released
 
 See the

--- a/docs/website/src/main/resources/README.md
+++ b/docs/website/src/main/resources/README.md
@@ -13,7 +13,7 @@ Eclipse GlassFish 5.1 is also Java EE 8 Compatible.
 
 This release contains new Jakarta EE 9 compatible APIs. This is an early alpha release of Eclipse GlassFish 6. See the download page to get your copy.
 
-### September 23, 2019 -- Eclipse GlassFish 5.1 is certified compatible with Eclipse Jakarta EE 8
+### September 10, 2019 -- Eclipse GlassFish 5.1 is certified compatible with Eclipse Jakarta EE 8
 
 Eclipse GlassFish 5.1 was certified as part of the release of the Jakarta EE 8 specification. This certification was completed without requiring any changes to Eclipse GlassFish 5.1, released in January of this same year.
 

--- a/docs/website/src/main/resources/download.md
+++ b/docs/website/src/main/resources/download.md
@@ -1,4 +1,22 @@
-# Eclipse GlassFish 5.1 Downloads
+# Eclipse GlassFish Downloads
+
+## Eclipse GlassFish 6, Prerelease, milestone
+
+This is a pre-release to allow users, vendors, and all community members a glimpse into the changes forthcoming with Jakarta EE 9. This is not a stable release and is intended to allow users to begin evaluation of the proposed name-space and pruning changes included in this new EE 9 specification release. For more details on Jakarta EE 9, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/). We welcome your feedback! Please include the details provided in the **info** link when reporting any [issues](https://github.com/eclipse-ee4j/glassfish/issues).
+
+* [Eclipse GlassFish 6, Full Platform 6.0.0-M1](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-M1.zip), - [info](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-M1.info)
+* [Eclipse Glassfish 6, Web Profile 6.0.0-M1](http://download.eclipse.org/ee4j/glassfish/web-6.0.0-M1.zip), - [info](http://download.eclipse.org/ee4j/glassfish/web-6.0.0-M1.info)
+
+## Eclipse GlassFish 6, latest checkpoint
+
+These are constantly evolving. Check the latest [PR activity](https://github.com/eclipse-ee4j/glassfish/pulls) to see what is new and changed. We welcome your feedback! Please include the details provided in the **info** link when reporting any [issues](https://github.com/eclipse-ee4j/glassfish/issues).
+
+* [Eclipse GlassFish 6, Full Platform 6.0.0-SNAPSHOT](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-SNAPSHOT-nightly.zip), - [info](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-SNAPSHOT-nightly.info)
+* [Eclipse Glassfish 6, Web Profile 6.0.0-SNAPSHOT](http://download.eclipse.org/ee4j/glassfish/web-6.0.0-SNAPSHOT-nightly.zip), - [info](http://download.eclipse.org/ee4j/glassfish/web-6.0.0-SNAPSHOT-nightly.info)
+
+## Eclipse GlassFish 5.1 Downloads
+
+These are the latest stable releases of Eclipse GlassFish
 
 * [Eclipse GlassFish 5.1 - Full Platform](https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip)
 * [Eclipse GlassFish 5.1 - Web Profile](https://www.eclipse.org/downloads/download.php?file=/glassfish/web-5.1.0.zip)


### PR DESCRIPTION
Changes for GlassFish GH Pages site:
New news items
Added M1 download links to web-site download page.
You can preview the changes at https://edbratt.github.io/glassfish/
(Not exactly sure how to "push" these over to the gh-pages branch, once this is merged. I may need some additional guidance from what is in the Docs. readme)