### PR TITLE
Added option javatest.security.noSecurityManager to TCKs

### DIFF
--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -153,7 +153,7 @@
                         <id>prepare-tck-and-glassfish</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                          
@@ -172,7 +172,6 @@
                                     </sequential>
                                 </macrodef>
                                 
-                                <concat append="true" destfile="app.jad">foo: bar</concat>
 
                                 <!-- Change configuration -->
                                 <copy file="${tck.home}/bin/ts.jte.jdk11" tofile="${tck.home}/bin/ts.jte" overwrite="true"  />
@@ -241,6 +240,18 @@
                                 </limit>
                                 <mkdir dir="${tck.home}/authenticationtckreport"/>
                                 <mkdir dir="${tck.home}/authenticationtckreport/authenticationtck"/>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml">
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
+                                </replace>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008"/>]]></replacevalue>
+                                </replace>
                             </target>
                         </configuration>
                         <goals>
@@ -282,12 +293,13 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
 
                                 <echo level="info" message="Start running all tests" />
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" resultproperty="testResult">
+                                    <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="run.all"/>
                                     <env key="LC_ALL" value="C" />
                                 </exec>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -149,7 +149,7 @@
                         <id>prepare-tck-and-glassfish</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
 
@@ -225,6 +225,18 @@
                                 </limit>
                                 <mkdir dir="${tck.home}/jacctckreport"/>
                                 <mkdir dir="${tck.home}/jacctckreport/jacctck"/>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml">
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
+                                </replace>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008"/>]]></replacevalue>
+                                </replace>
                             </target>
                         </configuration>
                         <goals>
@@ -266,13 +278,13 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
 
                                 <echo level="info" message="Start running all tests" />
-                                <exec executable="${ant.home}/bin/ant"
-                                      dir="${tck.tests.home}" resultproperty="testResult">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" resultproperty="testResult">
+                                    <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="deploy"/>
                                     <arg value="run.all"/>
                                     <env key="LC_ALL" value="C" />

--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -155,7 +155,7 @@
                         <id>prepare-tck-and-glassfish</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                          
@@ -225,8 +225,22 @@
                                         <arg value="domain1"/>
                                     </exec>
                                 </limit>
-                                <mkdir dir="${tck.home}/facestckreport"/>
-                                <mkdir dir="${tck.home}/facestckreport/facestck"/>
+                                <mkdir dir="${tck.home}/facesreport"/>
+                                <mkdir dir="${tck.home}/facesreport/faces"/>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml">
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m" />]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m" />
+                                <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
+                                </replace>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m" />]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m" />
+                                <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008"/>]]></replacevalue>
+                                </replace>
+                                
+                                
                             </target>
                         </configuration>
                         <goals>
@@ -266,21 +280,16 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
 
-                                <echo level="info" message="Start running all tests" />
+                                <echo level="info" message="Start running all tests" unless:set="run.test"/>
+                                <echo level="info" message="Start running single test" if:set="run.test"/>
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" resultproperty="testResult">
                                     <arg value="-Dutil.dir=${tck.home}"  />
-                                    <arg value="-Dtest=foo"  />
-                                    <arg value="-DnoSecurityMgr=true" />
-                                    
+                                    <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="runclient"/>
-                                     
-                                     <!--
-                                    <env key="ANT_OPTS" value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9009" />
-                                    -->
                                     <env key="LC_ALL" value="C" />
                                 </exec>
 

--- a/appserver/tests/tck/rest/pom.xml
+++ b/appserver/tests/tck/rest/pom.xml
@@ -153,7 +153,7 @@
                         <id>prepare-tck-and-glassfish</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                          
@@ -225,6 +225,18 @@
                                 </limit>
                                 <mkdir dir="${tck.home}/resttckreport"/>
                                 <mkdir dir="${tck.home}/resttckreport/resttck"/>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml">
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
+                                </replace>
+                                
+                                <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
+                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
+                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
+                                <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008"/>]]></replacevalue>
+                                </replace>
                             </target>
                         </configuration>
                         <goals>
@@ -269,13 +281,13 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
 
                                 <echo level="info" message="Start running all tests" />
-                                <exec executable="${ant.home}/bin/ant"
-                                      dir="${tck.tests.home}" resultproperty="testResult">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" resultproperty="testResult">
+                                    <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="runclient"/>
                                     <arg value="-Dkeywords=jaxrs.all"/>
                                     <env key="LC_ALL" value="C" />


### PR DESCRIPTION
This is needed to be able to run on JDK 18.
