### PR TITLE
Update maven plugins and poms accordingly.

### DIFF
--- a/appserver/admin/cli-optional/pom.xml
+++ b/appserver/admin/cli-optional/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -80,10 +80,11 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
-                        <manifestEntries>
-                               <Class-Path>../../modules/backup.jar ../../modules/common-util.jar ../../modules/glassfish-api.jar ../../modules/config-api.jar ../../modules/internal-api.jar ../../modules/config-types.jar ../../modules/grizzly-config.jar </Class-Path>
-                        </manifestEntries>
-                    </archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
++                           <classpathPrefix>../../modules</classpathPrefix>
+                        </manifest>
+                     </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/appserver/admin/cli/pom.xml
+++ b/appserver/admin/cli/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,10 +50,9 @@
                     <archive>
                         <manifest>
                             <mainClass>org.glassfish.admin.cli.AsadminMain</mainClass>
+                            <addClasspath>true</addClasspath>
++                           <classpathPrefix>../../modules</classpathPrefix>
                         </manifest>
-                        <manifestEntries>
-                            <Class-Path>../../modules/admin-cli.jar</Class-Path>
-                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/appserver/admin/template/pom.xml
+++ b/appserver/admin/template/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -83,7 +83,9 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
-                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <descriptors>
+                                <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
+                            </descriptors>
                             <finalName>classes</finalName>
                             <attach>false</attach>
                             <appendAssemblyId>false</appendAssemblyId>

--- a/appserver/distributions/glassfish/pom.xml
+++ b/appserver/distributions/glassfish/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,34 +17,19 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>glassfish</artifactId>
-    <name>Glassfish Distribution</name>
     <packaging>glassfish-distribution</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>glassfishbuild-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>create-domain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <name>Glassfish Distribution</name>
 
     <dependencies>
         <dependency>
@@ -74,4 +59,22 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-domain</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -164,6 +164,8 @@
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/lib/install/applications/metro</outputDirectory>
         </fileSet>
+        
+        <!-- admingui -->
         <fileSet>
             <directory>${temp.dir}/war</directory>
             <outputDirectory>${install.dir.name}/glassfish/lib/install/applications/__admingui</outputDirectory>
@@ -311,7 +313,6 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
-                <exclude>grizzly-npn-bootstrap.jar</exclude>
                 <exclude>grizzly-npn-api.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,16 +17,19 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
+
     <groupId>org.glassfish.main.distributions</groupId>
     <artifactId>distributions</artifactId>
+    <packaging>pom</packaging>
+
     <name>Glassfish distributions</name>
 
     <developers>
@@ -49,6 +52,12 @@
         </developer>
     </developers>
 
+    <modules>
+        <module>web</module>
+        <module>glassfish</module>
+        <module>glassfish-common</module>
+    </modules>
+
     <properties>
         <findbugs.skip>true</findbugs.skip>
         <stage.dir.name>stage</stage.dir.name>
@@ -59,42 +68,32 @@
         <create-domain.args>--user admin create-domain --template=${template.jar} --nopassword --savelogin=true --checkports=false --adminport 4848 --instanceport 8080 --keytooloptions CN=localhost domain1</create-domain.args>
     </properties>
 
-    <modules>
-        <module>web</module>
-        <module>glassfish</module>
-        <module>glassfish-common</module>
-    </modules>
-
     <build>
         <outputDirectory>${temp.dir}</outputDirectory>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <configuration>
