### PR TITLE
Fix #23662 Unexpected page displayed when execute multiple requests to the web application

### DIFF
--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/ResourceCache.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/ResourceCache.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,10 +291,11 @@ public class ResourceCache {
     public CacheEntry lookup(String name) {
 
         CacheEntry cacheEntry = null;
+        CacheEntry[] currentCache = cache;
         accessCount++;
-        int pos = find(cache, name);
-        if ((pos != -1) && (name.equals(cache[pos].name))) {
-            cacheEntry = cache[pos];
+        int pos = find(currentCache, name);
+        if ((pos != -1) && (name.equals(currentCache[pos].name))) {
+            cacheEntry = currentCache[pos];
         }
         if (cacheEntry == null) {
             try {


### PR DESCRIPTION
* Fixes #23662

org.apache.naming.resources.ResourceCache#lookup() method has a thread-unsafe problem that the cached entry array can be updated by other requests during processing with this method.  

ResourceCache class is originaly from Tomcat and this fix is also [from the Tomcat](
 https://github.com/apache/tomcat/commit/a21cf7e9826ba5937bbcf91600c7f022e7ab9e64#diff-55b3b19718b827b556a21328ee4e6e569d3fbd064ac46b1e014998c60b2c97bd).  
So, I worry about IP for this code.  
Thoughts?