### PR TITLE
Remove parent nucleus-parent for docs pom.xml to fix the build

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -101,6 +101,15 @@
                     <artifactId>glassfish-doc-maven-plugin</artifactId>
                     <version>1.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -20,11 +20,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.main</groupId>
-        <artifactId>nucleus-parent</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
-        <relativePath>../nucleus/parent</relativePath>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.6</version>
+        <relativePath />
     </parent>
+    <version>7.0.0-SNAPSHOT</version>
     <groupId>org.glassfish.docs</groupId>
     <artifactId>docs</artifactId>
     <packaging>pom</packaging>

--- a/docs/website/src/main/resources/README.md
+++ b/docs/website/src/main/resources/README.md
@@ -9,10 +9,19 @@ sponsored by the Eclipse Foundation.
 
 ## Latest News
 
+## November 18, 2021 -- Eclipse GlassFish 6.2.3 Available
+
+We are pleased to announce the release of Eclipse GlassFish 6.2.3. This release provides implementations
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.3 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.3 brings Admin console fixes, build times improvement, component updates, and bug fixes.
+
+GlassFish 6.2.3 compiles with JDK 11 to JDK 17 and runs on JDK 11 to JDK 17. GlassFish 6.2.3 also compiles and runs on JDK 18-EA releases.
+
+Note this release requires at least JDK 11. 
+
 ## October 1, 2021 -- Eclipse GlassFish 6.2.2 Available
 
 We are pleased to announce the release of Eclipse GlassFish 6.2.2. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.2 brings GlassFish embedded back to live, and contains an import fix for a memory leak. A major behind the scenes accomplishment is that all active tests now use JUnit 5.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.2 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.2 brings GlassFish embedded back to live, and contains an import fix for a memory leak. A major behind the scenes accomplishment is that all active tests now use JUnit 5.
 
 GlassFish 6.2.2 compiles with JDK 11 to JDK 17 and runs on JDK 11 to JDK 17. GlassFish 6.2.2 has been briefly tested with JDK 18-EA releases.
 
@@ -21,7 +30,7 @@ Note this release requires at least JDK 11.
 ## August 28, 2021 -- Eclipse GlassFish 6.2.1 Available
 
 We are happy to announce the release of Eclipse GlassFish 6.2.1. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.1 now has much improved support for JDK 17, and includes new component Eclipse Exousia, the standalone Jakarta Authorization implementation. GlassFish 6.2.1 compiles with JDK 11 to JDK 17.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.1 now has much improved support for JDK 17, and includes new component Eclipse Exousia, the standalone Jakarta Authorization implementation. GlassFish 6.2.1 compiles with JDK 11 to JDK 17.
 
 Note this release requires at least JDK 11.
 


### PR DESCRIPTION
To fix the Jenkins build job for docs, which gives "Could not find artifact org.glassfish.main:nucleus-parent:zip:resources:7.0.0-SNAPSHOT": https://ci.eclipse.org/glassfish/view/all/job/glassfish-docs-publish/507/console

Nothing from nucleus-parent is needed to build the docs and the parent isn't built together with the docs module, giving an error in the Jenkins job.

This PR also adds the missing news about the 6.2.3 release to the website.