### PR TITLE
Maven4 clear pom warnings because of dependency duplicates

### DIFF
--- a/nucleus/featuresets/atomic/pom.xml
+++ b/nucleus/featuresets/atomic/pom.xml
@@ -1034,38 +1034,5 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>${jakarta.jaxb-api.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-osgi</artifactId>
-            <version>${jakarta.jaxb-impl.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-            <version>${activation.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 </project>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -123,6 +123,7 @@
         <glassfish-management-api.version>3.2.3</glassfish-management-api.version>
         <hk2.version>3.0.2</hk2.version>
         <hk2.plugin.version>3.0.2</hk2.plugin.version>
+		<hk2.config-generator.version>2.5.0-b53</hk2.config-generator.version>
         <pfl.version>4.1.2</pfl.version>
 
         <gmbal.version>4.0.3</gmbal.version>   
@@ -614,6 +615,13 @@
         </resources>
         <pluginManagement>
             <plugins>
+
+				<plugin>
+					<groupId>org.glassfish.hk2</groupId>
+					<artifactId>config-generator</artifactId>
+					<version>${hk2.config-generator.version}</version>
+				</plugin>
+
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
                     <artifactId>hk2-inhabitant-generator</artifactId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -91,11 +91,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.glassfish.hk2</groupId>
-                    <artifactId>config-generator</artifactId>
-                    <version>2.5.0-b53</version>
-                </plugin>
-                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>antlr-maven-plugin</artifactId>
                     <version>2.1</version>


### PR DESCRIPTION
When building with Maven4, there are maven warnings because of some dependency duplication in pom files of nuclues components. This PR fixes all of these warnings. I did a clean release with tests enabled and all seems ok.

Can you please check this PR?
