### PR TITLE
Bump Exousia to 1.0.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -109,7 +109,7 @@
         <jakarta.authorization-api.version>2.0.0</jakarta.authorization-api.version>
         <jakarta.authentication-api.version>2.0.0</jakarta.authentication-api.version>
         <soteria.version>2.0.1</soteria.version>
-        <exousia.version>1.0.0-M3</exousia.version>
+        <exousia.version>1.0.0</exousia.version>
 
         <!-- Jakarta Messaging -->
         <jms-api.version>3.0.0</jms-api.version>


### PR DESCRIPTION
Exousia 1.00 is equal to the current M3,  but has its version bumped for release.