### PR TITLE
#23418 Security API TCK failures with NPE

### DIFF
--- a/nucleus/admin/template/src/main/resources/config/javaee.server.policy
+++ b/nucleus/admin/template/src/main/resources/config/javaee.server.policy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,6 +60,7 @@ grant codebase "file:/module/Web" {
     permission java.io.FilePermission "*", "read,write"; 
     permission java.io.FilePermission "SERVLET-CONTEXT-TEMPDIR", "read,write";
     permission java.util.PropertyPermission "*", "read";
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.jndi.ldap";
 };
 
 // Resource adapter EE permissions


### PR DESCRIPTION
Add required permission to resolve `ClassNotFoundException`

In the previous PR #23419 I made changes in `nucleus/security/core/src/main/resources/config/javaee.server.policy` which did not work.
