### PR TITLE
Fix #21841 Setting non-integer value to a config bean attribute with @Min or @Max and without dataType=Integer.class locks the config bean

### DIFF
--- a/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
+++ b/appserver/jdbc/jdbc-config/src/main/java/org/glassfish/jdbc/config/JdbcConnectionPool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -149,7 +150,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="8")
+    @Attribute(defaultValue = "8", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getSteadyPoolSize();
@@ -170,7 +171,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="32")
+    @Attribute(defaultValue = "32", dataType = Integer.class)
     @Min(value=1)
     @Max(value=Integer.MAX_VALUE)
     String getMaxPoolSize();
@@ -192,7 +193,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="60000")
+    @Attribute(defaultValue = "60000", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getMaxWaitTimeInMillis();
@@ -216,7 +217,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="2")
+    @Attribute(defaultValue = "2", dataType = Integer.class)
     @Min(value=1)
     @Max(value=Integer.MAX_VALUE)
     String getPoolResizeQuantity();
@@ -243,7 +244,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="300")
+    @Attribute(defaultValue = "300", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getIdleTimeoutInSeconds();
@@ -481,7 +482,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0")
+    @Attribute(defaultValue = "0", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getValidateAtmostOncePeriodInSeconds();
@@ -509,7 +510,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0")
+    @Attribute(defaultValue = "0", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getConnectionLeakTimeoutInSeconds();
@@ -551,7 +552,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0")
+    @Attribute(defaultValue = "0", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getConnectionCreationRetryAttempts();
@@ -574,7 +575,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="10")
+    @Attribute(defaultValue = "10", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getConnectionCreationRetryIntervalInSeconds();
@@ -706,7 +707,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0")
+    @Attribute(defaultValue = "0", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getStatementCacheSize();
@@ -745,7 +746,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0")
+    @Attribute(defaultValue = "0", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getStatementLeakTimeoutInSeconds();
@@ -824,7 +825,7 @@ public interface JdbcConnectionPool extends ConfigBeanProxy, Resource, ResourceP
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0")
+    @Attribute(defaultValue = "0", dataType = Integer.class)
     @Min(value=0)
     @Max(value=Integer.MAX_VALUE)
     String getMaxConnectionUsageCount();


### PR DESCRIPTION
* Fixes #21841

These properties are validated in JdbcConnectionPoolValidator$isValid() but the validation method calls Integer.parseInt() without checking the value type and throws NumberFormatException if the value is not Integer.
And, the caller org.jvnet.hk2.config.ConfigSupport$apply() does not catch the NumberFormatException in its own transaction.
That causes this issue.

On the other hand, org.glassfish.jdbc.config.JdbcConnectionPool has the annotation argument to avoid to set the invalid type value.
I think using this annotation argument is easer to deal with this issue.

Signed-off-by: 11rx4f <ryosuke.okada@fujitsu.com>