### PR TITLE
Fix #23646 White page is displayed when click "Reload" on the application deployment page.

### DIFF
--- a/appserver/admingui/common/src/main/resources/applications/deployTable.inc
+++ b/appserver/admingui/common/src/main/resources/applications/deployTable.inc
@@ -78,7 +78,7 @@
         <sun:hyperlink id="reloadLink" text="$resource{i18n.deployTable.reload}">
             <!command
                 gf.reloadApplication(appName="#{td.value.name}");
-                gf.redirect(page="#{request.contextPath}/#{pageSession.listPageLink}?alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}");
+                gf.redirect(page="#{pageSession.listPageLink}?alertType=${alertType}&alertSummary=${alertSummary}&alertDetail=${alertDetail}");
             />
         </sun:hyperlink>
         

--- a/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
+++ b/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
@@ -86,7 +86,7 @@
             <!command
                 setAttribute(key="click" value="$this{component}");
                 setAttribute(key="filterValue" value="#{click.selected}");
-                gf.redirect(page="#{request.contextPath}/#{pageSession.listPageLink}?filterValue=${filterValue}" );
+                gf.redirect(page="#{pageSession.listPageLink}?filterValue=${filterValue}" );
             />
         </sun:dropDown>
 


### PR DESCRIPTION

* Fixes #23646 

Note: "#{request.contextPath}" is no longer working in admin console.

Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>