### PR TITLE
Issue 23616 Fixed generators on jdk11 + tests

### DIFF
--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -222,6 +222,18 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.32</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.32</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/ejb/ejb-container/pom.xml
+++ b/appserver/ejb/ejb-container/pom.xml
@@ -225,14 +225,10 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.32</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.32</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
@@ -455,9 +455,10 @@ public class EJBUtils {
         }
 
         if (System.getSecurityManager() == null) {
-            return Wrapper._generate(generator.getAnchorClass(), props);
+            return Wrapper._generate(loader, generator.getAnchorClass().getProtectionDomain(), props);
         }
-        PrivilegedAction<Class<?>> action = () -> Wrapper._generate(generator.getAnchorClass(), props);
+        PrivilegedAction<Class<?>> action = () ->
+            Wrapper._generate(loader, generator.getAnchorClass().getProtectionDomain(), props);
         return AccessController.doPrivileged(action);
     }
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
@@ -544,10 +544,9 @@ public class EJBUtils {
 
 
     public static Class generateSEI(ClassGeneratorFactory cgf,
-                                    final String seiClassName,
                                     final ClassLoader loader,
                                     final Class beanClass) {
-        return generateAndLoad(cgf, seiClassName, loader, beanClass);
+        return generateAndLoad(cgf, cgf.className(), loader, beanClass);
 
     }
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EJBUtils.java
@@ -518,28 +518,15 @@ public class EJBUtils {
         }
     }
 
