### PR TITLE
Activate embedded profile by default

### DIFF
--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -39,7 +39,7 @@
         <profile>
             <id>embedded</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>release-phase-all</name>
                     <value>true</value>


### PR DESCRIPTION
The embedded profile will be activated by default. This adds a few minutes to the build.

Fixes #23429 
