### PR TITLE
#23418 Security API TCK failures with NPE

### DIFF
--- a/nucleus/security/core/src/main/resources/config/javaee.server.policy
+++ b/nucleus/security/core/src/main/resources/config/javaee.server.policy
@@ -59,6 +59,7 @@ grant codebase "file:/module/Web" {
     permission java.io.FilePermission "*", "read,write"; 
     permission java.io.FilePermission "SERVLET-CONTEXT-TEMPDIR", "read,write";
     permission java.util.PropertyPermission "*", "read";
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.jndi.ldap";
 };
 
 // Resource adapter EE permissions


### PR DESCRIPTION
Add required permission to resolve ClassNotFoundException

`com.sun.jndi.ldap` package is present in JDK but is not publicly visible. By adding the below permission the security manager will allow the web class loader to initialize the required class.

`permission java.lang.RuntimePermission "accessClassInPackage.com.sun.jndi.ldap";`

Fixes #23418 