### PR TITLE
Fix #23585 Status Code is 413, but the page displays 500

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishErrorPageGenerator.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishErrorPageGenerator.java
@@ -36,7 +36,7 @@ public class GlassfishErrorPageGenerator implements ErrorPageGenerator {
                     "The requested resource is not available.", "404");
         } else {
             return HttpUtils.getErrorPage(Version.getVersion(),
-                    "The server encountered an internal error that prevented it from fulfilling this request.", "500");
+                    "The server encountered an internal error that prevented it from fulfilling this request.", String.valueOf(status));
         }
    }
 }


### PR DESCRIPTION
Fix to display the status code in the error page.  

QuickLookTest has passed in local.