### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -117,7 +117,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.0.0</mq.version>
+        <mq.version>6.0.1</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
TCK - https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/17
```
$ curl -s https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/17/artifact/messaging-tck/bin/summary.txt | head -3
[javatest.batch] Number of Tests Passed      = 904
[javatest.batch] Number of Tests Failed      = 0
[javatest.batch] Number of Tests with Errors = 0
```