### PR TITLE
Explicit level for echo task

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1014,7 +1014,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <echo>Generating manifest for ${project.build.outputDirectory}/META-INF for
+                                <echo level="info">Generating manifest for ${project.build.outputDirectory}/META-INF for
                                     ${project.artifactId}</echo>
                                 <echo file="${basedir}/target/MANIFEST.MF">Manifest-Version: 1.0</echo>
                                 <copy toDir="${project.build.outputDirectory}/META-INF" overwrite="false">


### PR DESCRIPTION
Change for example output of echo in:
```
[INFO] --- maven-antrun-plugin:3.0.0:run (default-manifest) @ ant-tasks ---
[INFO] Executing tasks
[WARNING]      [echo] Generating manifest for appserver/ant-tasks/target/classes/META-INF for
[WARNING]      [echo]                                     ant-tasks
[INFO]      [copy] Copying 1 file to appserver/ant-tasks/target/classes/META-INF
[INFO] Executed tasks
```
which does not seem to be needed of (default) WARNING level.

It would reduce warnings to really requiring attention.

---

Baseline: 
```bash
$ curl --silent https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_build-and-test-using-jenkinsfile/job/master/514/consoleText | zgrep -a \\[WARNING | wc -l
1372
```

with this change:
```bash
$ curl --silent https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_build-and-test-using-jenkinsfile/job/PR-23599/1/consoleText | zgrep -a \\[WARNING |wc -l
794
```