### PR TITLE
Fix #23678 Clusters is highlighted instead of a cluster name on tree when clicking Instances tab on the cluster edit page

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterInstances.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterInstances.jsf
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,7 +56,6 @@
         />
     
     </event>
-"    <script type="text/javascript">admingui.nav.selectTreeNodeById(admingui.nav.TREE_ID+":clusterTreeNode");</script>
 <sun:form id="propertyForm">
 
 #include "/cluster/cluster/clusterTabs.inc"


### PR DESCRIPTION
* Fixes #23678

The cluster name should be highlighted when Clustered Server Instances page is displayed , but the highlight is moved to Clusters by javascript.  
And Clustered Server Instances page is navigated only from a cluster edit page highlighted the cluster name.  
so no need to update highlights.