### PR TITLE
Fix #23672 404 return when click back button on an instance page navigated from configrations page

### DIFF
--- a/appserver/admingui/common/src/main/resources/configuration/configurations.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/configurations.jsf
@@ -48,6 +48,7 @@
         setPageSessionAttribute(key="parentUrl" value="#{sessionScope.REST_URL}/configs");
         setPageSessionAttribute(key="childType" value="config");
         setPageSessionAttribute(key="rest-api" value="true");
+        setSessionAttribute(key="backPage" value="../../common/configuration/configurations");
         gf.getChildList(parentEndpoint="#{pageSession.parentUrl}", childType="#{pageSession.childType}", result="#{requestScope.listOfRows}");
         setPageSessionAttribute(key="confirmDeleteMsg" value="$resource{i18nc.msg.JS.confirmDeleteConfigs}");
         setPageSessionAttribute(key="createLink" value="#{request.contextPath}/common/configuration/configurationNew.jsf");


### PR DESCRIPTION
* Fixes #23672

The backPage attribution is required to go back to the previous page using the back button.
