### PR TITLE
Fix #23684 Config file for client JNLP not found when deploy application client

### DIFF
--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -53,7 +53,7 @@
             <outputDirectory>${install.dir.name}/glassfish/bin</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${temp.dir}/appclient-scripts/config</directory>
+            <directory>${temp.dir}/appclient-scripts/glassfish/config</directory>
             <outputDirectory>${install.dir.name}/glassfish/config</outputDirectory>
         </fileSet>
 


### PR DESCRIPTION
* Fixes #23684

The client-jnlp-config.properties file is missing because of repackaging by [this commit](https://github.com/javaee/glassfish/commit/ba87ab74781d9fa36aad6462a2c500439eac1e2c#diff-9ae07f55ca7bf2704f180a735efe7d7e).