### PR TITLE
Simple project to run test for resolved build_id

### DIFF
--- a/appserver/distributions/glassfish-common/pom.xml
+++ b/appserver/distributions/glassfish-common/pom.xml
@@ -89,6 +89,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
+                    <streamLogs>true</streamLogs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/appserver/distributions/glassfish-common/src/it/build-id/pom.xml
+++ b/appserver/distributions/glassfish-common/src/it/build-id/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.glassfish.main.distributions.its</groupId>
+    <artifactId>glassfish-common</artifactId>
+    <version>@project.version@</version>
+    <packaging>pom</packaging>
+
+</project>

--- a/appserver/distributions/glassfish-common/src/it/build-id/postbuild.groovy
+++ b/appserver/distributions/glassfish-common/src/it/build-id/postbuild.groovy
@@ -1,0 +1,13 @@
+properties = new Properties()
+new File(basedir, '../../dependency/glassfish/config/branding/glassfish-version.properties').withInputStream {
+  properties.load(it)
+}
+
+buildId = properties['build_id']
+
+assert !buildId.matches('.*\\$\\{.*\\}.*') :
+  "Build ID (${buildId}) contains unresolved property"
+
+assert buildId.matches('.+-b\\p{Digit}+-g\\p{XDigit}+ [\\p{Digit}-]+T[\\p{Digit}:]+\\+\\p{Digit}+') :
+  "Build ID (${buildId}) does not match expected pattern"
+

--- a/appserver/distributions/glassfish-common/src/it/build-id/postbuild.groovy
+++ b/appserver/distributions/glassfish-common/src/it/build-id/postbuild.groovy
@@ -8,6 +8,6 @@ buildId = properties['build_id']
 assert !buildId.matches('.*\\$\\{.*\\}.*') :
   "Build ID (${buildId}) contains unresolved property"
 
-assert buildId.matches('.+-b\\p{Digit}+-g\\p{XDigit}+ [\\p{Digit}-]+T[\\p{Digit}:]+\\+\\p{Digit}+') :
+assert buildId.matches('.+-b\\p{Digit}*-g\\p{XDigit}+ [\\p{Digit}-]+T[\\p{Digit}:]+\\+\\p{Digit}+') :
   "Build ID (${buildId}) does not match expected pattern"
 


### PR DESCRIPTION
Related to #23519, to avoid regression.

There is most probably better way to do it, but with `<packaging>distribution-fragment</packaging>` I'm not willing to (re)configure test compilation and execution. Filtered resources are not in default test-classpath in that module anyway.