### PR TITLE
javax.ejb.EJB to jakarta.ejb.EJB

### DIFF
--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/hello/session/client/Client.java.token
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/hello/session/client/Client.java.token
@@ -2,7 +2,7 @@ package com.sun.s1asdev.ejb.ejb30.hello.session.client;
 
 import java.io.*;
 import java.util.*;
-import javax.ejb.EJB;
+import jakarta.ejb.EJB;
 import javax.naming.InitialContext;
 import com.sun.s1asdev.ejb.ejb30.hello.session.*;
 import com.sun.ejte.ccl.reporter.SimpleReporterAdapter;


### PR DESCRIPTION
Hopefully the last one. The token file is used to generate Client.java which results in compilation error due to javax namespace. This occurs when ejb_group_1 test is executed.