### PR TITLE
Use current Ant version with maven-antrun-extended-plugin for faster rejar

### DIFF
--- a/appserver/extras/embedded/build.xml
+++ b/appserver/extras/embedded/build.xml
@@ -101,7 +101,8 @@
         <defaultexcludes add="META-INF/**.inf"/>
         <defaultexcludes add="META-INF/**.SF"/>
 
-        <rejar destfile="${finaljar}" duplicate="preserve" >
+        <!-- level 9 - on modern machines the CPU is so fast that the difference in time is low. -->
+        <rejar destfile="${finaljar}" duplicate="preserve" level="9" >
             <manifest>
                 <attribute name="Bundle-SymbolicName" value="${bundlename}"/>
                 <attribute name="Main-Class" value="com.sun.enterprise.glassfish.bootstrap.UberMain"/>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -639,6 +639,14 @@
                     <groupId>org.jvnet.maven-antrun-extended-plugin</groupId>
                     <artifactId>maven-antrun-extended-plugin</artifactId>
                     <version>1.43</version>
+                    <dependencies>
+                        <!-- Much faster rejar than with original 1.6.5 -->
+                        <dependency>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant</artifactId>
+                            <version>1.10.10</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- original plugin uses 1.6.5
- 1.10.10 is much faster
- result is nearly the same
  - smaller file, same content, more meaningful file permissions