-    public static Class loadGeneratedGenericEJBHomeClass
-        (ClassLoader appClassLoader) throws Exception {
 
+    public static Class<?> loadGeneratedGenericEJBHomeClass(ClassLoader appClassLoader) throws Exception {
         String className = getGenericEJBHomeClassName();
-
-        Class generatedGenericEJBHomeClass = null;
-
-        try {
-            generatedGenericEJBHomeClass = appClassLoader.loadClass(className);
-        } catch(Exception e) {
+        Class<?> generatedGenericEJBHomeClass = loadClassIgnoringExceptions(appClassLoader, className);
+        if (generatedGenericEJBHomeClass != null) {
+            return generatedGenericEJBHomeClass;
         }
-
-        if( generatedGenericEJBHomeClass == null ) {
-
-            GenericHomeGenerator gen =new GenericHomeGenerator(appClassLoader);
-
-
-            generatedGenericEJBHomeClass =generateAndLoad(gen, className,
-                    appClassLoader, EJBUtils.class);
-        }
-
-        return generatedGenericEJBHomeClass;
+        GenericHomeGenerator gen = new GenericHomeGenerator(appClassLoader);
+        return generateAndLoad(gen, className, appClassLoader, GenericHomeGenerator.class);
     }
 
 
@@ -620,10 +607,11 @@ public class EJBUtils {
         }
     }
 
-    private static Class loadClassIgnoringExceptions(ClassLoader classLoader, String className) {
+    private static Class<?> loadClassIgnoringExceptions(ClassLoader classLoader, String className) {
         try {
             return classLoader.loadClass(className);
-        } catch (Exception e) {
+        } catch (ClassNotFoundException e) {
+            _logger.log(FINE, "Could not load class: " + className + " by classloader " + classLoader, e);
             return null;
         }
     }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/base/io/EJBObjectOutputStreamHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/base/io/EJBObjectOutputStreamHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +19,7 @@ package com.sun.ejb.base.io;
 
 import com.sun.ejb.containers.BaseContainer;
 import com.sun.ejb.EJBUtils;
+import com.sun.ejb.codegen.RemoteGenerator;
 import com.sun.ejb.containers.EjbContainerUtilImpl;
 import com.sun.ejb.containers.RemoteBusinessWrapperBase;
 import com.sun.enterprise.container.common.spi.util.JavaEEIOUtils;
@@ -69,6 +71,7 @@ public class EJBObjectOutputStreamHandler
      * This code is needed to serialize non-Serializable objects that
      * can be part of a bean's state. See EJB2.0 section 7.4.1.
      */
+    @Override
     public Object replaceObject(Object obj)
             throws IOException {
         Object result = obj;
@@ -186,6 +189,7 @@ final class SerializableJNDIContext
         }
     }
 
+    @Override
     public Object createObject()
         throws IOException
     {
@@ -273,6 +277,7 @@ final class SerializableS1ASEJBHomeReference
     super(containerId);
     }
 
+    @Override
     public Object createObject()
         throws IOException
     {
@@ -299,14 +304,14 @@ final class SerializableS1ASEJBHomeReference
 final class SerializableS1ASEJBObjectReference
     extends AbstractSerializableS1ASEJBReference
 {
-    private byte[] instanceKey;
+    private final byte[] instanceKey;
     private Object sfsbKey;
     private long sfsbClientVersion;
     private boolean haEnabled;
 
     // If 3.0 Remote business view, the name of the remote business
     // interface to which this stub corresponds.
-    private String remoteBusinessInterface;
+    private final String remoteBusinessInterface;
 
     SerializableS1ASEJBObjectReference(long containerId, byte[] objKey,
             int keySize, String remoteBusinessInterfaceName) {
@@ -330,6 +335,7 @@ final class SerializableS1ASEJBObjectReference
         return haEnabled;
     }
 
+    @Override
     public Object createObject()
         throws IOException
     {
@@ -352,7 +358,7 @@ final class SerializableS1ASEJBObjectReference
 
                     } else {
 
-                        String generatedRemoteIntfName = EJBUtils.
+                        String generatedRemoteIntfName = RemoteGenerator.
                             getGeneratedRemoteIntfName(remoteBusinessInterface);
 
                         java.rmi.Remote remoteRef = container.

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/ClassGeneratorFactory.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/ClassGeneratorFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,14 +17,26 @@
 
 package com.sun.ejb.codegen;
 
+import org.glassfish.pfl.dynamic.codegen.spi.Wrapper;
 
-/** Convenience interface that defines a factory for ClassGenerator instances.
+/**
+ * Convenience interface that defines a factory for ClassGenerator instances.
  * It puts the class name of the generated class in a single place.
- * It must always be the case that evaluate().name().equals( className() ).
  */
-public interface ClassGeneratorFactory
-{
-    String className() ;
+public interface ClassGeneratorFactory {
 
+    /**
+     * @return name of the generated class or interface
+     */
+    String getGeneratedClassName();
+
+    /**
+     * @return loadable class of the same package as {@link #getGeneratedClassName()}
+     */
+    Class<?> getAnchorClass();
+
+    /**
+     * Calls {@link Wrapper} methods to configure the class definition.
+     */
     void evaluate();
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Generator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Generator.java
@@ -28,30 +28,19 @@ import java.util.List;
 public abstract class Generator implements ClassGeneratorFactory {
 
     /**
-     * Get the package name from the class name.
-     *
-     * @param className class name.
-     * @return the package name.
+     * @return the package name or null.
      */
-    protected String getPackageName(String className) {
-        int dot = className.lastIndexOf('.');
-        if (dot == -1) {
-            return null;
-        }
-        return className.substring(0, dot);
+    public static String getPackageName(String fullClassName) {
+        int dot = fullClassName.lastIndexOf('.');
+        return dot == -1 ? null : fullClassName.substring(0, dot);
     }
 
-
     /**
-     * @param className
      * @return simple class name (including wrapper class and dollar sign if it is internal class)
      */
-    protected String getBaseName(String className) {
-        int dot = className.lastIndexOf('.');
-        if (dot == -1) {
-            return className;
-        }
-        return className.substring(dot + 1);
+    public static String getBaseName(String fullClassName) {
+        int dot = fullClassName.lastIndexOf('.');
+        return dot == -1 ? fullClassName : fullClassName.substring(dot + 1);
     }
 
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Generator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Generator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,246 +18,102 @@
 package com.sun.ejb.codegen;
 
 import java.lang.reflect.Method;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.Vector;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import com.sun.enterprise.deployment.MethodDescriptor;
-import com.sun.logging.LogDomains;
-import org.glassfish.api.deployment.DeploymentContext;
-import org.glassfish.ejb.deployment.descriptor.ContainerTransaction;
-import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
-import org.glassfish.ejb.deployment.descriptor.EjbSessionDescriptor;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * The base class for all code generators.
  */
-public abstract class Generator {
-
-    protected static final Logger _logger = LogDomains.getLogger(Generator.class, LogDomains.EJB_LOGGER);
-
-    protected String ejbClassSymbol;
-
-    public abstract String getGeneratedClass();
-
+public abstract class Generator implements ClassGeneratorFactory {
 
     /**
      * Get the package name from the class name.
+     *
      * @param className class name.
      * @return the package name.
      */
     protected String getPackageName(String className) {
         int dot = className.lastIndexOf('.');
-        if (dot == -1)
+        if (dot == -1) {
             return null;
+        }
         return className.substring(0, dot);
     }
 
-    protected String getBaseName(String className) {
-        int dot = className.lastIndexOf('.');
-        if (dot == -1)
-            return className;
-        return className.substring(dot+1);
-    }
-
-    protected String printType(Class cls) {
-        if (cls.isArray()) {
-            return printType(cls.getComponentType()) + "[]";
-        } else {
-            return cls.getName();
-        }
-    }
-
-    protected Method[] removeDups(Method[] orig) {
-        // Remove duplicates from method array.
-        // Duplicates will arise if a class/intf and super-class/intf
-        // define methods with the same signature. Potentially the
-        // throws clauses of the methods may be different (note Java
-        // requires that the superclass/intf method have a superset of the
-        // exceptions in the derived method).
-        Vector nodups = new Vector();
-        for ( int i=0; i<orig.length; i++ ) {
-            Method m1 = orig[i];
-            boolean dup = false;
-            for ( Enumeration e=nodups.elements(); e.hasMoreElements(); ) {
-                Method m2 = (Method)e.nextElement();
-
-                // m1 and m2 are duplicates if they have the same signature
-                // (name and same parameters).
-                if ( !m1.getName().equals(m2.getName()) )
-                    continue;
-
-                Class[] m1parms = m1.getParameterTypes();
-                Class[] m2parms = m2.getParameterTypes();
-                if ( m1parms.length != m2parms.length )
-                    continue;
-
-                boolean parmsDup = true;
-                for ( int j=0; j<m2parms.length; j++ ) {
-                    if ( m1parms[j] != m2parms[j] ) {
-                        parmsDup = false;
-                        break;
-                    }
-                }
-                if ( parmsDup ) {
-                    dup = true;
-                    // Select which of the duplicate methods to generate
-                    // code for: choose the one that is lower in the
-                    // inheritance hierarchy: this ensures that the generated
-                    // method will compile.
-                    if ( m2.getDeclaringClass().isAssignableFrom(
-                                                    m1.getDeclaringClass()) ) {
-                        // m2 is a superclass/intf of m1, so replace m2 with m1
-                        nodups.remove(m2);
-                        nodups.add(m1);
-                    }
-                    break;
-                }
-            }
-
-            if ( !dup )
-                nodups.add(m1);
-        }
-        return (Method[])nodups.toArray(new Method[nodups.size()]);
-    }
 
     /**
-     * Return true if method is on a jakarta.ejb.EJBObject/EJBLocalObject/
-     * jakarta.ejb.EJBHome,jakarta.ejb.EJBLocalHome interface.
+     * @param className
+     * @return simple class name (including wrapper class and dollar sign if it is internal class)
      */
-    protected boolean isEJBIntfMethod(Class ejbIntfClz, Method methodToCheck) {
-        boolean isEJBIntfMethod = false;
-
-        Method[] ejbIntfMethods = ejbIntfClz.getMethods();
-        for(int i = 0; i < ejbIntfMethods.length; i++) {
-            Method next = ejbIntfMethods[i];
-            if(methodCompare(methodToCheck, next)) {
-                isEJBIntfMethod = true;
-
-                String ejbIntfClzName  = ejbIntfClz.getName();
-                Class methodToCheckClz = methodToCheck.getDeclaringClass();
-                if( !methodToCheckClz.getName().equals(ejbIntfClzName) ) {
-                    String[] logParams = {next.toString(), methodToCheck.toString()};
-                    _logger.log(Level.WARNING,
-                                "ejb.illegal_ejb_interface_override",
-                                logParams);
-                }
-
-                break;
-            }
+    protected String getBaseName(String className) {
+        int dot = className.lastIndexOf('.');
+        if (dot == -1) {
+            return className;
         }
-
-        return isEJBIntfMethod;
+        return className.substring(dot + 1);
     }
 
 
-    private boolean methodCompare(Method factoryMethod, Method homeMethod) {
+    /**
+     * Remove duplicates from method array.
+     * <p>
+     * Duplicates will arise if a class/intf and super-class/intf
+     * define methods with the same signature. Potentially the
+     * throws clauses of the methods may be different (note Java
+     * requires that the superclass/intf method have a superset of the
+     * exceptions in the derived method).
+     *
+     * @param methods
+     * @return methods which can be generated in an interface
+     */
+    protected Method[] removeRedundantMethods(Method[] methods) {
+        final List<Method> nodups = new ArrayList<>();
+        for (Method method : methods) {
+            boolean duplicationDetected = false;
+            final List<Method> previousResult = new ArrayList<>(nodups);
+            for (Method alreadyProcessed : previousResult) {
+                // m1 and m2 are duplicates if they have the same signature
+                // (name and same parameters).
+                if (!method.getName().equals(alreadyProcessed.getName())) {
+                    continue;
+                }
+                if (!haveSameParams(method, alreadyProcessed)) {
+                    continue;
+                }
+                duplicationDetected = true;
+                // Select which of the duplicate methods to generate
+                // code for: choose the one that is lower in the
+                // inheritance hierarchy: this ensures that the generated
+                // method will compile.
+                if (alreadyProcessed.getDeclaringClass().isAssignableFrom(method.getDeclaringClass())) {
+                    // alreadyProcessedMethod is a superclass/intf of method,
+                    // so replace it with more concrete method
+                    nodups.remove(alreadyProcessed);
+                    nodups.add(method);
+                }
+                break;
+            }
 
-        if (!factoryMethod.getName().equals(homeMethod.getName())) {
+            if (!duplicationDetected) {
+                nodups.add(method);
+            }
+        }
+        return nodups.toArray(new Method[nodups.size()]);
+    }
+
+
+    private boolean haveSameParams(final Method method1, final Method method2) {
+        Class<?>[] m1parms = method1.getParameterTypes();
+        Class<?>[] m2parms = method2.getParameterTypes();
+        if (m1parms.length != m2parms.length) {
             return false;
         }
-
-        Class[] factoryParamTypes = factoryMethod.getParameterTypes();
-        Class[] beanParamTypes = homeMethod.getParameterTypes();
-        if (factoryParamTypes.length != beanParamTypes.length) {
-            return false;
-        }
-        for(int i = 0; i < factoryParamTypes.length; i++) {
-            if (factoryParamTypes[i] != beanParamTypes[i]) {
+        for (int i = 0; i < m2parms.length; i++) {
+            if (m1parms[i] != m2parms[i]) {
                 return false;
             }
         }
-
-        // NOTE : Exceptions and return types are not part of equality check
         return true;
-    }
-
-
-    protected String getUniqueClassName(DeploymentContext context, String origName, String origSuffix,
-        Vector existingClassNames) {
-        String newClassName = null;
-        boolean foundUniqueName = false;
-        int count = 0;
-        while (!foundUniqueName) {
-            String suffix = origSuffix;
-            if (count > 0) {
-                suffix = origSuffix + count;
-            }
-            newClassName = origName + suffix;
-            if (!existingClassNames.contains(newClassName)) {
-                foundUniqueName = true;
-                existingClassNames.add(newClassName);
-            } else {
-                count++;
-            }
-        }
-        return newClassName;
-    }
-
-
-    protected String getTxAttribute(EjbDescriptor dd, Method method) {
-        // The TX_* strings returned MUST match the TX_* constants in
-        // com.sun.ejb.Container.
-        if (dd instanceof EjbSessionDescriptor && ((EjbSessionDescriptor) dd).getTransactionType().equals("Bean")) {
-            return "TX_BEAN_MANAGED";
-        }
-
-        String txAttr = null;
-        MethodDescriptor mdesc = new MethodDescriptor(method, ejbClassSymbol);
-        ContainerTransaction ct = dd.getContainerTransactionFor(mdesc);
-        if (ct != null) {
-            String attr = ct.getTransactionAttribute();
-            if (attr.equals(ContainerTransaction.NOT_SUPPORTED)) {
-                txAttr = "TX_NOT_SUPPORTED";
-            } else if (attr.equals(ContainerTransaction.SUPPORTS)) {
-                txAttr = "TX_SUPPORTS";
-            } else if (attr.equals(ContainerTransaction.REQUIRED)) {
-                txAttr = "TX_REQUIRED";
-            } else if (attr.equals(ContainerTransaction.REQUIRES_NEW)) {
-                txAttr = "TX_REQUIRES_NEW";
-            } else if (attr.equals(ContainerTransaction.MANDATORY)) {
-                txAttr = "TX_MANDATORY";
-            } else if (attr.equals(ContainerTransaction.NEVER)) {
-                txAttr = "TX_NEVER";
-            }
-        }
-
-        if (txAttr == null) {
-            throw new RuntimeException("Transaction Attribute not found for method " + method);
-        }
-        return txAttr;
-    }
-
-    protected String getSecurityAttribute(EjbDescriptor dd, Method m) {
-        // The SEC_* strings returned MUST match the SEC_* constants in
-        // com.sun.ejb.Container.
-        MethodDescriptor thisMethodDesc = new MethodDescriptor(m, ejbClassSymbol);
-        Set unchecked = dd.getUncheckedMethodDescriptors();
-        if (unchecked != null) {
-            Iterator i = unchecked.iterator();
-            while (i.hasNext()) {
-                MethodDescriptor md = (MethodDescriptor) i.next();
-                if (thisMethodDesc.equals(md)) {
-                    return "SEC_UNCHECKED";
-                }
-            }
-        }
-
-        Set excluded = dd.getExcludedMethodDescriptors();
-        if (excluded != null) {
-            Iterator i = excluded.iterator();
-            while (i.hasNext()) {
-                MethodDescriptor md = (MethodDescriptor) i.next();
-                if (thisMethodDesc.equals(md)) {
-                    return "SEC_EXCLUDED";
-                }
-            }
-        }
-
-        return "SEC_CHECKED";
     }
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/GenericHomeGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/GenericHomeGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,74 +17,70 @@
 
 package com.sun.ejb.codegen;
 
+import com.sun.ejb.containers.GenericEJBHome;
 
-import com.sun.ejb.EJBUtils;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
 
-import com.sun.enterprise.util.LocalStringManagerImpl;
-
-import static java.lang.reflect.Modifier.*;
-
-import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper.*;
+import static java.lang.reflect.Modifier.ABSTRACT;
+import static java.lang.reflect.Modifier.PUBLIC;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._String;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._arg;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._classGenerator;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._clear;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._end;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._interface;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._method;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._package;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._t;
 
 /**
  * This class is used to generate a sub-interface of the
  * GenericEJBHome interface that will be loaded within each
  * application.
  */
+public class GenericHomeGenerator extends Generator {
 
-public class GenericHomeGenerator extends Generator
-    implements ClassGeneratorFactory {
-
-    private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(GenericHomeGenerator.class);
-
-    private String genericEJBHomeClassName;
-    private ClassLoader loader;
+    /**
+     * This class name is relative to the classloader used, but has always the same name.
+     */
+    public static final String GENERIC_HOME_CLASSNAME = GenericHomeGenerator.class.getPackageName()
+        + ".GenericEJBHome_Generated";
 
     /**
      * Get the fully qualified name of the generated class.
      * @return the name of the generated class.
      */
-    public String getGeneratedClass() {
-        return genericEJBHomeClassName;
-    }
-
-    // For corba codegen infrastructure
-    public String className() {
-        return getGeneratedClass();
+    @Override
+    public final String getGeneratedClassName() {
+        return GENERIC_HOME_CLASSNAME;
     }
 
 
-    public GenericHomeGenerator(ClassLoader cl) throws GeneratorException {
-        super();
-
-        genericEJBHomeClassName = EJBUtils.getGenericEJBHomeClassName();
-        loader = cl;
+    @Override
+    public Class<?> getAnchorClass() {
+        return GenericHomeGenerator.class;
     }
 
 
+    @Override
     public void evaluate() {
-
         _clear();
 
-        String packageName = getPackageName(genericEJBHomeClassName);
-        String simpleName = getBaseName (genericEJBHomeClassName);
+        String packageName = getPackageName(getGeneratedClassName());
+        String simpleName = getBaseName(getGeneratedClassName());
 
         _package(packageName);
 
-        _interface(PUBLIC, simpleName,
-                   _t("com.sun.ejb.containers.GenericEJBHome"));
+        _interface(PUBLIC, simpleName, _t(GenericEJBHome.class.getName()));
 
-        // Create method
-        _method(PUBLIC | ABSTRACT, _t("java.rmi.Remote"),
-                "create", _t("java.rmi.RemoteException"));
+        _method(PUBLIC | ABSTRACT, _t(Remote.class.getName()), "create", _t(RemoteException.class.getName()));
 
         _arg(_String(), "generatedBusinessIntf");
 
         _end();
 
         _classGenerator() ;
-
-        return;
     }
 
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Remote30WrapperGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Remote30WrapperGenerator.java
@@ -17,7 +17,6 @@
 
 package com.sun.ejb.codegen;
 
-import com.sun.ejb.EJBUtils;
 import com.sun.ejb.containers.InternalEJBContainerException;
 import com.sun.ejb.containers.InternalRemoteException;
 import com.sun.ejb.containers.RemoteBusinessWrapperBase;
@@ -66,6 +65,18 @@ public final class Remote30WrapperGenerator extends Generator {
 
 
     /**
+     * Adds _Wrapper to the original name.
+     *
+     * @param businessIntf full class name
+     */
+    public static String getGeneratedRemoteWrapperName(String businessIntf) {
+        String packageName = getPackageName(businessIntf);
+        String simpleName = getBaseName(businessIntf);
+        String generatedSimpleName = "_" + simpleName + "_Wrapper";
+        return packageName == null ? generatedSimpleName : packageName + "." + generatedSimpleName;
+    }
+
+    /**
      * Construct the Wrapper generator with the specified deployment
      * descriptor and class loader.
      *
@@ -94,7 +105,7 @@ public final class Remote30WrapperGenerator extends Generator {
                 + ". A Remote Business interface MUST not extend jakarta.ejb.EJBObject.");
         }
 
-        remoteClientClassName = EJBUtils.getGeneratedRemoteWrapperName(businessIntfName);
+        remoteClientClassName = getGeneratedRemoteWrapperName(businessIntfName);
         remoteClientPackageName = getPackageName(remoteClientClassName);
         remoteClientSimpleName = getBaseName(remoteClientClassName);
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Remote30WrapperGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/Remote30WrapperGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,85 +17,104 @@
 
 package com.sun.ejb.codegen;
 
-import java.lang.reflect.Method;
-import java.util.*;
-
-
-import static java.lang.reflect.Modifier.*;
-
-import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper.*;
-import org.glassfish.pfl.dynamic.codegen.spi.Type ;
-import org.glassfish.pfl.dynamic.codegen.spi.Expression ;
-
 import com.sun.ejb.EJBUtils;
+import com.sun.ejb.containers.InternalEJBContainerException;
+import com.sun.ejb.containers.InternalRemoteException;
+import com.sun.ejb.containers.RemoteBusinessWrapperBase;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 
-public class Remote30WrapperGenerator extends Generator
-    implements ClassGeneratorFactory {
+import java.lang.reflect.Method;
+import java.rmi.AccessException;
+import java.rmi.NoSuchObjectException;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-    private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(Remote30WrapperGenerator.class);
+import org.glassfish.pfl.dynamic.codegen.spi.Expression;
+import org.glassfish.pfl.dynamic.codegen.spi.Type;
+import org.omg.CORBA.SystemException;
 
-    private String remoteInterfaceName;
-    private Class businessInterface;
-    private String remoteClientClassName;
-    private String remoteClientPackageName;
-    private String remoteClientSimpleName;
-    private Method[] bizMethods;
+import jakarta.ejb.EJBAccessException;
+import jakarta.ejb.EJBException;
+import jakarta.ejb.EJBTransactionRequiredException;
+import jakarta.ejb.EJBTransactionRolledbackException;
+import jakarta.ejb.NoSuchEJBException;
+import jakarta.transaction.TransactionRequiredException;
+import jakarta.transaction.TransactionRolledbackException;
 
-    private ClassLoader loader;
+import static java.lang.reflect.Modifier.PRIVATE;
+import static java.lang.reflect.Modifier.PUBLIC;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper.*;
 
-    public String getGeneratedClass() {
-        return remoteClientClassName;
-    }
+public final class Remote30WrapperGenerator extends Generator {
 
-    // For corba codegen infrastructure
-    public String className() {
-        return getGeneratedClass();
-    }
+    private static final LocalStringManagerImpl localStrings = new LocalStringManagerImpl(Remote30WrapperGenerator.class);
+    private static final Logger LOG = Logger.getLogger(Remote30WrapperGenerator.class.getName());
+
+    private final String remoteInterfaceName;
+    private final Class<?> businessInterface;
+    private final String remoteClientClassName;
+    private final String remoteClientPackageName;
+    private final String remoteClientSimpleName;
+    private final Method[] methodsToGenerate;
+
+    private final ClassLoader loader;
 
 
     /**
      * Construct the Wrapper generator with the specified deployment
      * descriptor and class loader.
      *
-     * @exception GeneratorException
+     * @param loader
+     * @param businessIntfName must already exist and be loadable by the loader
+     * @param remoteInterfaceName generated class will implement this
+     *
+     * @throws GeneratorException
      */
-    public Remote30WrapperGenerator(ClassLoader cl, String businessIntfName, String remoteIntfName)
+    public Remote30WrapperGenerator(ClassLoader loader, String businessIntfName, String remoteInterfaceName)
         throws GeneratorException {
-        super();
 
-        remoteInterfaceName = remoteIntfName;
-        loader = cl;
+        this.loader = loader;
+        this.remoteInterfaceName = remoteInterfaceName;
 
         try {
-            this.businessInterface = cl.loadClass(businessIntfName);
+            businessInterface = loader.loadClass(businessIntfName);
         } catch (ClassNotFoundException ex) {
-            throw new InvalidBean(
-            localStrings.getLocalString(
-            "generator.remote_interface_not_found",
-            "Business interface " + businessInterface + " not found "));
+            throw new InvalidBean(localStrings.getLocalString(
+                "generator.remote_interface_not_found",
+                "Business interface " + businessIntfName + " not found "));
         }
 
         if (jakarta.ejb.EJBObject.class.isAssignableFrom(businessInterface)) {
-            throw new GeneratorException("Invalid Remote Business Interface " +
-                 businessInterface + ". A Remote Business interface MUST " +
-                 "not extend jakarta.ejb.EJBObject.");
+            throw new GeneratorException("Invalid Remote Business Interface " + businessInterface
+                + ". A Remote Business interface MUST not extend jakarta.ejb.EJBObject.");
         }
 
-        remoteClientClassName = EJBUtils.
-            getGeneratedRemoteWrapperName(businessInterface.getName());
-
+        remoteClientClassName = EJBUtils.getGeneratedRemoteWrapperName(businessIntfName);
         remoteClientPackageName = getPackageName(remoteClientClassName);
         remoteClientSimpleName = getBaseName(remoteClientClassName);
 
-        bizMethods = removeDups(businessInterface.getMethods());
+        methodsToGenerate = removeRedundantMethods(businessInterface.getMethods());
 
         // NOTE : no need to remove ejb object methods because EJBObject
         // is only visible through the RemoteHome view.
-
     }
 
+    @Override
+    public String getGeneratedClassName() {
+        return remoteClientClassName;
+    }
 
+    @Override
+    public Class<?> getAnchorClass() {
+        return businessInterface;
+    }
+
+    @Override
     public void evaluate() {
 
         _clear();
@@ -107,7 +127,7 @@ public class Remote30WrapperGenerator extends Generator
         }
 
         _class(PUBLIC, remoteClientSimpleName,
-               _t("com.sun.ejb.containers.RemoteBusinessWrapperBase"),
+               _t(RemoteBusinessWrapperBase.class.getName()),
                _t(businessInterface.getName()));
 
         _data(PRIVATE, _t(remoteInterfaceName), "delegate_");
@@ -117,45 +137,42 @@ public class Remote30WrapperGenerator extends Generator
         _arg(_String(), "busIntf");
 
         _body();
-        _expr(_super(_s(_void(), _t("java.rmi.Remote"), _String()), _v("stub"), _v("busIntf")));
+        _expr(_super(_s(_void(), _t(Remote.class.getName()), _String()), _v("stub"), _v("busIntf")));
         _assign(_v("delegate_"), _v("stub"));
         _end();
 
-        for(int i = 0; i < bizMethods.length; i++) {
-            printMethodImpl(bizMethods[i]);
+        for (Method method : methodsToGenerate) {
+            printMethodImpl(method);
         }
 
         _end();
 
         try {
-            java.util.Properties p = new java.util.Properties();
+            Properties p = new Properties();
             p.put("Wrapper.DUMP_AFTER_SETUP_VISITOR", "true");
             p.put("Wrapper.TRACE_BYTE_CODE_GENERATION", "true");
             p.put("Wrapper.USE_ASM_VERIFIER", "true");
             _byteCode(loader, p);
         } catch(Exception e) {
-            System.out.println("Got exception when generating byte code");
-            e.printStackTrace();
+            LOG.log(Level.WARNING, "Got exception when generating byte code", e);
         }
 
         _classGenerator() ;
-
-        return;
     }
 
 
     private void printMethodImpl(Method m) {
-        List<Type> exceptionList = new LinkedList<Type>();
-        for (Class exception : m.getExceptionTypes()) {
+        List<Type> exceptionList = new LinkedList<>();
+        for (Class<?> exception : m.getExceptionTypes()) {
             exceptionList.add(Type.type(exception));
         }
 
         _method(PUBLIC, Type.type(m.getReturnType()), m.getName(), exceptionList);
 
         int i = 0;
-        List<Type> expressionListTypes = new LinkedList<Type>();
-        List<Expression> expressionList = new LinkedList<Expression>();
-        for (Class param : m.getParameterTypes()) {
+        List<Type> expressionListTypes = new LinkedList<>();
+        List<Expression> expressionList = new LinkedList<>();
+        for (Class<?> param : m.getParameterTypes()) {
             String paramName = "param" + i;
             _arg(Type.type(param), paramName);
             i++;
@@ -167,7 +184,7 @@ public class Remote30WrapperGenerator extends Generator
 
         _try();
 
-        Class returnType = m.getReturnType();
+        Class<?> returnType = m.getReturnType();
 
         if (returnType == void.class) {
             _expr(
@@ -177,76 +194,93 @@ public class Remote30WrapperGenerator extends Generator
                 _call(_v("delegate_"), m.getName(), _s(Type.type(returnType), expressionListTypes), expressionList));
         }
 
-        boolean doExceptionTranslation = !java.rmi.Remote.class.isAssignableFrom(businessInterface);
+        boolean doExceptionTranslation = !Remote.class.isAssignableFrom(businessInterface);
         if (doExceptionTranslation) {
+            _catch(_t(TransactionRolledbackException.class.getName()), "trex");
 
-            _catch(_t("jakarta.transaction.TransactionRolledbackException"), "trex");
-
-            _define( _t("java.lang.RuntimeException"), "r",
-                _new( _t("jakarta.ejb.EJBTransactionRolledbackException"), _s(_void())));
+            _define(_t(RuntimeException.class.getName()), "r",
+                _new(_t(EJBTransactionRolledbackException.class.getName()), _s(_void())));
             _expr(
-                _call( _v("r"), "initCause", _s(_t("java.lang.Throwable"), _t("java.lang.Throwable")), _v("trex"))
+                _call(
+                    _v("r"), "initCause",
+                    _s(_t(Throwable.class.getName()), _t(Throwable.class.getName())),
+                    _v("trex")
+                )
             );
             _throw(_v("r"));
 
-            _catch(_t("jakarta.transaction.TransactionRequiredException"), "treqex");
+            _catch(_t(TransactionRequiredException.class.getName()), "treqex");
 
-            _define( _t("java.lang.RuntimeException"), "r",
-                _new( _t("jakarta.ejb.EJBTransactionRequiredException"), _s(_void())));
+            _define(_t(RuntimeException.class.getName()), "r",
+                _new(_t(EJBTransactionRequiredException.class.getName()), _s(_void())));
+
             _expr(
-                _call( _v("r"), "initCause", _s(_t("java.lang.Throwable"), _t("java.lang.Throwable")), _v("treqex"))
+                _call(
+                    _v("r"), "initCause",
+                    _s(_t(Throwable.class.getName()), _t(Throwable.class.getName())),
+                    _v("treqex")
+                )
             );
             _throw(_v("r"));
 
-            _catch(_t("java.rmi.NoSuchObjectException"), "nsoe");
+            _catch(_t(NoSuchObjectException.class.getName()), "nsoe");
 
-            _define( _t("java.lang.RuntimeException"), "r",
-                _new( _t("jakarta.ejb.NoSuchEJBException"), _s(_void())));
+            _define(_t(RuntimeException.class.getName()), "r",
+                _new(_t(NoSuchEJBException.class.getName()), _s(_void())));
             _expr(
-                _call( _v("r"), "initCause", _s(_t("java.lang.Throwable"), _t("java.lang.Throwable")), _v("nsoe"))
+                _call(
+                    _v("r"), "initCause",
+                    _s(_t(Throwable.class.getName()), _t(Throwable.class.getName())),
+                    _v("nsoe")
+                )
             );
             _throw(_v("r"));
 
-            _catch(_t("java.rmi.AccessException"), "accex");
+            _catch(_t(AccessException.class.getName()), "accex");
 
-            _define( _t("java.lang.RuntimeException"), "r",
-                _new( _t("jakarta.ejb.EJBAccessException"), _s(_void())));
+            _define(_t(RuntimeException.class.getName()), "r",
+                _new(_t(EJBAccessException.class.getName()), _s(_void())));
             _expr(
-                _call( _v("r"), "initCause", _s(_t("java.lang.Throwable"), _t("java.lang.Throwable")), _v("accex"))
+                _call(
+                    _v("r"), "initCause",
+                    _s(_t(Throwable.class.getName()), _t(Throwable.class.getName())),
+                    _v("accex")
+                )
             );
             _throw(_v("r"));
 
-            _catch(_t("com.sun.ejb.containers.InternalEJBContainerException"), "iejbcEx");
+            _catch(_t(InternalEJBContainerException.class.getName()), "iejbcEx");
 
-            // This wraps an EJBException. Pull out the cause and throw
-            // it as is.
-            //_define( _t("java.lang.Throwable"), "r", _null());
-
-
-            // _throw(_cast(_t("jakarta.ejb.EJBException"), _v("r")));
             _throw(
-                _cast(_t("jakarta.ejb.EJBException"), _call( _v("iejbcEx"), "getCause", _s(_t("java.lang.Throwable"))))
+                _cast(
+                    _t(EJBException.class.getName()),
+                    _call(_v("iejbcEx"), "getCause", _s(_t(Throwable.class.getName())))
+                )
             );
 
 
-            _catch(_t("java.rmi.RemoteException"), "re");
+            _catch(_t(RemoteException.class.getName()), "re");
 
-            _throw( _new( _t("jakarta.ejb.EJBException"), _s(_void(), _t("java.lang.Exception")), _v("re")));
+            _throw( _new( _t(EJBException.class.getName()), _s(_void(), _t(Exception.class.getName())), _v("re")));
 
-            _catch( _t("org.omg.CORBA.SystemException"), "corbaSysEx");
-            _define( _t("java.lang.RuntimeException"), "r", _new( _t("jakarta.ejb.EJBException"), _s(_void())));
+            _catch( _t(SystemException.class.getName()), "corbaSysEx");
+            _define( _t(RuntimeException.class.getName()), "r", _new( _t(EJBException.class.getName()), _s(_void())));
             _expr(
-                _call( _v("r"), "initCause", _s(_t("java.lang.Throwable"), _t("java.lang.Throwable")), _v("corbaSysEx"))
+                _call(
+                    _v("r"), "initCause",
+                    _s(_t(Throwable.class.getName()), _t(Throwable.class.getName())),
+                    _v("corbaSysEx")
+                )
             );
             _throw(_v("r"));
 
             _end();
 
         } else {
-            _catch(_t("com.sun.ejb.containers.InternalEJBContainerException"), "iejbcEx");
+            _catch(_t(InternalEJBContainerException.class.getName()), "iejbcEx");
             _throw(
-                _new( _t("com.sun.ejb.containers.InternalRemoteException"),
-                _s(_void(), _t("com.sun.ejb.containers.InternalEJBContainerException")),
+                _new( _t(InternalRemoteException.class.getName()),
+                _s(_void(), _t(InternalEJBContainerException.class.getName())),
                 _v("iejbcEx"))
             );
             _end();

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/RemoteGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/RemoteGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,80 +17,88 @@
 
 package com.sun.ejb.codegen;
 
-import java.lang.reflect.Method;
-import java.io.*;
-import java.util.*;
 import com.sun.ejb.EJBUtils;
+import com.sun.ejb.containers.InternalEJBContainerException;
+import com.sun.ejb.containers.RemoteBusinessObject;
+import com.sun.enterprise.util.LocalStringManagerImpl;
 
-import static java.lang.reflect.Modifier.*;
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
 
-import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper.*;
 import org.glassfish.pfl.dynamic.codegen.spi.Type ;
 
-import com.sun.enterprise.util.LocalStringManagerImpl;
+import static java.lang.reflect.Modifier.ABSTRACT;
+import static java.lang.reflect.Modifier.PUBLIC;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._arg;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._classGenerator;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._clear;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._end;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._interface;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._method;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._package;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._t;
 
 /**
  * This class is used to generate the RMI-IIOP version of a
  * remote business interface.
  */
-
-public class RemoteGenerator extends Generator
-    implements ClassGeneratorFactory {
+public final class RemoteGenerator extends Generator {
 
     private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(RemoteGenerator.class);
 
+    private Class<?> businessInterface;
+    private final Method[] methodsToGenerate;
+    private final String remoteInterfacePackageName;
+    private final String remoteInterfaceSimpleName;
+    private final String remoteInterfaceName;
 
-    private Class businessInterface;
-    private Method[] bizMethods;
-    private String remoteInterfacePackageName;
-    private String remoteInterfaceSimpleName;
-    private String remoteInterfaceName;
-
-    /**
-     * Get the fully qualified name of the generated class.
-     * Note: the remote/local implementation class is in the same package
-     * as the bean class, NOT the remote/local interface.
-     * @return the name of the generated class.
-     */
-    public String getGeneratedClass() {
-        return remoteInterfaceName;
-    }
-
-    // For corba codegen infrastructure
-    public String className() {
-        return getGeneratedClass();
-    }
 
     /**
      * Construct the Wrapper generator with the specified deployment
      * descriptor and class loader.
-     * @exception GeneratorException
+     *
+     * @param classLoader
+     * @param businessIntf
+     * @throws InvalidBean if the businessInterface doesn't exist.
      */
-    public RemoteGenerator(ClassLoader cl, String businessIntf) throws GeneratorException {
-        super();
-
+    public RemoteGenerator(ClassLoader classLoader, String businessIntf) throws InvalidBean {
         try {
-            businessInterface = cl.loadClass(businessIntf);
+            businessInterface = classLoader.loadClass(businessIntf);
         } catch (ClassNotFoundException ex) {
             throw new InvalidBean(
-                localStrings.getLocalString(
-                    "generator.remote_interface_not_found",
-                    "Remote interface not found "));
+                localStrings.getLocalString("generator.remote_interface_not_found", "Remote interface not found "));
         }
 
-        remoteInterfaceName = EJBUtils.getGeneratedRemoteIntfName
-            (businessInterface.getName());
-
+        remoteInterfaceName = EJBUtils.getGeneratedRemoteIntfName(businessInterface.getName());
         remoteInterfacePackageName = getPackageName(remoteInterfaceName);
         remoteInterfaceSimpleName = getBaseName(remoteInterfaceName);
 
-        bizMethods = removeDups(businessInterface.getMethods());
+        methodsToGenerate = removeRedundantMethods(businessInterface.getMethods());
 
         // NOTE : no need to remove ejb object methods because EJBObject
         // is only visible through the RemoteHome view.
     }
 
+    /**
+     * Get the fully qualified name of the generated class.
+     * <p>
+     * Note: the remote/local implementation class is in the same package
+     * as the bean class, NOT the remote/local interface.
+     *
+     * @return the name of the generated class.
+     */
+    @Override
+    public String getGeneratedClassName() {
+        return remoteInterfaceName;
+    }
 
+    @Override
+    public Class<?> getAnchorClass() {
+        return businessInterface;
+    }
+
+    @Override
     public void evaluate() {
 
         _clear();
@@ -97,51 +106,46 @@ public class RemoteGenerator extends Generator
         if (remoteInterfacePackageName != null) {
             _package(remoteInterfacePackageName);
         } else {
-            // no-arg _package() call is required for default package
             _package();
         }
 
         _interface(PUBLIC, remoteInterfaceSimpleName,
-                   _t("java.rmi.Remote"),
-                   _t("com.sun.ejb.containers.RemoteBusinessObject"));
+            _t(java.rmi.Remote.class.getName()),
+            _t(RemoteBusinessObject.class.getName())
+        );
 
-        for(int i = 0; i < bizMethods.length; i++) {
-            printMethod(bizMethods[i]);
+        for (Method method : methodsToGenerate) {
+            printMethod(method);
         }
 
         _end();
 
         _classGenerator() ;
-
-        return;
-
     }
 
 
     private void printMethod(Method m) {
         boolean throwsRemoteException = false;
-        List<Type> exceptionList = new LinkedList<Type>();
-        for(Class exception : m.getExceptionTypes()) {
+        List<Type> exceptionList = new LinkedList<>();
+        for (Class<?> exception : m.getExceptionTypes()) {
             exceptionList.add(Type.type(exception));
-            if( exception.getName().equals("java.rmi.RemoteException") ) {
+            if (exception.getName().equals("java.rmi.RemoteException")) {
                 throwsRemoteException = true;
             }
         }
-        if( !throwsRemoteException ) {
+        if (!throwsRemoteException) {
             exceptionList.add(_t("java.rmi.RemoteException"));
         }
 
-        exceptionList.add(_t("com.sun.ejb.containers.InternalEJBContainerException"));
+        exceptionList.add(_t(InternalEJBContainerException.class.getName()));
         _method(PUBLIC | ABSTRACT, Type.type(m.getReturnType()), m.getName(), exceptionList);
 
         int i = 0;
-        for(Class param : m.getParameterTypes()) {
+        for (Class<?> param : m.getParameterTypes()) {
             _arg(Type.type(param), "param" + i);
             i++;
         }
 
         _end();
     }
-
-
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/RemoteGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/RemoteGenerator.java
@@ -17,7 +17,6 @@
 
 package com.sun.ejb.codegen;
 
-import com.sun.ejb.EJBUtils;
 import com.sun.ejb.containers.InternalEJBContainerException;
 import com.sun.ejb.containers.RemoteBusinessObject;
 import com.sun.enterprise.util.LocalStringManagerImpl;
@@ -55,6 +54,19 @@ public final class RemoteGenerator extends Generator {
 
 
     /**
+     * Adds _Remote to the original name.
+     *
+     * @param businessIntf full class name
+     */
+    public static String getGeneratedRemoteIntfName(String businessIntf) {
+        String packageName = getPackageName(businessIntf);
+        String simpleName = getBaseName(businessIntf);
+        String generatedSimpleName = "_" + simpleName + "_Remote";
+        return packageName == null ? generatedSimpleName : packageName + "." + generatedSimpleName;
+    }
+
+
+    /**
      * Construct the Wrapper generator with the specified deployment
      * descriptor and class loader.
      *
@@ -70,7 +82,7 @@ public final class RemoteGenerator extends Generator {
                 localStrings.getLocalString("generator.remote_interface_not_found", "Remote interface not found "));
         }
 
-        remoteInterfaceName = EJBUtils.getGeneratedRemoteIntfName(businessInterface.getName());
+        remoteInterfaceName = getGeneratedRemoteIntfName(businessInterface.getName());
         remoteInterfacePackageName = getPackageName(remoteInterfaceName);
         remoteInterfaceSimpleName = getBaseName(remoteInterfaceName);
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/ServiceInterfaceGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/ServiceInterfaceGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,21 +19,23 @@ package com.sun.ejb.codegen;
 
 
 import java.lang.reflect.Method;
-import java.util.List;
+import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.LinkedList;
-
-import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper.*;
+import java.util.List;
 import org.glassfish.pfl.dynamic.codegen.spi.Type ;
-
-import java.util.logging.Logger;
 
 import jakarta.jws.WebMethod;
 
-import static java.lang.reflect.Modifier.*;
-
-import com.sun.enterprise.util.LocalStringManagerImpl;
-import com.sun.logging.LogDomains;
+import static java.lang.reflect.Modifier.ABSTRACT;
+import static java.lang.reflect.Modifier.PUBLIC;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._arg;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._clear;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._end;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._interface;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._method;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._package;
+import static org.glassfish.pfl.dynamic.codegen.spi.Wrapper._t;
 
 /**
  * This class is responsible for generating the SEI when it is not packaged
@@ -40,98 +43,52 @@ import com.sun.logging.LogDomains;
  *
  * @author Jerome Dochez
  */
-public class ServiceInterfaceGenerator extends Generator
-    implements ClassGeneratorFactory {
+public class ServiceInterfaceGenerator extends Generator {
 
-    private static LocalStringManagerImpl localStrings =
-        new LocalStringManagerImpl(ServiceInterfaceGenerator.class);
-    private static Logger _logger=null;
-    static{
-       _logger=LogDomains.getLogger(ServiceInterfaceGenerator.class, LogDomains.DPL_LOGGER);
-    }
-
-    Class sib=null;
-    String serviceIntfName;
-    String packageName;
-    String serviceIntfSimpleName;
-    Method[] intfMethods;
+    private final Class<?> ejbClass;
+    private final String packageName;
+    private final String serviceIntfName;
+    private final String serviceIntfSimpleName;
+    private final Method[] intfMethods;
 
    /**
      * Construct the Wrapper generator with the specified deployment
      * descriptor and class loader.
-     * @exception GeneratorException.
      */
-    public ServiceInterfaceGenerator(ClassLoader cl, Class sib)
-        throws GeneratorException, ClassNotFoundException
-    {
-        super();
-
-        this.sib = sib;
-        serviceIntfSimpleName = getServiceIntfName();
-
-        packageName = getPackageName();
-        serviceIntfName = packageName + "." + serviceIntfSimpleName;
-
-        intfMethods = calculateMethods(sib, removeDups(sib.getMethods()));
+    public ServiceInterfaceGenerator(Class<?> ejbClass) {
+        this.ejbClass = ejbClass;
+        packageName = getPackageName(ejbClass.getName());
+        serviceIntfSimpleName = getServiceIntfName(ejbClass);
+        serviceIntfName = (packageName == null ? "" : packageName + ".") + serviceIntfSimpleName;
+        intfMethods = calculateMethods(ejbClass, removeRedundantMethods(ejbClass.getMethods()));
 
         // NOTE : no need to remove ejb object methods because EJBObject
         // is only visible through the RemoteHome view.
     }
 
-    public String getServiceIntfName() {
-        String serviceIntfSimpleName = sib.getSimpleName();
-        if (serviceIntfSimpleName.endsWith("EJB")) {
-            return serviceIntfSimpleName.substring(0, serviceIntfSimpleName.length()-3);
-        } else {
-            return serviceIntfSimpleName+"SEI";
-        }
-    }
-
-    public String getPackageName() {
-        return sib.getPackage().getName()+".internal.jaxws";
-    }
 
     /**
      * Get the fully qualified name of the generated class.
+     * <p>
      * Note: the remote/local implementation class is in the same package
      * as the bean class, NOT the remote/local interface.
+     *
      * @return the name of the generated class.
      */
-    public String getGeneratedClass() {
+    @Override
+    public String getGeneratedClassName() {
         return serviceIntfName;
     }
 
-    // For corba codegen infrastructure
-    public String className() {
-        return getGeneratedClass();
+
+    @Override
+    public Class<?> getAnchorClass() {
+        return ejbClass;
     }
 
-    private Method[] calculateMethods(Class sib, Method[] initialList) {
 
-        // we start by assuming the @WebMethod was NOT used on this class
-        boolean webMethodAnnotationUsed = false;
-        List<Method> list = new ArrayList<Method>();
-
-        for (Method m : initialList) {
-            WebMethod wm = m.getAnnotation(WebMethod.class);
-            if ( (wm != null) && !webMethodAnnotationUsed) {
-                webMethodAnnotationUsed=true;
-                // reset the list, this is the first annotated method we find
-                list.clear();
-            }
-            if (wm!=null) {
-                list.add(m);
-            } else {
-                if (!webMethodAnnotationUsed && !m.getDeclaringClass().equals(java.lang.Object.class)) {
-                    list.add(m);
-                }
-            }
-        }
-        return list.toArray(new Method[list.size()]);
-    }
-
+    @Override
     public void evaluate() {
-
         _clear();
 
         if (packageName != null) {
@@ -140,38 +97,31 @@ public class ServiceInterfaceGenerator extends Generator
 
         _interface(PUBLIC, serviceIntfSimpleName);
 
-        for(int i = 0; i < intfMethods.length; i++) {
-            printMethod(intfMethods[i]);
+        for (Method intfMethod : intfMethods) {
+            printMethod(intfMethod);
         }
 
         _end();
-
-        return;
-
     }
 
 
-    private void printMethod(Method m)
-    {
-
+    private void printMethod(Method m) {
         boolean throwsRemoteException = false;
-        List<Type> exceptionList = new LinkedList<Type>();
-        for(Class exception : m.getExceptionTypes()) {
+        List<Type> exceptionList = new LinkedList<>();
+        for (Class<?> exception : m.getExceptionTypes()) {
             exceptionList.add(Type.type(exception));
-            if( exception.getName().equals("java.rmi.RemoteException") ) {
+            if (exception.getName().equals(RemoteException.class.getName())) {
                 throwsRemoteException = true;
             }
-    }
-        if( !throwsRemoteException ) {
-            exceptionList.add(_t("java.rmi.RemoteException"));
+        }
+        if (!throwsRemoteException) {
+            exceptionList.add(_t(RemoteException.class.getName()));
         }
 
-        _method( PUBLIC | ABSTRACT, Type.type(m.getReturnType()),
-                 m.getName(), exceptionList);
+        _method(PUBLIC | ABSTRACT, Type.type(m.getReturnType()), m.getName(), exceptionList);
 
         int i = 0;
-
-        for(Class param : m.getParameterTypes()) {
+        for (Class<?> param : m.getParameterTypes()) {
             _arg(Type.type(param), "param" + i);
             i++;
         }
@@ -179,4 +129,36 @@ public class ServiceInterfaceGenerator extends Generator
         _end();
     }
 
+
+    private static String getServiceIntfName(Class<?> ejbClass) {
+        String serviceIntfSimpleName = ejbClass.getSimpleName();
+        if (serviceIntfSimpleName.endsWith("EJB")) {
+            return serviceIntfSimpleName.substring(0, serviceIntfSimpleName.length() - 3) + "_GeneratedSEI";
+        }
+        return serviceIntfSimpleName + "_GeneratedSEI";
+    }
+
+
+    private static Method[] calculateMethods(Class sib, Method[] initialList) {
+        // we start by assuming the @WebMethod was NOT used on this class
+        boolean webMethodAnnotationUsed = false;
+        List<Method> list = new ArrayList<>();
+
+        for (Method m : initialList) {
+            WebMethod wm = m.getAnnotation(WebMethod.class);
+            if (wm != null && !webMethodAnnotationUsed) {
+                webMethodAnnotationUsed = true;
+                // reset the list, this is the first annotated method we find
+                list.clear();
+            }
+            if (wm != null) {
+                list.add(m);
+            } else {
+                if (!webMethodAnnotationUsed && !m.getDeclaringClass().equals(Object.class)) {
+                    list.add(m);
+                }
+            }
+        }
+        return list.toArray(new Method[list.size()]);
+    }
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/AbstractSessionContextImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/AbstractSessionContextImpl.java
@@ -17,6 +17,7 @@
 package com.sun.ejb.containers;
 
 import com.sun.ejb.EjbInvocation;
+import com.sun.ejb.codegen.RemoteGenerator;
 import com.sun.enterprise.deployment.EjbDescriptor;
 import com.sun.enterprise.deployment.EjbSessionDescriptor;
 import org.glassfish.api.invocation.ComponentInvocation;
@@ -117,7 +118,7 @@ public abstract class AbstractSessionContextImpl
 
                 // Create a new client object from the stub for this
                 // business interface.
-                String generatedIntf = EJBUtils.getGeneratedRemoteIntfName(intfName);
+                String generatedIntf = RemoteGenerator.getGeneratedRemoteIntfName(intfName);
 
                 java.rmi.Remote stub =
                     ejbRemoteBusinessObjectImpl.getStub(generatedIntf);

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -1103,8 +1103,8 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             Class serviceEndpointIntfClass = loader.loadClass(webServiceEndpoint.getServiceEndpointInterface());
 
             if (!serviceEndpointIntfClass.isInterface()) {
-                ServiceInterfaceGenerator generator = new ServiceInterfaceGenerator(loader, ejbClass);
-                serviceEndpointIntfClass = EJBUtils.generateSEI(generator, loader, this.ejbClass);
+                ServiceInterfaceGenerator generator = new ServiceInterfaceGenerator(ejbClass);
+                serviceEndpointIntfClass = EJBUtils.generateSEI(generator, loader);
                 if (serviceEndpointIntfClass == null) {
                     throw new RuntimeException(localStrings.getLocalString("ejb.error_generating_sei",
                         "Error in generating service endpoint interface class for EJB class {0}", this.ejbClass));

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -609,11 +609,9 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                     // made before any EJB 3.0 Remote business interface
                     // runtime behavior is needed for a particular
                     // classloader.
-                    EJBUtils.loadGeneratedRemoteBusinessClasses(loader, next);
+                    String nextGen = EJBUtils.loadGeneratedRemoteBusinessClasses(loader, next);
 
-                    String nextGen = EJBUtils.getGeneratedRemoteIntfName(next);
-
-                    Class genRemoteIntf = loader.loadClass(nextGen);
+                    Class<?> genRemoteIntf = loader.loadClass(nextGen);
 
                     RemoteBusinessIntfInfo info = new RemoteBusinessIntfInfo();
                     info.generatedRemoteIntf = genRemoteIntf;

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -1104,7 +1104,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
             if (!serviceEndpointIntfClass.isInterface()) {
                 ServiceInterfaceGenerator generator = new ServiceInterfaceGenerator(loader, ejbClass);
-                serviceEndpointIntfClass = EJBUtils.generateSEI(generator, generator.getGeneratedClass(), loader, this.ejbClass);
+                serviceEndpointIntfClass = EJBUtils.generateSEI(generator, loader, this.ejbClass);
                 if (serviceEndpointIntfClass == null) {
                     throw new RuntimeException(localStrings.getLocalString("ejb.error_generating_sei",
                         "Error in generating service endpoint interface class for EJB class {0}", this.ejbClass));

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/BaseContainer.java
@@ -157,7 +157,7 @@ import jakarta.transaction.UserTransaction;
 public abstract class BaseContainer implements Container, EjbContainerFacade, JavaEEContainer {
     public enum ContainerType {
         STATELESS, STATEFUL, SINGLETON, MESSAGE_DRIVEN, ENTITY, READ_ONLY
-    };
+    }
 
     protected static final Logger _logger = LogFacade.getLogger();
 
@@ -383,7 +383,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     // Holds information such as remote reference factory that are associated
     // with a particular remote business interface
-    protected Map<String, RemoteBusinessIntfInfo> remoteBusinessIntfInfo = new HashMap<String, RemoteBusinessIntfInfo>();
+    protected Map<String, RemoteBusinessIntfInfo> remoteBusinessIntfInfo = new HashMap<>();
 
     //
     // END -- Data members for Remote views
@@ -404,9 +404,9 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected Map invocationInfoMap = new HashMap();
 
-    protected Map<TimerPrimaryKey, Method> scheduleIds = new HashMap<TimerPrimaryKey, Method>();
+    protected Map<TimerPrimaryKey, Method> scheduleIds = new HashMap<>();
 
-    Map<Method, List<ScheduledTimerDescriptor>> schedules = new HashMap<Method, List<ScheduledTimerDescriptor>>();
+    Map<Method, List<ScheduledTimerDescriptor>> schedules = new HashMap<>();
 
     // Need a separate map for web service methods since it's possible for
     // an EJB Remote interface to be a subtype of the Service Endpoint
@@ -427,7 +427,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(BaseContainer.class);
 
-    private ThreadLocal threadLocalContext = new ThreadLocal();
+    private final ThreadLocal threadLocalContext = new ThreadLocal();
 
     protected static final int CONTAINER_INITIALIZING = -1;
     protected static final int CONTAINER_STARTED = 0;
@@ -450,7 +450,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected ContainerInfo containerInfo;
 
-    private String _debugDescription;
+    private final String _debugDescription;
 
     //protected Agent callFlowAgent;
 
@@ -462,7 +462,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     private static final Class[] lifecycleCallbackAnnotationClasses = { AroundConstruct.class, PostConstruct.class, PreDestroy.class,
         PrePassivate.class, PostActivate.class };
 
-    private Set<Class> monitoredGeneratedClasses = new HashSet<Class>();
+    private final Set<Class> monitoredGeneratedClasses = new HashSet<>();
 
     protected InvocationManager invocationManager;
 
@@ -480,13 +480,13 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
     protected EjbOptionalIntfGenerator optIntfClassLoader;
 
-    private Set<String> publishedPortableGlobalJndiNames = new HashSet<String>();
+    private final Set<String> publishedPortableGlobalJndiNames = new HashSet<>();
 
-    private Set<String> publishedNonPortableGlobalJndiNames = new HashSet<String>();
+    private final Set<String> publishedNonPortableGlobalJndiNames = new HashSet<>();
 
-    private Set<String> publishedInternalGlobalJndiNames = new HashSet<String>();
+    private final Set<String> publishedInternalGlobalJndiNames = new HashSet<>();
 
-    private Map<String, JndiInfo> jndiInfoMap = new HashMap<String, JndiInfo>();
+    private final Map<String, JndiInfo> jndiInfoMap = new HashMap<>();
 
     private String optIntfClassName;
 
@@ -724,7 +724,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
 
                     List<ScheduledTimerDescriptor> list = schedules.get(method);
                     if (list == null) {
-                        list = new ArrayList<ScheduledTimerDescriptor>();
+                        list = new ArrayList<>();
                         schedules.put(method, list);
                     }
                     list.add(schd);
@@ -1136,7 +1136,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             }
         }
 
-        Map<String, Object> intfsForPortableJndi = new HashMap<String, Object>();
+        Map<String, Object> intfsForPortableJndi = new HashMap<>();
 
         // Root of portable global JNDI name for this bean
         String javaGlobalName = getJavaGlobalJndiNamePrefix();
@@ -1918,10 +1918,11 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 }
             } catch (Exception ex) {
                 _logger.log(Level.FINE, "Exception occurred in postInvokeTx  : [{0}]", ex);
-                if (ex instanceof EJBException)
+                if (ex instanceof EJBException) {
                     inv.exception = ex;
-                else
+                } else {
                     inv.exception = new EJBException(ex);
+                }
             }
 
             releaseContext(inv);
@@ -2021,13 +2022,15 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         if (!authorize(inv)) {
             // TODO see note above about additional special exception handling needed
             Throwable t = mapRemoteException(inv);
-            if (t instanceof RuntimeException)
+            if (t instanceof RuntimeException) {
                 throw (RuntimeException) t;
-            else if (t instanceof RemoteException)
+            } else if (t instanceof RemoteException) {
                 throw (RemoteException) t;
-            else
+            }
+            else {
                 throw new AccessException(
                     localStrings.getLocalString("ejb.client_not_authorized", "Client not authorized for this invocation")); // throw the AccessException
+            }
         }
     }
 
@@ -3062,7 +3065,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     protected String[] getPre30LifecycleMethodNames() {
         // null to match AroundConstruct
         return new String[] { null, "ejbCreate", "ejbRemove", "ejbPassivate", "ejbActivate" };
-    };
+    }
 
     private void initializeInterceptorManager() throws Exception {
         this.interceptorManager = new InterceptorManager(_logger, this, lifecycleCallbackAnnotationClasses, getPre30LifecycleMethodNames());
@@ -3098,15 +3101,13 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             if (hasRemoteHomeView) {
                 // Process Remote intf
                 Method[] methods = remoteIntf.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_REMOTE, remoteIntf);
                 }
 
                 // Process EJBHome intf
                 methods = homeIntf.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_HOME, homeIntf);
                 }
             }
@@ -3117,16 +3118,14 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                     // Get methods from generated remote intf but pass
                     // actual business interface as original interface.
                     Method[] methods = next.generatedRemoteIntf.getMethods();
-                    for (int i = 0; i < methods.length; i++) {
-                        Method method = methods[i];
+                    for (Method method : methods) {
                         addInvocationInfo(method, MethodDescriptor.EJB_REMOTE, next.remoteBusinessIntf);
                     }
                 }
 
                 // Process internal EJB RemoteBusinessHome intf
                 Method[] methods = remoteBusinessHomeIntf.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_HOME, remoteBusinessHomeIntf);
                 }
             }
@@ -3136,16 +3135,14 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
             if (hasLocalHomeView) {
                 // Process Local interface
                 Method[] methods = localIntf.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     InvocationInfo info = addInvocationInfo(method, MethodDescriptor.EJB_LOCAL, localIntf);
                     postProcessInvocationInfo(info);
                 }
 
                 // Process LocalHome interface
                 methods = localHomeIntf.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_LOCALHOME, localHomeIntf);
                 }
             }
@@ -3155,16 +3152,14 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 // Process Local Business interfaces
                 for (Class localBusinessIntf : localBusinessIntfs) {
                     Method[] methods = localBusinessIntf.getMethods();
-                    for (int i = 0; i < methods.length; i++) {
-                        Method method = methods[i];
+                    for (Method method : methods) {
                         addInvocationInfo(method, MethodDescriptor.EJB_LOCAL, localBusinessIntf);
                     }
                 }
 
                 // Process (internal) Local Business Home interface
                 Method[] methods = localBusinessHomeIntf.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_LOCALHOME, localBusinessHomeIntf);
                 }
             }
@@ -3175,15 +3170,13 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
                 String optClassName = EJBUtils.getGeneratedOptionalInterfaceName(ejbClass.getName());
                 ejbGeneratedOptionalLocalBusinessIntfClass = optIntfClassLoader.loadClass(optClassName);
                 Method[] methods = ejbGeneratedOptionalLocalBusinessIntfClass.getMethods();
-                for (int i = 0; i < methods.length; i++) {
-                    Method method = methods[i];
+                for (Method method : methods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_LOCAL, ejbGeneratedOptionalLocalBusinessIntfClass, false, true);
                 }
 
                 // Process generated Optional Local Business interface
                 Method[] optHomeMethods = ejbOptionalLocalBusinessHomeIntf.getMethods();
-                for (int i = 0; i < optHomeMethods.length; i++) {
-                    Method method = optHomeMethods[i];
+                for (Method method : optHomeMethods) {
                     addInvocationInfo(method, MethodDescriptor.EJB_LOCALHOME, ejbOptionalLocalBusinessHomeIntf);
                 }
 
@@ -3202,8 +3195,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
         if (isWebServiceEndpoint) {
             // Process Service Endpoint interface
             Method[] methods = webServiceEndpointIntf.getMethods();
-            for (int i = 0; i < methods.length; i++) {
-                Method method = methods[i];
+            for (Method method : methods) {
                 addInvocationInfo(method, MethodDescriptor.EJB_WEB_SERVICE, webServiceEndpointIntf);
             }
         }
@@ -3715,8 +3707,9 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     }
 
     private void enteringEjbContainer() {
-        if (interceptors == null)
+        if (interceptors == null) {
             return;
+        }
         for (EjbContainerInterceptor interceptor : interceptors) {
             try {
                 interceptor.preInvoke(ejbDescriptor);
@@ -3727,8 +3720,9 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     }
 
     private void leavingEjbContainer() {
-        if (interceptors == null)
+        if (interceptors == null) {
             return;
+        }
         for (EjbContainerInterceptor interceptor : interceptors) {
             try {
                 interceptor.postInvoke(ejbDescriptor);
@@ -4375,7 +4369,7 @@ public abstract class BaseContainer implements Container, EjbContainerFacade, Ja
     protected String[] getMonitoringMethodsArray(boolean hasGeneratedClasses) {
         String[] method_sigs = null;
         if (hasGeneratedClasses) {
-            List<String> methodList = new ArrayList<String>();
+            List<String> methodList = new ArrayList<>();
             for (Class clz : monitoredGeneratedClasses) {
                 for (Method m : clz.getDeclaredMethods()) {
                     methodList.add(EjbMonitoringUtils.stringify(m));

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EjbContainerServicesImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EjbContainerServicesImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,14 +17,18 @@
 
 package com.sun.ejb.containers;
 
+import com.sun.ejb.Container;
+import com.sun.ejb.spi.container.OptionalLocalInterfaceProvider;
+import com.sun.enterprise.deployment.EjbInterceptor;
+
+import jakarta.ejb.EJBException;
+import jakarta.ejb.NoSuchEJBException;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Proxy;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
-
-import jakarta.ejb.EJBException;
-import jakarta.ejb.NoSuchEJBException;
 
 import org.glassfish.ejb.LogFacade;
 import org.glassfish.ejb.api.EjbContainerServices;
@@ -31,10 +36,7 @@ import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
 import org.glassfish.ejb.deployment.descriptor.EjbSessionDescriptor;
 import org.jvnet.hk2.annotations.Service;
 
-import com.sun.ejb.Container;
-import com.sun.ejb.EJBUtils;
-import com.sun.ejb.spi.container.OptionalLocalInterfaceProvider;
-import com.sun.enterprise.deployment.EjbInterceptor;
+import static com.sun.ejb.codegen.AsmSerializableBeanGenerator.getGeneratedSerializableClassName;
 
 /**
  *
@@ -244,7 +246,7 @@ public class EjbContainerServicesImpl implements EjbContainerServices {
 
         for(String next : ejbManagedObjectClassNames) {
             // Add the serializable sub-class version of each name as well
-            serializableClassNames.add(EJBUtils.getGeneratedSerializableClassName(next));
+            serializableClassNames.add(getGeneratedSerializableClassName(next));
         }
 
         boolean isEjbManagedObject = ejbManagedObjectClassNames.contains(className) ||

--- a/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
+++ b/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
@@ -18,13 +18,16 @@ package com.sun.ejb;
 
 import com.sun.ejb.codegen.ClassGeneratorFactory;
 import com.sun.ejb.codegen.Generator;
+import com.sun.ejb.codegen.Remote30WrapperGenerator;
 import com.sun.ejb.codegen.ServiceInterfaceGenerator;
 
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import org.glassfish.pfl.dynamic.codegen.spi.Wrapper;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.Result;
@@ -34,7 +37,6 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
-import static java.lang.reflect.Modifier.PUBLIC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
@@ -47,53 +49,71 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author David Matejcek
  */
+@TestMethodOrder(OrderAnnotation.class)
 public class EJBUtilsTest {
 
+    /**
+     * The value shall be high enough to pass on all standard environments,
+     * but lower than when we are generating classes. See warmup results in logs.
+     */
+    private static final double MAX_TIME_PER_OPERATION = 1_000_000d;
     private static final ClassLoader loader = EJBUtilsTest.class.getClassLoader();
+    private static double firstRunScore;
 
     @Test
-    public void generateSEI_Benchmark() throws Exception {
+    @Order(1)
+    public void generateAndLoad_firstRun() throws Exception {
         Options options = new OptionsBuilder()
             .include(getClass().getName() + ".*")
-            .mode(Mode.AverageTime)
             .warmupIterations(0)
-            .measurementIterations(2)
-            .measurementTime(TimeValue.seconds(1L))
-            .forks(1)
-            .threads(20)
-            .shouldFailOnError(true)
-            .shouldDoGC(true)
-            .timeout(TimeValue.seconds(5L))
-            .timeUnit(TimeUnit.NANOSECONDS)
+            .measurementIterations(1).forks(1).measurementTime(TimeValue.milliseconds(50L))
+            // should be able to detect deadlocks and race conditions when generating classes
+            .threads(100).timeout(TimeValue.seconds(5L))
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .mode(Mode.SingleShotTime).shouldFailOnError(true)
             .build();
 
         Collection<RunResult> results = new Runner(options).run();
         assertThat(results, hasSize(1));
-        Result<?> result = results.iterator().next().getAggregatedResult().getPrimaryResult();
-        assertThat(result.getScore(), lessThan(100000d));
+        Result<?> primaryResult = results.iterator().next().getPrimaryResult();
+        firstRunScore = primaryResult.getScore();
+        assertThat(primaryResult.getScore(), lessThan(MAX_TIME_PER_OPERATION));
+    }
+
+
+    @Test
+    @Order(2)
+    public void generateAndLoad_Benchmark() throws Exception {
+        Options options = new OptionsBuilder()
+            .include(getClass().getName() + ".*")
+            .warmupBatchSize(1).warmupForks(0).warmupIterations(1).warmupTime(TimeValue.milliseconds(50L))
+            .measurementIterations(1).forks(1).measurementTime(TimeValue.milliseconds(200L))
+            // should be able to detect race conditions when loading classes generated in previous test
+            .threads(100).timeout(TimeValue.seconds(5L))
+            .timeUnit(TimeUnit.MICROSECONDS)
+            .mode(Mode.AverageTime).shouldFailOnError(true)
+            .build();
+
+        Collection<RunResult> results = new Runner(options).run();
+        assertThat(results, hasSize(1));
+        Result<?> primaryResult = results.iterator().next().getPrimaryResult();
+        assertThat(primaryResult.getScore(), lessThan(firstRunScore / 4));
     }
 
 
     @Benchmark
-    public void generateSei_Benchmark() throws Exception {
-        ClassGeneratorFactory generator = new CustomGenerator();
-        Class<?> newClass = EJBUtils.generateSEI(generator, loader, EJbUtilsEjbTestClass.class);
+    public void generateAndLoad() throws Exception {
+        // random interface for the test
+        String interfaceName = ClassGeneratorFactory.class.getName();
+        Generator generator = new Remote30WrapperGenerator(loader, interfaceName, interfaceName);
+        Class<?> newClass = EJBUtils.generateAndLoad(generator, loader);
         assertNotNull(newClass);
-        assertEquals(generator.className(), newClass.getName());
+        assertEquals(generator.getGeneratedClassName(), newClass.getName());
     }
 
 
     @Test
-    public void generateSei_ServiceInterfaceGenerator() throws Exception {
-        ServiceInterfaceGenerator generator = new ServiceInterfaceGenerator(loader, EJbUtilsEjbTestClass.class);
-        // FIXME: com.sun.ejb.EJBUtilsTest$EJbUtilsEjbTestClass doesn't have expected package com.sun.ejb.internal.jaxws
-        Class<?> newClass = EJBUtils.generateSEI(generator, loader, EJbUtilsEjbTestClass.class);
-        assertNotNull(newClass);
-        assertEquals(generator.className(), newClass.getName());
-    }
-
-
-    @Test
+    @Order(10)
     public void loadGeneratedRemoteBusinessClasses() throws Exception {
         EJBUtils.loadGeneratedRemoteBusinessClasses(EjbUtilsTestInterface.class.getName());
         Class<?> ifaceRemote = loader.loadClass("com.sun.ejb._EJBUtilsTest$EjbUtilsTestInterface_Remote");
@@ -105,6 +125,7 @@ public class EJBUtilsTest {
 
 
     @Test
+    @Order(20)
     public void loadGeneratedGenericEJBHomeClass() throws Exception {
         Class<?> newClass = EJBUtils.loadGeneratedGenericEJBHomeClass(loader);
         assertNotNull(newClass);
@@ -113,34 +134,18 @@ public class EJBUtilsTest {
         assertSame(newClass, EJBUtils.loadGeneratedGenericEJBHomeClass(loader));
     }
 
-    private static class CustomGenerator extends Generator implements ClassGeneratorFactory {
 
-        @Override
-        public String getGeneratedClass() {
-            return "com.sun.ejb.EJBUtilsTestImplFromCustomGenerator";
-        }
-
-        @Override
-        public String className() {
-            return getGeneratedClass();
-        }
-
-        @Override
-        public void evaluate() {
-            Wrapper._clear();
-            Wrapper._package(getPackageName(className()));
-            Wrapper._interface(PUBLIC, getBaseName(className()));
-            Wrapper._classGenerator();
-        }
+    @Test
+    @Order(30)
+    public void generateSEI() throws Exception {
+        Generator generator = new ServiceInterfaceGenerator(ClassGeneratorFactory.class);
+        Class<?> newClass = EJBUtils.generateSEI(generator, loader);
+        assertNotNull(newClass);
+        assertEquals(generator.getGeneratedClassName(), newClass.getName());
     }
 
 
     interface EjbUtilsTestInterface {
         void doSomething();
-    }
-
-
-    public static class EJbUtilsEjbTestClass {
-
     }
 }

--- a/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
+++ b/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
@@ -76,18 +76,9 @@ public class EJBUtilsTest {
     @Benchmark
     public void generateSei_Benchmark() throws Exception {
         ClassGeneratorFactory generator = new CustomGenerator();
-        Class<?> newClass = EJBUtils.generateSEI(generator, generator.className(), loader, EJbUtilsEjbTestClass.class);
+        Class<?> newClass = EJBUtils.generateSEI(generator, loader, EJbUtilsEjbTestClass.class);
         assertNotNull(newClass);
         assertEquals(generator.className(), newClass.getName());
-    }
-
-
-    @Test
-    public void generateSEI_callTwiceWithWrongParameters() throws Exception {
-        // FIXME: Class will be generated, but with different name -> consecutive call cannot find
-        // it and cannot generate it again.
-        EJBUtils.generateSEI(new CustomGenerator(), "com.acme.Fake", loader, EJbUtilsEjbTestClass.class);
-        EJBUtils.generateSEI(new CustomGenerator(), "com.acme.Fake", loader, EJbUtilsEjbTestClass.class);
     }
 
 
@@ -95,7 +86,7 @@ public class EJBUtilsTest {
     public void generateSei_ServiceInterfaceGenerator() throws Exception {
         ServiceInterfaceGenerator generator = new ServiceInterfaceGenerator(loader, EJbUtilsEjbTestClass.class);
         // FIXME: com.sun.ejb.EJBUtilsTest$EJbUtilsEjbTestClass doesn't have expected package com.sun.ejb.internal.jaxws
-        Class<?> newClass = EJBUtils.generateSEI(generator, generator.getGeneratedClass(), loader, EJbUtilsEjbTestClass.class);
+        Class<?> newClass = EJBUtils.generateSEI(generator, loader, EJbUtilsEjbTestClass.class);
         assertNotNull(newClass);
         assertEquals(generator.className(), newClass.getName());
     }

--- a/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
+++ b/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ejb;
+
+import com.sun.ejb.codegen.ClassGeneratorFactory;
+import com.sun.ejb.codegen.Generator;
+import com.sun.ejb.codegen.ServiceInterfaceGenerator;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import org.glassfish.pfl.dynamic.codegen.spi.Wrapper;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import static java.lang.reflect.Modifier.PUBLIC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author David Matejcek
+ */
+public class EJBUtilsTest {
+
+    private static final ClassLoader loader = EJBUtilsTest.class.getClassLoader();
+
+    @Test
+    public void generateSEI_Benchmark() throws Exception {
+        Options options = new OptionsBuilder()
+            .include(getClass().getName() + ".*")
+            .mode(Mode.AverageTime)
+            .warmupIterations(0)
+            .measurementIterations(2)
+            .measurementTime(TimeValue.seconds(1L))
+            .forks(1)
+            .threads(20)
+            .shouldFailOnError(true)
+            .shouldDoGC(true)
+            .timeout(TimeValue.seconds(5L))
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .build();
+
+        Collection<RunResult> results = new Runner(options).run();
+        assertThat(results, hasSize(1));
+        Result<?> result = results.iterator().next().getAggregatedResult().getPrimaryResult();
+        assertThat(result.getScore(), lessThan(100000d));
+    }
+
+
+    @Benchmark
+    public void generateSei_Benchmark() throws Exception {
+        ClassGeneratorFactory generator = new CustomGenerator();
+        Class<?> newClass = EJBUtils.generateSEI(generator, generator.className(), loader, EJbUtilsEjbTestClass.class);
+        assertNotNull(newClass);
+        assertEquals(generator.className(), newClass.getName());
+    }
+
+
+    @Test
+    public void generateSEI_callTwiceWithWrongParameters() throws Exception {
+        // FIXME: Class will be generated, but with different name -> consecutive call cannot find
+        // it and cannot generate it again.
+        EJBUtils.generateSEI(new CustomGenerator(), "com.acme.Fake", loader, EJbUtilsEjbTestClass.class);
+        EJBUtils.generateSEI(new CustomGenerator(), "com.acme.Fake", loader, EJbUtilsEjbTestClass.class);
+    }
+
+
+    @Test
+    public void generateSei_ServiceInterfaceGenerator() throws Exception {
+        ServiceInterfaceGenerator generator = new ServiceInterfaceGenerator(loader, EJbUtilsEjbTestClass.class);
+        // FIXME: com.sun.ejb.EJBUtilsTest$EJbUtilsEjbTestClass doesn't have expected package com.sun.ejb.internal.jaxws
+        Class<?> newClass = EJBUtils.generateSEI(generator, generator.getGeneratedClass(), loader, EJbUtilsEjbTestClass.class);
+        assertNotNull(newClass);
+        assertEquals(generator.className(), newClass.getName());
+    }
+
+
+    @Test
+    public void loadGeneratedRemoteBusinessClasses() throws Exception {
+        EJBUtils.loadGeneratedRemoteBusinessClasses(EjbUtilsTestInterface.class.getName());
+        Class<?> ifaceRemote = loader.loadClass("com.sun.ejb._EJBUtilsTest$EjbUtilsTestInterface_Remote");
+        assertTrue(ifaceRemote.isInterface());
+        Class<?> iface30 = loader.loadClass("com.sun.ejb.EJBUtilsTest$EjbUtilsTestInterface");
+        assertTrue(iface30.isInterface());
+        assertDoesNotThrow(() -> EJBUtils.loadGeneratedRemoteBusinessClasses(EjbUtilsTestInterface.class.getName()));
+    }
+
+
+    @Test
+    public void loadGeneratedGenericEJBHomeClass() throws Exception {
+        // FIXME: Uses EjbUtils as an anchor, but it is in different package - breaks JDK rules
+        // com.sun.ejb.codegen vs. com.sun.ejb.EjbUtils
+        Class<?> newClass = EJBUtils.loadGeneratedGenericEJBHomeClass(loader);
+        assertNotNull(newClass);
+        assertTrue(newClass.isInterface());
+        assertEquals("com.sun.ejb.codegen.GenericEJBHome_Generated", newClass.getName());
+    }
+
+    private static class CustomGenerator extends Generator implements ClassGeneratorFactory {
+
+        @Override
+        public String getGeneratedClass() {
+            return "com.sun.ejb.EJBUtilsTestImplFromCustomGenerator";
+        }
+
+        @Override
+        public String className() {
+            return getGeneratedClass();
+        }
+
+        @Override
+        public void evaluate() {
+            Wrapper._clear();
+            Wrapper._package(getPackageName(className()));
+            Wrapper._interface(PUBLIC, getBaseName(className()));
+            Wrapper._classGenerator();
+        }
+    }
+
+
+    interface EjbUtilsTestInterface {
+        void doSomething();
+    }
+
+
+    public static class EJbUtilsEjbTestClass {
+
+    }
+}

--- a/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
+++ b/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EJBUtilsTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -105,12 +106,11 @@ public class EJBUtilsTest {
 
     @Test
     public void loadGeneratedGenericEJBHomeClass() throws Exception {
-        // FIXME: Uses EjbUtils as an anchor, but it is in different package - breaks JDK rules
-        // com.sun.ejb.codegen vs. com.sun.ejb.EjbUtils
         Class<?> newClass = EJBUtils.loadGeneratedGenericEJBHomeClass(loader);
         assertNotNull(newClass);
         assertTrue(newClass.isInterface());
         assertEquals("com.sun.ejb.codegen.GenericEJBHome_Generated", newClass.getName());
+        assertSame(newClass, EJBUtils.loadGeneratedGenericEJBHomeClass(loader));
     }
 
     private static class CustomGenerator extends Generator implements ClassGeneratorFactory {

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -153,8 +153,11 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
         <javaee.version.old>8</javaee.version.old>
         <javaee.version.new>9</javaee.version.new>
+
         <easymock.version>4.3</easymock.version>
         <jmockit.version>1.49</jmockit.version>
+        <junit.version>5.8.1</junit.version>
+        <jmh.version>1.33</jmh.version>
         <osgi-resource-locator.version>1.0.3</osgi-resource-locator.version>
 
         <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
@@ -434,16 +437,17 @@
                 <artifactId>pfl-tf-tools</artifactId>
                 <version>${pfl.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.7.2</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
-                <version>5.7.2</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -464,6 +468,19 @@
                 <version>${jmockit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-core</artifactId>
+                <version>${jmh.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.openjdk.jmh</groupId>
+                <artifactId>jmh-generator-annprocess</artifactId>
+                <version>${jmh.version}</version>
+                <scope>test</scope>
+            </dependency>
+
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>

--- a/qa/src/main/resources/org/glassfish/qa/config/checkstyle/checkstyle-suppressions.xml
+++ b/qa/src/main/resources/org/glassfish/qa/config/checkstyle/checkstyle-suppressions.xml
@@ -6,5 +6,6 @@
 <suppressions>
     <!-- Generated sources break some rules and are usually out of our control -->
     <suppress checks=".*" files=".*[\\/]generated-sources[\\/].*" />
+    <suppress checks=".*" files=".*[\\/]generated-test-sources[\\/].*" />
     <suppress checks=".*" files="target[\\/]jackson-jaxb-src[\\/].*" />
 </suppressions>


### PR DESCRIPTION
Originally PFL used Unsafe class to generate classes. Since JDK11 it uses MethodInvocations, which verifies that the generated class has the same package as the anchor class. Generators were breaking the rule and under some circumstances it caused exceptions.

This PR also includes several tests and new test dependency: OpenJDK JMH. It's license is [here](https://github.com/openjdk/jmh/blob/master/LICENSE).