### PR TITLE
MicroProfile Config 3.0 Support

### DIFF
--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2022 Contributors to Eclipse Foundation.
     Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -836,6 +836,43 @@
         <dependency>
             <groupId>org.glassfish.main.deployment</groupId>
             <artifactId>deployment-jakartaee-full</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- MicroProfile Glassfish Connectors -->
+        <dependency>
+            <groupId>org.glassfish.main.microprofile</groupId>
+            <artifactId>microprofile-connectors</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- MicroProfile Config -->
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile.config-api.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.microprofile</groupId>
+            <artifactId>microprofile-config</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/appserver/microprofile/config/pom.xml
+++ b/appserver/microprofile/config/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.microprofile</groupId>
+        <artifactId>microprofile-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>microprofile-config</artifactId>
+    <packaging>glassfish-jar</packaging>
+
+    <name>GlassFish MicroProfile Config</name>
+
+    <dependencies>
+        <!-- APIs -->
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <version>${smallrye-config.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <!-- Internal Dependencies -->
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>glassfish-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.web</groupId>
+            <artifactId>weld-integration</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <supportedProjectTypes>
+                        <supportedProjectType>glassfish-jar</supportedProjectType>
+                    </supportedProjectTypes>
+                    <instructions>
+                        <Export-Package>
+                            org.glassfish.microprofile.config,
+                        </Export-Package>
+                        <Private-Package>
+                            io.smallrye.config,
+                            io.smallrye.config.common,
+                            io.smallrye.config.inject,
+
+                            io.smallrye.common.annotation,
+                            io.smallrye.common.classloader,
+                            io.smallrye.common.constraint,
+                            io.smallrye.common.expression,
+                            io.smallrye.common.function,
+                            io.smallrye.config.common.utils,
+                        </Private-Package>
+                        <Include-Resource>
+                            {maven-resources},
+                            {maven-dependencies},
+                            META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/
+                        </Include-Resource>
+                    </instructions>
+                    <unpackBundle>true</unpackBundle>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/appserver/microprofile/config/pom.xml
+++ b/appserver/microprofile/config/pom.xml
@@ -34,10 +34,11 @@
     <dependencies>
         <!-- APIs -->
         <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config</artifactId>
-            <version>${smallrye-config.version}</version>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config</artifactId>
+            <version>${helidon-config.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
@@ -71,13 +72,40 @@
                         <supportedProjectType>glassfish-jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
+                        <!-- A list of packages that are exposed to classes outside the bundle -->
                         <Export-Package>
                             org.glassfish.microprofile.config,
-                            io.smallrye.config,
+                            io.helidon.config.mp,
                         </Export-Package>
+                        <!-- A list of dependencies to include in the bundle (as they're not native OSGI bundles) -->
                         <Embed-Dependency>
-                            artifactId=smallrye*;inline=true,
+                            <!--
+                                The helidon MP config dependency tree, illustrating what we actually output to the GF bundle
+                            -->
+                            groupId=io.helidon.microprofile.config;inline=true,
+                                groupId=io.helidon.config;artifactId=helidon-config-mp;inline=true,
+                                    groupId=io.helidon.common;artifactId=helidon-common;inline=true,
+                                    groupId=io.helidon.common;artifactId=helidon-common-service-loader;inline=true,
+                                    groupId=io.helidon.config;artifactId=helidon-config-yaml-mp;inline=true,
+                                    groupId=io.helidon.config;artifactId=helidon-config;inline=true,
+                                        <!--
+                                        groupId=io.helidon.common;artifactId=helidon-common-reactive;inline=true,
+                                            groupId=io.helidon.common;artifactId=helidon-common-mapper;inline=true, -->
+                                        groupId=io.helidon.common;artifactId=helidon-common-media-type;inline=true,
+                            groupId=io.helidon.config;artifactId=helidon-config-yaml;inline=true,
+                                artifactId=snakeyaml;inline=true,
+                            <!--
+                            groupId=io.helidon.config;artifactId=helidon-config-encryption;inline=true,
+                                groupId=io.helidon.common;artifactId=helidon-common-key-util;inline=true,
+                                    groupId=io.helidon.common;artifactId=helidon-common-configurable;inline=true,
+                                        groupId=io.helidon.common;artifactId=helidon-common-context;inline=true,
+                                groupId=io.helidon.common;artifactId=helidon-common-crypto;inline=true,
+                            groupId=io.helidon.config;artifactId=helidon-config-object-mapping;inline=true, -->
                         </Embed-Dependency>
+                        <!--
+                            Include transitive dependencies (note that this only include compile scoped dependencies,
+                            other scoped dependencies still need explicit inclusion)
+                        -->
                         <Embed-Transitive>true</Embed-Transitive>
                         <Multi-Release>true</Multi-Release>
                         <Include-Resource>
@@ -85,7 +113,6 @@
                             META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/,
                         </Include-Resource>
                     </instructions>
-                    <unpackBundle>true</unpackBundle>
                 </configuration>
                 <executions>
                     <execution>

--- a/appserver/microprofile/config/pom.xml
+++ b/appserver/microprofile/config/pom.xml
@@ -73,23 +73,16 @@
                     <instructions>
                         <Export-Package>
                             org.glassfish.microprofile.config,
-                        </Export-Package>
-                        <Private-Package>
                             io.smallrye.config,
-                            io.smallrye.config.common,
-                            io.smallrye.config.inject,
-
-                            io.smallrye.common.annotation,
-                            io.smallrye.common.classloader,
-                            io.smallrye.common.constraint,
-                            io.smallrye.common.expression,
-                            io.smallrye.common.function,
-                            io.smallrye.config.common.utils,
-                        </Private-Package>
+                        </Export-Package>
+                        <Embed-Dependency>
+                            artifactId=smallrye*;inline=true,
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Multi-Release>true</Multi-Release>
                         <Include-Resource>
                             {maven-resources},
-                            {maven-dependencies},
-                            META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/
+                            META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/,
                         </Include-Resource>
                     </instructions>
                     <unpackBundle>true</unpackBundle>

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ApplicationClassConverter.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ApplicationClassConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import jakarta.annotation.Priority;
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * A patched class converter to use the current context classloader, rather than the bundle classloader.
+ * This will allow access to webapp classes
+ */
+@Priority(2)
+@SuppressWarnings("rawtypes")
+public class ApplicationClassConverter implements Converter<Class> {
+
+    @Override
+    public Class<?> convert(String stringValue) throws IllegalArgumentException, NullPointerException {
+        try {
+            return Class.forName(stringValue, true, Thread.currentThread().getContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Failed to convert property " + stringValue + " to class", e);
+        }
+    }
+
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigApplicationContainer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigApplicationContainer.java
@@ -15,11 +15,16 @@
  */
 package org.glassfish.microprofile.config;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.glassfish.api.deployment.ApplicationContainer;
 import org.glassfish.api.deployment.ApplicationContext;
 import org.glassfish.api.deployment.DeploymentContext;
 
+import java.net.JarURLConnection;
+
 public class ConfigApplicationContainer implements ApplicationContainer<Object> {
+
+    private static final String JAR_URL_PROTOCOL = "jar";
 
     private final DeploymentContext deploymentContext;
 
@@ -34,6 +39,17 @@ public class ConfigApplicationContainer implements ApplicationContainer<Object> 
 
     @Override
     public boolean start(ApplicationContext startupContext) throws Exception {
+
+        // Set the JAR caching behaviour for config init
+        // (to prevent using cached microprofile-config file contents)
+        final var shouldCacheJarContents = JarURLConnection.getDefaultUseCaches(JAR_URL_PROTOCOL);
+        JarURLConnection.setDefaultUseCaches(JAR_URL_PROTOCOL, false);
+
+        ConfigProvider.getConfig(startupContext.getClassLoader());
+
+        // Reset the JAR caching behaviour
+        JarURLConnection.setDefaultUseCaches(JAR_URL_PROTOCOL, shouldCacheJarContents);
+
         return true;
     }
 

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigApplicationContainer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigApplicationContainer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import org.glassfish.api.deployment.ApplicationContainer;
+import org.glassfish.api.deployment.ApplicationContext;
+import org.glassfish.api.deployment.DeploymentContext;
+
+public class ConfigApplicationContainer implements ApplicationContainer<Object> {
+
+    private final DeploymentContext deploymentContext;
+
+    public ConfigApplicationContainer(DeploymentContext deploymentContext) {
+        this.deploymentContext = deploymentContext;
+    }
+
+    @Override
+    public Object getDescriptor() {
+        return null;
+    }
+
+    @Override
+    public boolean start(ApplicationContext startupContext) throws Exception {
+        return true;
+    }
+
+    @Override
+    public boolean stop(ApplicationContext stopContext) {
+        return true;
+    }
+
+    @Override
+    public boolean suspend() {
+        return false;
+    }
+
+    @Override
+    public boolean resume() throws Exception {
+        return false;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return deploymentContext.getFinalClassLoader();
+    }
+
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigContainer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigContainer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import org.glassfish.api.container.Container;
+import org.glassfish.api.deployment.Deployer;
+import org.jvnet.hk2.annotations.Service;
+
+@Service(name = "org.glassfish.microprofile.config.ConfigContainer")
+public class ConfigContainer implements Container {
+
+    @Override
+    public Class<? extends Deployer> getDeployer() {
+        return ConfigDeployer.class;
+    }
+
+    @Override
+    public String getName() {
+        return "MicroProfile Config";
+    }
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
@@ -15,7 +15,6 @@
  */
 package org.glassfish.microprofile.config;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.glassfish.api.container.Container;
 import org.glassfish.api.deployment.ApplicationContainer;

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.glassfish.api.container.Container;
+import org.glassfish.api.deployment.ApplicationContainer;
+import org.glassfish.api.deployment.Deployer;
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.api.deployment.MetaData;
+import org.jvnet.hk2.annotations.Service;
+
+import java.util.ServiceLoader;
+
+@Service
+public class ConfigDeployer implements Deployer {
+
+    @Override
+    public MetaData getMetaData() {
+        return null;
+    }
+
+    @Override
+    public boolean prepare(DeploymentContext deploymentContext) {
+        return true;
+    }
+
+    @Override
+    public ApplicationContainer load(Container container, DeploymentContext deploymentContext) {
+
+        // Initialise Config providers
+        final var resolver = ServiceLoader.load(ConfigProviderResolver.class).iterator().next();
+        ConfigProviderResolver.setInstance(resolver);
+
+        return new ConfigApplicationContainer(deploymentContext);
+    }
+
+    @Override
+    public void unload(ApplicationContainer applicationContainer, DeploymentContext deploymentContext) {}
+
+    @Override
+    public void clean(DeploymentContext deploymentContext) {}
+
+    @Override
+    public Object loadMetaData(Class aClass, DeploymentContext deploymentContext) {
+        return null;
+    }
+}

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,1 +1,1 @@
-io.smallrye.config.inject.ConfigExtension
+io.helidon.microprofile.config.ConfigCdiExtension

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+io.smallrye.config.inject.ConfigExtension

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
@@ -1,0 +1,1 @@
+io.smallrye.config.SmallRyeConfigProviderResolver

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
@@ -1,1 +1,1 @@
-io.smallrye.config.SmallRyeConfigProviderResolver
+io.helidon.config.mp.MpConfigProviderResolver

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.Converter
@@ -1,0 +1,1 @@
+org.glassfish.microprofile.config.ApplicationClassConverter

--- a/appserver/microprofile/connectors/pom.xml
+++ b/appserver/microprofile/connectors/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.microprofile</groupId>
+        <artifactId>microprofile-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>microprofile-connectors</artifactId>
+    <packaging>glassfish-jar</packaging>
+
+    <name>GlassFish MicroProfile Connectors</name>
+
+    <dependencies>
+        <!-- APIs -->
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <version>${smallrye-config.version}</version>
+        </dependency>
+
+        <!-- Internal Dependencies -->
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>glassfish-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>internal-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/appserver/microprofile/connectors/pom.xml
+++ b/appserver/microprofile/connectors/pom.xml
@@ -34,9 +34,9 @@
     <dependencies>
         <!-- APIs -->
         <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config</artifactId>
-            <version>${smallrye-config.version}</version>
+            <groupId>io.helidon.microprofile.config</groupId>
+            <artifactId>helidon-microprofile-config</artifactId>
+            <version>${helidon-config.version}</version>
         </dependency>
 
         <!-- Internal Dependencies -->

--- a/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/ConfigSniffer.java
+++ b/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/ConfigSniffer.java
@@ -15,9 +15,12 @@
  */
 package org.glassfish.microprofile.connector;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ArchiveType;
+import org.glassfish.hk2.classmodel.reflect.Types;
 import org.glassfish.internal.deployment.GenericSniffer;
 import org.jvnet.hk2.annotations.Service;
 
@@ -30,6 +33,16 @@ public class ConfigSniffer extends GenericSniffer {
 
     public ConfigSniffer() {
         super("mp-config", null, null);
+    }
+
+    @Override
+    public boolean handles(DeploymentContext context) {
+
+        // Check if Config is used statically
+        final var types = context.getTransientAppMetaData(Types.class.getName(), Types.class);
+        final boolean mpConfigUsed = types != null && types.getBy(Config.class.getName()) != null;
+
+        return mpConfigUsed || super.handles(context);
     }
 
     @Override

--- a/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/ConfigSniffer.java
+++ b/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/ConfigSniffer.java
@@ -20,10 +20,12 @@ import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ArchiveType;
+import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.hk2.classmodel.reflect.Types;
 import org.glassfish.internal.deployment.GenericSniffer;
 import org.jvnet.hk2.annotations.Service;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 
 @Service
@@ -43,6 +45,17 @@ public class ConfigSniffer extends GenericSniffer {
         final boolean mpConfigUsed = types != null && types.getBy(Config.class.getName()) != null;
 
         return mpConfigUsed || super.handles(context);
+    }
+
+    @Override
+    public boolean handles(ReadableArchive location) {
+        try {
+            if (location.exists("META-INF/microprofile-config.properties")) return true;
+            if (location.exists("WEB-INF/classes/META-INF/microprofile-config.properties")) return true;
+        } catch (IOException e) {
+            // ignore
+        }
+        return false;
     }
 
     @Override

--- a/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/ConfigSniffer.java
+++ b/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/ConfigSniffer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.connector;
+
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.glassfish.api.deployment.archive.ArchiveType;
+import org.glassfish.internal.deployment.GenericSniffer;
+import org.jvnet.hk2.annotations.Service;
+
+import java.lang.annotation.Annotation;
+
+@Service
+public class ConfigSniffer extends GenericSniffer {
+
+    private static final String[] containers = { "org.glassfish.microprofile.config.ConfigContainer" };
+
+    public ConfigSniffer() {
+        super("mp-config", null, null);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends Annotation>[] getAnnotationTypes() {
+        return new Class[]{
+                ConfigProperty.class,
+                ConfigProperties.class,
+        };
+    }
+
+    @Override
+    public String[] getContainersNames() {
+        return containers;
+    }
+
+    @Override
+    public boolean supportsArchiveType(ArchiveType archiveType) {
+        return archiveType != null && archiveType.toString().equals("war");
+    }
+}

--- a/appserver/microprofile/pom.xml
+++ b/appserver/microprofile/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main</groupId>
+        <artifactId>glassfish-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.main.microprofile</groupId>
+    <artifactId>microprofile-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>GlassFish MicroProfile modules</name>
+
+    <modules>
+        <module>config</module>
+        <module>connectors</module>
+    </modules>
+</project>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -68,6 +68,7 @@
         <module>orb</module>
         <module>appclient</module>
         <module>ant-tasks</module>
+        <module>microprofile</module>
     </modules>
 
     <scm>
@@ -154,6 +155,9 @@
         <jakarta.mvc-api.version>2.0.0</jakarta.mvc-api.version>
         <krazo.version>2.0.1</krazo.version>
 
+        <!-- MicroProfile Config -->
+        <microprofile.config-api.version>3.0.1</microprofile.config-api.version>
+        <smallrye-config.version>3.0.0-RC1</smallrye-config.version>
 
         <!-- Admin console components -->
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -157,7 +157,7 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.0.1</microprofile.config-api.version>
-        <smallrye-config.version>3.0.0-RC1</smallrye-config.version>
+        <helidon-config.version>3.0.0-M2</helidon-config.version>
 
         <!-- Admin console components -->
 

--- a/appserver/tests/tck/microprofile/arquillian.xml
+++ b/appserver/tests/tck/microprofile/arquillian.xml
@@ -1,0 +1,21 @@
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian  https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <defaultProtocol type="Servlet 5.0"/>
+
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
+
+    <container qualifier="arquillian-glassfish">
+        <configuration>
+            <property name="debug">true</property>
+            <property name="allowConnectingToRunningServer">false</property>
+            <property name="adminHost">localhost</property>
+            <property name="adminPort">4848</property>
+            <property name="enableDerby">${enableDerby:false}</property>
+            <property name="outputToConsole">true</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/appserver/tests/tck/microprofile/config/pom.xml
+++ b/appserver/tests/tck/microprofile/config/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.tests.tck</groupId>
+        <artifactId>glassfish-external-tck-microprofile</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>glassfish-external-tck-microprofile-config</artifactId>
+    <packaging>pom</packaging>
+
+    <name>TCK: MicroProfile Config</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-tck</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile.config-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- Unpack the GF install -->
+                    <execution>
+                        <id>unpack-glassfish</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>tck-suite.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+
+                    <!-- Required for org.eclipse.microprofile.config.tck.CDIPropertyNameMatchingTest -->
+                    <environmentVariables>
+                        <MP_TCK_ENV_DUMMY>dummy</MP_TCK_ENV_DUMMY>
+                        <my_int_property>45</my_int_property>
+                        <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
+                        <my_string_property>haha</my_string_property>
+                        <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
+                        <config_ordinal>45</config_ordinal>
+                        <customer_name>Bob</customer_name>
+                    </environmentVariables>
+
+                    <systemProperties>
+                        <!-- We have put these values into mp.tck.properties above -->
+                        <mp.tck.prop.dummy>dummy</mp.tck.prop.dummy>
+                        <customer.hobby>Tennis</customer.hobby>
+                        <config_ordinal>120</config_ordinal>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/tests/tck/microprofile/config/pom.xml
+++ b/appserver/tests/tck/microprofile/config/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>glassfish-external-tck-microprofile-config</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <name>TCK: MicroProfile Config</name>
 
@@ -76,7 +76,6 @@
                     </environmentVariables>
 
                     <systemProperties>
-                        <!-- We have put these values into mp.tck.properties above -->
                         <mp.tck.prop.dummy>dummy</mp.tck.prop.dummy>
                         <customer.hobby>Tennis</customer.hobby>
                         <config_ordinal>120</config_ordinal>

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
@@ -15,46 +15,20 @@
  */
 package org.glassfish.microprofile.config.tck;
 
+import org.glassfish.microprofile.config.tck.client.BeansXmlTransformer;
+import org.glassfish.microprofile.config.tck.client.ConfigDeploymentExceptionTransformer;
+import org.glassfish.microprofile.config.tck.client.LibraryIncluder;
+import org.glassfish.microprofile.config.tck.remote.ConfigRemoteArquillianExtension;
 import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.test.spi.TestClass;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ArchivePath;
-import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
-import org.jboss.shrinkwrap.api.asset.UrlAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
-import java.io.File;
-import java.net.URL;
-import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-import static java.lang.String.format;
-import static java.util.logging.Level.SEVERE;
-
-/**
- * This extension performs the following duties for TCK runs:
- *  - Adding Hamcrest to each deployment, to prevent ClassNotFoundExceptions when running hamcrest tests
- *  - Replacing beans.xml files with ones declaring the 'all' bean discovery type.
- *    This is because version 3.0.1 of the TCK still deploys an empty beans.xml due to a faulty assumption that
- *    CDI < 4 is still defaulting to the 'all' type.
- */
-public class ConfigArquillianExtension implements LoadableExtension, ApplicationArchiveProcessor {
+public class ConfigArquillianExtension implements LoadableExtension {
 
     private static final Logger LOGGER = Logger.getLogger(ConfigArquillianExtension.class.getName());
-    private static final String BEANS_XML_PATH = format("/META-INF%sbeans.xml", ArchivePath.SEPARATOR);
-    private static final String LIB_DIR_PATH = format("WEB-INF%slib", ArchivePath.SEPARATOR);
-
-    private final URL beansXmlResource;
-
-    public ConfigArquillianExtension() {
-        this.beansXmlResource = getClass().getClassLoader().getResource("beans.xml");
-        if (beansXmlResource == null) {
-            throw new IllegalStateException("Unable to find beans.xml resource in test dir");
-        }
-    }
 
     /**
      * Register this object as an Arquillian extension
@@ -62,54 +36,11 @@ public class ConfigArquillianExtension implements LoadableExtension, Application
      */
     @Override
     public void register(ExtensionBuilder extensionBuilder) {
-        extensionBuilder.service(ApplicationArchiveProcessor.class, getClass());
+
+        LOGGER.info("Client Arquillian extension registered");
+
+        extensionBuilder.service(ApplicationArchiveProcessor.class, BeansXmlTransformer.class);
+        extensionBuilder.service(ApplicationArchiveProcessor.class, LibraryIncluder.class);
         extensionBuilder.service(DeploymentExceptionTransformer.class, ConfigDeploymentExceptionTransformer.class);
-    }
-
-    @Override
-    public void process(Archive<?> archive, TestClass testClass) {
-        if (!(archive instanceof WebArchive)) {
-            return;
-        }
-        replaceBeansXml(archive);
-        addDependencies((WebArchive) archive);
-    }
-
-    private void replaceBeansXml(Archive<?> archive) {
-        final var beansXml = archive.get(BEANS_XML_PATH);
-        if (beansXml != null) {
-            LOGGER.info(() -> format("Replacing beans.xml in archive [%s]", archive.getName()));
-            archive.add(new UrlAsset(beansXmlResource), BEANS_XML_PATH);
-        }
-        processLibraries(archive, this::replaceBeansXml);
-    }
-
-    private void addDependencies(WebArchive archive) {
-        try {
-            archive.addAsLibraries(resolveDependency("org.hamcrest:hamcrest:2.2"));
-        } catch (Exception e) {
-            LOGGER.log(SEVERE, "Error adding dependencies", e);
-        }
-    }
-
-    private static void processLibraries(Archive<?> archive, Consumer<Archive<?>> consumer) {
-        final var libDir = archive.get(LIB_DIR_PATH);
-
-        if (libDir != null) {
-            libDir.getChildren()
-                    .forEach(node -> {
-                        final var asset = node.getAsset();
-                        if (asset instanceof ArchiveAsset) {
-                            LOGGER.info(() -> format("Processing subarchive [%s]", node.getPath()));
-                            consumer.accept(((ArchiveAsset) asset).getArchive());
-                        }
-                    });
-        }
-    }
-
-    private static File[] resolveDependency(String coordinates) {
-        return Maven.resolver()
-                .resolve(coordinates)
-                .withoutTransitivity().asFile();
     }
 }

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
@@ -18,10 +18,8 @@ package org.glassfish.microprofile.config.tck;
 import org.glassfish.microprofile.config.tck.client.BeansXmlTransformer;
 import org.glassfish.microprofile.config.tck.client.ConfigDeploymentExceptionTransformer;
 import org.glassfish.microprofile.config.tck.client.LibraryIncluder;
-import org.glassfish.microprofile.config.tck.remote.ConfigRemoteArquillianExtension;
 import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
-import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 
 import java.util.logging.Logger;
@@ -42,5 +40,8 @@ public class ConfigArquillianExtension implements LoadableExtension {
         extensionBuilder.service(ApplicationArchiveProcessor.class, BeansXmlTransformer.class);
         extensionBuilder.service(ApplicationArchiveProcessor.class, LibraryIncluder.class);
         extensionBuilder.service(DeploymentExceptionTransformer.class, ConfigDeploymentExceptionTransformer.class);
+
+        // Register this class as an Arquillian event observer
+        extensionBuilder.observer(BeansXmlTransformer.class);
     }
 }

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import java.io.File;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.SEVERE;
+
+/**
+ * This extension performs the following duties for TCK runs:
+ *  - Adding Hamcrest to each deployment, to prevent ClassNotFoundExceptions when running hamcrest tests
+ */
+public class ConfigArquillianExtension implements LoadableExtension, ApplicationArchiveProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(ConfigArquillianExtension.class.getName());
+
+    /**
+     * Register this object as an Arquillian extension
+     * @param extensionBuilder a context object for the extension
+     */
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(ApplicationArchiveProcessor.class, getClass());
+    }
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if (!(archive instanceof WebArchive)) {
+            return;
+        }
+        addDependencies((WebArchive) archive);
+    }
+
+    private void addDependencies(WebArchive archive) {
+        try {
+            archive.addAsLibraries(resolveDependency("org.hamcrest:hamcrest:2.2"));
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "Error adding dependencies", e);
+        }
+    }
+
+    private static File[] resolveDependency(String coordinates) {
+        return Maven.resolver()
+                .resolve(coordinates)
+                .withoutTransitivity().asFile();
+    }
+}

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
@@ -19,21 +19,41 @@ import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArch
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 import java.io.File;
+import java.net.URL;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+import static java.lang.String.format;
 import static java.util.logging.Level.SEVERE;
 
 /**
  * This extension performs the following duties for TCK runs:
  *  - Adding Hamcrest to each deployment, to prevent ClassNotFoundExceptions when running hamcrest tests
+ *  - Replacing beans.xml files with ones declaring the 'all' bean discovery type.
+ *    This is because version 3.0.1 of the TCK still deploys an empty beans.xml due to a faulty assumption that
+ *    CDI < 4 is still defaulting to the 'all' type.
  */
 public class ConfigArquillianExtension implements LoadableExtension, ApplicationArchiveProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(ConfigArquillianExtension.class.getName());
+    private static final String BEANS_XML_PATH = format("/META-INF%sbeans.xml", ArchivePath.SEPARATOR);
+    private static final String LIB_DIR_PATH = format("WEB-INF%slib", ArchivePath.SEPARATOR);
+
+    private final URL beansXmlResource;
+
+    public ConfigArquillianExtension() {
+        this.beansXmlResource = getClass().getClassLoader().getResource("beans.xml");
+        if (beansXmlResource == null) {
+            throw new IllegalStateException("Unable to find beans.xml resource in test dir");
+        }
+    }
 
     /**
      * Register this object as an Arquillian extension
@@ -49,7 +69,17 @@ public class ConfigArquillianExtension implements LoadableExtension, Application
         if (!(archive instanceof WebArchive)) {
             return;
         }
+        replaceBeansXml(archive);
         addDependencies((WebArchive) archive);
+    }
+
+    private void replaceBeansXml(Archive<?> archive) {
+        final var beansXml = archive.get(BEANS_XML_PATH);
+        if (beansXml != null) {
+            LOGGER.info(() -> format("Replacing beans.xml in archive [%s]", archive.getName()));
+            archive.add(new UrlAsset(beansXmlResource), BEANS_XML_PATH);
+        }
+        processLibraries(archive, this::replaceBeansXml);
     }
 
     private void addDependencies(WebArchive archive) {
@@ -57,6 +87,21 @@ public class ConfigArquillianExtension implements LoadableExtension, Application
             archive.addAsLibraries(resolveDependency("org.hamcrest:hamcrest:2.2"));
         } catch (Exception e) {
             LOGGER.log(SEVERE, "Error adding dependencies", e);
+        }
+    }
+
+    private static void processLibraries(Archive<?> archive, Consumer<Archive<?>> consumer) {
+        final var libDir = archive.get(LIB_DIR_PATH);
+
+        if (libDir != null) {
+            libDir.getChildren()
+                    .forEach(node -> {
+                        final var asset = node.getAsset();
+                        if (asset instanceof ArchiveAsset) {
+                            LOGGER.info(() -> format("Processing subarchive [%s]", node.getPath()));
+                            consumer.accept(((ArchiveAsset) asset).getArchive());
+                        }
+                    });
         }
     }
 

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigArquillianExtension.java
@@ -15,6 +15,7 @@
  */
 package org.glassfish.microprofile.config.tck;
 
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.TestClass;
@@ -62,6 +63,7 @@ public class ConfigArquillianExtension implements LoadableExtension, Application
     @Override
     public void register(ExtensionBuilder extensionBuilder) {
         extensionBuilder.service(ApplicationArchiveProcessor.class, getClass());
+        extensionBuilder.service(DeploymentExceptionTransformer.class, ConfigDeploymentExceptionTransformer.class);
     }
 
     @Override

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigDeploymentExceptionTransformer.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/ConfigDeploymentExceptionTransformer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config.tck;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
+
+/**
+ * The common GlassFishClientCommon handler will always throw a GlassfishClientException,
+ * with a message from the response. Since Glassfish prefixes errors with "CDI deployment failure"
+ * when a CDI deployment error is thrown, we can safely convert this error to the expected
+ * exception type.
+ */
+public class ConfigDeploymentExceptionTransformer implements DeploymentExceptionTransformer {
+
+    @Override
+    public Throwable transform(Throwable throwable) {
+        if (throwable != null && throwable.getMessage().contains("CDI deployment failure")) {
+            return new DeploymentException(throwable);
+        }
+        return throwable;
+    }
+
+}

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/BeansXmlTransformer.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/BeansXmlTransformer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config.tck.client;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+
+import java.net.URL;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+/**
+ * This extension replaces beans.xml files with ones declaring the 'all' bean discovery type.
+ * This is because version 3.0.1 of the TCK still deploys an empty beans.xml due to a faulty assumption that
+ * CDI < 4 is still defaulting to the 'all' type.
+ */
+public class BeansXmlTransformer implements ApplicationArchiveProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(BeansXmlTransformer.class.getName());
+
+    private static final String BEANS_XML_PATH = format("/META-INF%sbeans.xml", ArchivePath.SEPARATOR);
+    private static final String LIB_DIR_PATH = format("WEB-INF%slib", ArchivePath.SEPARATOR);
+
+    private final URL beansXmlResource;
+
+    public BeansXmlTransformer() {
+        this.beansXmlResource = getClass().getClassLoader().getResource("beans.xml");
+        if (beansXmlResource == null) {
+            throw new IllegalStateException("Unable to find beans.xml resource in test dir");
+        }
+    }
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        replaceBeansXml(archive);
+    }
+
+    private void replaceBeansXml(Archive<?> archive) {
+        final var beansXml = archive.get(BEANS_XML_PATH);
+        if (beansXml != null) {
+            LOGGER.info(() -> format("Replacing beans.xml in archive [%s]", archive.getName()));
+            archive.add(new UrlAsset(beansXmlResource), BEANS_XML_PATH);
+        }
+        processLibraries(archive, this::replaceBeansXml);
+    }
+
+    private static void processLibraries(Archive<?> archive, Consumer<Archive<?>> consumer) {
+        final var libDir = archive.get(LIB_DIR_PATH);
+
+        if (libDir != null) {
+            for (var node : libDir.getChildren()) {
+                final var asset = node.getAsset();
+                if (asset instanceof ArchiveAsset) {
+                    LOGGER.info(() -> format("Processing subarchive [%s]", node.getPath()));
+                    consumer.accept(((ArchiveAsset) asset).getArchive());
+                }
+            }
+        }
+    }
+}

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/ConfigDeploymentExceptionTransformer.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/ConfigDeploymentExceptionTransformer.java
@@ -20,15 +20,14 @@ import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTr
 
 /**
  * The common GlassFishClientCommon handler will always throw a GlassfishClientException,
- * with a message from the response. Since Glassfish prefixes errors with "CDI deployment failure"
- * when a CDI deployment error is thrown, we can safely convert this error to the expected
+ * with a message from the response. Deployment errors can safely be converted to the expected
  * exception type.
  */
 public class ConfigDeploymentExceptionTransformer implements DeploymentExceptionTransformer {
 
     @Override
     public Throwable transform(Throwable throwable) {
-        if (throwable != null && throwable.getMessage().contains("CDI deployment failure")) {
+        if (throwable != null && throwable.getMessage().contains("Error occurred during deployment")) {
             return new DeploymentException(throwable);
         }
         return throwable;

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/ConfigDeploymentExceptionTransformer.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/ConfigDeploymentExceptionTransformer.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package org.glassfish.microprofile.config.tck;
+package org.glassfish.microprofile.config.tck.client;
 
 import jakarta.enterprise.inject.spi.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;

--- a/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/LibraryIncluder.java
+++ b/appserver/tests/tck/microprofile/config/src/main/java/org/glassfish/microprofile/config/tck/client/LibraryIncluder.java
@@ -1,0 +1,44 @@
+package org.glassfish.microprofile.config.tck.client;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import java.io.File;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.SEVERE;
+
+/**
+ *  This extension adds certain libraries to deployed Arquillian apps.
+ *
+ *  Libraries added:
+ *      - Hamcrest, to prevent ClassNotFoundExceptions when running hamcrest tests
+ */
+public class LibraryIncluder implements ApplicationArchiveProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(LibraryIncluder.class.getName());
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+
+        // Only process web archives
+        if (!(archive instanceof WebArchive)) return;
+        final var webArchive = (WebArchive) archive;
+
+        try {
+            // Add Hamcrest
+            webArchive.addAsLibraries(resolveDependency("org.hamcrest:hamcrest:2.2"));
+        } catch (Exception e) {
+            LOGGER.log(SEVERE, "Error adding dependencies", e);
+        }
+    }
+
+    private static File[] resolveDependency(String coordinates) {
+        return Maven.resolver()
+                .resolve(coordinates)
+                .withoutTransitivity().asFile();
+    }
+}

--- a/appserver/tests/tck/microprofile/config/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/appserver/tests/tck/microprofile/config/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.glassfish.microprofile.config.tck.ConfigArquillianExtension

--- a/appserver/tests/tck/microprofile/config/src/main/resources/beans.xml
+++ b/appserver/tests/tck/microprofile/config/src/main/resources/beans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       bean-discovery-mode="all" version="4.0">
+</beans>

--- a/appserver/tests/tck/microprofile/config/src/test/java/org/glassfish/microprofile/config/tck/ContainerSetup.java
+++ b/appserver/tests/tck/microprofile/config/src/test/java/org/glassfish/microprofile/config/tck/ContainerSetup.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config.tck;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Setup the container via a test that runs before the TCK
+ */
+public class ContainerSetup extends Arquillian {
+
+    @Deployment
+    public static Archive<?> deployment() {
+        return ShrinkWrap.create(WebArchive.class, "container-setup.war");
+    }
+
+    @Test
+    public void setup() {
+        // Setup TCK required system properties
+        System.setProperty("mp.tck.prop.dummy", "dummy");
+        System.setProperty("customer.hobby", "Tennis");
+        System.setProperty("config_ordinal", "120");
+    }
+}

--- a/appserver/tests/tck/microprofile/config/tck-suite.xml
+++ b/appserver/tests/tck/microprofile/config/tck-suite.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<!--
+
+    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<suite name="MicroProfile Config TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="MicroProfile Config TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.config.tck.*" />
+        </packages>
+    </test>
+
+</suite>

--- a/appserver/tests/tck/microprofile/config/tck-suite.xml
+++ b/appserver/tests/tck/microprofile/config/tck-suite.xml
@@ -17,7 +17,13 @@
 
 -->
 
-<suite name="MicroProfile Config TCK" verbose="2" configfailurepolicy="continue" >
+<suite name="MicroProfile Config TCK" verbose="2" configfailurepolicy="continue">
+
+    <test name="MicroProfile Config TCK Setup">
+        <classes>
+            <class name="org.glassfish.microprofile.config.tck.ContainerSetup" />
+        </classes>
+    </test>
 
     <test name="MicroProfile Config TCK">
         <packages>

--- a/appserver/tests/tck/microprofile/pom.xml
+++ b/appserver/tests/tck/microprofile/pom.xml
@@ -102,7 +102,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-spi</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>

--- a/appserver/tests/tck/microprofile/pom.xml
+++ b/appserver/tests/tck/microprofile/pom.xml
@@ -42,6 +42,18 @@
         <module>config</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.7.0.Alpha10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.distributions</groupId>
@@ -69,6 +81,32 @@
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>glassfish-client-ee9</artifactId>
             <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-impl-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/tck/microprofile/pom.xml
+++ b/appserver/tests/tck/microprofile/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.tests.tck</groupId>
+        <artifactId>tck</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>glassfish-external-tck-microprofile</artifactId>
+
+    <packaging>pom</packaging>
+
+    <name>TCK: MicroProfile</name>
+
+    <properties>
+        <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
+        <glassfish.version>${project.version}</glassfish.version>
+        <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
+    </properties>
+
+    <modules>
+        <module>config</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <version>${glassfish.version}</version>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required dependencies for Arquillian deployments -->
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <version>${weld.version}</version>
+        </dependency>
+
+        <!-- Arquillian -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-glassfish-managed-6</artifactId>
+            <version>1.0.0.Alpha1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.omnifaces.arquillian</groupId>
+            <artifactId>glassfish-client-ee9</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Unpack the GF install -->
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>unpack-glassfish</id>
+                            <phase>pre-integration-test</phase>
+                            <goals>
+                                <goal>unpack-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <includeArtifactIds>glassfish</includeArtifactIds>
+                                <outputDirectory>${project.build.directory}</outputDirectory>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <systemProperties>
+                            <glassfish.home>${glassfish.home}</glassfish.home>
+
+                            <!-- Use the Arquillian XML from the parent in each child module -->
+                            <arquillian.xml>${project.parent.basedir}/arquillian.xml</arquillian.xml>
+                            <arquillian.launch>arquillian-glassfish</arquillian.launch>
+                        </systemProperties>
+                        <environmentVariables>
+                            <GLASSFISH_HOME>${glassfish.home}</GLASSFISH_HOME>
+                        </environmentVariables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <!-- Unpack the GF install -->
+                    <execution>
+                        <id>unpack-glassfish</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/tests/tck/pom.xml
+++ b/appserver/tests/tck/pom.xml
@@ -41,6 +41,7 @@
         <module>authentication</module>
         <module>authorization</module>
         <module>cdi</module>
+        <module>microprofile</module>
         <module>concurrency</module>
     </modules>
 


### PR DESCRIPTION
This change supports the deployment of MicroProfile Config 3.0 compatible applications, and modifies GF full profile to pass the MP Config 3.0.1 TCK by using the Smallrye Config 3.0.0.RC1 implementation.

The Smallrye dependencies are currently inlined in the implementation module, with the `org.glassfish.microprofile.config` and `io.smallrye.config` packages exported. If further Smallrye dependencies are used in future, it may be helpful to export the common utilities to their own module to reduce bundle size. I've inlined the dependencies to improve performance rather than loading nested JARs, although I'm happy to change this if required.

A sniffer module has been created to enable the respective MP implementations when they are detected, although the module defers the specific deployment steps to Smallrye.

The TCK needed a few modifications which are detailed in the commit messages:
- The TCK assumes that empty beans.xml files imply the `all` bean discovery mode. Since CDI 4.0 this is no longer the case, so all empty beans.xml files are replaced with a correct implementation by an Arquillian extension.
- The TCK depends on some system properties, which an initial custom test is used to configure in a container neutral way.
- The official Arquillian GlassFish connector throws all exceptions as `GlassFishClientException`s, which fails the deployment assertions. An Arquillian extension is used to cast these exceptions when the message is correct.
- Hamcrest is required by some deployments, but not included. The Arquillian extension handles this.