### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,7 +116,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.1.0-M1</mq.version>
+        <mq.version>6.1.0-M2</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
[TCK run](https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/22):
```
[javatest.batch] Number of Tests Passed      = 904
[javatest.batch] Number of Tests Failed      = 0
[javatest.batch] Number of Tests with Errors = 0
...
[javatest.batch] Mar 27, 2021, 8:47:33 AM Finished executing all tests, wait for cleanup...
[javatest.batch] Mar 27, 2021, 8:47:33 AM Harness done with cleanup from test run.
[javatest.batch] Total time = 3,247s
[javatest.batch] Setup time = 0s
[javatest.batch] Cleanup time = 0s
[javatest.batch] Test results: passed: 904
```
against [jakarta-messaging-tck-3.0.1](https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-910/jakarta-messaging-tck-3.0.1-tckinfo.txt)
```
***********************************************************************************
***                        TCK bundle information                               ***
*** Name:       jakarta-messaging-tck-3.0.1.zip                                     ***
*** Bundle Copied to URL:    http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-910/jakarta-messaging-tck-3.0.1.zip ***
*** Date and size: date: 2021-03-25 16:04:11.000000000 +0000, size(b): 8870431        ***
*** SHA256SUM: 7ef9c92184d6da3c6e932308ce38bb98a6d6215e4f19297e0c24cf3bd4b71ddc ***
***                                                                             ***
***********************************************************************************
```