### PR TITLE
Failed to create signed jar for appclient

### DIFF
--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/servedcontent/ASJarSigner.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/jws/servedcontent/ASJarSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,8 +72,8 @@ public class ASJarSigner implements PostConstruct {
     /** default alias for signing if the admin does not specify one */
     private static final String DEFAULT_ALIAS_VALUE = "s1as";
 
-    private static final String DEFAULT_DIGEST_ALGORITHM = "SHA1";
-    private static final String DEFAULT_KEY_ALGORITHM = "RSA";
+    private static final String DEFAULT_DIGEST_ALGORITHM = "SHA-1";
+    private static final String DEFAULT_SIGNATURE_ALGORITHM = "SHA1withRSA";
     
     private static final SecuritySupport securitySupport = SecuritySupport.getDefaultInstance();
 
@@ -154,7 +154,7 @@ public class ASJarSigner implements PostConstruct {
                 
                 JarSigner signer = new JarSigner.Builder(privateKey, certPath)
                         .digestAlgorithm(DEFAULT_DIGEST_ALGORITHM)
-                        .signatureAlgorithm(DEFAULT_KEY_ALGORITHM)
+                        .signatureAlgorithm(DEFAULT_SIGNATURE_ALGORITHM)
                         .build();
                 
                 // TODO: add Attributes to Manifest and additionalContent

--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -138,3 +138,8 @@ grant codeBase "jrt:/jdk.compiler" {
       permission java.lang.RuntimePermission "getenv.JDK_JAVAC_OPTIONS";
       permission java.lang.RuntimePermission "createClassLoader";
 };
+
+// Following grant block is required for using JDK JarSigner
+grant {
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
+};


### PR DESCRIPTION
`ASJarSigner.java` fails with  `java.security.NoSuchAlgorithmException: RSA Signature not available` when creating a signed jar for appclient. See error logs below.

This PR changes the `DEFAULT_DIGEST_ALGORITHM` from `SHA1` to `SHA-1` and `DEFAULT_SIGNATURE_ALGORITHM` from `RSA` to `SHA1withRSA`.

See https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#signature-algorithms

```
[2021-03-16T07:52:27.338+0000] [glassfish 6.1] [WARNING] [NCLS-CORE-00090] [jakarta.enterprise.system.core] [tid: _ThreadID=39 _ThreadName=http-listener-1(4)] [timeMillis: 1615881147338] [levelValue: 900] [[
  Internal Server error: /___JWSappclient/___system/s1as/glassfish/lib/gf-client.jar
java.lang.RuntimeException: java.io.IOException: java.lang.Exception: Error attempting to create signed jar /opt/jakartaee-tck/vi/glassfish6/glassfish/lib/gf-client.jar with alias s1as
	at org.glassfish.appclient.server.core.jws.AppClientHTTPAdapter.service(AppClientHTTPAdapter.java:170)
	at com.sun.enterprise.v3.services.impl.ContainerMapper$HttpHandlerCallable.call(ContainerMapper.java:440)
	at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:144)
	at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:174)
	at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:153)
	at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:196)
	at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:88)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:246)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:178)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:118)
	at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:96)
	at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:51)
	at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:510)
	at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:82)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:83)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$100(WorkerThreadIOStrategy.java:34)
	at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:101)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535)
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.io.IOException: java.lang.Exception: Error attempting to create signed jar /opt/jakartaee-tck/vi/glassfish6/glassfish/lib/gf-client.jar with alias s1as
	at org.glassfish.appclient.server.core.jws.servedcontent.AutoSignedContent.isAvailable(AutoSignedContent.java:120)
	at org.glassfish.appclient.server.core.jws.RestrictedContentAdapter.serviceContent(RestrictedContentAdapter.java:204)
	at org.glassfish.appclient.server.core.jws.AppClientHTTPAdapter.service(AppClientHTTPAdapter.java:166)
	... 19 more
Caused by: java.lang.Exception: Error attempting to create signed jar /opt/jakartaee-tck/vi/glassfish6/glassfish/lib/gf-client.jar with alias s1as
	at org.glassfish.appclient.server.core.jws.servedcontent.ASJarSigner.signJar(ASJarSigner.java:168)
	at org.glassfish.appclient.server.core.jws.servedcontent.ASJarSigner.signJar(ASJarSigner.java:106)
	at org.glassfish.appclient.server.core.jws.servedcontent.AutoSignedContent.createSignedFile(AutoSignedContent.java:154)
	at org.glassfish.appclient.server.core.jws.servedcontent.AutoSignedContent.isAvailable(AutoSignedContent.java:118)
	... 21 more
Caused by: java.security.NoSuchAlgorithmException: RSA Signature not available
	at java.base/java.security.Signature.getInstance(Signature.java:267)
	at jdk.jartool/jdk.security.jarsigner.JarSigner$Builder.signatureAlgorithm(JarSigner.java:237)
	at org.glassfish.appclient.server.core.jws.servedcontent.ASJarSigner.signJar(ASJarSigner.java:157)
	... 24 more
]]
```