### PR TITLE
Remove resolver jar

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -203,7 +203,6 @@
         <!-- Woodstox property needed to pass StAX TCK -->
         <jvm-options>-Dcom.ctc.wstx.returnNullForDefaultNamespace=true</jvm-options>
         <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-        <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/resolver.jar</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
@@ -388,7 +387,6 @@
              <jvm-options>-Dfelix.fileinstall.disableConfigSave=false</jvm-options>
              <!-- End of OSGi bundle configurations -->
              <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/resolver.jar</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>

--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -258,7 +258,6 @@
                 <include>appserv-rt.jar</include>
                 <include>gf-client.jar</include>
                 <include>grizzly-npn-bootstrap.jar</include>
-                <include>resolver.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/lib</outputDirectory>
         </fileSet>
@@ -330,7 +329,6 @@
                 <exclude>mejb.jar</exclude>
                 <exclude>weld-se-core.jar</exclude>
                 <exclude>weld-se-shaded.jar</exclude>
-                <exclude>resolver.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/glassfish/modules</outputDirectory>
         </fileSet>

--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -813,10 +813,5 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.sun.org.apache.xml.internal</groupId>
-            <artifactId>resolver</artifactId>
-            <version>20050927</version>
-        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/quicklook/gfproject/build-impl.xml
+++ b/appserver/tests/quicklook/gfproject/build-impl.xml
@@ -51,9 +51,6 @@
             <include name="**/amx-javaee.jar"/>
             <include name="**/gf-client-module.jar"/>
         </fileset>
-        <fileset dir="${glassfish.home}/lib">
-            <include name="**/resolver.jar"/>
-        </fileset>
 	<fileset dir="${maven.repo.local}/com/beust/jcommander">
 	    <include name="**/1.72/jcommander-1.72.jar"/>
 	</fileset>


### PR DESCRIPTION
With metro 3.0.1-b01, the resolver.jar is no longer required to resolve `com.sun.org.apache.xml.internal.resolver.CatalogManager` in `com.sun.xml.ws.util.xml.XmlCatalogUtil`. See https://github.com/eclipse-ee4j/glassfish/issues/23373 for more details

I had introduced this jar as a stop-gap till the webservices-osgi.jar got multi release support.