### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,7 +116,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.1.0-M2</mq.version>
+        <mq.version>6.1.0-RC1</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
[TCK run](https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/23/):
```
[javatest.batch] Number of Tests Passed      = 904
[javatest.batch] Number of Tests Failed      = 0
[javatest.batch] Number of Tests with Errors = 0
...
[javatest.batch] Mar 30, 2021, 6:10:08 PM Finished executing all tests, wait for cleanup...
[javatest.batch] Mar 30, 2021, 6:10:08 PM Harness done with cleanup from test run.
[javatest.batch] Total time = 3,200s
[javatest.batch] Setup time = 0s
[javatest.batch] Cleanup time = 0s
[javatest.batch] Test results: passed: 904
```
against [jakarta-messaging-tck-3.0.1.zip](https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-910/jakarta-messaging-tck-3.0.1.zip)
```
***********************************************************************************
***                        TCK bundle information                               ***
*** Name:       jakarta-messaging-tck-3.0.1.zip                                     ***
*** Bundle Copied to URL:    http://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/staged-910/jakarta-messaging-tck-3.0.1.zip ***
*** Date and size: date: 2021-03-30 05:19:37.000000000 +0000, size(b): 8870410        ***
*** SHA256SUM: 256405c589c6997178f7c9fc9b1d05bb537730a77ca98537a815b0aa91f0f016 ***
***                                                                             ***
***********************************************************************************
```
