### PR TITLE
Bump OpenMQ version to 6.2.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -113,7 +113,7 @@
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>
-        <mq.version>6.2.0-M1</mq.version>
+        <mq.version>6.2.0</mq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.0.0</jakarta-persistence-api.version>


### PR DESCRIPTION
TCK: https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/33/