### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,7 +116,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.0.0</mq.version>
+        <mq.version>6.1.0-M1</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
TCK run: https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/20

```
[javatest.batch] Number of Tests Passed      = 903
[javatest.batch] Number of Tests Failed      = 1
[javatest.batch] Number of Tests with Errors = 0
...
[javatest.batch] FAILED........com/sun/ts/tests/signaturetest/jms/JMSSigTest.java#signatureTest_from_standalone
```
