### PR TITLE
Add new permission for Derby 10.15

### DIFF
--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -128,6 +128,9 @@
       permission java.net.SocketPermission "*", "listen";
       permission java.net.SocketPermission "*", "accept";
       permission java.io.FilePermission       "<<ALL FILES>>", "write,read";
+
+      // Added for Derby 10.15.1.3 and above
+      permission org.apache.derby.shared.common.security.SystemPermission "engine", "usederbyinternals";
 
  };
 //Added for creating stub on JDK 11


### PR DESCRIPTION
`org.apache.derby.security.SystemPermission` is changed to `org.apache.derby.shared.common.security.SystemPermission` in Derby 10.15.

This permission is required if the server is started with an explicit policy file. The asadmin command to start the database does not use any policy file and derby creates its own basic security policy. The server.policy file is used in the TCK to start the derby server which is currently failing because this permission is missing.

Should resolve https://github.com/eclipse-ee4j/jakartaee-tck/issues/627 and hopefully start passing test cases dependent of database.