### PR TITLE
A bit more flexibility for TCK tests

### DIFF
--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -32,7 +32,7 @@
     <artifactId>tests</artifactId>
     <packaging>pom</packaging>
 
-    <name>GlassFish Tests related modules</name>
+    <name>GlassFish Tests</name>
 
     <profiles>
         <profile>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -34,10 +34,21 @@
 
     <name>GlassFish Tests related modules</name>
 
-    <modules>
-        <module>tck</module>
-        <!-- module>quicklook</module -->
-    </modules>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>tck</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>fastest</id>
+            <modules />
+        </profile>
+    </profiles>
 
     <build>
         <pluginManagement>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -156,17 +156,19 @@
                         </goals>
                         <configuration>
                             <target>
-                                <!-- start the server -->
-                                <exec executable="${glassfish.home}/glassfish/bin/asadmin"
-                                    dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="start-domain"/>
-                                </exec>
-
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
+                                         classpathref="maven.plugin.classpath" />
+                                <!-- If domain fails to start, we don't want to wait 10 minutes -->
+                                <limit maxwait="30" failonerror="true">
+                                    <exec executable="${glassfish.home}/glassfish/bin/asadmin"
+                                        dir="${glassfish.home}/glassfish/bin">
+                                        <arg value="start-domain"/>
+                                    </exec>
+                                </limit>
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
                                     <arg value="config.vi" />
                                     <env key="tck.home" value="${tck.home}"/>
                                 </exec>
-
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
                                     <arg value="enable.jacc"  />
                                     <env key="tck.home" value="${tck.home}"/>
@@ -185,22 +187,16 @@
                             <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
-
-                                <!-- Stop the server -->
                                 <exec executable="${glassfish.home}/glassfish/bin/asadmin"
                                     dir="${glassfish.home}/glassfish/bin">
                                     <arg value="stop-domain"/>
                                 </exec>
-
-                                <!-- Start the server -->
                                 <exec executable="${glassfish.home}/glassfish/bin/asadmin"
                                     dir="${glassfish.home}/glassfish/bin">
                                     <arg value="start-domain"/>
                                 </exec>
 
                                 <echo message="Start running all tests" />
-
-                                <!-- Run all the tests -->
                                 <exec executable="${ant.home}/bin/ant"
                                       dir="${tck.tests.home}" resultproperty="testResult">
                                     <arg value="deploy"/>
@@ -219,19 +215,14 @@
                                     </then>
                                 </if>
 
-                                <!-- Stop the server -->
                                 <exec executable="${glassfish.home}/glassfish/bin/asadmin" dir="${glassfish.home}/glassfish/bin">
                                     <arg value="stop-domain" />
                                 </exec>
                             </target>
-
-
                         </configuration>
                     </execution>
-
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -33,10 +33,12 @@
 
     <properties>
         <ant.home>${project.build.directory}/ant</ant.home>
+        <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
         <tck.home>${project.build.directory}/tck</tck.home>
         <glassfish.home>${tck.home}/glassfish6</glassfish.home>
         <glassfish.version>${project.version}</glassfish.version>
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests</tck.tests.home>
+        <tck.tests.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/promoted/jakarta-authorization-tck-2.0.1.zip</tck.tests.url>
     </properties>
 
     <dependencies>
@@ -102,16 +104,13 @@
                         <configuration>
                             <target>
                                 <!-- Grab TCK - download, unzip and rename TCK -->
-                                <get
-                                    src="https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/promoted/jakarta-authorization-tck-2.0.1.zip"
-                                    dest="${project.build.directory}/tck.zip" skipexisting="true" />
+                                <get src="${tck.tests.url}" dest="${project.build.directory}/tck.zip" skipexisting="true" />
                                 <unzip src="${project.build.directory}/tck.zip" dest="${project.build.directory}" />
                                 <move file="${project.build.directory}/authorization-tck"
                                     tofile="${project.build.directory}/tck" />
 
