### PR TITLE
Allow tuning of the interval for monitoring concurrent tasks

### DIFF
--- a/appserver/admingui/concurrent/src/main/help/en/help/ref-executorserviceedit.html
+++ b/appserver/admingui/concurrent/src/main/help/en/help/ref-executorserviceedit.html
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,6 +57,14 @@
 <dt>Hung After</dt>
 <dd>
 <p>The number of seconds tasks can execute before they are considered unresponsive. The default value is 0.</p>
+</dd>
+<dt>Hung Logger Initial Delay</dt>
+<dd>
+<p>The number of seconds to delay logging the detection of hung tasks. The default value is 60.</p>
+</dd>
+<dt>Hung Logger Interval</dt>
+<dd>
+<p>The number of seconds between logging the detection of hung tasks. The default value is 60.</p>
 </dd>
 <dt>Deployment Order</dt>
 <dd>

--- a/appserver/admingui/concurrent/src/main/help/en/help/ref-executorservicenew.html
+++ b/appserver/admingui/concurrent/src/main/help/en/help/ref-executorservicenew.html
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,6 +47,14 @@
 <dt>Hung After</dt>
 <dd>
 <p>The number of seconds tasks can execute before they are considered unresponsive. The default value is 0.</p>
+</dd>
+<dt>Hung Logger Initial Delay</dt>
+<dd>
+<p>The number of seconds to delay logging the detection of hung tasks. The default value is 60.</p>
+</dd>
+<dt>Hung Logger Interval</dt>
+<dd>
+<p>The number of seconds between logging the detection of hung tasks. The default value is 60.</p>
 </dd>
 <dt>Description</dt>
 <dd>

--- a/appserver/admingui/concurrent/src/main/help/en/help/ref-scheduledexecutorserviceedit.html
+++ b/appserver/admingui/concurrent/src/main/help/en/help/ref-scheduledexecutorserviceedit.html
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,6 +57,14 @@
 <dt>Hung After</dt>
 <dd>
 <p>The number of seconds tasks can execute before they are considered unresponsive. The default value is 0.</p>
+</dd>
+<dt>Hung Logger Initial Delay</dt>
+<dd>
+<p>The number of seconds to delay logging the detection of hung tasks. The default value is 60.</p>
+</dd>
+<dt>Hung Logger Interval</dt>
+<dd>
+<p>The number of seconds between logging the detection of hung tasks. The default value is 60.</p>
 </dd>
 <dt>Deployment Order</dt>
 <dd>

--- a/appserver/admingui/concurrent/src/main/help/en/help/ref-scheduledexecutorservicenew.html
+++ b/appserver/admingui/concurrent/src/main/help/en/help/ref-scheduledexecutorservicenew.html
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,6 +47,14 @@
 <dt>Hung After</dt>
 <dd>
 <p>The number of seconds tasks can execute before they are considered unresponsive. The default value is 0.</p>
+</dd>
+<dt>Hung Logger Initial Delay</dt>
+<dd>
+<p>The number of seconds to delay logging the detection of hung tasks. The default value is 60.</p>
+</dd>
+<dt>Hung Logger Interval</dt>
+<dd>
+<p>The number of seconds between logging the detection of hung tasks. The default value is 60.</p>
 </dd>
 <dt>Description</dt>
 <dd>

--- a/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
+++ b/appserver/admingui/concurrent/src/main/resources/managedExecutorServiceAttr.inc
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,6 +63,14 @@
        
        <sun:property id="hungafter" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.hungAfterSeconds}"  helpText="$resource{i18ncon.hungAfterSecondsHelp}">
             <sun:textField id="hungafter" styleClass="integer" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['hungAfterSeconds']}" />
+            <sun:staticText id="sec" style="padding: 8pt" text="$resource{i18n.common.Seconds}"/>
+       </sun:property>
+       <sun:property id="hungLoggerInitialDelay" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.hungLoggerInitialDelaySeconds}"  helpText="$resource{i18ncon.hungLoggerInitialDelaySecondsHelp}">
+            <sun:textField id="hungLoggerInitialDelay" styleClass="integer" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['hungLoggerInitialDelaySeconds']}" />
+            <sun:staticText id="sec" style="padding: 8pt" text="$resource{i18n.common.Seconds}"/>
+       </sun:property>
+       <sun:property id="hungLoggerInterval" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18ncon.hungLoggerIntervalSeconds}"  helpText="$resource{i18ncon.hungLoggerIntervalSecondsHelp}">
+            <sun:textField id="hungLoggerInterval" styleClass="integer" columns="$int{55}" maxLength="#{sessionScope.fieldLengths['maxLength.common.description']}" text="#{pageSession.valueMap['hungLoggerIntervalSeconds']}" />
             <sun:staticText id="sec" style="padding: 8pt" text="$resource{i18n.common.Seconds}"/>
        </sun:property>
        <sun:property id="deploymentOrder" labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" rendered="#{edit}" label="$resource{i18n.common.resource.deploymentOrder}"  helpText="$resource{i18n.common.resource.deploymentOrderHelp}">

