### PR TITLE
Add argument to match format

### DIFF
--- a/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigModel.java
+++ b/nucleus/hk2/hk2-config/src/main/java/org/jvnet/hk2/config/ConfigModel.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -864,6 +865,7 @@ public final class ConfigModel {
             throw new ConfigurationException("%s doesn't have the mandatory '%s' metadata", injector.getImplementation(), ConfigMetadata.TARGET);
         if(key==null ^ indexTypeName==null)
             throw new ConfigurationException("%s has inconsistent '%s=%s' and '%s=%s' metadata",
+                injector.getImplementation(),
                 ConfigMetadata.KEY, key, ConfigMetadata.TARGET, indexTypeName);
         this.targetTypeName = targetTypeName;
         this.keyedAs = indexTypeName;


### PR DESCRIPTION
A `format` call with an insufficient number of arguments causes an `IllegalFormatException`.