### PR TITLE
Update Jakarta Connectors to 2.0.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -127,7 +127,7 @@
         <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
 
         <!-- Jakarta Connectors -->
-        <jakarta.resource-api.version>2.0.0-RC3</jakarta.resource-api.version>
+        <jakarta.resource-api.version>2.0.0</jakarta.resource-api.version>
 
         <!-- Jakarta Batch -->
         <jakarta.batch-api.version>2.0.0</jakarta.batch-api.version>


### PR DESCRIPTION
Jakarta Connectors 2.0.0 is staged and 2.0.0-RC3 seems to have been removed.

https://jakarta.oss.sonatype.org/content/repositories/staging/jakarta/resource/jakarta.resource-api/