--- a/appserver/admingui/concurrent/src/main/resources/org/glassfish/concurrent/admingui/Strings.properties
+++ b/appserver/admingui/concurrent/src/main/resources/org/glassfish/concurrent/admingui/Strings.properties
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -93,6 +94,10 @@ longRunningTasks=Long-Running Tasks:
 longRunningTasksHelp=Use the resource for long-running tasks. If enabled, long-running tasks are not reported as stuck.
 hungAfterSeconds=Hung After:
 hungAfterSecondsHelp=Number of seconds tasks can execute before they are considered unresponsive
+hungLoggerInitialDelaySeconds=Hung Logger Initial Delay:
+hungLoggerInitialDelaySecondsHelp=Number of seconds to delay logging the detection of hung tasks.
+hungLoggerIntervalSeconds=Hung Logger Interval:
+hungLoggerIntervalSecondsHelp=Number of seconds between logging the detection of hung tasks.
 corePoolSize=Core Size:
 corePoolSizeHelp=Number of threads to keep in a thread pool
 maximumPoolSize=Maximum Pool Size:

--- a/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-connector/src/main/java/org/glassfish/concurrent/config/ManagedExecutorServiceBase.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -86,6 +87,38 @@ public interface ManagedExecutorServiceBase extends ConfigBeanProxy,
      *              {@link String }
      */
     void setHungAfterSeconds(String value) throws PropertyVetoException;
