### PR TITLE
Issue #23507 Fixed path to tsharness in EmbeddedRunnerITest

### DIFF
--- a/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
@@ -124,7 +124,7 @@ public class EmbeddedRunnerITest {
         }
 
         return String.join(":", List.of(
-            localRepository + "/com/sun/tsharness/1.4/tsharness-1.4.jar",
+            localRepository + "/org/glassfish/main/tests/tck/tsharness/" + glassfishVersion + "/tsharness-" + glassfishVersion + ".jar",
             localRepository + "/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2.jar",
             System.getProperty("glassfish.home") + "/glassfish/lib/embedded/glassfish-embedded-static-shell.jar",
             copiedEjbJar.toString()


### PR DESCRIPTION
- the bug was introduced recently in fc1c976a13a9345642df0c2d33150ea3e3a9de63 and caused the failure on weekly jenkins build https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_weekly_build/88
