### PR TITLE
Fix #23660 Add element 'Status' to the instance's General Information page on the web console

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterInstanceEdit.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterInstanceEdit.jsf
@@ -161,7 +161,9 @@
             <sun:property id="instanceName"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncs.instanceName}" >
                 <sun:staticText id="instanceName" text="#{pageSession.instanceName}" />
             </sun:property>
-
+            <sun:property id="statusProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.common.status}">
+                <sun:staticText id="status" text="#{pageSession.statusString}" />
+            </sun:property>
         <sun:property id="jvmProp" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n.inst.JVMLabel}">
             <sun:hyperlink id="jvmlink" text="$resource{i18nc.inst.jvmReport}"
                 onClick="javascript:


### PR DESCRIPTION
* Fixes #23660
* Related #18301

When developing GlassFish 4.x, the page was modified to fix #18301. 
At that time, the status element was removed. I think it is mistake, so I'll add the status element again.

Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>