### PR TITLE
Fix#23405 Add an entry to enable TLS1.3 for HTTPS

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
@@ -1263,8 +1263,16 @@ public class PECoyoteConnector extends Connector {
         if (Boolean.valueOf(sslConfig.getTls12Enabled())) {
             if (needComma) {
                 sslProtocolsBuf.append(", ");
+            } else {
+                needComma = true;
             }
             sslProtocolsBuf.append("TLSv1.2");
+        }
+        if (Boolean.valueOf(sslConfig.getTls13Enabled())) {
+            if (needComma) {
+                sslProtocolsBuf.append(", ");
+            }
+            sslProtocolsBuf.append("TLSv1.3");
         }
         if (Boolean.valueOf(sslConfig.getSsl3Enabled()) ||
                 Boolean.valueOf(sslConfig.getTlsEnabled())) {

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
@@ -128,6 +128,9 @@ public class SSLConfigurator extends SSLEngineConfigurator {
                 if (Boolean.parseBoolean(ssl.getTls12Enabled())) {
                     tmpSSLArtifactsList.add("TLSv1.2");
                 }
+                if (Boolean.parseBoolean(ssl.getTls13Enabled())) {
+                    tmpSSLArtifactsList.add("TLSv1.3");
+                }
                 if (Boolean.parseBoolean(ssl.getSsl3Enabled())
                         || Boolean.parseBoolean(ssl.getTlsEnabled())) {
                     tmpSSLArtifactsList.add("SSLv2Hello");

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
@@ -35,6 +35,7 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     boolean TLS_ENABLED = true;
     boolean TLS11_ENABLED = true;
     boolean TLS12_ENABLED = true;
+    boolean TLS13_ENABLED = true;
     boolean TLS_ROLLBACK_ENABLED = true;
     boolean RENEGOTIATE_ON_CLIENT_AUTH_WANT = true;
     int MAX_CERT_LENGTH = 5;
@@ -183,6 +184,14 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
     String getTls12Enabled();
 
     void setTls12Enabled(String value);
+
+    /**
+     * Determines whether TLS 1.3 is enabled.
+     */
+    @Attribute(defaultValue = "" + TLS13_ENABLED, dataType = Boolean.class)
+    String getTls13Enabled();
+
+    void setTls13Enabled(String value);
 
     /**
      * Determines whether TLS rollback is enabled. TLS rollback should be enabled for Microsoft Internet Explorer 5.0


### PR DESCRIPTION
This is the minimum fix to enable TLS 1.3 for HTTPS on GlassFish.   refs #23405

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>