### PR TITLE
Fix #23652 Deployment failure in embedded glassfish

### DIFF
--- a/appserver/extras/embedded/all/src/assembly/package.xml
+++ b/appserver/extras/embedded/all/src/assembly/package.xml
@@ -102,4 +102,9 @@
             <outputDirectory></outputDirectory>
         </fileSet>
     </fileSets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
 </assembly>


### PR DESCRIPTION
Fixes #23652 

By this fix, `META-INF/services/*` files are now merged when building embedded glassfish.
