### PR TITLE
Integrate Metro 3.0.0-M3, includes JAXB 3.0.0-M5

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -152,7 +152,7 @@
         <jsp-impl.version>3.0.0-RC1</jsp-impl.version>
 
         <!-- Used for Jakarta XML Web Services -->
-        <woodstox.version>5.3.0</woodstox.version>
+        <woodstox.version>6.2.1</woodstox.version>
         <stax2-api.version>4.2.1</stax2-api.version>
 
         <!-- Jakarta Standard Tag Library -->

--- a/appserver/tests/quicklook/wsit/JaxwsFromWsdl/etc/custom-client.xml
+++ b/appserver/tests/quicklook/wsit/JaxwsFromWsdl/etc/custom-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,12 +17,12 @@
 
 -->
 
-<bindings 
+<bindings
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+    xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
     wsdlLocation="http://localhost:8080/JaxwsFromWsdl/addnumbers?wsdl"
-    xmlns="http://java.sun.com/xml/ns/jaxws">    
+    xmlns="https://jakarta.ee/xml/ns/jaxws">
     <bindings node="ns1:definitions" xmlns:ns1="http://schemas.xmlsoap.org/wsdl/">
         <package name="jaxwsfromwsdl.client"/>
     </bindings>

--- a/appserver/tests/quicklook/wsit/JaxwsFromWsdl/etc/custom-server.xml
+++ b/appserver/tests/quicklook/wsit/JaxwsFromWsdl/etc/custom-server.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,12 +17,12 @@
 
 -->
 
-<bindings 
+<bindings
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+    xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
     xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
     wsdlLocation="AddNumbers.wsdl"
-    xmlns="http://java.sun.com/xml/ns/jaxws">
+    xmlns="https://jakarta.ee/xml/ns/jaxws">
     <bindings node="ns1:definitions" xmlns:ns1="http://schemas.xmlsoap.org/wsdl/">
         <package name="jaxwsfromwsdl.server"/>
     </bindings>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -93,14 +93,14 @@
         <hibernate-validator.version>7.0.0.Alpha6</hibernate-validator.version>
 
         <!-- Jakarta Web Services -->
-        <webservices.version>3.0.0-M2</webservices.version>
+        <webservices.version>3.0.0-M3</webservices.version>
         
         <!-- Jakarta Inject -->
         <jakarta.inject-api.version>2.0.0</jakarta.inject-api.version> 
               
         <!-- Jakarta XML Binding -->
         <jakarta.jaxb-api.version>3.0.0</jakarta.jaxb-api.version>
-        <jakarta.jaxb-impl.version>3.0.0-M4</jakarta.jaxb-impl.version>
+        <jakarta.jaxb-impl.version>3.0.0-M5</jakarta.jaxb-impl.version>
         
         <!-- Jakarta REST -->
         <jax-rs-api.spec.version>3.0</jax-rs-api.spec.version>


### PR DESCRIPTION
this includes move to the new jakarta.ee namespace, see the change in quicklooks. Note that this may cause some regressions in (platform) TCKs. I prefer to fix them in the next integration (mostly to simplify debugging/testing of changes on my end) but I'm open to alternatives...