### PR TITLE
Revert EL to RC1 as otherwise master is borked

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -82,8 +82,8 @@
         <!-- Jakarta API Versions -->
         
         <!-- Jakarta EL -->
-        <jakarta.el.version>4.0.0-RC2</jakarta.el.version>
-        <jakarta.el-api.version>4.0.0-RC2</jakarta.el-api.version>
+        <jakarta.el.version>4.0.0-RC1</jakarta.el.version>
+        <jakarta.el-api.version>4.0.0-RC1</jakarta.el-api.version>
 
         <!-- Jakarta Servlet -->
         <servlet-api.version>5.0.0-M1</servlet-api.version>        


### PR DESCRIPTION
master is borked with OSGI errors if we upgrade to EL RC2. This PR gets master back to stable.

Signed-off-by: smillidge <steve.millidge@payara.fish>


