### PR TITLE
Fix #23582, local packaged file is deleted when push redeploy button from the web console

### DIFF
--- a/appserver/admingui/common/src/main/resources/applications/redeployFrame.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/redeployFrame.jsf
@@ -94,6 +94,10 @@
                 }
                 gf.redeploy(filePath="$attribute{filePath}", deployMap="#{pageSession.deployMap}" convertToFalse="#{pageSession.convertToFalse}"
                         valueMap="#{pageSession.valueMap}" );
+                if(${needUpload}) {
+                    gf.logger(logString="Deleting the file uploaded to Temp Directory", level="INFO");
+                    deleteFileFromTempDir(deleteTempFile="$attribute{filePath}");
+                }
 		gf.redirect(page="#{request.contextPath}/common/removeFrame.jsf?#{request.contextPath}/common/applications/applications.jsf&alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}&bare=true");
                 />
         </sun:button>


### PR DESCRIPTION
Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>

Fix #23582. Related to https://github.com/javaee/glassfish/pull/21827
So fix code "appserver/admingui/common/src/main/resources/applications/redeployFrame.jsf".  
I pasted the code of the previous fix in the appropriate place.