### PR TITLE
Jenkins related changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ def jobs_all = [
   "ql_gf_full_profile_all",
   "ql_gf_web_profile_all",
   "web_jsp",
-  
+
   "deployment_all",
   "ejb_group_1",
   "ejb_group_2",
@@ -65,10 +65,10 @@ def generateStage(job) {
                         sleep 60
                         checkout scm
                       }
-                      
+
                       // run the test
                       unstash 'build-bundles'
-                      
+
                       try {
                           retry(3) {
                               timeout(time: 2, unit: 'HOURS') {
@@ -91,27 +91,27 @@ def generateStage(job) {
 }
 
 pipeline {
-  
+
   options {
     // keep at most 50 builds
     buildDiscarder(logRotator(numToKeepStr: '10'))
-    
+
     // preserve the stashes to allow re-running a test stage
     preserveStashes()
-    
+
     // issue related to default 'implicit' checkout, disable it
     skipDefaultCheckout()
-    
+
     // abort pipeline if previous stage is unstable
     skipStagesAfterUnstable()
-    
+
     // show timestamps in logs
     timestamps()
-    
+
     // global timeout, abort after 6 hours
     timeout(time: 6, unit: 'HOURS')
   }
-  
+
   agent {
     kubernetes {
       label "${env.label}"
@@ -163,7 +163,7 @@ spec:
       - name: "jenkins-home"
         mountPath: "/home/jenkins"
         readOnly: false
-      - name: maven-repo-shared-storage 
+      - name: maven-repo-shared-storage
         mountPath: /home/jenkins/.m2/repository
       - name: settings-xml
         mountPath: /home/jenkins/.m2/settings.xml
@@ -187,14 +187,17 @@ spec:
 """
     }
   }
-  
+
   environment {
     S1AS_HOME = "${WORKSPACE}/glassfish6/glassfish"
     APS_HOME = "${WORKSPACE}/appserver/tests/appserv-tests"
     TEST_RUN_LOG = "${WORKSPACE}/tests-run.log"
     GF_INTERNAL_ENV = credentials('gf-internal-env')
+    PORT_ADMIN=4848
+    PORT_HTTP=8080
+    PORT_HTTPS=8181
   }
-  
+
   stages {
     stage('build') {
       agent {
@@ -205,21 +208,21 @@ spec:
       steps {
         container('glassfish-ci') {
           timeout(time: 1, unit: 'HOURS') {
-            
+
             // do the scm checkout
             checkout scm
-            
+
             // do the build
             sh '''
               echo Maven version
               mvn -v
-              
+
               echo User
               id
-              
+
               echo Uname
               uname -a
-              
+
               bash -xe ./gfbuild.sh build_re_dev
             '''
             archiveArtifacts artifacts: 'bundles/*.zip'
@@ -229,7 +232,7 @@ spec:
         }
       }
     }
-    
+
     stage('tests') {
       steps {
         script {

--- a/appserver/tests/appserv-tests/config.properties
+++ b/appserver/tests/appserv-tests/config.properties
@@ -17,11 +17,11 @@
 
 admin.domain=domain1
 admin.domain.dir=${env.S1AS_HOME}/domains
-admin.port=4848
+admin.port=${env.PORT_ADMIN}
 admin.user=admin
 admin.host=localhost
-http.port=8080
-https.port=8181
+http.port=${env.PORT_HTTP}
+https.port=${env.PORT_HTTPS}
 http.alternate.port=12345
 http.host=localhost
 http.address=127.0.0.1

--- a/appserver/tests/appserv-tests/devtests/cdi/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/cdi/run_test.sh
@@ -29,7 +29,7 @@ test_run(){
 
     printf "\n%s \n\n" "===== TEST RUN - STARTING GLASSFISH AND DB ====="
     ${S1AS_HOME}/bin/asadmin start-domain
-    if [ "${JACOCO_ENABLED}" != "" ]; then
+    if [ "${JACOCO_ENABLED}" = "true" ]; then
         ${S1AS_HOME}/bin/asadmin create-jvm-options -javaagent\\:${WORKSPACE}/bundles/org.jacoco.agent.jar=destfile=${WORKSPACE}/cdi.exec,append=true,includes=org/glassfish/**\\:com/sun/enterprise/**
         ${S1AS_HOME}/bin/asadmin restart-domain
     fi

--- a/appserver/tests/appserv-tests/devtests/cdi/run_test.sh
+++ b/appserver/tests/appserv-tests/devtests/cdi/run_test.sh
@@ -18,51 +18,55 @@
 test_run(){
     printf "\n%s \n\n" "===== TEST RUN - MAIN ====="
 
-        # Fix for false positive
-        echo "<property name=\"libraries\" value=\"' '\"/>" >> smoke-tests/simple-wab-with-cdi/build.properties
-        find . -name "RepRunConf.txt" | xargs rm -f
-        rm         -rf *.output alltests.res ${APS_HOME}/test_results*
+    # Fix for false positive
+    echo "<property name=\"libraries\" value=\"' '\"/>" >> smoke-tests/simple-wab-with-cdi/build.properties
+    find . -name "RepRunConf.txt" | xargs rm -f
+    rm -rf *.output alltests.res ${APS_HOME}/test_results*
 
-        # Run the tests
-        set +e
-        ant clean -e -q > /dev/null
+    # Run the tests
+    set +e
+    ant clean -e -q > /dev/null
 
-        printf "\n%s \n\n" "===== TEST RUN - STARTING GLASSFISH AND DB ====="
-        ${S1AS_HOME}/bin/asadmin start-domain
-        ${S1AS_HOME}/bin/asadmin start-database
+    printf "\n%s \n\n" "===== TEST RUN - STARTING GLASSFISH AND DB ====="
+    ${S1AS_HOME}/bin/asadmin start-domain
+    if [ "${JACOCO_ENABLED}" != "" ]; then
+        ${S1AS_HOME}/bin/asadmin create-jvm-options -javaagent\\:${WORKSPACE}/bundles/org.jacoco.agent.jar=destfile=${WORKSPACE}/cdi.exec,append=true,includes=org/glassfish/**\\:com/sun/enterprise/**
+        ${S1AS_HOME}/bin/asadmin restart-domain
+    fi
+    ${S1AS_HOME}/bin/asadmin start-database
 
-        printf "\n%s \n\n" "===== TEST RUN - RUNNING TESTS for ${TARGET} ====="
-        ant ${TARGET} | tee ${TEST_RUN_LOG}
+    printf "\n%s \n\n" "===== TEST RUN - RUNNING TESTS for ${TARGET} ====="
+    ant ${TARGET} | tee ${TEST_RUN_LOG}
 
-        printf "\n%s \n\n" "===== TEST RUN - STOPPING GLASSFISH AND DB ====="
-        ${S1AS_HOME}/bin/asadmin stop-domain
-        ${S1AS_HOME}/bin/asadmin stop-database
-        set -e
+    printf "\n%s \n\n" "===== TEST RUN - STOPPING GLASSFISH AND DB ====="
+    ${S1AS_HOME}/bin/asadmin stop-domain
+    ${S1AS_HOME}/bin/asadmin stop-database
+    set -e
 }
 
 get_test_target(){
     printf "\n%s \n\n" "===== GETTING TEST TARGET ====="
-        case ${1} in
-                cdi_all )
-                        TARGET=all
-                        export TARGET;;
-        esac
+    case ${1} in
+        cdi_all )
+            TARGET=all
+            export TARGET;;
+    esac
 }
 
 
 run_test_id(){
-        unzip_test_resources ${WORKSPACE}/bundles/glassfish.zip
-        cd `dirname ${0}`
-        test_init
-        get_test_target ${1}
-        test_run
-        check_successful_run
+    unzip_test_resources ${WORKSPACE}/bundles/glassfish.zip
+    cd `dirname ${0}`
+    test_init
+    get_test_target ${1}
+    test_run
+    check_successful_run
     generate_junit_report ${1}
     change_junit_report_class_names
 }
 
 list_test_ids(){
-        echo cdi_all
+    echo cdi_all
 }
 
 OPT=${1}
@@ -70,9 +74,9 @@ TEST_ID=${2}
 source `dirname ${0}`/../../../common_test.sh
 
 case ${OPT} in
-        list_test_ids )
-                list_test_ids;;
-        run_test_id )
-                trap "copy_test_artifacts ${TEST_ID}" EXIT
-                run_test_id ${TEST_ID} ;;
+    list_test_ids )
+        list_test_ids;;
+    run_test_id )
+        trap "copy_test_artifacts ${TEST_ID}" EXIT
+        run_test_id ${TEST_ID} ;;
 esac

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -44,6 +44,7 @@
         <port.derby>11527</port.derby>
         <port.http>18080</port.http>
         <port.https>18181</port.https>
+        <port.jms>17676</port.jms>
         <port.jmx>18686</port.jmx>
         <port.orb>13700</port.orb>
         <port.orb.mutual>13920</port.orb.mutual>
@@ -193,6 +194,17 @@
 
                                 <limit maxwait="60">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                        <arg value="delete-domain"/>
+                                        <arg value="domain1" />
+                                    </exec>
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                        <arg value="create-domain"/>
+                                        <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
+                                        <arg value="--user=admin" />
+                                        <arg value="--nopassword" />
+                                        <arg value="domain1" />
+                                    </exec>
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="start-domain"/>
                                     </exec>
 
@@ -201,43 +213,14 @@
                                         <then>
                                             <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                                 <arg value="create-jvm-options" />
+                                                <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
                                             </exec>
                                         </then>
                                     </if>
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.admin-service.jmx-connector.system.port=${port.jmx}"/>
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.network-config.network-listeners.network-listener.http-listener-1.port=${port.http}"/>
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.network-config.network-listeners.network-listener.http-listener-2.port=${port.https}"/>
-                                    </exec>
-
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.iiop-service.iiop-listener.orb-listener-1.port=${port.orb}"/>
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.iiop-service.iiop-listener.SSL.port=${port.orb.ssl}"/>
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.iiop-service.iiop-listener.SSL_MUTUALAUTH.port=${port.orb.mutual}"/>
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="set"/>
-                                        <arg value="configs.config.server-config.network-config.network-listeners.network-listener.admin-listener.port=${port.admin}"/>
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="stop-domain"/>
-                                        <!--  -->
-                                        <arg value="--kill=true"/>
+                                        <arg value="domain1"/>
                                     </exec>
                                 </limit>
                                 <mkdir dir="${tck.home}/jacctckreport"/>

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+set -e
+
+echo "This script can be temporarily used for local testing until we integrate current set of tests to Maven";
+echo "First argument is a version of GlassFish used for testing. It will be downloaded by Maven command";
+echo "Second argument is a test set id, one of:
+cdi_all, ql_gf_full_profile_all, \n
+\n
+web_jsp, deployment_all, ejb_group_1
+ejb_group_2, ejb_group_3, ejb_web_all, cdi_all, ql_gf_full_profile_all, ql_gf_nucleus_all, \
+ql_gf_web_profile_all, nucleus_admin_all, jdbc_all, batch_all, persistence_all, \
+connector_group_1, connector_group_2, connector_group_3, connector_group_4";
+
+echo "If you need to use a different JAVA_HOME than is used by your system, export it or edit this script.";
+echo "";
+
+install_glassfish() {
+  mvn clean -N org.apache.maven.plugins:maven-dependency-plugin:3.2.0:copy \
+  -Dartifact=org.glassfish.main.distributions:glassfish:${GF_VERSION}:zip \
+  -Dmdep.stripVersion=true \
+  -DoutputDirectory=${WORKSPACE}/bundles
+}
+
+install_jacoco() {
+  mvn -N org.apache.maven.plugins:maven-dependency-plugin:3.2.0:copy \
+  -Dartifact=org.jacoco:org.jacoco.agent:0.8.7:jar:runtime \
+  -Dmdep.stripVersion=true \
+  -Dmdep.stripClassifier=true \
+  -DoutputDirectory=${WORKSPACE}/bundles
+}
+
+####################################
+
+export GF_VERSION="$1"
+export JACOCO_ENABLED="true"
+test="${2}"
+
+# uncomment and edit this line if your system uses another version.
+export JAVA_HOME=/usr/lib/jvm/jdk11
+
+if [ -z "${GF_VERSION}" ]
+  then echo "No version supplied."
+  exit 1;
+fi
+if [ -z "${test}" ]
+  then echo "No test supplied."
+  exit 2;
+fi
+
+export WORKSPACE="$(pwd)/target"
+export TEST_RUN_LOG="${WORKSPACE}/tests-run.log"
+export CLASSPATH="${WORKSPACE}/glassfish6/javadb"
+export APS_HOME="$(pwd)/appserver/tests/appserv-tests"
+export S1AS_HOME="${WORKSPACE}/glassfish6/glassfish"
+export PORT_ADMIN="4848"
+export PORT_HTTP="8080"
+export PORT_HTTPS="8181"
+install_glassfish;
+install_jacoco;
+
+./appserver/tests/gftest.sh run_test "${test}"
+


### PR DESCRIPTION
I started using docker-based jenkins, but I found some limitations blocking me. As I don't want affect Eclipse's Glassfish build, I had to find some compromise.

This PR contains these changes:
- trimmed tabs and trailing spaces from the Jenkinsfile
- explicitly set ports for tests (can be changed on other environments, required price is low)
- JaCoCo support in local testing (can be enabled on Jenkins too)