+
+    /**
+     * Gets the value of the hungLoggerInitialDelaySeconds property.
+     *
+     * @return possible object is {@link String }
+     */
+    @Attribute(defaultValue = "60", dataType = Long.class)
+    @Min(value = 0)
+    String getHungLoggerInitialDelaySeconds();
+
+    /**
+     * Sets the value of the hungLoggerInitialDelaySeconds property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    void setHungLoggerInitialDelaySeconds(String value) throws PropertyVetoException;
+
+    /**
+     * Gets the value of the hungLoggerIntervalSeconds property.
+     *
+     * @return possible object is {@link String }
+     */
+    @Attribute(defaultValue = "60", dataType = Long.class)
+    @Min(value = 1)
+    String getHungLoggerIntervalSeconds();
+
+    /**
+     * Sets the value of the hungLoggerIntervalSeconds property.
+     *
+     * @param value allowed object is {@link String }
+     */
+    void setHungLoggerIntervalSeconds(String value) throws PropertyVetoException;
 
     /**
      * Gets the value of the corePoolSize property.

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorServiceBase.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/CreateManagedExecutorServiceBase.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -55,6 +56,12 @@ public class CreateManagedExecutorServiceBase {
     @Param(name="hungafterseconds", alias="hungAfterSeconds", defaultValue="0", optional=true)
     protected Integer hungafterseconds;
 
+    @Param(name = "hungloggerinitialdelayseconds", alias = "hungLoggerInitialDelaySeconds", defaultValue = "60", optional = true)
+    protected Integer hungloggerinitialdelayseconds;
+
+    @Param(name = "hungloggerintervalseconds", alias = "hungLoggerIntervalSeconds", defaultValue = "60", optional = true)
+    protected Integer hungloggerintervalseconds;
+
     @Param(name="corepoolsize", alias="corePoolSize", defaultValue="0", optional=true)
     protected Integer corepoolsize;
 
@@ -83,6 +90,8 @@ public class CreateManagedExecutorServiceBase {
             longrunningtasks.toString());
         attrList.put(ResourceConstants.HUNG_AFTER_SECONDS,
             hungafterseconds.toString());
+        attrList.put(ResourceConstants.HUNG_LOGGER_INITIAL_DELAY_SECONDS, hungloggerinitialdelayseconds.toString());
+        attrList.put(ResourceConstants.HUNG_LOGGER_INTERVAL_SECONDS, hungloggerintervalseconds.toString());
         attrList.put(ResourceConstants.CORE_POOL_SIZE,
             corepoolsize.toString());
         attrList.put(ResourceConstants.KEEP_ALIVE_SECONDS,

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/admin/ManagedExecutorServiceBaseManager.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,6 +61,8 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
     protected String contextInfo = CONTEXT_INFO_DEFAULT_VALUE;
     protected String longRunningTasks = Boolean.FALSE.toString();
     protected String hungAfterSeconds = "0";
+    protected String hungLoggerInitialDelaySeconds = "60";
+    protected String hungLoggerIntervalSeconds = "60";
     protected String corePoolSize = "0";
     protected String keepAliveSeconds = "60";
     protected String threadLifetimeSeconds = "0";
@@ -141,6 +144,8 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         threadPriority = (String) attributes.get(THREAD_PRIORITY);
         longRunningTasks = (String) attributes.get(LONG_RUNNING_TASKS);
         hungAfterSeconds = (String) attributes.get(HUNG_AFTER_SECONDS);
+        hungLoggerInitialDelaySeconds = (String) attributes.get(HUNG_LOGGER_INITIAL_DELAY_SECONDS);
+        hungLoggerIntervalSeconds = (String) attributes.get(HUNG_LOGGER_INTERVAL_SECONDS);
         corePoolSize = (String) attributes.get(CORE_POOL_SIZE);
         keepAliveSeconds = (String) attributes.get(KEEP_ALIVE_SECONDS);
         threadLifetimeSeconds = (String) attributes.get(THREAD_LIFETIME_SECONDS);
@@ -169,6 +174,8 @@ public abstract class ManagedExecutorServiceBaseManager implements ResourceManag
         managedExecutorService.setContextInfo(contextInfo);
         managedExecutorService.setThreadPriority(threadPriority);
         managedExecutorService.setHungAfterSeconds(hungAfterSeconds);
+        managedExecutorService.setHungLoggerInitialDelaySeconds(hungLoggerInitialDelaySeconds);
+        managedExecutorService.setHungLoggerIntervalSeconds(hungLoggerIntervalSeconds);
         managedExecutorService.setCorePoolSize(corePoolSize);
         managedExecutorService.setKeepAliveSeconds(keepAliveSeconds);
         managedExecutorService.setThreadLifetimeSeconds(threadLifetimeSeconds);

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -171,7 +172,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
         }
         managedExecutorServiceMap.put(jndiName, mes);
         if (config.getHungAfterSeconds() > 0L && !config.isLongRunningTasks()) {
-            scheduleInternalTimer();
+            scheduleInternalTimer(config.getHungLoggerInitialDelaySeconds(), config.getHungLoggerIntervalSeconds());
         }
         return mes;
     }
@@ -213,7 +214,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
         }
         managedScheduledExecutorServiceMap.put(jndiName, mes);
         if (config.getHungAfterSeconds() > 0L && !config.isLongRunningTasks()) {
-            scheduleInternalTimer();
+            scheduleInternalTimer(config.getHungLoggerInitialDelaySeconds(), config.getHungLoggerIntervalSeconds());
         }
         return mes;
     }
@@ -299,7 +300,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
         return contextTypeArray.toArray(contextTypes);
     }
 
-    private void scheduleInternalTimer() {
+    private void scheduleInternalTimer(long initialDelay, long interval) {
         if (internalScheduler == null) {
             String name = "glassfish-internal";
             ManagedThreadFactoryImpl managedThreadFactory = new ManagedThreadFactoryImpl(
@@ -316,7 +317,7 @@ public class ConcurrentRuntime implements PostConstruct, PreDestroy {
                     createContextService(name + "-contextservice",
                             CONTEXT_INFO_CLASSLOADER, "true", false),
                     AbstractManagedExecutorService.RejectPolicy.ABORT);
-            internalScheduler.scheduleAtFixedRate(new HungTasksLogger(), 1L, 1L, TimeUnit.MINUTES);
+            internalScheduler.scheduleAtFixedRate(new HungTasksLogger(), initialDelay, interval, TimeUnit.SECONDS);
         }
     }
 

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedExecutorServiceConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +25,8 @@ import org.glassfish.concurrent.config.ManagedExecutorService;
 public class ManagedExecutorServiceConfig extends BaseConfig  {
 
     private int hungAfterSeconds;
+    private long hungLoggerInitialDelaySeconds;
+    private long hungLoggerIntervalSeconds;
     private boolean longRunningTasks;
     private int threadPriority;
     private int corePoolSize;
@@ -35,6 +38,8 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
     public ManagedExecutorServiceConfig(ManagedExecutorService config) {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         hungAfterSeconds = parseInt(config.getHungAfterSeconds(), 0);
+        hungLoggerInitialDelaySeconds = parseLong(config.getHungLoggerInitialDelaySeconds(), 60);
+        hungLoggerIntervalSeconds = parseLong(config.getHungLoggerIntervalSeconds(), 60);
         longRunningTasks = Boolean.valueOf(config.getLongRunningTasks());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
         corePoolSize = parseInt(config.getCorePoolSize(), 0);
@@ -46,6 +51,14 @@ public class ManagedExecutorServiceConfig extends BaseConfig  {
 
     public int getHungAfterSeconds() {
         return hungAfterSeconds;
+    }
+
+    public long getHungLoggerInitialDelaySeconds() {
+        return hungLoggerInitialDelaySeconds;
+    }
+
+    public long getHungLoggerIntervalSeconds() {
+        return hungLoggerIntervalSeconds;
     }
 
     public boolean isLongRunningTasks() {

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/deployer/ManagedScheduledExecutorServiceConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +25,8 @@ import org.glassfish.concurrent.config.ManagedScheduledExecutorService;
 public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
 
     private int hungAfterSeconds;
+    private long hungLoggerInitialDelaySeconds;
+    private long hungLoggerIntervalSeconds;
     private boolean longRunningTasks;
     private int threadPriority;
     private int corePoolSize;
@@ -33,6 +36,8 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
     public ManagedScheduledExecutorServiceConfig(ManagedScheduledExecutorService config) {
         super(config.getJndiName(), config.getContextInfo(), config.getContextInfoEnabled());
         hungAfterSeconds = parseInt(config.getHungAfterSeconds(), 0);
+        hungLoggerInitialDelaySeconds = parseLong(config.getHungLoggerInitialDelaySeconds(), 60);
+        hungLoggerIntervalSeconds = parseLong(config.getHungLoggerIntervalSeconds(), 60);
         longRunningTasks = Boolean.valueOf(config.getLongRunningTasks());
         threadPriority = parseInt(config.getThreadPriority(), Thread.NORM_PRIORITY);
         corePoolSize = parseInt(config.getCorePoolSize(), 0);
@@ -42,6 +47,14 @@ public class ManagedScheduledExecutorServiceConfig extends BaseConfig {
 
     public int getHungAfterSeconds() {
         return hungAfterSeconds;
+    }
+
+    public long getHungLoggerInitialDelaySeconds() {
+        return hungLoggerInitialDelaySeconds;
+    }
+
+    public long getHungLoggerIntervalSeconds() {
+        return hungLoggerIntervalSeconds;
     }
 
     public boolean isLongRunningTasks() {

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-executor-service.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-executor-service.1
@@ -12,6 +12,8 @@ SYNOPSIS
            [--threadpriority threadpriority]
            [--longrunningtasks={false|true}]
            [--hungafterseconds hungafterseconds]
+           [--hungloggerinitialdelayseconds hungloggerinitialdelayseconds]
+           [--hungloggerintervalseconds hungloggerintervalseconds]
            [--corepoolsize corepoolsize]
            [--maximumpoolsize maximumpoolsize]
            [--keepaliveseconds keepaliveseconds]
@@ -61,6 +63,14 @@ OPTIONS
            Specifies the number of seconds that a task can execute before it
            is considered unresponsive. The default value is 0, which means
            that tasks are never considered unresponsive.
+
+       --hungloggerinitialdelayseconds
+           Specifies the number of seconds to delay logging the detection of
+           hung tasks. The default value is 60.
+
+       --hungloggerintervalseconds
+           Specifies the number of seconds between logging the detection of
+           hung tasks. The default value is 60.
 
        --corepoolsize
            Specifies the number of threads to keep in a thread pool, even if

--- a/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-scheduled-executor-service.1
+++ b/appserver/concurrent/concurrent-impl/src/main/manpages/org/glassfish/concurrent/admin/create-managed-scheduled-executor-service.1
@@ -12,6 +12,8 @@ SYNOPSIS
            [--threadpriority threadpriority]
            [--longrunningtasks={false|true}]
            [--hungafterseconds hungafterseconds]
+           [--hungloggerinitialdelayseconds hungloggerinitialdelayseconds]
+           [--hungloggerintervalseconds hungloggerintervalseconds]
            [--corepoolsize corepoolsize]
            [--keepaliveseconds keepaliveseconds]
            [--threadlifetimeseconds threadlifetimeseconds]
@@ -59,6 +61,14 @@ OPTIONS
            Specifies the number of seconds that a task can execute before it
            is considered unresponsive. The default value is 0, which means
            that tasks are never considered unresponsive.
+
+       --hungloggerinitialdelayseconds
+           Specifies the number of seconds to delay logging the detection of
+           hung tasks. The default value is 60.
+
+       --hungloggerintervalseconds
+           Specifies the number of seconds between logging the detection of
+           hung tasks. The default value is 60.
 
        --corepoolsize
            Specifies the number of threads to keep in a thread pool, even if

--- a/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
+++ b/appserver/resources/resources-connector/src/main/java/org/glassfish/resources/admin/cli/ResourceConstants.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -223,6 +224,8 @@ public final class ResourceConstants {
     public static final String THREAD_PRIORITY = "thread-priority";
     public static final String LONG_RUNNING_TASKS = "long-runnings-tasks";
     public static final String HUNG_AFTER_SECONDS = "hung-after-seconds";
+    public static final String HUNG_LOGGER_INITIAL_DELAY_SECONDS = "hung-logger-initial-delay-seconds";
+    public static final String HUNG_LOGGER_INTERVAL_SECONDS = "hung-logger-interval-seconds";
     public static final String CORE_POOL_SIZE = "core-pool-size";
     public static final String MAXIMUM_POOL_SIZE = "maximum-pool-size";
     public static final String KEEP_ALIVE_SECONDS = "keep-alive-seconds";

--- a/docs/reference-manual/src/main/jbake/content/create-managed-executor-service.adoc
+++ b/docs/reference-manual/src/main/jbake/content/create-managed-executor-service.adoc
@@ -27,6 +27,8 @@ asadmin [asadmin-options] create-managed-executor-service [--help]
 [--threadpriority threadpriority]
 [--longrunningtasks={false|true}]
 [--hungafterseconds hungafterseconds]
+[--hungloggerinitialdelayseconds hungloggerinitialdelayseconds]
+[--hungloggerintervalseconds hungloggerintervalseconds]
 [--corepoolsize corepoolsize]
 [--maximumpoolsize maximumpoolsize]
 [--keepaliveseconds keepaliveseconds]
@@ -81,6 +83,12 @@ asadmin-options::
   Specifies the number of seconds that a task can execute before it is
   considered unresponsive. The default value is 0, which means that
   tasks are never considered unresponsive.
+`--hungloggerinitialdelayseconds`::
+  Specifies the number of seconds to delay logging the detection of hung
+  tasks. The default value is 60.
+`--hungloggerintervalseconds`::
+  Specifies the number of seconds between logging the detection of hung
+  tasks. The default value is 60.
 `--corepoolsize`::
   Specifies the number of threads to keep in a thread pool, even if they
   are idle. The default value is 0. +

--- a/docs/reference-manual/src/main/jbake/content/create-managed-scheduled-executor-service.adoc
+++ b/docs/reference-manual/src/main/jbake/content/create-managed-scheduled-executor-service.adoc
@@ -27,6 +27,8 @@ asadmin [asadmin-options] create-managed-scheduled-executor-service [--help]
 [--threadpriority threadpriority]
 [--longrunningtasks={false|true}]
 [--hungafterseconds hungafterseconds]
+[--hungloggerinitialdelayseconds hungloggerinitialdelayseconds]
+[--hungloggerintervalseconds hungloggerintervalseconds]
 [--corepoolsize corepoolsize]
 [--keepaliveseconds keepaliveseconds]
 [--threadlifetimeseconds threadlifetimeseconds]
@@ -79,6 +81,12 @@ asadmin-options::
   Specifies the number of seconds that a task can execute before it is
   considered unresponsive. The default value is 0, which means that
   tasks are never considered unresponsive.
+`--hungloggerinitialdelayseconds`::
+  Specifies the number of seconds to delay logging the detection of hung
+  tasks. The default value is 60.
+`--hungloggerintervalseconds`::
+  Specifies the number of seconds between logging the detection of hung
+  tasks. The default value is 60.
 `--corepoolsize`::
   Specifies the number of threads to keep in a thread pool, even if they
   are idle. The default value is 0, which means that a thread is created


### PR DESCRIPTION
Signed-off-by: 11rx4f <ryosuke.okada@fujitsu.com>

* Related #21561

GlassFish has the function that monitors tasks and prints the warning message if it detects hung tasks for concurrent resources.  
User can specify the threshold for determining whether the task hung (using hung-after-seconds).  
On the other hand, the interval for monitoring and printing warning log is not tunable because it is hard-coded as 1 minute.  
Therefore, GlassFish will continue to print warning logs every minute until the hang condition is resolved (if the task is night batch, on all night).  
so the interval should be tunable.  