### PR TITLE
#23420 The asadmin start-database command needs to include derbyshared.jar on the classpath for JDK11 support

### DIFF
--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DatabaseCommand.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DatabaseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,6 +76,7 @@ public abstract class DatabaseCommand extends CLICommand {
 	sClasspath.add(new File(sInstallRoot, "lib/asadmin/cli-optional.jar"));
         sDatabaseClasspath
                 .add(dbLocation,"lib","derby.jar")
+                .add(dbLocation,"lib","derbyshared.jar")
                 .add(dbLocation,"lib","derbytools.jar")
                 .add(dbLocation,"lib","derbynet.jar")
                 .add(dbLocation,"lib","derbyclient.jar");


### PR DESCRIPTION
Fixes #23420 