### PR TITLE
Issue #23734 Using X509Certificate in java.security instead of javax.security

### DIFF
--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/JSSESupport.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/JSSESupport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  * Copyright (c) 2007-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -19,35 +20,26 @@ package org.glassfish.grizzly.config.ssl;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
-import javax.security.cert.X509Certificate;
 
 import org.glassfish.grizzly.Grizzly;
 import org.glassfish.grizzly.ssl.SSLSupport;
 
-/* JSSESupport
-
-   Concrete implementation class for JSSE
-   Support classes.
-
-   This will only work with JDK 1.2 and up since it
-   depends on JDK 1.2's certificate support
-
-   @author EKR
-   @author Craig R. McClanahan
-   Parts cribbed from JSSECertCompat
-   Parts cribbed from CertificatesValve
+/**
+ * Concrete implementation class for JSSE Support classes.
+ *
+ * @author EKR
+ * @author Craig R. McClanahan
  */
-
 class JSSESupport implements SSLSupport {
-    /**
-     * Default Logger.
-     */
     private final static Logger logger = Grizzly.logger(JSSESupport.class);
 
     /**
@@ -55,7 +47,7 @@ class JSSESupport implements SSLSupport {
      * when using a cipher suite containing the specified cipher name.  The
      * underlying data came from the TLS Specification (RFC 2246), Appendix C.
      */
-    private static final CipherData ciphers[] = {
+    private static final CipherData[] ciphers = {
         new CipherData("_WITH_NULL_", 0),
         new CipherData("_WITH_IDEA_CBC_", 128),
         new CipherData("_WITH_RC2_CBC_40_", 40),
@@ -70,7 +62,6 @@ class JSSESupport implements SSLSupport {
 
     protected SSLSocket ssl;
 
-    // START SJSAS 6439313
     /**
      * The SSLEngine used to support SSL over NIO.
      */
@@ -81,130 +72,119 @@ class JSSESupport implements SSLSupport {
      * The SSLSession contains SSL information.
      */
     protected SSLSession session;
-    // END SJSAS 6439313
 
-    JSSESupport(SSLSocket sock){
-        ssl=sock;
-        // START SJSAS 6439313
+    JSSESupport(SSLSocket sock) {
+        ssl = sock;
         session = ssl.getSession();
-        // END SJSAS 6439313
     }
 
-    // START SJSAS 6439313
-    JSSESupport(SSLEngine sslEngine){
+
+    JSSESupport(SSLEngine sslEngine) {
         this.sslEngine = sslEngine;
         session = sslEngine.getSession();
     }
-    // END SJSAS 6439313
 
+
+    @Override
     public String getCipherSuite() throws IOException {
-        // Look up the current SSLSession
-        /* SJSAS 6439313
-        SSLSession session = ssl.getSession();
-         */
-        if (session == null)
+        if (session == null) {
             return null;
+        }
         return session.getCipherSuite();
     }
 
-    public Object[] getPeerCertificateChain()
-        throws IOException {
+
+    @Override
+    public Object[] getPeerCertificateChain() throws IOException {
         return getPeerCertificateChain(false);
     }
 
-    protected java.security.cert.X509Certificate []
-        getX509Certificates(SSLSession session) throws IOException {
-        X509Certificate jsseCerts[] = null;
-        try{
-            jsseCerts = session.getPeerCertificateChain();
-        } catch (Throwable ex){
+
+    protected Certificate[] getX509Certificates(SSLSession session) throws IOException {
+        Certificate[] jsseCerts = null;
+        try {
+            jsseCerts = session.getPeerCertificates();
+        } catch (Throwable ex) {
             // Get rid of the warning in the logs when no Client-Cert is
             // available
         }
 
-        if(jsseCerts == null)
+        if (jsseCerts == null) {
             jsseCerts = new X509Certificate[0];
-        java.security.cert.X509Certificate [] x509Certs =
-            new java.security.cert.X509Certificate[jsseCerts.length];
+        }
+        X509Certificate[] x509Certs = new X509Certificate[jsseCerts.length];
         for (int i = 0; i < x509Certs.length; i++) {
             try {
                 byte buffer[] = jsseCerts[i].getEncoded();
-                CertificateFactory cf =
-                    CertificateFactory.getInstance("X.509");
-                ByteArrayInputStream stream =
-                    new ByteArrayInputStream(buffer);
-                x509Certs[i] = (java.security.cert.X509Certificate)
-                    cf.generateCertificate(stream);
-                if(logger.isLoggable(Level.FINEST))
-                    logger.log(Level.FINE,"Cert #" + i + " = " + x509Certs[i]);
-            } catch(Exception ex) {
-                logger.log(Level.SEVERE,"Error translating " + jsseCerts[i], ex);
+                CertificateFactory cf = CertificateFactory.getInstance("X.509");
+                ByteArrayInputStream stream = new ByteArrayInputStream(buffer);
+                x509Certs[i] = (X509Certificate) cf.generateCertificate(stream);
+                if (logger.isLoggable(Level.FINEST)) {
+                    logger.log(Level.FINE, "Cert #" + i + " = " + x509Certs[i]);
+                }
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, "Error translating " + jsseCerts[i], ex);
                 return null;
             }
         }
 
-        if ( x509Certs.length < 1 )
+        if (x509Certs.length < 1) {
             return null;
+        }
         return x509Certs;
     }
-    public Object[] getPeerCertificateChain(boolean force)
-        throws IOException {
-        // Look up the current SSLSession
-        /* SJSAS 6439313
-        SSLSession session = ssl.getSession();
-         */
-        if (session == null)
+
+
+    @Override
+    public Object[] getPeerCertificateChain(boolean force) throws IOException {
+        if (session == null) {
             return null;
+        }
 
         // Convert JSSE's certificate format to the ones we need
-        X509Certificate [] jsseCerts = null;
+        Certificate[] jsseCerts = null;
         try {
-            jsseCerts = session.getPeerCertificateChain();
-        } catch(Exception bex) {
+            jsseCerts = session.getPeerCertificates();
+        } catch (Exception bex) {
             // ignore.
         }
-        if (jsseCerts == null)
+        if (jsseCerts == null) {
             jsseCerts = new X509Certificate[0];
-        if(jsseCerts.length <= 0 && force) {
+        }
+        if (jsseCerts.length <= 0 && force) {
             session.invalidate();
             handShake();
-            /* SJSAS 6439313
-            session = ssl.getSession();
-             */
-            // START SJSAS 6439313
-            if ( ssl == null)
+            if (ssl == null) {
                 session = sslEngine.getSession();
-            else
+            } else {
                 session = ssl.getSession();
-            // END SJSAS 6439313
+            }
         }
         return getX509Certificates(session);
     }
+
 
     protected void handShake() throws IOException {
         ssl.setNeedClientAuth(true);
         ssl.startHandshake();
     }
+
+
     /**
      * Copied from <code>org.apache.catalina.valves.CertificateValve</code>
      */
-    public Integer getKeySize()
-        throws IOException {
-        // Look up the current SSLSession
-        /* SJSAS 6439313
-        SSLSession session = ssl.getSession();
-         */
-        SSLSupport.CipherData c_aux[]=ciphers;
-        if (session == null)
+    @Override
+    public Integer getKeySize() throws IOException {
+        if (session == null) {
             return null;
+        }
         Integer keySize = (Integer) session.getValue(KEY_SIZE_KEY);
         if (keySize == null) {
             int size = 0;
             String cipherSuite = session.getCipherSuite();
-
-            for (int i = 0; i < c_aux.length; i++) {
-                if (cipherSuite.indexOf(c_aux[i].phrase) >= 0) {
-                    size = c_aux[i].keySize;
+            for (CipherData element : ciphers) {
+                if (cipherSuite.indexOf(element.phrase) >= 0) {
+                    size = element.keySize;
                     break;
                 }
             }
@@ -214,28 +194,28 @@ class JSSESupport implements SSLSupport {
         return keySize;
     }
 
-    public String getSessionId()
-        throws IOException {
-        // Look up the current SSLSession
-        /* SJSAS 6439313
-        SSLSession session = ssl.getSession();
-         */
-        if (session == null)
+
+    @Override
+    public String getSessionId() throws IOException {
+        if (session == null) {
             return null;
+        }
         // Expose ssl_session (getId)
-        byte [] ssl_session = session.getId();
-        if ( ssl_session == null)
+        byte[] ssl_session = session.getId();
+        if (ssl_session == null) {
             return null;
-        StringBuilder buf=new StringBuilder("");
-        for(int x=0; x<ssl_session.length; x++) {
-            String digit=Integer.toHexString((int)ssl_session[x]);
-            if (digit.length()<2) buf.append('0');
-            if (digit.length()>2) digit=digit.substring(digit.length()-2);
+        }
+        StringBuilder buf = new StringBuilder(32);
+        for (byte element : ssl_session) {
+            String digit = Integer.toHexString(element);
+            if (digit.length() < 2) {
+                buf.append('0');
+            }
+            if (digit.length() > 2) {
+                digit = digit.substring(digit.length() - 2);
+            }
             buf.append(digit);
         }
         return buf.toString();
     }
-
-
 }
-

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishSSLSupport.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassfishSSLSupport.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,20 +17,21 @@
 
 package com.sun.enterprise.security.ssl;
 
+import com.sun.enterprise.security.SecurityLoggerInfo;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
-import javax.security.cert.X509Certificate;
 
 import org.glassfish.grizzly.ssl.SSLSupport;
-
-import com.sun.enterprise.security.SecurityLoggerInfo;
 
 /**
  *
@@ -84,8 +86,8 @@ public class GlassfishSSLSupport implements SSLSupport {
         if (session == null) {
             return null;
         }
-        X509Certificate[] certs = null;
-        certs = session.getPeerCertificateChain();
+        Certificate[] certs = null;
+        certs = session.getPeerCertificates();
         if (certs == null) {
             certs = new X509Certificate[0];
         }
@@ -151,9 +153,9 @@ public class GlassfishSSLSupport implements SSLSupport {
     }
 
     private Object[] getX509Certs() {
-        X509Certificate certs[] = null;
+        Certificate[] certs = null;
         try {
-            certs = session.getPeerCertificateChain();
+            certs = session.getPeerCertificates();
         } catch (Throwable ex) {
             // Get rid of the warning in the logs when no Client-Cert is
             // available
@@ -162,13 +164,13 @@ public class GlassfishSSLSupport implements SSLSupport {
         if (certs == null) {
             certs = new X509Certificate[0];
         }
-        java.security.cert.X509Certificate[] x509Certs = new java.security.cert.X509Certificate[certs.length];
+        X509Certificate[] x509Certs = new X509Certificate[certs.length];
         for (int i = 0; i < x509Certs.length; i++) {
             try {
                 byte buffer[] = certs[i].getEncoded();
                 CertificateFactory cf = CertificateFactory.getInstance("X.509");
                 ByteArrayInputStream stream = new ByteArrayInputStream(buffer);
-                x509Certs[i] = (java.security.cert.X509Certificate) cf.generateCertificate(stream);
+                x509Certs[i] = (X509Certificate) cf.generateCertificate(stream);
                 if (logger.isLoggable(Level.FINEST)) {
                     logger.log(Level.FINE, "Cert #{0} = {1}", new Object[] { i, x509Certs[i] });
                 }


### PR DESCRIPTION
* The `javax.security` version was deprecated in Java 9, and will be removed.
* Closes #23734 