### PR TITLE
Fix #23633 Message do not print properly when iiop listener port changed to invalid value

### DIFF
--- a/appserver/orb/orb-enabler/pom.xml
+++ b/appserver/orb/orb-enabler/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,4 +62,14 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/appserver/orb/orb-enabler/src/main/java/org/glassfish/orb/admin/config/LocalStrings.properties
+++ b/appserver/orb/orb-enabler/src/main/java/org/glassfish/orb/admin/config/LocalStrings.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+port-pattern=must be between 1 and 65535, or reference a system property using the form ${SYSTEM_PROPERTY_NAME}


### PR DESCRIPTION
Fix: #23633

Add LocalStrings.properties to appserver/orb/orb-enabler for org.glassfish.orb.admin.config.IiopListener class, which was moved from nucleus/admin/config-api on https://github.com/javaee/glassfish/pull/21828.

This property message copied from nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/LocalStrings.properties

QuickLookTest has passed locally.