### PR TITLE
Fix #23772 The create-file-user subcommand with passwordfile option isn't usable in embedded glassfish.

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/CommandExecutorImpl.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/CommandExecutorImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -98,7 +99,7 @@ public class CommandExecutorImpl implements org.glassfish.embeddable.CommandRunn
         if (globalOptions.size() > 0) {
             String pwfile = globalOptions.getOne(ProgramOptions.PASSWORDFILE);
             if (pwfile != null && pwfile.length() > 0) {
-                Map<String, String> passwords = CLIUtil.readPasswordFileOptions(pwfile, true);
+                Map<String, String> passwords = CLIUtil.readPasswordFileOptions(pwfile, false);
                 for (CommandModel.ParamModel opt : commandModel.getParameters()) {
                     if (opt.getParam().password()) {
                         String pwdname = opt.getName();


### PR DESCRIPTION
* Fixes #23772

There is a bug in the process of getting the password value from the loaded password file.

In the process of create-file-user subcommand, `CLIUtil.readPasswordFileOptions()` is called in `CommandExecutorImple.getParameters()`. Since the second argument of this method is always true, keys of the map `passwords` have the prefix "AS_ADMIN_".

https://github.com/eclipse-ee4j/glassfish/blob/4d6a8b5f8d1cb66f78852bfd9093a0e1fb887b24/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/CommandExecutorImpl.java#L101

For example, if the contents of the passward file is as follows, the key of the user password in the map `passwords` is "AS_ADMIN_USERPASSWORD".
```text
AS_ADMIN_USERPASSWORD=mypassword
```

On the other hand, the variable `pwdname`, which is the key to get the user password from the map `passwords`, is "userpassword".  
Therefore, `passwords.get(pwdname)` always returns null.

https://github.com/eclipse-ee4j/glassfish/blob/4d6a8b5f8d1cb66f78852bfd9093a0e1fb887b24/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/CommandExecutorImpl.java#L104-L108

I think the second argument of `CLIUtil.readPasswordFileOptions()` should be false here. With this fix, keys of the map `passwords` are no longer prefixed with "AS_ADMIN_", and converted to lowercase. (If the password file is the above example, the key of the map `passwords` is "userpassword")

https://github.com/eclipse-ee4j/glassfish/blob/4d6a8b5f8d1cb66f78852bfd9093a0e1fb887b24/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLIUtil.java#L57-L58

Signed-off-by: kosakak <kosaka.koki@fujitsu.com>