-                        <includeEmptyDirs>true</includeEmptyDirs>
-                    </configuration>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>clean-domain</id>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                            <configuration>
+                                <directory>${project.build.directory}</directory>
+                                <includes>
+                                    <include>${stage.dir.name}/**/domains/**</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
                     <executions>
-                        <execution>
-                            <id>create-domain</id>
-                            <phase>process-resources</phase>
-                            <configuration>
-                                <executable>${stage.dir}/${install.dir.name}/bin/asadmin</executable>
-                                <commandlineArgs>${create-domain.args}</commandlineArgs>
-                            </configuration>
-                        </execution>
                         <execution>
                             <id>default-featuresets-dependencies</id>
                             <phase>process-resources</phase>
@@ -114,6 +113,17 @@
                                 </mappings>
                             </configuration>
                         </execution>
+                        
+                        <execution>
+                            <id>create-domain</id>
+                            <phase>process-resources</phase>
+                            <configuration>
+                                <executable>${stage.dir}/${install.dir.name}/bin/asadmin</executable>
+                                <commandlineArgs>${create-domain.args}</commandlineArgs>
+                            </configuration>
+                        </execution>
+                        
+                        <!-- Build glassfish.zip -->
                         <execution>
                             <id>default-zip</id>
                             <phase>package</phase>
@@ -185,21 +195,17 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>clean-domain</id>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                            <configuration>
-                                <directory>${project.build.directory}</directory>
-                                <includes>
-                                    <include>${stage.dir.name}/**/domains/**</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <configuration>
+                        <includeEmptyDirs>true</includeEmptyDirs>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,34 +17,19 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>distributions</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>web</artifactId>
-    <name>Glassfish Web Distribution</name>
     <packaging>glassfish-distribution</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>glassfishbuild-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>create-domain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <name>Glassfish Web Distribution</name>
 
     <dependencies>
         <dependency>
@@ -82,4 +67,22 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-domain</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/appserver/distributions/web/src/main/assembly/web.xml
+++ b/appserver/distributions/web/src/main/assembly/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -228,7 +228,6 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
-                <exclude>grizzly-npn-bootstrap.jar</exclude>
                 <exclude>grizzly-npn-api.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>

--- a/nucleus/admin/config-api/src/test/java/com/sun/enterprise/configapi/tests/UnprocessedEventsTest.java
+++ b/nucleus/admin/config-api/src/test/java/com/sun/enterprise/configapi/tests/UnprocessedEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,6 +82,19 @@ public class UnprocessedEventsTest  extends ConfigApiTest
             // check the result.
             String port = listener.getPort();
             assertEquals(port, "8908");
+
+            // ensure events are delivered.
+            transactions.waitForDrain();
+            assertNotNull(unprocessed);
+            
+            ConfigSupport.apply(new SingleConfigCode<NetworkListener>() {
+                public Object run(NetworkListener param) {
+                    param.setPort("8080");
+                    return null;
+                }
+            }, listener);
+                        
+            assertEquals(listener.getPort(), "8080");
 
             // ensure events are delivered.
             transactions.waitForDrain();

--- a/nucleus/core/api-exporter/pom.xml
+++ b/nucleus/core/api-exporter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,18 +17,21 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main.core</groupId>
         <artifactId>nucleus-core</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>api-exporter</artifactId>
     <packaging>glassfish-jar</packaging>
+
     <name>GlassFish API Exporter Module</name>
     <description>This bundle exposes APIs to application class loader hierarchy</description>
-    
+
     <developers>
         <developer>
             <id>ss141213</id>
@@ -40,31 +43,30 @@
         </developer>
     </developers>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-api</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <!-- Whenever you change this, please change core/kernel/.../APIClassLoaderServiceImpl.java -->
-                            <Bundle-SymbolicName>GlassFish-Application-Common-Module</Bundle-SymbolicName>
-                            <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
-                            <!-- This is the most important attribute of this bundle -->
-                            <DynamicImport-Package>*</DynamicImport-Package>
-                            <Bundle-Name>${project.name}</Bundle-Name>
-                            <Bundle-Description>${project.description}</Bundle-Description> 
-                        </manifestEntries>
-                    </archive>
+                    <instructions>
+                        <!-- Whenever you change this, please change core/kernel/.../APIClassLoaderServiceImpl.java -->
+                        <Bundle-SymbolicName>GlassFish-Application-Common-Module</Bundle-SymbolicName>
+                        <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
+                        <!-- This is the most important attribute of this bundle -->
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Bundle-Description>${project.description}</Bundle-Description>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2</artifactId>
-        </dependency>
-    </dependencies>
 </project>

--- a/nucleus/distributions/atomic/pom.xml
+++ b/nucleus/distributions/atomic/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,16 +17,36 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>nucleus-distributions</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>atomic</artifactId>
-    <name>Glassfish Atomic Distribution</name>
     <packaging>glassfish-distribution</packaging>
+
+    <name>Glassfish Atomic Distribution</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.featuresets</groupId>
+            <artifactId>atomic</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>nucleus-common</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -46,21 +66,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.glassfish.main.featuresets</groupId>
-            <artifactId>atomic</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.distributions</groupId>
-            <artifactId>nucleus-common</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-            <optional>true</optional>
-        </dependency>
-    </dependencies>
 </project>

--- a/nucleus/distributions/atomic/src/main/assembly/atomic.xml
+++ b/nucleus/distributions/atomic/src/main/assembly/atomic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -142,7 +142,6 @@
                 <exclude>org.osgi.util.promise.jar</exclude>
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
-                <exclude>grizzly-npn-bootstrap.jar</exclude>
                 <exclude>grizzly-npn-api.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/modules</outputDirectory>

--- a/nucleus/distributions/nucleus-common/pom.xml
+++ b/nucleus/distributions/nucleus-common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,15 +17,18 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>nucleus-distributions</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>nucleus-common</artifactId>
     <packaging>distribution-fragment</packaging>
+
     <name>Nucleus distribution Common module</name>
 
     <build>

--- a/nucleus/distributions/nucleus/pom.xml
+++ b/nucleus/distributions/nucleus/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,34 +17,19 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
         <groupId>org.glassfish.main.distributions</groupId>
         <artifactId>nucleus-distributions</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>nucleus-new</artifactId>
-    <name>Nucleus Distribution</name>
-    <packaging>glassfish-distribution</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>glassfishbuild-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>create-domain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+   <artifactId>nucleus-new</artifactId>
+   <packaging>glassfish-distribution</packaging>
+
+   <name>Nucleus Distribution</name>
 
    <dependencies>
         <dependency>
@@ -62,4 +47,22 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+   <build>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>glassfishbuild-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-domain</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
+++ b/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -99,7 +99,7 @@
         <fileSet>
             <directory>${temp.dir}</directory>
             <includes>
-                <include>grizzly-npn-bootstrap.jar</include>
+                <include>grizzly-npn-api.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/modules/endorsed</outputDirectory>
         </fileSet>
@@ -141,6 +141,7 @@
                 <exclude>org.apache.felix.gogo.runtime.jar</exclude>
                 <exclude>org.apache.felix.gogo.shell.jar</exclude>
                 <exclude>org.apache.felix.scr.jar</exclude>
+                <exclude>grizzly-npn-api.jar</exclude>
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,16 +17,19 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.glassfish.main</groupId>
         <artifactId>glassfish-nucleus-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
-    <packaging>pom</packaging>
+
     <groupId>org.glassfish.main.distributions</groupId>
     <artifactId>nucleus-distributions</artifactId>
+    <packaging>pom</packaging>
+
     <name>Nucleus distributions</name>
 
     <developers>
@@ -49,6 +52,12 @@
         </developer>
     </developers>
 
+    <modules>
+        <module>nucleus-common</module>
+        <module>atomic</module>
+        <module>nucleus</module>
+    </modules>
+
     <properties>
         <findbugs.skip>true</findbugs.skip>
         <stage.dir.name>stage</stage.dir.name>
@@ -59,42 +68,34 @@
         <create-domain.args>--user admin create-domain --nopassword --savelogin=true --checkports=false --adminport 4848 --instanceport 8080 --keytooloptions CN=localhost domain1</create-domain.args>
     </properties>
 
-    <modules>
-        <module>nucleus-common</module>
-        <module>atomic</module>
-        <module>nucleus</module>
-    </modules>
-
     <build>
         <outputDirectory>${temp.dir}</outputDirectory>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>clean-domain</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                            <configuration>
+                                <directory>${project.build.directory}</directory>
+                                <includes>
+                                    <include>${stage.dir.name}/domains/**</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <configuration>
-                        <includeEmptyDirs>true</includeEmptyDirs>
-                    </configuration>
-                </plugin>
+                
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
                     <executions>
-                        <execution>
-                            <id>create-domain</id>
-                            <phase>process-resources</phase>
-                            <configuration>
-                                <executable>${stage.dir}/${nucleus.install.dir.name}/bin/nadmin</executable>
-                                <commandlineArgs>${create-domain.args}</commandlineArgs>
-                            </configuration>
-                        </execution>
                         <execution>
                             <id>default-featuresets-dependencies</id>
                             <phase>process-resources</phase>
@@ -110,6 +111,16 @@
                                 </mappings>
                             </configuration>
                         </execution>
+                        
+                        <execution>
+                            <id>create-domain</id>
+                            <phase>process-resources</phase>
+                            <configuration>
+                                <executable>${stage.dir}/${nucleus.install.dir.name}/bin/nadmin</executable>
+                                <commandlineArgs>${create-domain.args}</commandlineArgs>
+                            </configuration>
+                        </execution>
+                        
                         <execution>
                             <id>default-zip</id>
                             <phase>package</phase>
@@ -135,6 +146,7 @@
                         </execution>
                     </executions>
                 </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
@@ -158,24 +170,21 @@
                         <useProjectArtifact>false</useProjectArtifact>
                     </configuration>
                 </plugin>
+                
+                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+                
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>clean-domain</id>
-                            <phase>initialize</phase>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                            <configuration>
-                                <directory>${project.build.directory}</directory>
-                                <includes>
-                                    <include>${stage.dir.name}/domains/**</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <configuration>
+                        <includeEmptyDirs>true</includeEmptyDirs>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved. 
+<!-- Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved. 
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v. 2.0, which is available at http://www.eclipse.org/legal/epl-2.0. 
     This Source Code may also be made available under the following Secondary 
@@ -94,6 +94,14 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <instructions>
                         <Import-Package>!android.os,*</Import-Package>
@@ -103,14 +111,6 @@
                         <Include-Resource>META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/</Include-Resource>
                     </instructions>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>bundle</id>
-                        <goals>
-                            <goal>bundle</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/nucleus/hk2/config-types/pom.xml
+++ b/nucleus/hk2/config-types/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,9 +50,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.glassfish.main.hk2</groupId>
+                <groupId>org.glassfish.hk2</groupId>
                 <artifactId>config-generator</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <excludes>**/.ade_path/**</excludes>
                     <supportedProjectTypes>jar,glassfish-jar</supportedProjectTypes>

--- a/nucleus/hk2/pom.xml
+++ b/nucleus/hk2/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,6 @@
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>config-generator</artifactId>
-                <version>2.5.0-b53</version>
                 <executions>
                     <execution>
                         <id>default-generate-test-injectors</id>
@@ -53,7 +52,6 @@
     <modules>
         <module>tiger-types</module>
         <module>hk2-config</module>
-        <module>config-generator</module>
         <module>config-types</module>
     </modules>
 </project>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@
         <findbugs.threshold>High</findbugs.threshold>
         <findbugs.common>exclude-common.xml</findbugs.common>
         <findbugs.exclude />
-        <findbugs.version>3.0.3</findbugs.version>
+        <findbugs.version>3.0.5</findbugs.version>
         <findbugs.glassfish.logging.validLoggerPrefixes>jakarta.enterprise</findbugs.glassfish.logging.validLoggerPrefixes>
         
         <!-- Jakarta API Versions -->
@@ -127,11 +127,9 @@
         <gmbal.version>4.0.2</gmbal.version>   
         <shoal.version>2.0.0</shoal.version>
         <ha-api.version>3.1.12</ha-api.version>
-        <glassfishbuild.version>3.2.27</glassfishbuild.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
         <command-security-plugin.version>1.0.11</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
-        <copyright-plugin.version>1.50</copyright-plugin.version>
 
         <!-- 3rd party dependencies -->
         <stax-api.version>1.0-2</stax-api.version>
@@ -197,17 +195,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.7</version>
+                    <version>1.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>5.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <compilerArgument>-Djava.endorsed.dirs=${project.build.directory}/endorsed</compilerArgument>
                         <source>1.8</source>
@@ -223,32 +221,32 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
-                    <version>${glassfishbuild.version}</version>
+                    <version>3.2.27</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.4.1</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>3.0.0-M4</version>
                     <configuration>
                         <useSystemClassLoader>true</useSystemClassLoader>
                         <forkCount>0</forkCount>
@@ -257,67 +255,52 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jvnet.updatecenter2</groupId>
-                    <artifactId>maven-makepkgs-plugin</artifactId>
-                    <version>0.5.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-remote-resources-plugin</artifactId>
-                    <version>1.1</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.4.3</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.7</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-eclipse-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>1.8</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>${copyright-plugin.version}</version>
+                    <version>2.4</version>
                     <configuration>
                         <scm>git</scm>
                         <scmOnly>true</scmOnly>
@@ -369,6 +352,28 @@
         </pluginManagement>
 
         <plugins>
+            <!-- Sets minimal Maven version to 3.5.4 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.4</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        
             <!-- force cleaning of the local repository
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -468,14 +473,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                    <skip>${deploy.skip}</skip>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-inhabitant-generator</artifactId>
@@ -483,32 +481,15 @@
                     <supportedProjectTypes>jar,ejb,war,glassfish-jar</supportedProjectTypes>
                 </configuration>
             </plugin>
+            
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
+                <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <downloadSources>true</downloadSources>
-                    <downloadJavadocs>true</downloadJavadocs>
-                    <addGroupIdToProjectName>true</addGroupIdToProjectName>
+                    <useSystemClassLoader>true</useSystemClassLoader>
+                    <forkCount>0</forkCount>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathLayoutType>custom</classpathLayoutType>
-                            <customClasspathLayout>${artifact.artifactId}.${artifact.extension}</customClasspathLayout>
-                        </manifest>
-                    </archive>
-                    <excludes>
-                        <exclude>**/.ade_path/**</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
+            
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -516,10 +497,7 @@
                     <!-- By default, we don't export anything. -->
                     <Export-Package />
                     <instructions>
-                        <!-- Read all the configuration from osgi.bundle file, if it exists.
-                             See Felix-699 to find out why we use ${basedir}.
-                        -->
-                        <_include>-${basedir}/osgi.bundle</_include>
+                        <_include>-osgi.bundle</_include>
                     </instructions>
                     <excludeDependencies>tools-jar</excludeDependencies>
                     <supportedProjectTypes>
@@ -527,6 +505,50 @@
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <niceManifest>true</niceManifest>
+                </configuration>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-manifest</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo>Generating manifest for ${project.build.outputDirectory}/META-INF for ${project.artifactId}</echo>
+                                <echo file="${basedir}/target/MANIFEST.MF">Manifest-Version: 1.0</echo>
+                                <copy toDir="${project.build.outputDirectory}/META-INF" overwrite="false">
+                                    <fileset dir="${basedir}/target" includes="MANIFEST.MF">
+                                        <present targetdir="${project.build.outputDirectory}/META-INF" present="srconly" />
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathLayoutType>custom</classpathLayoutType>
+                            <customClasspathLayout>${artifact.artifactId}.${artifact.extension}</customClasspathLayout>
+                        </manifest>
+                        
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                    <excludes>
+                        <exclude>**/.ade_path/**</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             
@@ -540,13 +562,17 @@
                     </excludes>
                 </configuration>
             </plugin>
+            
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <useSystemClassLoader>true</useSystemClassLoader>
-                    <forkCount>0</forkCount>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <skip>${javadoc.skip}</skip>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>osgiversion-maven-plugin</artifactId>
@@ -558,6 +584,15 @@
                 <configuration>
                     <dropVersionComponent>qualifier</dropVersionComponent>
                     <versionPropertyName>project.osgi.version</versionPropertyName>
+                </configuration>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+                    <skip>${deploy.skip}</skip>
                 </configuration>
             </plugin>
 
@@ -599,15 +634,6 @@
                 <version>${command-security-plugin.version}</version>
                 <configuration>
                     <isFailureFatal>${command.security.maven.plugin.isFailureFatal}</isFailureFatal>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <detectOfflineLinks>false</detectOfflineLinks>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                    <skip>${javadoc.skip}</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -91,9 +91,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.glassfish.main.hk2</groupId>
+                    <groupId>org.glassfish.hk2</groupId>
                     <artifactId>config-generator</artifactId>
-                    <version>${project.version}</version>
+                    <version>2.5.0-b53</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -122,7 +122,6 @@
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>config-generator</artifactId>
-                <version>2.5.0-b53</version>
                 <configuration>
                     <excludes>**/.ade_path/**</excludes>
                     <supportedProjectTypes>jar,glassfish-jar</supportedProjectTypes>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -79,6 +79,32 @@
     -->
     <build>
         <defaultGoal>install</defaultGoal>
+        
+        <plugins>
+            <!-- Sets minimal Maven version to 3.5.4 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.4</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        
+        
         <pluginManagement>
             <plugins>
                 <plugin>


### PR DESCRIPTION
Update Maven plugin versions, which fixes build issues and exceptions (like concurrent modification) when building on newer JDKs.

Update poms in project for the changes some of these plugin updates cause.
