### PR TITLE
Bump OpenMQ and JMS API versions

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -117,7 +117,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0-RC1</jms-api.version>
-        <mq.version>6.0.0-M1</mq.version>
+        <mq.version>6.0.0-M2</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,7 +116,7 @@
         <soteria.version>2.0.0-M3</soteria.version>
 
         <!-- Jakarta Messaging -->
-        <jms-api.version>3.0.0-RC1</jms-api.version>
+        <jms-api.version>3.0.0</jms-api.version>
         <mq.version>6.0.0-M2</mq.version>
 
         <!-- Jakarta Persistence -->


### PR DESCRIPTION
There is new M-build of OpenMQ staged at https://jakarta.oss.sonatype.org/content/repositories/staging/org/glassfish/mq/mq-distribution/6.0.0-M2/.