### PR TITLE
Fix #21863 appclient can't pass arguments with double-quote properly

### DIFF
--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -342,6 +342,19 @@ public class CLIBootstrap {
     }
 
     /**
+     * Quotes the string, on non-Windows systems escaping metacharacters ('\', '"', '$', '`').
+     *
+     * @param string
+     * @return
+     */
+    static String quoteEscapedArgument(String string) {
+        if(! OS.isWindows()) {
+            string = string.replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$").replace("`", "\\`");
+        }
+        return "\"" + string + "\"";
+    }
+
+    /**
      * Replaces commas in an argument value (which can confuse the ACC agent argument parsing because shells strip out
      * double-quotes) with a special sequence.
      *
@@ -541,7 +554,7 @@ public class CLIBootstrap {
         }
     }
 
-    private class CommandLineArgument extends CommandLineElement {
+    class CommandLineArgument extends CommandLineElement {
         CommandLineArgument(String patternString, int flags) {
             super(patternString, flags);
         }
@@ -551,14 +564,8 @@ public class CLIBootstrap {
             if (commandLine.length() > 0) {
                 commandLine.append(' ');
             }
-            commandLine.append((useQuotes ? quoteCommandLineArgument(v) : v));
+            commandLine.append((useQuotes ? quoteEscapedArgument(v) : v));
             return commandLine;
-        }
-        private String quoteCommandLineArgument(String s) {
-            if(! OS.isWindows()) {
-                s = s.replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$").replace("`", "\\`");
-            }
-            return "\"" + s + "\"";
         }
     }
 

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -348,7 +348,7 @@ public class CLIBootstrap {
      * @return
      */
     static String quoteEscapedArgument(String string) {
-        if(! OS.isWindows()) {
+        if(!OS.isWindows()) {
             string = string.replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$").replace("`", "\\`");
         }
         return "\"" + string + "\"";
@@ -560,11 +560,11 @@ public class CLIBootstrap {
         }
         @Override
         StringBuilder format(final StringBuilder commandLine,
-                final boolean useQuotes, final String v) {
+                final boolean useQuotes, final String nextArg) {
             if (commandLine.length() > 0) {
                 commandLine.append(' ');
             }
-            commandLine.append((useQuotes ? quoteEscapedArgument(v) : v));
+            commandLine.append((useQuotes ? quoteEscapedArgument(nextArg) : nextArg));
             return commandLine;
         }
     }

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -348,7 +348,7 @@ public class CLIBootstrap {
      * @return
      */
     static String quoteEscapedArgument(String string) {
-        if(!OS.isWindows()) {
+        if (!OS.isWindows()) {
             string = string.replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$").replace("`", "\\`");
         }
         return "\"" + string + "\"";

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -100,7 +100,7 @@ public class CLIBootstrap {
         jvmValuedOptions = new JVMValuedOption("-classpath|-cp", userVMArgs.evJVMValuedOptions),
         jvmPropertySettings = new JVMOption("-D.*", userVMArgs.evJVMPropertySettings),
         otherJVMOptions = new JVMOption("-.*", userVMArgs.evOtherJVMOptions),
-        arguments = new CommandLineElement(".*", Pattern.DOTALL);
+        arguments = new CommandLineArgument(".*", Pattern.DOTALL);
 
     /** Records how the user specifies the main class: -jar xxx.jar, -client xxx.jar, or a.b.MainClass */
     private final JVMMainOption jvmMainSetting = new JVMMainOption();
@@ -532,6 +532,27 @@ public class CLIBootstrap {
             commandLine.append((useQuotes ? quoteSuppressTokenSubst(v) : v));
 
             return commandLine;
+        }
+    }
+
+    private class CommandLineArgument extends CommandLineElement {
+        CommandLineArgument(String patternString, int flags) {
+            super(patternString, flags);
+        }
+        @Override
+        StringBuilder format(final StringBuilder commandLine,
+                final boolean useQuotes, final String v) {
+            if (commandLine.length() > 0) {
+                commandLine.append(' ');
+            }
+            commandLine.append((useQuotes ? quoteCommandLineArgument(v) : v));
+            return commandLine;
+        }
+        private String quoteCommandLineArgument(String s) {
+            if(! OS.isWindows()) {
+                s = s.replace("\\", "\\\\").replace("\"", "\\\"").replace("$", "\\$").replace("`", "\\`");
+            }
+            return "\"" + s + "\"";
         }
     }
 

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -190,8 +190,14 @@ public class CLIBootstrap {
         /*
          * The pattern matches a quoted string (double quotes around a string containing no double quote) or a non-quoted string
          * (a string containing no white space or quotes).
+         * Note:
+         * escapedDoubleQuoteRegex matches a double quote following odd number of
+         * backslash as an escaped string.
          */
-        Pattern argPattern = Pattern.compile("\"([^\"]+)\"|([^\"\\s]+)");
+        final String escapedDoubleQuoteRegex = "?:(?<!\\\\)(?:(?:\\\\\\\\)*\\\\)\"";
+        Pattern argPattern = Pattern.compile(
+                "\"((" + escapedDoubleQuoteRegex + "|[^\"])*)\""
+                        + "|((" + escapedDoubleQuoteRegex + "|[^\"\\s])+)");
 
         Matcher matcher = argPattern.matcher(inputArgs);
         List<String> argList = new ArrayList<>();

--- a/appserver/appclient/client/acc/src/test/java/org/glassfish/appclient/client/CLIBootstrapTest.java
+++ b/appserver/appclient/client/acc/src/test/java/org/glassfish/appclient/client/CLIBootstrapTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import com.sun.enterprise.util.OS;
 import java.lang.reflect.Constructor;
@@ -109,5 +110,27 @@ public class CLIBootstrapTest {
                 assertEquals(actual.toString(), expect);
             }
         });
+    }
+
+    @Test
+    public void testAcceptabilityForEscapedDoubleQuotes() throws Throwable {
+        runTestUsingConvertInputArgsVariable("a\\\"b c\\\"d", new String[] { "a\\\"b", "c\\\"d" });
+    }
+
+    @Test
+    public void testAcceptabilityForQuotedEscapedDoubleQuotes() throws Throwable {
+        runTestUsingConvertInputArgsVariable("\"a \\\" b \\\" c\"", new String[] { "a \\\" b \\\" c" });
+    }
+
+    @Test
+    public void testAcceptabilityForQuotedEmptyStr() throws Throwable {
+        runTestUsingConvertInputArgsVariable("\"\"", new String[] { "" });
+    }
+
+    private void runTestUsingConvertInputArgsVariable( String inputArgs, String[] expect) throws Throwable {
+        Method convertInputArgsVariableMethod = CLIBootstrap.class.getDeclaredMethod("convertInputArgsVariable", String.class);
+        convertInputArgsVariableMethod.setAccessible(true);
+        String[] actual = (String[]) convertInputArgsVariableMethod.invoke(new CLIBootstrap(), inputArgs);
+        assertArrayEquals(actual, expect);
     }
 }

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient
@@ -75,4 +75,4 @@ esac
 
 chooseJava
 
-eval `"${ACCJava}" -Dorg.glassfish.appclient.shell $cygwinProp -classpath "${_AS_INSTALL}/lib/gf-client.jar" org.glassfish.appclient.client.CLIBootstrap "$@"`
+eval "`"${ACCJava}" -Dorg.glassfish.appclient.shell $cygwinProp -classpath "${_AS_INSTALL}/lib/gf-client.jar" org.glassfish.appclient.client.CLIBootstrap "$@"`"


### PR DESCRIPTION
* Fixes #21863

I confirmed that the issue is reproduced in GlassFish 6.2.1 and the changes fix the all of problems listed in the issue.
Also I added UnitTest for a new inner class `CommandLineArgument` and a existing method `convertInputArgsVariable`.
One of the changes does not handle the double quotes enough, so I changed the regex to handle even non-quoted string.
