### PR TITLE
Fix #23700 Add properties file to ejb-full-container

### DIFF
--- a/appserver/ejb/ejb-full-container/src/main/resources/com/sun/logging/enterprise/system/container/ejb/LogStrings.properties
+++ b/appserver/ejb/ejb-full-container/src/main/resources/com/sun/logging/enterprise/system/container/ejb/LogStrings.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2004, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+ejb.timer_service_init_error=EJB5108:Unable to initialize EJB Timer Service. The possible cause is the timer resource is not configured correctly, the database has not been started, or the timer database table has not been created.
+ejb.timer_service_started=EJB5109:EJB Timer Service started successfully for data source [{0}]
+ejb.cancel_entity_timer=EJB5112:Error cancelling timer with pkey [{0}]
+ejb.cancel_entity_timers=EJB5113:Error cancelling timers for container [{0}] and pkey [{1}]
+ejb.destroy_timers_error=EJB5114:Error destroying timers for container [{0}]
+ejb.create_timer_failure=EJB5117:Timer creation failed for container [{0}] primary key [{1}] and info [{2}]
+ejb.remove_timer_failure=EJB5118:Failure removing timer bean [{0}]


### PR DESCRIPTION
* Fixes #23700 

There is no properties file about the message keys in `appserver/ejb/ejb-full-container`, so the logger in `ejb-full-container` cannot print messages correctly.  

These properties are copied from `appserver/ejb/ejb-container`.

Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>