-                                <!-- Grab ANT - download, unzip, rename and chmod Ant 1.10.9 -->
-                                <get src="https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip"
-                                    dest="${project.build.directory}/ant.zip" skipexisting="true" />
+                                <!-- Grab ANT - download, unzip, rename and chmod Ant -->
+                                <get src="${ant.zip.url}" dest="${project.build.directory}/ant.zip" skipexisting="true" />
                                 <unzip src="${project.build.directory}/ant.zip" dest="${project.build.directory}" />
                                 <move file="${project.build.directory}/apache-ant-${ant.version}"
                                     tofile="${project.build.directory}/ant" />

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -29,7 +29,7 @@
     <artifactId>glassfish-external-tck-authorization</artifactId>
     <packaging>pom</packaging>
 
-    <name>GlassFish - External - TCK - Authorization</name>
+    <name>GlassFish Tests - TCK - Authorization</name>
 
     <properties>
         <ant.home>${project.build.directory}/ant</ant.home>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -35,8 +35,19 @@
         <ant.home>${project.build.directory}/ant</ant.home>
         <tck.home>${project.build.directory}/tck</tck.home>
         <glassfish.home>${tck.home}/glassfish6</glassfish.home>
+        <glassfish.version>${project.version}</glassfish.version>
         <tck.tests.home>${tck.home}/src/com/sun/ts/tests</tck.tests.home>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <type>zip</type>
