### PR TITLE
Fix #23531 enable-secure-admin does not work with latest JDK11

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/HttpConnectorAddress.java
@@ -127,7 +127,7 @@ public final class HttpConnectorAddress {
     private SSLSocketFactory createAdminSSLSocketFactory(String alias, String protocol) {
         try {
             if (protocol == null) {
-                protocol = "TLSv1";
+                protocol = "TLS";
             }
             SSLContext cntxt = SSLContext.getInstance(protocol);
             /*


### PR DESCRIPTION
Signed-off-by: 11rx4f <ryosuke.okada@fujitsu.com>

TLSv 1.0 has been disabled in the latest JDK 11.
So, asadmin does not work properly when you call enable-secure-admin.

QuickLookTest was successful in local environment.