### PR TITLE
Fix CNAME. 

### DIFF
--- a/docs/website/src/main/resources/CNAME
+++ b/docs/website/src/main/resources/CNAME
@@ -1,0 +1,1 @@
+glassfish.org


### PR DESCRIPTION
This file was accidentally committed to the gh-pages branch by the webmaster. Needs to be here in order for the glassfish.org domain to work.