### PR TITLE
Add Jakarta MVC 2.0 implementation Eclipse Krazo

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -263,6 +263,38 @@
             </exclusions>
         </dependency>
 
+        <!-- Jakarta MVC -->
+        <dependency>
+            <groupId>jakarta.mvc</groupId>
+            <artifactId>jakarta.mvc-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.krazo</groupId>
+            <artifactId>krazo-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.krazo</groupId>
+            <artifactId>krazo-jersey</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- glassfish-grizzly-full -->
         <dependency>
             <groupId>org.glassfish.main.grizzly</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -161,6 +161,10 @@
         <weld.version>4.0.1.SP1</weld.version>
         <jboss.classfilewriter.version>1.2.4.Final</jboss.classfilewriter.version>
 
+        <!-- Jakarta MVC -->
+        <mvc-api.version>2.0.0</mvc-api.version>
+        <krazo.version>2.0.1</krazo.version>
+
         <!-- Admin console components -->
         <jsftemplating.version>3.0.0</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
@@ -498,6 +502,22 @@
                 <version>${jboss.classfilewriter.version}</version>
             </dependency>
 
+            <!-- Jakarta MVC -->
+            <dependency>
+                <groupId>jakarta.mvc</groupId>
+                <artifactId>jakarta.mvc-api</artifactId>
+                <version>${mvc-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.krazo</groupId>
+                <artifactId>krazo-core</artifactId>
+                <version>${krazo.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.krazo</groupId>
+                <artifactId>krazo-jersey</artifactId>
+                <version>${krazo.version}</version>
+            </dependency>
 
             <!-- Admin console components -->
             <dependency>


### PR DESCRIPTION
This pull request adds the [Jakarta MVC 2.0](https://jakarta.ee/specifications/mvc/2.0/) implementation [Eclipse Krazo 2.0.1](https://eclipse-ee4j.github.io/krazo/downloads/2.0.1.html) to Eclipse Glassfish. Eclipse Krazo already provides the required OSGi manifests and no special integration code is required, so that adding the Jakarta MVC API and Eclipse Krazo to `glassfish/modules` is sufficient.

The TCK report of running the [Jakarta MVC TCK 2.0.0](https://download.eclipse.org/jakartaee/mvc/2.0/jakarta-mvc-tck-2.0.0.zip) against this branch can be found here:

https://eclipse-ee4j.github.io/krazo/reports/2.0.1-glassfish-integration/surefire-report.html

To run the TCK yourself, just start Glassfish (web or full distribution) and run the following commands:

```
$ git clone https://github.com/eclipse-ee4j/krazo.git && cd krazo
$ git checkout 2.0.1 
$ mvn -Pstaging -pl tck -Dtck-env=glassfish-module verify
```

It would be awesome to see Eclipse Glassfish supporting Jakarta MVC 2.0 out of the box.
