### PR TITLE
#23721 Fix ant not able to execute java tasks in JDK 18.

### DIFF
--- a/appserver/tests/appserv-tests/devtests/cdi/alternatives/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/alternatives/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/ambiguous-deps/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/ambiguous-deps/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/decorators/decorators-over-beans-from-producer-methods/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/decorators/decorators-over-beans-from-producer-methods/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/decorators/simple-decorator/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/decorators/simple-decorator/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/events/conditional-observer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/events/conditional-observer/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/events/event-producers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/events/event-producers/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/events/event-qualifiers-with-members/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/events/event-qualifiers-with-members/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/events/multiple-event-qualifiers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/events/multiple-event-qualifiers/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/events/simple-event-observers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/events/simple-event-observers/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/injection-point/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/injection-point/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-bean-validation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-bean-validation/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -69,7 +70,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java fork="true" classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true" >
           <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspend},address=${jpda.port}"/>
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-binding-type-inheritance/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-binding-type-inheritance/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-binding-type-with-members/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-binding-type-with-members/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-business-method-interception/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-business-method-interception/build.xml
@@ -66,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-invalid-interceptor-specified-at-beans-xml/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-invalid-interceptor-specified-at-beans-xml/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-multiple-interceptor-binding-annotations/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-multiple-interceptor-binding-annotations/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-multiple-interceptors-for-a-binding-type/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-multiple-interceptors-for-a-binding-type/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-use-of-at-interceptors/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-use-of-at-interceptors/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-use-of-interceptors-in-ejbs-through-at-interceptors/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-use-of-interceptors-in-ejbs-through-at-interceptors/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-use-of-interceptors-in-ejbs-through-interceptor-bindings/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/interceptors/interceptors-use-of-interceptors-in-ejbs-through-interceptor-bindings/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-injection-no-interface-ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-injection-no-interface-ejb/build.xml
@@ -65,7 +65,7 @@
         </target>
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection-extended-transaction-context/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection-extended-transaction-context/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/javaee-component-resource-typesafe-injection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/javaee-component-resource-typesafe-injection/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jms-resource-producer-field-in-library-jar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jms-resource-producer-field-in-library-jar/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -93,7 +94,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jms-resource-producer-field/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jms-resource-producer-field/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -78,7 +79,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection-non-serializable/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection-non-serializable/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection-passivating-scope/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection-passivating-scope/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection-with-singleton-ejb-producer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection-with-singleton-ejb-producer/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/jpa-resource-injection/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/no-interface-ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/no-interface-ejb/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
         </target>
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/slsb-injection-into-sessionscoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/slsb-injection-into-sessionscoped/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
         </target>
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/builtin-beans/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/builtin-beans/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-extension-alternative/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-extension-alternative/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -93,7 +94,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-javaee-injection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-javaee-injection/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -91,7 +92,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-ordering-reversed/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-ordering-reversed/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -89,7 +90,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
             <arg value="${http.host}" />
             <arg value="${http.port}" />
             <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-ordering/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib-ordering/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -89,7 +90,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
             <arg value="${http.host}" />
             <arg value="${http.port}" />
             <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/cdi-servlet-3.0-annotation-with-web-inf-lib/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -81,7 +82,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/embedded-resource-adapter-as-bean-archive/ra/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/embedded-resource-adapter-as-bean-archive/ra/build.xml
@@ -1,5 +1,6 @@
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2002, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
 
   <target name="sendMessage" depends="init-common">
     <echo message="Class path is ${s1astest.classpath}"/>
-    <java fork="true" classname="connector.Messages" failonerror="true">
+    <java classname="connector.Messages" fork="true" failonerror="true">
       <arg line="add Foo TestMessage"/>
       <classpath>
         <pathelement location="${s1astest.classpath}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/no-interface-local-view-proxy-serializable/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/no-interface-local-view-proxy-serializable/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -76,7 +77,7 @@
 
 
         <target name="run" depends="init-common">
