### PR TITLE
Fix #23578 Cannot enbale Security Manager from the admin console

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
@@ -770,7 +770,8 @@ public class SecurityHandler {
             Map<String, Object> payload = new HashMap<String, Object>();
             payload.put("target", configName);
             for (String option : newOptions) {
-                ArrayList kv = InstanceHandler.getKeyValuePair(option);
+                String option1 = UtilHandlers.escapePropertyValue(option);
+                ArrayList kv = InstanceHandler.getKeyValuePair(option1);
                 payload.put((String)kv.get(0), kv.get(1));
             }
             RestUtil.restRequest(endpoint, payload, "POST", handlerCtx, false);


### PR DESCRIPTION
Fixed that failed to enable Security Manager on admin console.  
It may become unnecessary soon because of JEP 411, but it is a bug at this time, so I fixed it.

QuickLookTest was successful in local environment.