### PR TITLE
Fix #23642 CLI031 is printed out when execute list-resource-adapter-configs command

### DIFF
--- a/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/ListResourceAdapterConfigs.java
+++ b/appserver/connectors/admin/src/main/java/org/glassfish/connectors/admin/cli/ListResourceAdapterConfigs.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +20,6 @@ package org.glassfish.connectors.admin.cli;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Resources;
 import com.sun.enterprise.util.LocalStringManagerImpl;
-import com.sun.enterprise.util.SystemPropertyConstants;
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
@@ -67,8 +67,8 @@ public class ListResourceAdapterConfigs implements AdminCommand {
     @Param(name="long", optional=true, defaultValue="false", shortName="l", alias="verbose")
     private Boolean long_opt;
 
-    @Param(primary = true, optional = true, defaultValue = SystemPropertyConstants.DAS_SERVER_NAME, alias = "targetName", obsolete = true)
-    private String target ;
+    @Param(primary = true, optional = true, alias = "targetName", obsolete = true)
+    private String target;
 
     @Inject
     private Domain domain;


### PR DESCRIPTION
* Fixes #23642

Removing default value of @param on target field.
* Same as #21927