### PR TITLE
Fix #23654 org.glassfish.deployment.admin.DeployCommand is leaked

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/UndeployCommand.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -312,6 +313,8 @@ public class UndeployCommand extends UndeployCommandParameters implements AdminC
             ExtendedDeploymentContext deploymentContext = null;
             try {
                 deploymentContext = deployment.getBuilder(logger, this, report).source(source).build();
+                // Remove old metadata to avoid object leak
+                deploymentContext.getSource().removeArchiveMetaData(DeploymentProperties.COMMAND_PARAMS);
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "Cannot create context for undeployment ", e);
                 report.setMessage(localStrings.getLocalString("undeploy.contextcreation.failed","Cannot create context for undeployment : {0} ", e.getMessage()));


### PR DESCRIPTION
* Fixes #23654

When deploy is executed, a DeployCommand instance is stored in FileArchive#archiveMetaData.
In redeploy process, the DeployCommand instance is not removed, but new instance is stored in the archiveMetaData, so the old one leaks.

QuickLookTest has passed in local.