### PR TITLE
Update command security plugin to 1.0.13, bring JDK 17 compatibility.

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -130,7 +130,7 @@
         <shoal.version>2.0.0</shoal.version>
         <ha-api.version>3.1.13</ha-api.version>
         <logging-annotation-processor.version>1.9</logging-annotation-processor.version>
-        <command-security-plugin.version>1.0.12</command-security-plugin.version>
+        <command-security-plugin.version>1.0.13</command-security-plugin.version>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
 
         <!-- 3rd party dependencies -->


### PR DESCRIPTION
See https://github.com/eclipse-ee4j/glassfish-security-plugin/pull/20

Signed-off-by: arjantijms <arjan.tijms@gmail.com>