-                <java classname="test.client.WebTest">
+                <java classname="test.client.WebTest" fork="true">
                         <arg value="${http.host}" />
                         <arg value="${http.port}" />
                         <arg value="${contextroot}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/servlet-context-injection-cdi/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/servlet-context-injection-cdi/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/simple-managed-bean-interceptor-noargconstructor-missing/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/simple-managed-bean-interceptor-noargconstructor-missing/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/simple-managed-bean-interceptor-nonnull-package/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/simple-managed-bean-interceptor-nonnull-package/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/standalone-resource-adapter-as-bean-archive/ra/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/standalone-resource-adapter-as-bean-archive/ra/build.xml
@@ -1,5 +1,6 @@
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2002, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
 
   <target name="sendMessage" depends="init-common">
     <echo message="Class path is ${s1astest.classpath}"/>
-    <java fork="true" classname="connector.Messages" failonerror="true">
+    <java classname="connector.Messages" fork="true" failonerror="true">
       <arg line="add Foo TestMessage"/>
       <classpath>
         <pathelement location="${s1astest.classpath}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/managed-beans/managed-bean-lifecycle-polymorphism/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/managed-beans/managed-bean-lifecycle-polymorphism/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/managed-beans/managed-bean-via-resource-injection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/managed-beans/managed-bean-via-resource-injection/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/osgi-cdi/simple-wab-with-cdi/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/osgi-cdi/simple-wab-with-cdi/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -71,7 +72,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/bean-interface/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/bean-interface/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/bean-manager/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/bean-manager/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/injection-target/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/injection-target/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/new-bean-registration-extension-in-lib/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/new-bean-registration-extension-in-lib/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -94,7 +95,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/new-bean-registration/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/new-bean-registration/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/package-private-extension-constructor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/package-private-extension-constructor/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/process-injection-target/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/process-injection-target/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/simple-portable-extension/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/portable-extensions/simple-portable-extension/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -67,7 +68,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/producer-methods/producer-method-disposes/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/producer-methods/producer-method-disposes/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/producer-methods/producer-method-qualifiers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/producer-methods/producer-method-qualifiers/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/producer-methods/producer-method-runtimepolymorphism/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/producer-methods/producer-method-runtimepolymorphism/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/programmatic-lookup/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/programmatic-lookup/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/qualifiers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/qualifiers/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/scopes/dependent-scope/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/scopes/dependent-scope/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/scopes/new-qualifier/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/scopes/new-qualifier/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/scopes/singleton-scope/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/scopes/singleton-scope/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/cdi-servlet-3.0-annotation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/cdi-servlet-3.0-annotation/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/cdi-servlet-filter-3.0-annotation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/cdi-servlet-filter-3.0-annotation/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/optional-unbundled-beans/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/optional-unbundled-beans/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -69,7 +70,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-managed-bean-interceptor-nonnull-package/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-managed-bean-interceptor-nonnull-package/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-managed-bean-interceptor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-managed-bean-interceptor/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-managed-bean/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-managed-bean/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-wab-with-cdi/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-wab-with-cdi/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -69,7 +70,7 @@
 
     <target name="run" depends="init-common">
         <sleep seconds="25"/>
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/slf4j-visibility/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/slf4j-visibility/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/specialization/alternative-leaks/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/specialization/alternative-leaks/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/specialization/specialization-simple/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/specialization/specialization-simple/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/stereotypes/alternative-stereotypes/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/stereotypes/alternative-stereotypes/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/stereotypes/interceptor-bindings-for-stereotypes/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/stereotypes/interceptor-bindings-for-stereotypes/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/stereotypes/stereotype-stacking/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/stereotypes/stereotype-stacking/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -66,7 +67,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="test.client.WebTest">
+        <java classname="test.client.WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/unproxyable-deps/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/unproxyable-deps/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-            <java classname="WebTest">
+            <java classname="WebTest" fork="true">
               <arg value="${http.host}"/>
               <arg value="${http.port}"/>
               <arg value="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/unsatisfied-deps/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/unsatisfied-deps/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
+	Copyright (c) 2021 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@
     </target>
 
     <target name="run" depends="init-common">
-        <java classname="WebTest">
+        <java classname="WebTest" fork="true">
           <arg value="${http.host}"/>
           <arg value="${http.port}"/>
           <arg value="${contextroot}"/>


### PR DESCRIPTION
Ant on JDK 18 only supports fork mode, so added fork=true for CDI tests. 

To keep PRs somewhat manageable, more to follow for other tests.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>

