### PR TITLE
Small cleanups in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ nb-configuration.xml
 .DS_Store
 .project
 .settings/
-appserver/appclient/client/acc-config/temp/
 appserver/security/jaspic-provider-framework/auth.conf
 appserver/tests/appserv-tests/devtests/web/JSESSIONID
 /bundles/

--- a/appserver/admingui/cluster/pom.xml
+++ b/appserver/admingui/cluster/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console Clustering Support Plugin</name>
     <description>Clustering support plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console Common</name>
     <description>This bundle contains common code that may be shared across plugins.</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/appserver/admingui/community-theme/pom.xml
+++ b/appserver/admingui/community-theme/pom.xml
@@ -82,28 +82,9 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <excludes>
-                    <exclude>**/*.jar</exclude>
-                </excludes>
-            </resource>
-        </resources>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
@@ -120,7 +101,5 @@
             <artifactId>woodstock-webui-jsf-suntheme</artifactId>
             <scope>provided</scope>
         </dependency>
-
-
     </dependencies>
 </project>

--- a/appserver/admingui/concurrent/pom.xml
+++ b/appserver/admingui/concurrent/pom.xml
@@ -31,26 +31,6 @@
     <name>Admin Console Concurrent Plugin</name>
     <description>Concurrent (JSR236)  plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/corba/pom.xml
+++ b/appserver/admingui/corba/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console Corba Plugin</name>
     <description>Corba plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -30,34 +30,6 @@
 
     <name>Admin Console Core Jar</name>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <excludes>
-                    <exclude>**/*.jar</exclude>
-                </excludes>
-            </resource>
-        </resources>
-    </build>
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/dataprovider/pom.xml
+++ b/appserver/admingui/dataprovider/pom.xml
@@ -43,19 +43,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <!-- Configure maven-bundle-plugin which takes care of
                      OSGi packaging -->
                 <!-- We need to override the plugin settings -->

--- a/appserver/admingui/devtests/pom.xml
+++ b/appserver/admingui/devtests/pom.xml
@@ -204,19 +204,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>2.4.1</version>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>

--- a/appserver/admingui/ejb-lite/pom.xml
+++ b/appserver/admingui/ejb-lite/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console EJB Local (Lite) Plugin</name>
     <description>EJB Local (Lite) plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/ejb/pom.xml
+++ b/appserver/admingui/ejb/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console EJB Container Plugin</name>
     <description>EJB container plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/full/pom.xml
+++ b/appserver/admingui/full/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console Full distribution plugin</name>
     <description>Plugin bundle for GlassFish v3 Admin Console common-full package</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/jackson-jaxb/pom.xml
+++ b/appserver/admingui/jackson-jaxb/pom.xml
@@ -93,7 +93,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>add-jackson-jaxb-src</id>

--- a/appserver/admingui/jca/pom.xml
+++ b/appserver/admingui/jca/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console Connectors Plugin</name>
     <description>Connectors plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/jdbc/pom.xml
+++ b/appserver/admingui/jdbc/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console JDBC Plugin</name>
     <description>JDBC plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -73,18 +73,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/appserver/admingui/jts/pom.xml
+++ b/appserver/admingui/jts/pom.xml
@@ -31,27 +31,6 @@
     <name>Admin Console JTS Plugin</name>
     <description>Transaction Service plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/web/pom.xml
+++ b/appserver/admingui/web/pom.xml
@@ -30,27 +30,6 @@
     <name>Admin Console Web Container Plugin</name>
     <description>Web container plugin bundle for GlassFish Admin Console</description>
 
-    <developers>
-        <!-- See parent POM -->
-    </developers>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/appserver/appclient/client/acc-config/pom.xml
+++ b/appserver/appclient/client/acc-config/pom.xml
@@ -51,12 +51,12 @@
         generated using JAXB from sun-application-client-container_x_y.dtd.
     -->
     <properties>
