### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,7 +116,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.1.0</mq.version>
+        <mq.version>6.1.1</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
This is micro release of OpenMQ, the same as 6.1.0 with 
- jakarta.json updated to [2.0.1](https://repo.maven.apache.org/maven2/org/glassfish/jakarta.json/2.0.1/)
- jakarta.xml.soap-api updated to [2.0.1](https://repo.maven.apache.org/maven2/jakarta/xml/soap/jakarta.xml.soap-api/2.0.1/)