### PR TITLE
Fix #23703 Unable to avoid creating a JDBC Connection Pool with the Datasource Classname whose length is over 512

### DIFF
--- a/appserver/admingui/jdbc/src/main/resources/poolPropertyNew.inc
+++ b/appserver/admingui/jdbc/src/main/resources/poolPropertyNew.inc
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,7 +45,7 @@
                 />
         </sun:dropDown>
         "<br/>
-        <sun:textField id="datasourceField"  columns="$int{60}" maxLength="#{sessionScope.fieldLengths['jdbcPool.datasource']}" text="#{wizardPoolExtra.DatasourceClassnameField}"  disabled="#{!wizardPoolExtra.dsClassname}" >
+        <sun:textField id="datasourceField"  columns="$int{60}" maxLength="#{sessionScope.fieldLengths['maxLength.jdbcPool.datasource']}" text="#{wizardPoolExtra.DatasourceClassnameField}"  disabled="#{!wizardPoolExtra.dsClassname}" >
             <!afterCreate
                 getClientId(component="$this{component}" clientId=>$page{datasourceClassNameFieldId});
             />


### PR DESCRIPTION
* Fixes #23703 

Signed-off-by: kaido207 <kaido.hiroki@fujitsu.com>
