### PR TITLE
Fix QuickLook Full Profile Test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,8 @@ env.label = "glassfish-ci-pod-${UUID.randomUUID().toString()}"
 
 // list of test ids
 def jobs = [
-  "cdi_all"
+  "cdi_all",
+  "ql_gf_full_profile_all"
 ]
 
 

--- a/appserver/tests/quicklook/gfproject/build-impl.xml
+++ b/appserver/tests/quicklook/gfproject/build-impl.xml
@@ -49,18 +49,10 @@
             <include name="**/glassfish-api.jar"/>
             <include name="**/amx-core.jar"/>
             <include name="**/amx-javaee.jar"/>
-            <include name="**/gf-client.jar"/>
-            <include name="**/jaxws-api.jar"/>
-            <include name="**/webservices-osgi.jar"/>
-            <include name="**/webservices-rt.jar"/>
-            <include name="**/jaxb-osgi.jar"/>
-            <include name="**/jakarta.activation-api.jar"/>
-        </fileset>
-        <fileset dir="${glassfish.home}/modules/endorsed">
-            <include name="**/webservices-api-osgi.jar"/>
-            <include name="**/jakarta.xml.bind-api.jar"/>
-            <include name="**/jakarta.annotation-api.jar"/>
             <include name="**/gf-client-module.jar"/>
+        </fileset>
+        <fileset dir="${glassfish.home}/lib">
+            <include name="**/resolver.jar"/>
         </fileset>
 	<fileset dir="${maven.repo.local}/com/beust/jcommander">
 	    <include name="**/1.72/jcommander-1.72.jar"/>

--- a/appserver/tests/quicklook/gfproject/build-impl.xml
+++ b/appserver/tests/quicklook/gfproject/build-impl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/appserver/tests/quicklook/gfproject/db-targets.xml
+++ b/appserver/tests/quicklook/gfproject/db-targets.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -204,6 +204,6 @@
 <target name="initprop" >
     <echo message="JavaDB Database Location : ${derby.home}" />
     <property name="ips.derby" value="${glassfish.home}/../javadb"/>
-    <property name="db.class.path" value="${derby.home}/lib/derbyclient.jar:${ips.derby}/lib/derbyclient.jar"/>
+    <property name="db.class.path" value="${derby.home}/lib/derbyshared.jar:${derby.home}/lib/derbytools.jar:${derby.home}/lib/derbyclient.jar:${ips.derby}/lib/derbyclient.jar"/>
 </target>
 </project>

--- a/appserver/tests/quicklook/gfproject/derby.properties
+++ b/appserver/tests/quicklook/gfproject/derby.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,5 +24,5 @@ db.datasource=org.apache.derby.jdbc.ClientDataSource
 db.delimiter=;
 db.name=sun-appserv-samples
 db.url=jdbc:derby://localhost:${db.port}/${db.name};create=true;
-derby.home=${glassfish.home}/javadb
+derby.home=${glassfish.home}/../javadb
 ##Edit asadminpassword.txt file in same directory


### PR DESCRIPTION
The Apache Derby 10.15.2.0 seems to require `permission java.lang.RuntimePermission "getenv.SOURCE_DATE_EPOCH"` to be added to java.policy file to start the database in Network Mode.

The below file needs to be created in the user home directory
~/.java.policy
```
grant {
  permission java.lang.RuntimePermission "getenv.SOURCE_DATE_EPOCH";
};
```