### PR TITLE
Exception in thread "Thread-0" java.lang.NoClassDefFoundError #21258

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingOutputStream.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -188,7 +188,17 @@ public class LoggingOutputStream extends ByteArrayOutputStream {
 
         public LoggingPrintStream(ByteArrayOutputStream os) {
             super(os, true);
-
+            ensureLoaded(StackTraceObjects.class);
+        }
+        
+        private void ensureLoaded(Class<?> k) {
+            try {
+                Class.forName(k.getName());
+            } catch (ClassNotFoundException ex) {
+                throw (NoClassDefFoundError)
+                    new NoClassDefFoundError(ex.toString()).initCause(ex);
+            } catch (SecurityException ignore) {
+            }
         }
 
         public void setLogger(Logger l) {


### PR DESCRIPTION
This is a fix for https://github.com/eclipse-ee4j/glassfish/issues/21258.  I'm the original submitter of this issue which was closed without a patch.  This pull request fixes the java.lang.NoClassDefFoundError by ensuring the needed class is loaded prior to GF being shutdown. The MailHandler in JavaMail 1.5.3 and later mostly work around the issue but it still can occur under the right conditions.  

Any code that registers a shutdown hook and write throwables to System.err or calls printStackTrace() could trigger this NoClassDefFoundError on LoggingOutputStream$StackTraceObjects.  3rd party java.util.logging.Hander instances would be the most common path as the java.util.logging.LogManager$Cleaner invokes Handler::close -> Handler::reportError ->ErrorManager:: error->Throwable::printStackTrace()-> com.sun.common.util.logging.LoggingOutputStream::println(Throwable).  This path will succeed only if StackTraceObjects was loaded prior to GF as described in https://github.com/eclipse-ee4j/glassfish/issues/21258.

The original test case for this was:
1. Installing the MailHandler (version older than JavaMail 1.5.3).
2. Set the wrong credentials in the logging.properties or stop smtp server.
3. Ensure MailHandler verification is set to remote to verify the SMTP login settings..
4. Shutdown GF.
5. Error contained in the MailHandler and the SMTP do not show in the console logs due to this issue.