-        <extracted-dtd-root>temp</extracted-dtd-root>
+        <extracted-dtd-root>target/extracted</extracted-dtd-root>
         <extracted-dtd-top-level-directory>${extracted-dtd-root}/glassfish</extracted-dtd-top-level-directory>
         <extracted-dtd-directory>${extracted-dtd-top-level-directory}/lib/dtds</extracted-dtd-directory>
         <dtd-for-jaxb-compilation>glassfish-application-client-container_1_3.dtd</dtd-for-jaxb-compilation>
         <config-dtd-file>*-application-client-container*.dtd</config-dtd-file>
-        <added-test-classpath>${project.build.directory}/../${extracted-dtd-root}</added-test-classpath>
+        <added-test-classpath>${project.basedir}/${extracted-dtd-root}</added-test-classpath>
         <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
     </properties>
 
@@ -186,24 +186,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <!-- Adds the temp directory (which holds the extracted DTD)
-                to the directories cleaned by the 'clean' phase. -->
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>clean-extracted-dtd</id>
-                    </execution>
-                </executions>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${extracted-dtd-root}</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
+++ b/appserver/appclient/client/acc-config/src/test/java/org/glassfish/appclient/client/acc/config/util/XMLTest.java
@@ -16,31 +16,37 @@
 
 package org.glassfish.appclient.client.acc.config.util;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+
 import javax.xml.parsers.ParserConfigurationException;
