### PR TITLE
Fixed build stability when executed with -TC8

### DIFF
--- a/appserver/admin/template/pom.xml
+++ b/appserver/admin/template/pom.xml
@@ -29,6 +29,14 @@
     <name>Appserver template</name>
     <description>Appserver template</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.admin</groupId>
+            <artifactId>nucleus-domain</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
@@ -36,7 +44,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>validate</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>


### PR DESCRIPTION
- Maven reactor doesn't see the configuration of the maven dependency plugin
  when maven creates the dependency tree to build, so the dependency has to be
  explicitly declared also as a module's dependency
- validate phase should be used just to validate the build reactor, not to
  generate module's resources from dependencies.
- see also: https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference