### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -118,7 +118,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.1.1</mq.version>
+        <mq.version>6.2.0-M1</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
This OpenMQ version:
- needs at least Java 11 to run,
- has no GlassFish customization in `etc/imqenv.conf` (but this file is adjusted for GF in this project now).