### PR TITLE
Issue #23507 Unzip should respect the WORKSPACE property

### DIFF
--- a/appserver/tests/common_test.sh
+++ b/appserver/tests/common_test.sh
@@ -63,7 +63,7 @@ unzip_test_resources(){
   printf "\n%s \n\n" "===== UNZIP TEST RESOURCES ====="
   for i in "${@}"; do
     if [[ ${i} == *.zip* ]]; then
-      unzip -qq -o ${i}
+      unzip -qq -o ${i} -d ${WORKSPACE}
     else
       tar --overwrite -xf ${i}
     fi


### PR DESCRIPTION
- in my new local script I tried to move workspace to the target directory,
  but just cdi_all respects it, while others use it also to find tests etc.
  So this is just a tiny step to reduce generated garbage when running tests
  locally