### PR TITLE
Fix #23670 Exclude the header buttons from the method 'disableAllButtons()' effective range.

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -94,7 +94,7 @@ function disableAllButtons() {
     var inputs = document.getElementsByTagName("input");
     for ( i=0; i < inputs.length; i++) {
         component = inputs[i];
-        if (component.type == "submit"){
+        if (component.type == "submit" && !component.id.startsWith("Masthead:")){
             component.disabled=true;
         }
     }


### PR DESCRIPTION
* Fixes #23670

This issue is occured in `adminjsf.js#disableAllButtons()`.  
Calling this method, not only the buttons used in property sheet but the two header buttons `Logout` and `Help` are disabled.  

I think `adminjsf.js#disableAllButtons()` is used to avoid operation conflicts.  
These header buttons do not cause the conflicts, but the method also disable them. so I exclude the header elements prefixed with `Masthead:` from the range affected by `adminjsf.js#disableAllButtons()`.  

Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>