### PR TITLE
Fix various JDK11 warnings.

### DIFF
--- a/appserver/ha/ha-file-store/pom.xml
+++ b/appserver/ha/ha-file-store/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
@@ -16,20 +17,21 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>ha-file-store</artifactId>
-    <packaging>glassfish-jar</packaging>
-    
-    <name>GlassFish ha-file-store</name>
 
-    <developers>
+   <artifactId>ha-file-store</artifactId>
+   <packaging>glassfish-jar</packaging>
+
+   <name>GlassFish ha-file-store</name>
+
+   <developers>
         <developer>
             <id>mk111283</id>
             <name>Mahesh Kannan</name>
@@ -42,7 +44,7 @@
 	</developer>
     </developers>
 
-    <dependencies>
+   <dependencies>
         <dependency>
             <groupId>org.glassfish.ha</groupId>
             <artifactId>ha-api</artifactId>
@@ -52,18 +54,4 @@
             <artifactId>hk2-core</artifactId>
         </dependency>
     </dependencies>
-    
-    <build>
-        <!-- needed to build with JDK 1.5 or higher -->
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/appserver/ha/ha-shoal-cache-bootstrap/pom.xml
+++ b/appserver/ha/ha-shoal-cache-bootstrap/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
@@ -16,20 +17,21 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>ha-shoal-cache-bootstrap</artifactId>
-    <packaging>glassfish-jar</packaging>
-    
-    <name>GlassFish ha-shoal-cache-bootstrap</name>
 
-    <developers>
+   <artifactId>ha-shoal-cache-bootstrap</artifactId>
+   <packaging>glassfish-jar</packaging>
+
+   <name>GlassFish ha-shoal-cache-bootstrap</name>
+
+   <developers>
         <developer>
             <id>mk111283</id>
             <name>Mahesh Kannan</name>
@@ -42,7 +44,7 @@
 	</developer>
     </developers>
 
-    <dependencies>
+   <dependencies>
         <dependency>
             <groupId>org.glassfish.ha</groupId>
             <artifactId>ha-api</artifactId>
@@ -57,18 +59,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    
-    <build>
-        <!-- needed to build with JDK 1.5 or higher -->
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/appserver/ha/ha-shoal-store/pom.xml
+++ b/appserver/ha/ha-shoal-store/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
@@ -16,20 +17,21 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
    <parent>
         <groupId>org.glassfish.main.ha</groupId>
         <artifactId>ha</artifactId>
         <version>6.1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>ha-shoal-cache-store</artifactId>
-    <packaging>glassfish-jar</packaging>
-    
-    <name>GlassFish ha-shoal-store</name>
 
-    <developers>
+   <artifactId>ha-shoal-cache-store</artifactId>
+   <packaging>glassfish-jar</packaging>
+
+   <name>GlassFish ha-shoal-store</name>
+
+   <developers>
         <developer>
             <id>mk111283</id>
             <name>Mahesh Kannan</name>
@@ -42,7 +44,7 @@
 	</developer>
     </developers>
 
-    <dependencies>
+   <dependencies>
         <dependency>
             <groupId>org.glassfish.ha</groupId>
             <artifactId>ha-api</artifactId>
@@ -67,18 +69,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-    
-    <build>
-        <!-- needed to build with JDK 1.5 or higher -->
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/GroupOfNames.java
+++ b/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/GroupOfNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 package com.sun.jndi.ldap.obj;
 
 import java.security.Principal;
-import java.security.acl.Group;
+import com.sun.enterprise.security.GroupPrincipal;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -112,7 +112,7 @@ import com.sun.jndi.ldap.LdapURL;
  *
  * @author Vincent Ryan
  */
