### PR TITLE
#23424 ejb30/sec TCK failures

### DIFF
--- a/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtils.java
+++ b/appserver/security/ejb.security/src/main/java/com/sun/enterprise/iiop/security/GSSUtils.java
@@ -376,9 +376,11 @@ public class GSSUtils {
         if (token[index] != 0x06)
             throw new GSSException(GSSException.DEFECTIVE_TOKEN);
 
-        byte[] buf = new byte[token.length - index];
+        // add first two bytes to the MECH_OID_LEN
+        int oidlen = token[index+1] + 2;
+        byte[] buf = new byte[oidlen];
 
-        System.arraycopy(token, index, buf, 0, token.length - index);
+        System.arraycopy(token, index, buf, 0, oidlen);
 
         Oid mechoid = getOID(buf);
 


### PR DESCRIPTION
Copy the OID to buffer excluding the name

Fixes #23424 

Before fix, running the `main` method in `GSSUtils.java` throws : `GSSException: Improperly formatted ASN.1 DER encoding for Oid`

```
Returning OID in DER format
    OID = 2.23.130.1.1.1
    DER OID: 06 06 67 81 02 01 01 01
GSSUP_MECH_OID: 06 06 67 81 02 01 01 01
Returning OID in DER format
    OID = 1.3.6.1.5.6.4
    DER OID: 06 06 2b 06 01 05 06 04
GSS_NT_EXPORT_NAME_OID: 06 06 2b 06 01 05 06 04
Returning OID in DER format
    OID = 2.23.130.1.2.1
    DER OID: 06 06 67 81 02 01 02 01
GSS_NT_SCOPED_USERNAME_OID: 06 06 67 81 02 01 02 01
Returning OID in DER format
    OID = 2.23.130.1.1.1
    DER OID: 06 06 67 81 02 01 01 01
Length byte array : 82 01 d3
 Der length = 467
Returning OID in DER format
    OID = 2.23.130.1.1.1
    DER OID: 06 06 67 81 02 01 01 01
Attempting to import mechanism independent name
04 01 00 08 06 06 67 81 02 01 01 01 00 00 00 07
    64 65 66 61 75 6c 74
Mech OID length = 8
Mechanism specific name:
64 65 66 61 75 6c 74
Successfully imported mechanism independent name
BAR:default
Returning OID in DER format
    OID = 2.23.130.1.1.1
    DER OID: 06 06 67 81 02 01 01 01
Going to create a mechanism independent token
Mechanism independent token created:
60 24 06 06 67 81 02 01 01 01 64 75 6d 6d 79 5f
    67 73 73 5f 65 78 70 6f 72 74 5f 73 65 63 5f 63
    6f 6e 74 65 78 74
FOO:60 24 06 06 67 81 02 01 01 01 64 75 6d 6d 79 5f
    67 73 73 5f 65 78 70 6f 72 74 5f 73 65 63 5f 63
    6f 6e 74 65 78 74
Received mechanism independent token:
60 24 06 06 67 81 02 01 01 01 64 75 6d 6d 79 5f
    67 73 73 5f 65 78 70 6f 72 74 5f 73 65 63 5f 63
    6f 6e 74 65 78 74
Attempting to verify tokenheader in the mechanism independent token.
Mech OID length + Mech specific length = 36
Mechanism OID index : 2
iiop.IOexception
GSSException: Improperly formatted ASN.1 DER encoding for Oid
        at java.security.jgss/org.ietf.jgss.Oid.<init>(Oid.java:115)
        at com.sun.enterprise.iiop.security.GSSUtils.getOID(GSSUtils.java:279)
        at com.sun.enterprise.iiop.security.GSSUtils.verifyTokenHeader(GSSUtils.java:383)
        at com.sun.enterprise.iiop.security.GSSUtils.getMechToken(GSSUtils.java:334)
        at com.sun.enterprise.iiop.security.GSSUtils.main(GSSUtils.java:481)

iiop.name_exception
java.lang.NullPointerException
        at com.sun.enterprise.iiop.security.GSSUtils.dumpHex(GSSUtils.java:104)
        at com.sun.enterprise.iiop.security.GSSUtils.main(GSSUtils.java:483)
```