### PR TITLE
Updated minimum JDK version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Building
 
 Prerequisites:
 
-* JDK8+
+* JDK11+
 * Maven 3.0.3+
 
 Currently in the master branch artifacts are being pulled from OSSRH staging.


### PR DESCRIPTION
Just a minor fix for the `README.md` file which currently lists JDK8 as a minimum JDK version. 

However, building Glassfish with JDK8 fails:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.981 s
[INFO] Finished at: 2021-05-22T13:33:39+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project tiger-types: Fatal error compiling: invalid target release: 11 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :tiger-types
```

AFAIK the `-release` flag was added in JDK9. But I guess that actually JDK11 is required.