-import org.xml.sax.EntityResolver;
-import javax.xml.transform.sax.SAXSource;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Properties;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
+import javax.xml.transform.sax.SAXSource;
+
 import org.glassfish.appclient.client.acc.config.ClientContainer;
 import org.glassfish.appclient.client.acc.config.TargetServer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -109,18 +115,12 @@ public class XMLTest {
             throws JAXBException, FileNotFoundException, ParserConfigurationException, SAXException, IOException {
         ClientContainer result = null;
         InputStream is = XMLTest.class.getResourceAsStream(configPath);
+        assertNotNull("cannot locate test file " + configPath, configPath);
         try {
-            if (is == null) {
-                fail("cannot locate test file " + configPath);
-            }
             JAXBContext jc = JAXBContext.newInstance(ClientContainer.class );
-
             Unmarshaller u = jc.createUnmarshaller();
-
             final SAXSource src = setUpToUseLocalDTDs(is);
-
             result = (ClientContainer) u.unmarshal(src);
-
             return result;
         } finally {
             is.close();
@@ -147,7 +147,7 @@ public class XMLTest {
      */
     private static class LocalEntityResolver implements EntityResolver {
 
-        private static enum ACC_INFO {
+        private enum ACC_INFO {
             SUN_ACC(
                 "-//Sun Microsystems Inc.//DTD Application Server 8.0 Application Client Container//EN",
                 "dtds/sun-application-client-container_1_2.dtd"),
@@ -185,7 +185,7 @@ public class XMLTest {
                 initPublicIdToLocalPathMap();
 
         private static Map<String,String> initPublicIdToLocalPathMap() {
-            final Map<String,String> result = new HashMap<String,String>();
+            final Map<String,String> result = new HashMap<>();
             for (ACC_INFO accInfo : ACC_INFO.values()) {
                 result.put(accInfo.publicID, accInfo.uri.toASCIIString());
             }

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -73,24 +73,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>clean-domain</id>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                            <configuration>
-                                <directory>${project.build.directory}</directory>
-                                <includes>
-                                    <include>${stage.dir.name}/**/domains/**</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
                     <executions>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -85,7 +85,7 @@
         <version_prefix />
         <version_suffix />
         <major_version>6</major_version>
-        <minor_version>1</minor_version>
+        <minor_version>2</minor_version>
         <update_version>0</update_version>
         <install.dir.name>glassfish6</install.dir.name>
 

--- a/appserver/tests/admingui/auto-test/pom.xml
+++ b/appserver/tests/admingui/auto-test/pom.xml
@@ -54,18 +54,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>

--- a/appserver/tests/admingui/pom.xml
+++ b/appserver/tests/admingui/pom.xml
@@ -59,19 +59,6 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.4.1</version>
-                    <executions>
-                        <execution>
-                            <id>auto-clean</id>
-                            <phase>initialize</phase>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>2.3.1</version>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -113,19 +113,6 @@
                     <enableAssertions>false</enableAssertions>
                 </configuration>
             </plugin>
-            <!-- force a clean in the initialize phase. See IT: 12780 -->
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/nucleus/distributions/atomic/pom.xml
+++ b/nucleus/distributions/atomic/pom.xml
@@ -61,7 +61,6 @@
                         </goals>
                         <phase>process-resources</phase>
                     </execution>
-
                 </executions>
             </plugin>
         </plugins>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -74,26 +74,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>clean-domain</id>
-                            <phase>initialize</phase>
-                            <goals>
-                                <goal>clean</goal>
-                            </goals>
-                            <configuration>
-                                <directory>${project.build.directory}</directory>
-                                <includes>
-                                    <include>${stage.dir.name}/domains/**</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-                <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
                     <executions>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -718,13 +718,14 @@
                         <skip>${checkstyle.skip}</skip>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <excludes>**/generated-sources/**/*</excludes>
-                        <!-- build-helper-plugin adds root as a resource path, but checkstyle doesn't use the filter and adds everything -->
+                        <!--
+                         build-helper-plugin adds the root as a resource path, but checkstyle overrides
+                         the filter and adds all property files in the tree
+                        -->
                         <resourceExcludes>
-                        **/appserver/**/target/**/*,
-                        **/appserver/**/src/main/resources/**/*,
-                        **/deployment/**/src/main/resources/**/*,
-                        **/target/classes/**/*,
-                        **/target/test-classes/**/*
+                            **/appserver/**/src/main/resources/**/*,
+                            **/deployment/**/src/main/resources/**/*,
+                            **/target/**/*,
                         </resourceExcludes>
                     </configuration>
                     <dependencies>
@@ -737,7 +738,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.42</version>
+                            <version>8.43</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -789,7 +790,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -926,18 +927,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
-                    <execution>
-                        <id>find-root</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>rootlocation</goal>
-                        </goals>
-                        <configuration>
-                            <rootLocationProperty>legal.doc.source</rootLocationProperty>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>add-resource</id>
                         <phase>generate-resources</phase>
@@ -961,7 +951,7 @@
                         <configuration>
                             <resources>
                                 <resource>
-                                    <directory>${legal.doc.source}</directory>
+                                    <directory>${maven.multiModuleProjectDirectory}</directory>
                                     <includes>
                                         <include>NOTICE.md</include>
                                         <include>LICENSE.md</include>


### PR DESCRIPTION
- In https://github.com/eclipse-ee4j/glassfish/pull/23486 I forgot to update the minor version from 1 to 2
- Checkstyle had issues with the project root resource folder added for LICENSE and NOTICE files, which should be added into each artifact. Checkstyle used the directory, but ignored the filter and replaced it with it's own - `**/*.properties`. This PR resolves it by excluding paths added by mistake; probably it would be better later replace that adding external resources with some assembly artifact, so we would be compliant with maven rules.
- While I was working on that, I noticed that when I use the `-pl `parameter, LICENSE and NOTICE files are not added to the artifact, because Maven resolves the directory to the basedir of the project defined by the `-pl `parameter. However since Maven 3.3.1 it is possible to use another parameter: `maven.multiModuleProjectDirectory`
- I removed those 'auto-clean' executions, because they obey standard Maven rules and can be simply done by standard execution of the `clean` phase.

### Tests
```
mvn clean install -Pstaging -TC8 -pl :acc-config
mvn install -Pstaging -TC8 -pl :acc-config
mvn clean install -Pstaging -TC8
Total time:  04:01 min (Wall Clock)
mvn install -Pstaging -TC8
Total time:  03:30 min (Wall Clock)
mvn clean install -Pstaging -TC16
Total time:  04:08 min (Wall Clock)
```
