### PR TITLE
Change to grizzly-npn-api instead of grizzly-npn-bootstrap

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -207,7 +207,7 @@
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/webservices-api-osgi.jar</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-api.jar</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
       </java-config>
@@ -392,7 +392,7 @@
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/webservices-api-osgi.jar</jvm-options>
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-api.jar</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
          </java-config>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -173,7 +173,7 @@
         <jvm-options>-XX:NewRatio=2</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
+        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-api.jar</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
       </java-config>
@@ -321,7 +321,7 @@
              <!-- End of OSGi bundle configurations -->
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-bootstrap.jar</jvm-options>
+             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/endorsed/grizzly-npn-api.jar</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
          </java-config>


### PR DESCRIPTION
Resolves the `ClassNotFoundException` thrown on startup for `org.glassfish.grizzly.npn.AlpnServerNegotiator
`