+            <version>${glassfish.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
@@ -54,7 +65,7 @@
                                 <artifactItem>
                                     <groupId>org.glassfish.main.distributions</groupId>
                                     <artifactId>glassfish</artifactId>
-                                    <version>${project.version}</version>
+                                    <version>${glassfish.version}</version>
                                     <type>zip</type>
                                     <outputDirectory>${tck.home}</outputDirectory>
                                 </artifactItem>
@@ -64,10 +75,8 @@
                 </executions>
             </plugin>
 
-
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.ant</groupId>
@@ -86,14 +95,12 @@
                         </exclusions>
                     </dependency>
                 </dependencies>
-                
                 <executions>
                     <execution>
                         <id>Grab-TCK-ANT-Configure-ts</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
                             <target>
-                            
                                 <!-- Grab TCK - download, unzip and rename TCK -->
                                 <get
                                     src="https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee9-eftl/promoted/jakarta-authorization-tck-2.0.1.zip"
@@ -103,34 +110,36 @@
                                     tofile="${project.build.directory}/tck" />
 
                                 <!-- Grab ANT - download, unzip, rename and chmod Ant 1.10.9 -->
-                                <get src="https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.zip"
+                                <get src="https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip"
                                     dest="${project.build.directory}/ant.zip" skipexisting="true" />
                                 <unzip src="${project.build.directory}/ant.zip" dest="${project.build.directory}" />
-                                <move file="${project.build.directory}/apache-ant-1.10.9"
+                                <move file="${project.build.directory}/apache-ant-${ant.version}"
                                     tofile="${project.build.directory}/ant" />
                                 <chmod dir="${ant.home}/bin" perm="ugo+rx" includes="*" />
 
+                                <!-- Change configuration -->
                                 <copy file="${tck.home}/bin/ts.jte.jdk11" tofile="${tck.home}/bin/ts.jte" overwrite="true"  />
+                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                    match="orb\.port=.*"
+                                    replace="orb\.port=3699" />
+                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                    match="javaee\.level=.*"
+                                    replace="javaee\.level=full" />
+                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                    match="jacc\.home=.*"
+                                    replace="jacc\.home=${tck.home}/glassfish6/glassfish" />
+                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                    match="report\.dir=.*"
+                                    replace="report\.dir=${tck.home}/jacctckreport/jacctck" />
+                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
+                                    match="work\.dir=.*"
+                                    replace="work\.dir=${tck.home}/jacctckwork/jacctck" />
 
-                                <!-- Configure ts.jte  -->
-
-                                <replaceregexp file="${tck.home}/bin/ts.jte" match="orb\.port=.*"
-                                    replace="orb\.port=3699" byline="true" />
-                                <replaceregexp file="${tck.home}/bin/ts.jte" match="javaee\.level=.*"
-                                    replace="javaee\.level=full" byline="true" />
-                                <replaceregexp file="${tck.home}/bin/ts.jte" match="jacc\.home=.*"
-                                    replace="jacc\.home=${tck.home}/glassfish6/glassfish" byline="true" />
-                                <replaceregexp file="${tck.home}/bin/ts.jte" match="report\.dir=.*"
-                                    replace="report\.dir=${tck.home}/jacctckreport/jacctck" byline="true" />
-                                <replaceregexp file="${tck.home}/bin/ts.jte" match="work\.dir=.*"
-                                    replace="work\.dir=${tck.home}/jacctckwork/jacctck" byline="true" />
-                                    
-                                <replaceregexp file="${tck.home}/bin/build.xml" byline="true" 
-                                    match="&lt;/project&gt;" 
+                                <!-- Run just selected subset tests -->
+                                <replaceregexp file="${tck.home}/bin/build.xml" byline="true"
+                                    match="&lt;/project&gt;"
                                     replace="&lt;property name=&quot;all.test.dir&quot; value=&quot;com/sun/ts/tests/jacc/,com/sun/ts/tests/signaturetest/jacc,com/sun/ts/tests/common/vehicle/&quot; /&gt; &lt;/project&gt;" />
-                            
-                                <!-- Create directory where the report is written to.  -->
-                            
+
                                 <mkdir dir="${tck.home}/jacctckreport"/>
                                 <mkdir dir="${tck.home}/jacctckreport/jacctck"/>
                             </target>
@@ -166,7 +175,7 @@
                             </target>
                         </configuration>
                     </execution>
-                    
+
                      <execution>
                         <id>Run-TCK-tests</id>
                         <phase>integration-test</phase>
@@ -177,21 +186,21 @@
                             <target>
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
-                            
+
                                 <!-- Stop the server -->
                                 <exec executable="${glassfish.home}/glassfish/bin/asadmin"
                                     dir="${glassfish.home}/glassfish/bin">
                                     <arg value="stop-domain"/>
                                 </exec>
-                            
+
                                 <!-- Start the server -->
                                 <exec executable="${glassfish.home}/glassfish/bin/asadmin"
                                     dir="${glassfish.home}/glassfish/bin">
                                     <arg value="start-domain"/>
                                 </exec>
-                            
+
                                 <echo message="Start running all tests" />
-                            
+
                                 <!-- Run all the tests -->
                                 <exec executable="${ant.home}/bin/ant"
                                       dir="${tck.tests.home}" resultproperty="testResult">
@@ -206,7 +215,6 @@
                                     </not>
                                     <then>
                                         <echo message="Running tests failed." />
-                                        
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
                                         <echo message="${contents}" />
                                     </then>
@@ -218,7 +226,7 @@
                                 </exec>
                             </target>
 
-                           
+
                         </configuration>
                     </execution>
 

--- a/appserver/tests/tck/pom.xml
+++ b/appserver/tests/tck/pom.xml
@@ -31,5 +31,5 @@
 
     <modules>
         <module>authorization</module>
-  </modules>
+    </modules>
 </project>

--- a/appserver/tests/tck/pom.xml
+++ b/appserver/tests/tck/pom.xml
@@ -29,6 +29,8 @@
     <artifactId>tests.tck</artifactId>
     <packaging>pom</packaging>
 
+    <name>GlassFish Tests - TCK</name>
+
     <modules>
         <module>authorization</module>
     </modules>

--- a/nucleus/tests/admin/pom.xml
+++ b/nucleus/tests/admin/pom.xml
@@ -62,7 +62,7 @@ of COPY_LIB map constant.)
     <groupId>org.glassfish.tests</groupId>
     <artifactId>nucleus-admin</artifactId>
 
-    <name>Nucleus Admin Devtests</name>
+    <name>Nucleus Tests - Admin</name>
     <description>This pom describes how to run admin developer tests on the Nucleus Bundle</description>
 
     <dependencies>

--- a/nucleus/tests/pom.xml
+++ b/nucleus/tests/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>nucleus-tests</artifactId>
     <packaging>pom</packaging>
 
-    <name>GlassFish Tests related modules</name>
+    <name>Nucleus Tests</name>
 
     <modules>
         <module>admin</module>


### PR DESCRIPTION
This PR should be merged after #23536 as it is based on it's commit.

- I always had problems to distinguish nucleus and appserver, now I know why - nucleus tests had the same name
- TCK test can use different GlassFish version (can be useful to compare results)
- TCK module downloads Ant and tck tests from an url - now it is possible to locally configure file from the file system.
- there was also a race condition between modules - under some circumstances the TCK module used old or incomplete zip file, because it did not define any dependency on it (dependency plugin just works with artifacts, but doesn't affect module's dependencies and build ordering).
