### PR TITLE
Integrate xml binding API 3.0.1, impl 3.0.1-b01

### DIFF
--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -562,36 +562,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- glassfish-appclient -->
         <dependency>

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -114,36 +114,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- glassfish-corba -->
         <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -148,13 +148,9 @@
         <wasp.version>3.0.1</wasp.version>
         
         <!-- Used for Jakarta XML Web Services -->
-        <woodstox.version>6.2.1</woodstox.version>
+        <woodstox.version>6.2.4</woodstox.version>
         <stax2-api.version>4.2.1</stax2-api.version>
   
-        <jaxws-api.version>2.3.1</jaxws-api.version>
-        <soap-api.version>1.4.0</soap-api.version>
-        <jakarta.jws-api.version>2.1.0</jakarta.jws-api.version>
-
         <!-- Jakarta Standard Tag Library -->
         <jstl-api.version>2.0.0</jstl-api.version>
         <jstl-impl.version>2.0.0</jstl-impl.version>
@@ -436,21 +432,6 @@
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
                 <version>${stax2-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.ws</groupId>
-                <artifactId>jaxws-api</artifactId>
-                <version>${jaxws-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.xml.soap</groupId>
-                <artifactId>javax.xml.soap-api</artifactId>
-                <version>${soap-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>jakarta.jws</groupId>
-                <artifactId>jakarta.jws-api</artifactId>
-                <version>${jakarta.jws-api.version}</version>
             </dependency>
             
             <!-- Jakarta XML Binding -->

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -151,18 +151,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.jws</groupId>
-            <artifactId>jakarta.jws-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <version>${easymock.version}</version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -99,8 +99,8 @@
         <jakarta.inject-api.version>2.0.0</jakarta.inject-api.version> 
               
         <!-- Jakarta XML Binding -->
-        <jakarta.jaxb-api.version>3.0.0</jakarta.jaxb-api.version>
-        <jakarta.jaxb-impl.version>3.0.0</jakarta.jaxb-impl.version>
+        <jakarta.jaxb-api.version>3.0.1</jakarta.jaxb-api.version>
+        <jakarta.jaxb-impl.version>3.0.1-b01</jakarta.jaxb-impl.version>
         
         <!-- Jakarta REST -->
         <jax-rs-api.spec.version>3.0</jax-rs-api.spec.version>
@@ -111,7 +111,7 @@
         <mail.version>2.0.0</mail.version>
         
         <!-- Jakarta Activation -->
-        <activation.version>2.0.0</activation.version>
+        <activation.version>2.0.1</activation.version>
         
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>2.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
activation 2.0.1

this also removes `javax` deps which were added after 6.0


NOTE: API dependencies are in staging only and should not be published yet

@arjantijms jaxb-impl 3.0.1-b01 has been updated in staging and QL are passing for me now. 