### PR TITLE
Update to Tyrus 2.0.0-RC1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -100,7 +100,7 @@
 
         <!-- Jakarta WebSocket -->
         <websocket-api.version>2.0.0</websocket-api.version>
-        <tyrus.version>2.0.0-M3</tyrus.version>
+        <tyrus.version>2.0.0-RC1</tyrus.version>
 
         <!-- Jakarta Concurrency -->
         <concurrent-api.version>2.0.0</concurrent-api.version>


### PR DESCRIPTION
Tyrus 2.0.0-RC1 is to be used for the WebSocket bullet