### PR TITLE
Integrate hibernate validator 7.0.2.

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -91,7 +91,7 @@
 
         <!-- Jakarta Validation -->
         <jakarta.validation.version>3.0.0</jakarta.validation.version>
-        <hibernate-validator.version>7.0.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>7.0.2.Final</hibernate-validator.version>
 
         <!-- Jakarta Web Services -->
         <webservices.version>3.0.3</webservices.version>
@@ -137,7 +137,7 @@
         <!-- 3rd party dependencies -->
         <stax-api.version>1.0-2</stax-api.version>
         <jboss.logging.annotation.version>2.2.1.Final</jboss.logging.annotation.version>
-        <jboss.logging.version>3.4.2.Final</jboss.logging.version>
+        <jboss.logging.version>3.4.3.Final</jboss.logging.version>
         <javassist.version>3.28.0-GA</javassist.version>
         <fasterxml.classmate.version>1.5.1</fasterxml.classmate.version>
         <jsch.version>0.1.56</jsch.version>


### PR DESCRIPTION
Integrate Hibernate Validator 7.0.2 (including JBoss logging)

Release notes: https://in.relation.to/2021/12/14/hibernate-validator-702-621-final-released/
Release notes: https://github.com/jboss-logging/jboss-logging/releases/tag/3.4.3.Final
Detailed what's new: https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HV%20AND%20fixVersion%20%3D%207.0.2.Final%20ORDER%20BY%20updated

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>
