### PR TITLE
#23692: improve build time by avoiding unnecessarry resources filtering

### DIFF
--- a/appserver/admin/template/pom.xml
+++ b/appserver/admin/template/pom.xml
@@ -88,6 +88,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>create-artifact</id>
                         <phase>process-resources</phase>
                         <goals>
                             <goal>single</goal>

--- a/appserver/distributions/glassfish-common/pom.xml
+++ b/appserver/distributions/glassfish-common/pom.xml
@@ -87,7 +87,11 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default-single</id>
+                        <id>create-artifact</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -172,6 +172,7 @@
                         <attach>false</attach>
                         <appendAssemblyId>false</appendAssemblyId>
                         <useProjectArtifact>false</useProjectArtifact>
+                        <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -154,25 +154,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>default-single</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>single</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <descriptors>
-                            <descriptor>${basedir}/src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
                         </descriptors>
                         <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
                         <finalName>${stage.dir.name}</finalName>
                         <attach>false</attach>
                         <appendAssemblyId>false</appendAssemblyId>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/nucleus/distributions/nucleus-common/pom.xml
+++ b/nucleus/distributions/nucleus-common/pom.xml
@@ -37,7 +37,11 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>process-step3</id>
+                        <id>create-artifact</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -130,25 +130,15 @@
 
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>default-single</id>
-                            <phase>process-resources</phase>
-                            <goals>
-                                <goal>single</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                     <configuration>
                         <descriptors>
-                            <descriptor>${basedir}/src/main/assembly/${project.artifactId}.xml</descriptor>
+                            <descriptor>src/main/assembly/${project.artifactId}.xml</descriptor>
                         </descriptors>
                         <ignoreMissingDescriptor>false</ignoreMissingDescriptor>
                         <finalName>${stage.dir.name}</finalName>
                         <attach>false</attach>
                         <appendAssemblyId>false</appendAssemblyId>
                         <useProjectArtifact>false</useProjectArtifact>
-                        <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     </configuration>
                 </plugin>
 

--- a/nucleus/distributions/pom.xml
+++ b/nucleus/distributions/pom.xml
@@ -148,6 +148,7 @@
                         <attach>false</attach>
                         <appendAssemblyId>false</appendAssemblyId>
                         <useProjectArtifact>false</useProjectArtifact>
+                        <ignoreMissingDescriptor>true</ignoreMissingDescriptor>
                     </configuration>
                 </plugin>
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -70,6 +70,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.commonResourcesDirectory>${project.build.directory}/common-resources</project.build.commonResourcesDirectory>
+        <legal.doc.source>${project.build.commonResourcesDirectory}/legal</legal.doc.source>
         <findbugs.skip>false</findbugs.skip>
         <findbugs.threshold>High</findbugs.threshold>
         <findbugs.common>exclude-common.xml</findbugs.common>
@@ -966,11 +968,7 @@
                         <configuration>
                             <resources>
                                 <resource>
-                                    <directory>${maven.multiModuleProjectDirectory}</directory>
-                                    <includes>
-                                        <include>NOTICE.md</include>
-                                        <include>LICENSE.md</include>
-                                    </includes>
+                                    <directory>${legal.doc.source}</directory>
                                     <targetPath>META-INF</targetPath>
                                 </resource>
                             </resources>
@@ -995,6 +993,51 @@
                         </goals>
                         <configuration>
                             <message>Building in ${project.basedir} </message>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>common-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/resources.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-resource</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main</groupId>
+                                    <artifactId>nucleus-parent</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>resources</classifier>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.commonResourcesDirectory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -999,7 +999,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -1018,7 +1017,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/nucleus/parent/src/main/assembly/resources.xml
+++ b/nucleus/parent/src/main/assembly/resources.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>resources</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/../..</directory>
+            <outputDirectory>legal</outputDirectory>
+            <includes>
+                <include>LICENSE.md</include>
+                <include>NOTICE.md</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
having legal resources in an extra artifact improves the speed of the build by not filtering source tree in every module

Relates to #23692 
