### PR TITLE
Remove module jars from Xbootclasspath

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -204,9 +204,6 @@
         <jvm-options>-XX:NewRatio=2</jvm-options>
         <!-- Woodstox property needed to pass StAX TCK -->
         <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/webservices-api-osgi.jar</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/resolver.jar</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
@@ -393,9 +390,6 @@
              -->
              <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
              <!-- End of OSGi bundle configurations -->
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/webservices-api-osgi.jar</jvm-options>
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/resolver.jar</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -171,8 +171,6 @@
         <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
         <!-- End of OSGi bundle configurations -->
         <jvm-options>-XX:NewRatio=2</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
@@ -322,8 +320,6 @@
              -->
              <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
              <!-- End of OSGi bundle configurations -->
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.annotation-api.jar</jvm-options>
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/modules/jakarta.xml.bind-api.jar</jvm-options>
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>


### PR DESCRIPTION
The below Xbootclasspath entries are not present in 6.0 and is added recently.

- jakarta.annotation-api.jar
- jakarta.xml.bind-api.jar
- webservices-api-osgi.jar

The server seems to start fine without these entries. Is there any reason for these jars to be added to the bootclasspath?