### PR TITLE
javax -> jakarta namespace in template files

### DIFF
--- a/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/client/Client.java.dsd
+++ b/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/client/Client.java.dsd
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,8 @@ package com.sun.s1asdev.ejb.ejb30.persistence.tx_propagation.client;
 import java.io.*;
 import java.util.*;
 import java.sql.*;
-import javax.ejb.EJB;
-import javax.transaction.UserTransaction;
+import jakarta.ejb.EJB;
+import jakarta.transaction.UserTransaction;
 import jakarta.annotation.*;
 import jakarta.annotation.sql.*;
 import javax.sql.DataSource;

--- a/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/client/Client.java.nodsd
+++ b/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/client/Client.java.nodsd
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,8 +19,8 @@ package com.sun.s1asdev.ejb.ejb30.persistence.tx_propagation.client;
 import java.io.*;
 import java.util.*;
 import java.sql.*;
-import javax.ejb.EJB;
-import javax.transaction.UserTransaction;
+import jakarta.ejb.EJB;
+import jakarta.transaction.UserTransaction;
 import jakarta.annotation.*;
 import jakarta.annotation.sql.*;
 import javax.sql.DataSource;

--- a/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/ejb/SfulBean.java.dsd
+++ b/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/ejb/SfulBean.java.dsd
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,18 +23,18 @@ import java.util.HashMap;
 
 import javax.naming.InitialContext;
 
-import javax.ejb.Stateful;
-import javax.ejb.EJB;
-import javax.persistence.PersistenceContextType;
-import javax.persistence.PersistenceContext;
-import javax.persistence.EntityNotFoundException;
+import jakarta.ejb.Stateful;
+import jakarta.ejb.EJB;
+import jakarta.persistence.PersistenceContextType;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.annotation.sql.*;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.EJBException;
+import jakarta.ejb.TransactionAttribute;
+import jakarta.ejb.TransactionAttributeType;
+import jakarta.ejb.EJBException;
 
 @DataSourceDefinition(name = "java:app/jdbc/xa",
                         className = "org.apache.derby.jdbc.ClientXADataSource",

--- a/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/ejb/SfulBean.java.nodsd
+++ b/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/ejb/SfulBean.java.nodsd
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,18 +23,18 @@ import java.util.HashMap;
 
 import javax.naming.InitialContext;
 
-import javax.ejb.Stateful;
-import javax.ejb.EJB;
-import javax.persistence.PersistenceContextType;
-import javax.persistence.PersistenceContext;
-import javax.persistence.EntityNotFoundException;
+import jakarta.ejb.Stateful;
+import jakarta.ejb.EJB;
+import jakarta.persistence.PersistenceContextType;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.annotation.sql.*;
 
-import javax.persistence.EntityManager;
+import jakarta.persistence.EntityManager;
 
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.EJBException;
+import jakarta.ejb.TransactionAttribute;
+import jakarta.ejb.TransactionAttributeType;
+import jakarta.ejb.EJBException;
 
 @Stateful
 @EJB(name="ejb/SfulBean", 


### PR DESCRIPTION
Fixes compilation failures when `jdbc_all` tests are run.

