### PR TITLE
Fix OSGI errors in webservices12 tests

### DIFF
--- a/appserver/appclient/client/acc/osgi.bundle
+++ b/appserver/appclient/client/acc/osgi.bundle
@@ -26,5 +26,6 @@
 # The result is a non start-able OSGi bundle.
 # Making this import optional.
 Import-Package: \
+                        !org.glassfish.appclient.client.acc.agent.*, \
                         org.jboss.weld.environment.se;resolution:=optional, \
                         *


### PR DESCRIPTION
Fixes a lot of OSGI errors in webservices12 test suite leaving 16 remaining failures

Signed-off-by: smillidge <steve.millidge@payara.fish>
