### PR TITLE
Fix #23608 Add properties file to resources-runtime

### DIFF
--- a/appserver/resources/resources-runtime/src/main/java/com/sun/logging/enterprise/resource/resourceadapter/LogStrings.properties
+++ b/appserver/resources/resources-runtime/src/main/java/com/sun/logging/enterprise/resource/resourceadapter/LogStrings.properties
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+customrsrc.create_ref_error=RAR5008:Error in creating a naming Reference for custom resource [{0}]
+RAR5008.diag.cause.1=Naming provider and port are not set in the initial context
+RAR5008.diag.cause.2=The Naming provider is not up
+RAR5008.diag.check.1=Check the jndi.properties file has the naming provider host and port specified
+RAR5008.diag.check.2=Check if the naming provider is up and listening on the port specified in the domain.xml
+customrsrc.create_ref_error_excp=RAR5045:Error in creating a naming Reference for custom resource
+RAR5045.diag.cause.1=Naming provider and port are not set in the jndi provider's property file
+RAR5045.diag.cause.2=The Naming provider is not up
+RAR5045.diag.check.1=Check the jndi.properties file has the naming provider host and port specified
+RAR5045.diag.check.2=Check if the naming provider is up and listening on the port specified in the domain.xml
+jndi.factory_load_error=RAR5009:Cannot load external-jndi-resource factory-class ''[{0}]''
+RAR5009.diag.cause.1=Could not create an instance of factory-class.
+RAR5009.diag.check.1=Make sure that factory-class name is configured correctly.
+RAR5009.diag.check.2=Make sure that factory-class is available in the classpath of the application server
+jndi.factory_class_unexpected=RAR5010:external-jndi-resource factory-class ''[{0}]'' must be of type javax.naming.spi.InitialContextFactory
+RAR5010.diag.cause.1=External JNDI resource has a wrong factory-class configuration
+RAR5010.diag.check.1=Verify that factory class is an instance of javax.naming.spi.InitialContextFactory
+jndi.initial_context_error=RAR5011:Exception thrown creating initial context for external JNDI factory ''[{0}]''
+RAR5011.diag.cause.1=Could not create Initial Context.
+RAR5011.diag.check.1=Make sure that the external-jndi-resource configuration is sufficient to create an initial context.
+jndi.initial_context_error_excp=RAR5047:Exception thrown creating initial context for external JNDI factory [{0}]
+RAR5047.diag.cause.1=Could not create Initial Context.
+RAR5047.diag.check.1=Make sure that the external-jndi-resource configuration is sufficient to create an initial context.
+jndi.factory_create_error=RAR5012:Cannot create external-jndi-resource factory-class ''[{0}]''
+RAR5012.diag.cause.1=Could not create Initial context factory.
+RAR5012.diag.check.1=Make sure that the external-jndi-resource configuration is sufficient to create an initial context factory
+gf.resources.module.scope.deployment.failure=RAR8069: Failed to create resources (defined in glassfish-resources.xml) bundled in module [ {0} ], of application [ {1} ] : [ {2} ]
+RAR8069.diag.cause.1=Invalid resource definition
+RAR8069.diag.check.1=Check whether attributes and properties of resource-definitions conform to the constraints
+gf.resources.app.scope.deployment.failure=RAR8070: Failed to create resources (defined in glassfish-resources.xml) bundled in application [ {0} ] : [ {1} ]
+RAR8070.diag.cause.1=Invalid resource definition
+RAR8070.diag.check.1=Check whether attributes and properties of resource-definitions conform to the constraints
+

--- a/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/LocalStrings.properties
+++ b/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/LocalStrings.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+duplicate.resource.sun.resource.xml=The resource [ {0} ] at {1} is a duplicate resource within archive. The deployment will go through normally. Only one resource will be created for all duplicates.
+conflict.resource.sun.resource.xml=The resource [ {0} ] at {1} is having a conflict with another resource defined within archive.
+conflict.resource.with.domain.xml=The resource [ {0} ] is having a conflict with resource defined in domain.xml.
+resource.attributes=The attributes of above resource are {0}.


### PR DESCRIPTION
Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>

Fix #23608.
There is no properties file in `appserver/resources/resources-runtime` so the logger in resources-runtime cannot print messages correctly.

I add a properties file containing the messages used in resources-runtime. This messages are copied from `appserver/connectors/connectors-runtime`.

