### PR TITLE
Fix #23595 Add LocalStrings.properties to mail-connector

### DIFF
--- a/appserver/resources/mail/mail-connector/src/main/java/org/glassfish/resources/mail/config/LocalStrings.properties
+++ b/appserver/resources/mail/mail-connector/src/main/java/org/glassfish/resources/mail/config/LocalStrings.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+resourcename.isnot.unique=Name is already used by another resource.


### PR DESCRIPTION
Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>

Fix #23595.
This PR follow up https://github.com/eclipse-ee4j/glassfish/issues/21866#issuecomment-422120067

After this change
```
remote failure: Unable to create Mail Resource DerbyPool. Constraints for this MailResource configuration have been violated: on property [  ] violation reason [ Name is already used by another resource. ]
Command create-mail-resource failed.
```

