### PR TITLE
#23031 Update docker image for JDK 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,16 +70,7 @@ def generateStage(job) {
                           retry(3) {
                               timeout(time: 2, unit: 'HOURS') {
                                 sh """
-                                  export JAVA_HOME=/usr/lib/jvm/jdk11
-                                  JAVA_HOME=/usr/lib/jvm/jdk11
-                                  export PATH=/usr/lib/jvm/jdk11/bin:${PATH}
-                                  PATH=/usr/lib/jvm/jdk11/bin:${PATH}
                                   export CLASSPATH=$WORKSPACE/glassfish6/javadb
-                                  
-                                  echo ${JAVA_HOME}
-                                  
-                                  java -version
-                                  
                                   ./appserver/tests/gftest.sh run_test ${job}
                                 """
                               }
@@ -161,7 +152,7 @@ spec:
         cpu: "1"
   - name: glassfish-ci
     # Docker image defined in this project in [glassfish]/etc/docker/Dockerfile
-    image: ee4jglassfish/ci:tini-jdk-8.252-11.0.7
+    image: ee4jglassfish/ci:tini-jdk-11.0.10
     args:
     - cat
     tty: true
@@ -226,9 +217,6 @@ spec:
               
               echo Uname
               uname -a
-              
-              export JAVA_HOME=/usr/lib/jvm/jdk11
-              export PATH=${JAVA_HOME}/bin:${PATH}
               
               bash -xe ./gfbuild.sh build_re_dev
             '''

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -4,14 +4,11 @@ ADD ./entrypoint.sh /etc/
 
 #
 # The JDK was got from the following releases:
-#  -JDK8: https://github.com/AdoptOpenJDK/openjdk8-upstream-binaries/
-#         releases/download/jdk8u252-b09/OpenJDK8U-jdk_x64_linux_8u252b09.tar.gz
 #  -JDK11: https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/
-#          releases/download/jdk-11.0.7%2B10/OpenJDK11U-jdk_x64_linux_11.0.7_10.tar.gz
+#          releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_11.0.10_9.tar.gz
 # Since the JDK is a very large file, download and add the file manually.
 #
-ADD ./openjdk-8u252-b09 /usr/lib/jvm/jdk8
-ADD ./openjdk-11.0.7+10 /usr/lib/jvm/jdk11
+ADD ./openjdk-11.0.10_9 /usr/lib/jvm/jdk11
 
 RUN chmod +x /etc/entrypoint.sh && \
     #
@@ -22,9 +19,8 @@ RUN chmod +x /etc/entrypoint.sh && \
     #
     # setup jdk
     #
-    cp -Lf /etc/pki/java/cacerts /usr/lib/jvm/jdk8/jre/lib/security/cacerts && \
-    ln -s /usr/lib/jvm/jdk8/bin/* /bin/ && \
     cp -Lf /etc/pki/java/cacerts /usr/lib/jvm/jdk11/lib/security/cacerts && \
+    ln -s /usr/lib/jvm/jdk11/bin/* /bin/ && \
     #
     # install maven
     #
@@ -56,7 +52,7 @@ RUN chmod +x /etc/entrypoint.sh && \
     chmod 777 -R /home/jenkins/.m2/repository/org/glassfish/main && \
     chown -R jenkins:root /home/jenkins
 
-ENV JAVA_HOME /usr/lib/jvm/jdk8
+ENV JAVA_HOME /usr/lib/jvm/jdk11
 ENV MAVEN_HOME /usr/share/maven
 ENV M2_HOME /usr/share/maven
 ENV ANT_HOME /usr/share/ant

--- a/etc/docker/Makefile
+++ b/etc/docker/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-IMAGE_TAG = jdk-8.181
+IMAGE_TAG = tini-jdk-11.0.10
 
 .PHONY: clean docker-clean docker-build docker-push
 


### PR DESCRIPTION
The current CI uses a fat docker image with both JDK 8 and JDK 11 installed (ee4jglassfish/ci:tini-jdk-8.252-11.0.7).
Since it is no longer necessary to use JDK8 for GlassFish build, I created and pushed an docker image with latest JDK11 installed (ee4jglassfish/ci:tini-jdk-11.0.10).
https://hub.docker.com/layers/ee4jglassfish/ci/tini-jdk-11.0.10/images/sha256-09a5b6da861f984431bb0654db18faaa6c22622d83b2c78b556973ecb0294cc7?context=explore

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>