### PR TITLE
Fix quick look tests when database doesn't start

### DIFF
--- a/appserver/tests/quicklook/gfproject/db-targets.xml
+++ b/appserver/tests/quicklook/gfproject/db-targets.xml
@@ -19,7 +19,7 @@
 
 <project name="db-targets" default="all" basedir=".">
 
-<target name="start-derby" depends="setOSConditions" if="v3">
+<target name="start-derby" depends="setOSConditions" >
     <antcall target="start-derby-unix"/>
     <antcall target="start-derby-windows"/>
 </target>
@@ -38,7 +38,7 @@
     </exec>
 </target>
 
-<target name="stop-derby" depends="setOSConditions" if="v3">
+<target name="stop-derby" depends="setOSConditions" >
     <antcall target="stop-derby-unix"/>
     <antcall target="stop-derby-windows"/>
 </target>


### PR DESCRIPTION
Remove of v3 property broke quick look tests

Signed-off-by: smillidge <steve.millidge@payara.fish>

