### PR TITLE
Migrate git-commit-id-plugin to new coordinates and 5.x release

### DIFF
--- a/appserver/distributions/glassfish-common/pom.xml
+++ b/appserver/distributions/glassfish-common/pom.xml
@@ -65,8 +65,8 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.glassfish.build</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -824,9 +824,9 @@
                     <version>${replacer.plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.4</version>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
+                    <version>5.0.0</version>
                     <executions>
                         <execution>
                             <id>get-the-git-infos</id>


### PR DESCRIPTION
This was suggested in https://github.com/eclipse-ee4j/glassfish/pull/23519#issuecomment-877861397

https://github.com/git-commit-id/git-commit-id-maven-plugin/#relocation-of-the-project