### PR TITLE
#23388 Unable to create domain in nucleus distribution

### DIFF
--- a/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
+++ b/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
@@ -145,7 +145,6 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>
-                <exclude>jakarta.xml.bind-api.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/modules</outputDirectory>
         </fileSet>


### PR DESCRIPTION
jakarta.xml.bind-api.jar is missing in modules

Fixes #23388 