### PR TITLE
Fix #23590, Fix typo.

### DIFF
--- a/appserver/admingui/core/src/main/java/org/glassfish/admingui/handlers/WoodstockHandler.java
+++ b/appserver/admingui/core/src/main/java/org/glassfish/admingui/handlers/WoodstockHandler.java
@@ -94,7 +94,7 @@ public class WoodstockHandler {
                 Files.delete(pathToFile);
 
             } catch (IOException x) {
-                logger.log(Level.WARNING, GuiUtil.getCommonMessage("log.fileCouldntFound", new Object[]{"" + deleteTempFile}));
+                logger.log(Level.WARNING, GuiUtil.getCommonMessage("log.fileCouldntbeFound", new Object[]{"" + deleteTempFile}));
 
             } catch (SecurityException e) {
 


### PR DESCRIPTION
Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>

Fix #23590, Fix typo.
`log.fileCouldntFound` -> `log.fileCouldntbeFound`