### PR TITLE
Fix #23594 AS-CDI-00005 with no message in the server.log

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +79,7 @@ import jakarta.enterprise.inject.spi.InjectionTarget;
  */
 public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
 
-    private Logger logger = Logger.getLogger(BeanDeploymentArchiveImpl.class.getName());
+    private Logger logger = CDILoggerInfo.getLogger();
 
     private ReadableArchive archive;
     private String id;

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldContextListener.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldContextListener.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,7 +37,7 @@ import jakarta.servlet.jsp.JspFactory;
  */
 public class WeldContextListener implements ServletContextListener {
 
-    private Logger logger = Logger.getLogger(WeldContextListener.class.getName());
+    private Logger logger = CDILoggerInfo.getLogger();
 
     @Inject
     private BeanManager beanManager;

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -89,7 +90,7 @@ import jakarta.servlet.jsp.tagext.JspTag;
 @Service
 public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationContainer> implements PostConstruct, EventListener {
 
-    private Logger logger = Logger.getLogger(WeldDeployer.class.getName());
+    private Logger logger = CDILoggerInfo.getLogger();
 
     public static final String WELD_EXTENSION = "org.glassfish.weld";
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/jsf/WeldFacesConfigProvider.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/jsf/WeldFacesConfigProvider.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +47,7 @@ public class WeldFacesConfigProvider implements FacesConfigResourceProvider {
     private static final String HABITAT_ATTRIBUTE = "org.glassfish.servlet.habitat";
     private InvocationManager invokeMgr;
 
-    private Logger logger = Logger.getLogger(WeldFacesConfigProvider.class.getName());
+    private Logger logger = CDILoggerInfo.getLogger();
 
     private static final String SERVICES_FACES_CONFIG = "META-INF/services/faces-config.xml";
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/EjbServicesImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,7 +57,7 @@ import jakarta.interceptor.AroundTimeout;
  */
 public class EjbServicesImpl implements EjbServices {
     private ServiceLocator services;
-    private Logger logger = Logger.getLogger(EjbServicesImpl.class.getName());
+    private Logger logger = CDILoggerInfo.getLogger();
 
     public EjbServicesImpl(ServiceLocator h) {
         services = h;


### PR DESCRIPTION
Fix: #23594

Some weld-integration classes use Logger.getLogger(Class.class.getName()),
but the messsages are defined in org.glassfish.cdi.CDILoggerInfo.
Therefore, the logger gotten from CDILoggerInfo to print messages correctly.