### PR TITLE
Fix #23634 Change @ExecuteOn targets for some of security commands.

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateFileUser.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/CreateFileUser.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -70,7 +71,7 @@ import jakarta.inject.Named;
 @Service(name = "create-file-user")
 @PerLookup
 @I18n("create.file.user")
-@ExecuteOn({ RuntimeType.ALL })
+@ExecuteOn({ RuntimeType.DAS, RuntimeType.INSTANCE })
 @TargetType({ CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CONFIG })
 @RestEndpoints({
     @RestEndpoint(configBean = AuthRealm.class, opType = RestEndpoint.OpType.POST, path = "create-user", description = "Create", params = {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/DeleteFileUser.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/DeleteFileUser.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,7 +67,7 @@ import jakarta.inject.Named;
 @Service(name = "delete-file-user")
 @PerLookup
 @I18n("delete.file.user")
-@ExecuteOn({ RuntimeType.ALL })
+@ExecuteOn({ RuntimeType.DAS, RuntimeType.INSTANCE })
 @TargetType({ CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CONFIG })
 @RestEndpoints({
     @RestEndpoint(configBean = AuthRealm.class, opType = RestEndpoint.OpType.DELETE, path = "delete-user", description = "Delete", params = {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/UpdateFileUser.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/cli/UpdateFileUser.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,7 +67,7 @@ import jakarta.inject.Named;
 @Service(name = "update-file-user")
 @PerLookup
 @I18n("update.file.user")
-@ExecuteOn({ RuntimeType.ALL })
+@ExecuteOn({ RuntimeType.DAS, RuntimeType.INSTANCE })
 @TargetType({ CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER, CommandTarget.CONFIG })
 @RestEndpoints({
     @RestEndpoint(configBean = AuthRealm.class, opType = RestEndpoint.OpType.POST, path = "update-user", description = "Update Users", params = {


### PR DESCRIPTION
Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>

Fix #23634.  
If set `@ExecuteOn` to `RuntimeType.ALL`, some of security commands will also be executed on other instances when it is executed on DAS, which causes the commands to fail.