-public class GroupOfNames implements Group {
+public class GroupOfNames implements GroupPrincipal {
 
     private static final boolean debug = false;
     private static final String OBJECT_CLASS = "groupOfNames";
@@ -382,7 +382,7 @@ public class GroupOfNames implements Group {
      * @return Enumeration The list of members of the group. 
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then each element in the enumeration is of class 
-     *         {@link java.security.acl.Group} or
+     *         {@link com.sun.enterprise.security.GroupPrincipal} or
      *         {@link java.security.Principal}. However, when additional
      *         object factories are active then the enumeration may contain
      *         elements of a different class.
@@ -842,7 +842,7 @@ class Members implements NamingEnumeration {
     /**
      * Retrieve the next member of the group.
      * Some members may themselves be groups. Such a member is returned as 
-     * an object of class {@link java.security.acl.Group}.
+     * an object of class {@link com.sun.enterprise.security.GroupPrincipal}.
      * <p>
      * Note that in order to determine whether a member is itself a group
      * this method reads each member's LDAP entry. As this is potentially an
@@ -857,7 +857,7 @@ class Members implements NamingEnumeration {
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then an object of class 
      *         {@link java.security.Principal} or
-     *         {@link java.security.acl.Group} is returned.
+     *         {@link com.sun.enterprise.security.GroupPrincipal} is returned.
      *         However, when additional object factories are active then an
      *         object of a different class may be returned.
      * @throws NoSuchElementException If no more members exist or if a
@@ -876,7 +876,7 @@ class Members implements NamingEnumeration {
     /**
      * Retrieve the next member of the group.
      * Some members may themselves be groups. Such a member is returned as 
-     * an object of class {@link java.security.acl.Group}.
+     * an object of class {@link com.sun.enterprise.security.GroupPrincipal}.
      * <p>
      * Note that in order to determine whether a member is itself a group
      * this method reads each member's LDAP entry. As this is potentially an
@@ -891,7 +891,7 @@ class Members implements NamingEnumeration {
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then an object of class 
      *         {@link java.security.Principal} or
-     *         {@link java.security.acl.Group} is returned.
+     *         {@link com.sun.enterprise.security.GroupPrincipal} is returned.
      *         However, when additional object factories are active then an
      *         object of a different class may be returned.
      * @throws NamingException If a problem is encountered while retrieving the

--- a/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/GroupOfURLs.java
+++ b/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/GroupOfURLs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 package com.sun.jndi.ldap.obj;
 
 import java.security.Principal;
-import java.security.acl.Group;
+import com.sun.enterprise.security.GroupPrincipal;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -112,7 +112,7 @@ import com.sun.jndi.ldap.LdapURL;
  *
  * @author Vincent Ryan
  */
-public class GroupOfURLs implements Group {
+public class GroupOfURLs implements GroupPrincipal {
 
     private static final boolean debug = false;
     private static final String OBJECT_CLASS = "groupOfURLs";
@@ -358,7 +358,7 @@ public class GroupOfURLs implements Group {
      * @return Enumeration The list of members of the group.
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then each element in the enumeration is of class 
-     *         {@link java.security.acl.Group} or
+     *         {@link com.sun.enterprise.security.GroupPrincipal} or
      *         {@link java.security.Principal} However, when additional
      *         object factories are active then the enumeration may contain
      *         elements of a different class.
@@ -393,7 +393,7 @@ public class GroupOfURLs implements Group {
      * @return Enumeration The list of members that satisfy the filter.
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then each element in the enumeration is of class 
-     *         {@link java.security.acl.Group} or
+     *         {@link com.sun.enterprise.security.GroupPrincipal} or
      *         {@link java.security.Principal} However, when additional
      *         object factories are active then the enumeration may contain
      *         elements of a different class.
@@ -972,13 +972,13 @@ class Members implements NamingEnumeration {
     /**
      * Retrieve the next member of the group.
      * Some members may themselves be groups. Such a member is returned as 
-     * an object of class {@link java.security.acl.Group}.
+     * an object of class {@link com.sun.enterprise.security.GroupPrincipal}.
      *
      * @return The next member of the group.
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then an object of class 
      *         {@link java.security.Principal} or
-     *         {@link java.security.acl.Group} is returned.
+     *         {@link com.sun.enterprise.security.GroupPrincipal} is returned.
      *         However, when additional object factories are active then an
      *         object of a different class may be returned.
      * @throws NoSuchElementException If no more members exist or if a
@@ -997,13 +997,13 @@ class Members implements NamingEnumeration {
     /**
      * Retrieve the next member of the group.
      * Some members may themselves be groups. Such a member is returned as 
-     * an object of class {@link java.security.acl.Group}.
+     * an object of class {@link com.sun.enterprise.security.GroupPrincipal}.
      *
      * @return The next member of the group.
      *         When only the {@link LdapGroupFactory} object factory is active 
      *         then an object of class 
      *         {@link java.security.Principal} or
-     *         {@link java.security.acl.Group} is returned.
+     *         {@link com.sun.enterprise.security.GroupPrincipal} is returned.
      *         However, when additional object factories are active then an
      *         object of a different class may be returned.
      * @throws NamingException If a problem is encountered while retrieving the

--- a/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/LdapGroupFactory.java
+++ b/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/LdapGroupFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,7 @@
 
 package com.sun.jndi.ldap.obj;
 
-import java.security.acl.Group;
+import com.sun.enterprise.security.GroupPrincipal;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import javax.naming.*;

--- a/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/LdapGroupFactory.java
+++ b/appserver/ldapbp/src/main/java/com/sun/jndi/ldap/obj/LdapGroupFactory.java
@@ -16,7 +16,6 @@
 
 package com.sun.jndi.ldap.obj;
 
-import com.sun.enterprise.security.GroupPrincipal;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import javax.naming.*;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/realm/JAASRealm.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/realm/JAASRealm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ import static com.sun.logging.LogCleanerUtil.neutralizeForLog;
 import javax.security.auth.Subject;
 import javax.security.auth.login.*;
 import java.security.Principal;
-import java.security.acl.Group;
+import com.sun.enterprise.security.GroupPrincipal;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -398,9 +398,9 @@ public class JAASRealm
                 roles.add(principal.getName());
             }
             // Same as Jboss - that's a pretty clean solution
-            if( (principal instanceof Group) &&
+            if( (principal instanceof GroupPrincipal) &&
                  "Roles".equals( principal.getName())) {
-                Group grp=(Group)principal;
+                GroupPrincipal grp=(GroupPrincipal)principal;
                 Enumeration en=grp.members();
                 while( en.hasMoreElements() ) {
                     Principal roleP=(Principal)en.nextElement();

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -90,8 +90,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <excludes>
                         <exclude>**/.ade_path/**</exclude>
                         <exclude>**/ha/spi/*.java</exclude>

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ASURLClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -962,9 +962,14 @@ public class ASURLClassLoader
         /**
          * @see java.lang.Object#finalize()
          */
+        @Deprecated(since = "6.1.0", forRemoval = true)
         protected void finalize() throws IOException {
-            super.finalize();
-            reallyClose();
+            try {
+                super.finalize();
+                reallyClose();
+            } catch (Throwable t) {
+                throw new IOException(t);
+            }
         }
     }
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -689,6 +689,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M4</version>
                     <configuration>
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                         <useSystemClassLoader>true</useSystemClassLoader>
                         <forkCount>1</forkCount>
                     </configuration>

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/GroupPrincipal.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/GroupPrincipal.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Contributors to Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.security;
+
+import java.util.Enumeration;
+import java.security.Principal;
+
+/**
+ * A group of principals.
+ * 
+ * @author Arjan Tijms
+ *
+ */
+public interface GroupPrincipal extends Principal {
+
+    /**
+     * Returns true when the given principal is in this group.
+     * 
+     * <p>
+     * A recursive search is done, meaning that if a principal is in a group which is itself in this group, the result is
+     * true.
+     *
+     * @param principal the principal for which we check to be in this group.
+     *
+     * @return true if the principal is in this group, false otherwise.
+     */
+    boolean isMember(Principal principal);
+
+    /**
+     * Returns an enumeration of all the principals in this group.
+     * 
+     * <p>
+     * The returned principals can include principals that are besides instanced of Principal also instances of
+     * GroupPrincipal.
+     *
+     * @return an enumeration of principals in this group, potentially including nested group principals.
+     */
+    Enumeration<? extends Principal> members();
+
+}


### PR DESCRIPTION
Specially, removed the usage of `java.security.acl.Group`, since it's
deprecated and will be removed (we can already see in later JDK versions
it's indeed remove there). Replaced it with a replacement class.

Also deprecated the one usage of a finalizer, and updated several poms
that were explicitly referring to ancient Java versions (at the time
they were intended for newer versions than the main version)

Signed-off-by: arjantijms <arjan.tijms@gmail.com>