### PR TITLE
Fix #23528 transactional annotation

### DIFF
--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -161,5 +161,11 @@
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.transaction</groupId>
+            <artifactId>jta</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequired.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorRequired.java
@@ -23,12 +23,14 @@ import static java.util.logging.Level.INFO;
 
 import java.util.logging.Logger;
 
+import com.sun.enterprise.transaction.TransactionManagerHelper;
 import jakarta.annotation.Priority;
 import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.TransactionalException;
+import jakarta.transaction.TransactionManager;
 
 /**
  * Transactional annotation Interceptor class for Required transaction type, ie
@@ -61,6 +63,10 @@ public class TransactionalInterceptorRequired extends TransactionalInterceptorBa
                 _logger.log(INFO, CDI_JTA_MBREQUIRED);
                 try {
                     getTransactionManager().begin();
+                    TransactionManager tm = getTransactionManager();
+                    if(tm instanceof TransactionManagerHelper){
+                        ((TransactionManagerHelper)tm).preInvokeTx(true);
+                    }
                 } catch (Exception exception) {
                     _logger.log(INFO, CDI_JTA_MBREQUIREDBT, exception);
                     throw new TransactionalException(
@@ -77,6 +83,10 @@ public class TransactionalInterceptorRequired extends TransactionalInterceptorBa
             } finally {
                 if (isTransactionStarted) {
                     try {
+                        TransactionManager tm = getTransactionManager();
+                        if(tm instanceof TransactionManagerHelper){
+                            ((TransactionManagerHelper)tm).postInvokeTx(false, true);
+                        }
                         // Exception handling for proceed method call above can set TM/TRX as setRollbackOnly
                         if (getTransactionManager().getTransaction().getStatus() == STATUS_MARKED_ROLLBACK) {
                             getTransactionManager().rollback();

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionScopedBeanTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionScopedBeanTest.java
@@ -16,6 +16,7 @@
 
 package org.glassfish.cdi.transaction;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.Test;
 
 import jakarta.enterprise.context.spi.Contextual;
@@ -37,6 +38,7 @@ public class TransactionScopedBeanTest {
         Contextual<LocalBean> contextual = (Contextual<LocalBean>) mockSupport.createMock(Contextual.class);
         CreationalContext<LocalBean> creationalContext = (CreationalContext<LocalBean>) mockSupport.createMock(CreationalContext.class);
         TransactionScopedContextImpl transactionScopedContext = mockSupport.createMock(TransactionScopedContextImpl.class);
+        transactionScopedContext.beansPerTransaction = new ConcurrentHashMap<>();
 
         // test getContextualInstance
         TransactionScopedBean<LocalBean> transactionScopedBean = getTransactionScopedBean(mockSupport, localBean, contextual,


### PR DESCRIPTION
Signed-off-by: dsano82 <sano.daiki@fujitsu.com>

Fix https://github.com/eclipse-ee4j/glassfish/issues/23528

An application exception makes no rollback in the annotated method if we use other than JPA as an O/R mapper.
So, allow transactions with Transactional annotations to be enlisted into the global transaction.

QuickLookTest was successful in local environment.









