### PR TITLE
Integrate Soteria 2.0.0

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1178,6 +1178,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.soteria</groupId>
+            <artifactId>soteria.spi.bean.decorator.weld</artifactId>
+            <exclusions><exclusion><groupId>*</groupId><artifactId>*</artifactId></exclusion></exclusions>
+        </dependency>
+        <dependency>
             <groupId>jakarta.security.enterprise</groupId>
             <artifactId>jakarta.security.enterprise-api</artifactId>
             <exclusions>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -113,7 +113,7 @@
         <jakarta.security.enterprise-api.version>2.0.0</jakarta.security.enterprise-api.version>
         <jakarta.authorization-api.version>2.0.0</jakarta.authorization-api.version>
         <jakarta.authentication-api.version>2.0.0</jakarta.authentication-api.version>
-        <soteria.version>2.0.0-M3</soteria.version>
+        <soteria.version>2.0.0</soteria.version>
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
@@ -250,6 +250,11 @@
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
                 <artifactId>jakarta.security.enterprise</artifactId>
+                <version>${soteria.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.soteria</groupId>
+                <artifactId>soteria.spi.bean.decorator.weld</artifactId>
                 <version>${soteria.version}</version>
             </dependency>
             


### PR DESCRIPTION
Jakarta Security TCK has been run against GlassFish 6 RC2 and Soteria
2.0.0.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>
