### PR TITLE
Add EE 10 schemas

### DIFF
--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/application-client_10.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/application-client_10.xsd
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="10">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application client 10
+      deployment descriptor.  The deployment descriptor must
+      be named "META-INF/application-client.xml" in the
+      application client's jar file.  All application client
+      deployment descriptors must indicate the application
+      client schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd"
+      version="10">
+      ...
+      </application-client>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_10.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="application-client"
+               type="jakartaee:application-clientType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application-client element is the root element of an
+        application client deployment descriptor.  The application
+        client deployment descriptor describes the enterprise bean 
+        components and external resources referenced by the 
+        application client.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of an
+          application client's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name must
+          be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:unique name="ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an enterprise bean 
+          reference. The enterprise bean reference is an entry 
+          in the application client's environment and is relative to the
+          java:comp/env context. The name must be unique within the
+          application client.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the application client
+          code. The name is a JNDI name relative to the
+          java:comp/env context and must be unique within an
+          application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the
+          name of a message destination reference; its value is
+          the message destination reference name used in the
+          application client code. The name is a JNDI name
+          relative to the java:comp/env context and must be unique
+          within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="application-clientType">
+    <xsd:sequence>
+      <xsd:element name="module-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="callback-handler"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The callback-handler element names a class provided by
+            the application.  The class must have a no args
+            constructor and must implement the
+            jakarta.security.auth.callback.CallbackHandler
+            interface.  The class will be instantiated by the
+            application client container and used by the container
+            to collect authentication information from the user.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="10"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 10.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/application_10.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/application_10.xsd
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="https://jakarta.ee/xml/ns/jakartaee" xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="10">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application 10 deployment
+      descriptor.  The deployment descriptor must be named
+      "META-INF/application.xml" in the application's ear file.
+      All application deployment descriptors must indicate
+      the application schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+      version="10">
+      ...
+      </application>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/application_10.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_10.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="application" type="jakartaee:applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application element is the root element of a Jakarta EE
+        application deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="context-root-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The context-root element content must be unique
+          in the ear. 
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:module/jakartaee:web"/>
+      <xsd:field xpath="jakartaee:context-root"/>
+    </xsd:unique>
+    <xsd:unique name="security-role-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The security-role-name element content
+          must be unique in the ear.  
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The applicationType defines the structure of the
+        application. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="application-name" type="jakartaee:string" minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="initialize-in-order" type="jakartaee:generic-booleanType" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            If initialize-in-order is true, modules must be initialized
+            in the order they're listed in this deployment descriptor,
+            with the exception of application client modules, which can
+            be initialized in any order.
+            If initialize-in-order is not set or set to false, the order
+            of initialization is unspecified and may be product-dependent.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="module" type="jakartaee:moduleType" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The application deployment descriptor must have one
+            module element for each Jakarta EE module in the
+            application package. A module element is defined 
+            by moduleType definition. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="security-role" type="jakartaee:security-roleType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="library-directory" type="jakartaee:pathType" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The library-directory element specifies the pathname
+            of a directory within the application package, relative
+            to the top level of the application package.  All files
+            named "*.jar" in this directory must be made available
+            in the class path of all components included in this
+            application package.  If this element isn't specified,
+            the directory named "lib" is searched.  An empty element
+            may be used to disable searching.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry" type="jakartaee:env-entryType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref" type="jakartaee:ejb-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref" type="jakartaee:ejb-local-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref" type="jakartaee:resource-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref" type="jakartaee:resource-env-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref" type="jakartaee:message-destination-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref" type="jakartaee:persistence-context-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref" type="jakartaee:persistence-unit-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="message-destination" type="jakartaee:message-destinationType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="data-source" type="jakartaee:data-sourceType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory" type="jakartaee:jms-connection-factoryType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination" type="jakartaee:jms-destinationType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="mail-session" type="jakartaee:mail-sessionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory" type="jakartaee:connection-factory-resourceType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="administered-object" type="jakartaee:administered-objectType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version" type="jakartaee:dewey-versionType" fixed="10" use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 10.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="moduleType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The moduleType defines a single Jakarta EE module and contains a
+        connector, ejb, java, or web element, which indicates the
+        module type and contains a path to the module file, and an
+        optional alt-dd element, which specifies an optional URI to
+        the post-assembly version of the deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="connector" type="jakartaee:pathType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The connector element specifies the URI of a
+              resource adapter archive file, relative to the
+              top level of the application package.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="ejb" type="jakartaee:pathType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb element specifies the URI of an ejb-jar,
+              relative to the top level of the application
+              package.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="java" type="jakartaee:pathType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The java element specifies the URI of a java
+              application client module, relative to the top
+              level of the application package.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="web" type="jakartaee:webType"/>
+      </xsd:choice>
+      <xsd:element name="alt-dd" type="jakartaee:pathType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The alt-dd element specifies an optional URI to the
+            post-assembly version of the deployment descriptor
+            file for a particular Jakarta EE module.  The URI must
+            specify the full pathname of the deployment
+            descriptor file relative to the application's root
+            directory. If alt-dd is not specified, the deployer
+            must read the deployment descriptor from the default
+            location and file name required by the respective
+            component specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webType defines the web-uri and context-root of
+        a web application module.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="web-uri" type="jakartaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The web-uri element specifies the URI of a web
+            application file, relative to the top level of the
+            application package.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-root" type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The context-root element specifies the context root
+            of a web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/beans_4_0.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/beans_4_0.xsd
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ JBoss, Home of Professional Open Source
+~ Copyright 2021, Red Hat, Inc., and individual contributors
+~ by the @authors tag. See the copyright.txt in the distribution for a
+~ full listing of individual contributors.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~ http://www.apache.org/licenses/LICENSE-2.0
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+           elementFormDefault="qualified"
+           targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+           version="4.0">
+
+  <xs:annotation>
+    <xs:documentation>
+      <![CDATA[[
+         Jakarta Contexts and Dependency Injection (CDI) defines
+         a set of complementary services that help improve the structure
+         of application code. beans.xml is used to enable CDI services
+         for the current bean archive as well as to enable named
+         interceptors, decorators and alternatives for the current bean
+         archive.
+         
+
+         This is the XML Schema for the beans.xml deployment
+         descriptor for CDI 4.0.  The deployment descriptor must be named
+         "META-INF/beans.xml" or "WEB-INF/beans.xml" in a war file.
+         All application deployment descriptors may indicate
+         the application schema by using the Java EE namespace:
+
+         https://jakarta.ee/xml/ns/jakartaee
+
+         and may indicate the version of the schema by
+         using the version element as shown below:
+
+         <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+         version="4.0">
+            ...
+         </beans>
+
+        The deployment descriptor may indicate the published version of
+        the schema using the xsi:schemaLocation attribute for the Java EE
+        namespace with the following location:
+
+        https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd
+
+     ]]>
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="beans">
+    <xs:annotation>
+      <xs:documentation>
+        Bean classes of enabled beans must be
+        deployed in bean archives. A library jar, EJB jar,
+        application client jar or rar archive is a bean archive if
+        it has a file named beans.xml in the META-INF directory. The
+        WEB-INF/classes directory of a war is a bean archive if
+        there is a file named beans.xml in the WEB-INF directory of
+        the war. A directory in the JVM classpath is a bean archive
+        if it has a file named beans.xml in the META-INF directory.
+
+        When running in a CDI Lite environment, the bean-discovery-mode
+        attribute is the only configuration value read from a beans.xml file.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all >
+        <xs:element ref="jakartaee:interceptors" minOccurs="0"/>
+        <xs:element ref="jakartaee:decorators" minOccurs="0" />
+        <xs:element ref="jakartaee:alternatives" minOccurs="0" />
+        <xs:element ref="jakartaee:scan" minOccurs="0" />
+        <xs:element ref="jakartaee:trim" minOccurs="0"/>
+      </xs:all>
+      <xs:attribute name="version" default="4.0">
+        <xs:annotation>
+          <xs:documentation>
+            The version of CDI this beans.xml is for. If the version is "4.0" (or
+            later), then the attribute bean-discovery-mode must be added.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="bean-discovery-mode" use="optional" default="annotated">
+        <xs:annotation>
+          <xs:documentation>
+            It is strongly recommended you use "annotated". This is now the default and it
+            is also the default as of 4.0 when an empty beans.xml file is seen. When running
+            in a CDI Lite  environment, this is the only aspect of the beans.xml file that
+            is used.
+
+            If the bean discovery mode is "all", then all types in this
+            archive will be considered. If the bean discovery mode is
+            "annotated", then only those types with bean defining annotations will be
+            considered. If the bean discovery mode is "none", then no
+            types will be considered.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="annotated">
+              <xs:annotation>
+                <xs:documentation>
+                  Only those types with bean defining annotations will be
+                  considered.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="all">
+              <xs:annotation>
+                <xs:documentation>
+                  All types in this archive will be considered.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+              <xs:annotation>
+                <xs:documentation>
+                  This archive will be ignored.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="scan">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[The <scan> element allows exclusion of classes and packages from consideration. Various filters may be applied, and may be conditionally activated.]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="exclude">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[The exclude filter allows exclusion of classes and packages through the use of Ant-style glob matches. For example, <exclude name="com.acme.**"> would exclude all classes and subpackages of com.acme.]]>
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+              <xs:element name="if-class-available">
+                <xs:annotation>
+                  <xs:documentation>
+                    <![CDATA[Activates the filter only if the class specified can be loaded.]]>
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[If the named class can be loaded then, then the filter will be activated.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="if-class-not-available">
+                <xs:annotation>
+                  <xs:documentation>
+                    <![CDATA[Activates the filter only if the class specified cannot be loaded.]]>
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[If the named class cannot be loaded then, then the filter will be activated.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="if-system-property">
+                <xs:annotation>
+                  <xs:documentation>
+                    <![CDATA[If both name and value are specified, then the named system property must be set, and have the specified value for the filter to be activated. If only the name is specified, then the named system property must be set for the filter to be activated.]]>
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[The name of the system property that must be set for the filter to be active.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="value" type="xs:string" use="optional">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[Optional. The value that the system property must have for the filter to be active.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="name" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[The name of the class or package to exclude. Ant-style glob matches are supported. For example, <exclude name="com.acme.**"> would exclude all classes and subpackages of com.acme.]]>
+                </xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:pattern value="([a-zA-Z_$][a-zA-Z\d_$]*\.)*([a-zA-Z_$][a-zA-Z\d_$]*|\*|\*\*)"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="interceptors">
+    <xs:annotation>
+      <xs:documentation>
+        By default, a bean archive has no enabled
+        interceptors bound via interceptor bindings. An interceptor
+        must be explicitly enabled by listing its class under the
+        &lt;interceptors&gt; element of the beans.xml file of the
+        bean archive. The order of the interceptor declarations
+        determines the interceptor ordering. Interceptors which
+        occur earlier in the list are called first. If the same
+        class is listed twice under the &lt;interceptors&gt;
+        element, the container automatically detects the problem and
+        treats it as a deployment problem.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="class" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;class&gt; element
+              must specify the name of an interceptor class. If
+              there is no class with the specified name, or if
+              the class with the specified name is not an
+              interceptor class, the container automatically
+              detects the problem and treats it as a deployment
+              problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="decorators">
+    <xs:annotation>
+      <xs:documentation>
+        By default, a bean archive has no enabled
+        decorators. A decorator must be explicitly enabled by
+        listing its bean class under the &lt;decorators&gt; element
+        of the beans.xml file of the bean archive. The order of the
+        decorator declarations determines the decorator ordering.
+        Decorators which occur earlier in the list are called first.
+        If the same class is listed twice under the
+        &lt;decorators&gt; element, the container automatically
+        detects the problem and treats it as a deployment problem.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="class" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;class&gt; element
+              must specify the name of a decorator class. If
+              there is no class with the specified name, or if
+              the class with the specified name is not a
+              decorator class, the container automatically
+              detects the problem and treats it as a deployment
+              problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="alternatives">
+    <xs:annotation>
+      <xs:documentation>
+        An alternative is a bean that must be
+        explicitly declared in the beans.xml file if it should be
+        available for lookup, injection or EL resolution. By
+        default, a bean archive has no selected alternatives. An
+        alternative must be explicitly declared using the
+        &lt;alternatives&gt; element of the beans.xml file of the
+        bean archive. The &lt;alternatives&gt; element contains a
+        list of bean classes and stereotypes. An alternative is
+        selected for the bean archive if either: the alternative is
+        a managed bean or session bean and the bean class of the
+        bean is listed, or the alternative is a producer method,
+        field or resource, and the bean class that declares the
+        method or field is listed, or any @Alternative stereotype of
+        the alternative is listed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="class" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;class&gt; element
+              must specify the name of an alternative bean class.
+              If there is no class with the specified name, or if
+              the class with the specified name is not an
+              alternative bean class, the container automatically
+              detects the problem and treats it as a deployment
+              problem. If the same class is listed twice under
+              the &lt;alternatives&gt; element, the container
+              automatically detects the problem and treats it as
+              a deployment problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+        <xs:element name="stereotype" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;stereotype&gt;
+              element must specify the name of an @Alternative
+              stereotype annotation. If there is no annotation
+              with the specified name, or the annotation is not
+              an @Alternative stereotype, the container
+              automatically detects the problem and treats it as
+              a deployment problem. If the same stereotype is
+              listed twice under the &lt;alternatives&gt;
+              element, the container automatically detects the
+              problem and treats it as a deployment problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trim" type="xs:string" fixed="">
+    <xs:annotation>
+      <xs:documentation>
+        If an explicit bean archive contains the &lt;trim/&lt; element in its beans.xml file, types that don’t have
+        either a bean defining annotation (as defined in Bean defining annotations) or any scope annotation,
+        are removed from the set of discovered types.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:element>
+
+</xs:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/jakartaee_10.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/jakartaee_10.xsd
@@ -1,0 +1,2739 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee" xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified" version="10">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following definitions that appear in the common
+      shareable schema(s) of Jakarta EE deployment descriptors should be
+      interpreted with respect to the context they are included:
+      
+      Deployment Component may indicate one of the following:
+      Jakarta EE application;
+      application client;
+      web application;
+      enterprise bean;
+      resource adapter; 
+      
+      Deployment File may indicate one of the following:
+      ear file;
+      war file;
+      jar file;
+      rar file;
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xsd:include schemaLocation="jakartaee_web_services_client_2_0.xsd"/>
+
+  <xsd:group name="descriptionGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained description related
+        elements consistent across Jakarta EE deployment descriptors.
+        
+        All elements may occur multiple times with different languages,
+        to support localization of the content.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="display-name" type="jakartaee:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="icon" type="jakartaee:iconType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="jndiEnvironmentRefsGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained JNDI environment
+        reference elements consistent across Jakarta EE deployment descriptors.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="env-entry" type="jakartaee:env-entryType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref" type="jakartaee:ejb-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref" type="jakartaee:ejb-local-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref" type="jakartaee:resource-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref" type="jakartaee:resource-env-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref" type="jakartaee:message-destination-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref" type="jakartaee:persistence-context-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref" type="jakartaee:persistence-unit-refType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="post-construct" type="jakartaee:lifecycle-callbackType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy" type="jakartaee:lifecycle-callbackType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="data-source" type="jakartaee:data-sourceType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory" type="jakartaee:jms-connection-factoryType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination" type="jakartaee:jms-destinationType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="mail-session" type="jakartaee:mail-sessionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory" type="jakartaee:connection-factory-resourceType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="administered-object" type="jakartaee:administered-objectType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to most
+        JNDI resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+      <xsd:element name="lookup-name" type="jakartaee:xsdStringType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve a resource reference.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceBaseGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to all the
+        JNDI resource elements. It does not include the lookup-name
+        element, that is only applicable to some resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="mapped-name" type="jakartaee:xsdStringType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this resource should be
+            mapped to.  The name of this resource, as defined by the
+            resource's name element or defaulted, is a name that is
+            local to the application component using the resource.
+            (It's a name in the JNDI java:comp/env namespace.)  Many
+            application servers provide a way to map these local
+            names to names of resources known to the application
+            server.  This mapped name is often a global JNDI name,
+            but may be a name of any form.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="injection-target" type="jakartaee:injection-targetType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="administered-objectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of an administered object.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this administered object.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            administered object being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's interface type.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name" type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's class name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter" type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Property of the administered object property.  This may be a 
+            vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-factory-resourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Connector Connection Factory resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name" type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified class name of the connection factory 
+            interface. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter" type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transaction-support" type="jakartaee:transaction-supportType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The level of transaction support the connection factory 
+            needs to support. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="data-sourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a DataSource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this DataSource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            data source being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            DataSource, XADataSource or ConnectionPoolDataSource
+            implementation class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="server-name" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Database server name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-number" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Port number where a server is listening for requests.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="database-name" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of a database on a server.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="url" type="jakartaee:jdbc-urlType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            A JDBC URL. If the <code>url</code> property is specified
+            along with other standard <code>DataSource</code> properties
+            such as <code>serverName</code>, <code>databaseName</code>
+            and <code>portNumber</code>, the more specific properties will
+            take precedence and <code>url</code> will be ignored.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JDBC DataSource property.  This may be a vendor-specific
+            property or a less commonly used DataSource property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="login-timeout" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Sets the maximum time in seconds that this data source
+            will wait while attempting to connect to a database.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional" type="jakartaee:xsdBooleanType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="isolation-level" type="jakartaee:isolation-levelType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Isolation level for connections.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="initial-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Number of connections that should be created when a
+            connection pool is initialized.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-idle-time" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The number of seconds that a physical connection should
+            remain unused in the pool before the connection is
+            closed for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-statements" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The total number of statements that a connection pool
+            should keep open.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The description type is used by a description element to
+        provide text describing the parent element.  The elements
+        that use this type should include any information that the
+        Deployment Component's Deployment File file producer wants
+        to provide to the consumer of the Deployment Component's
+        Deployment File (i.e., to the Deployer). Typically, the
+        tools used by such a Deployment File consumer will display
+        the description when processing the parent element that
+        contains the description.
+        
+        The lang attribute defines the language that the
+        description is provided in. The default value is "en" (English). 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:xsdStringType">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="dewey-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a dewey decimal that is used
+        to describe versions of documents. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="display-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The display-name type contains a short name that is intended
+        to be displayed by tools. It is used by display-name
+        elements.  The display name need not be unique.
+        
+        Example: 
+        
+        ...
+        <display-name xml:lang="en">
+        Employee Self Service
+        </display-name>
+        
+        The value of the xml:lang attribute is "en" (English) by default. 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:string">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-linkType is used by ejb-link
+        elements in the ejb-ref or ejb-local-ref elements to specify
+        that an enterprise bean reference is linked to enterprise bean.
+        
+        The value of the ejb-link element must be the ejb-name of an
+        enterprise bean in the same ejb-jar file or in another ejb-jar
+        file in the same Jakarta EE application unit. 
+        
+        Alternatively, the name in the ejb-link element may be
+        composed of a path name specifying the ejb-jar containing the
+        referenced enterprise bean with the ejb-name of the target
+        bean appended and separated from the path name by "#".  The
+        path name is relative to the Deployment File containing
+        Deployment Component that is referencing the enterprise
+        bean.  This allows multiple enterprise beans with the same
+        ejb-name to be uniquely identified.
+        
+        Examples:
+        
+        <ejb-link>EmployeeRecord</ejb-link>
+        
+        <ejb-link>../products/product.jar#ProductEJB</ejb-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-local-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-local-refType is used by ejb-local-ref elements for
+        the declaration of a reference to an enterprise bean's local
+        home or to the local business interface of a 3.0 bean.
+        The declaration consists of:
+        
+        - an optional description
+        - the enterprise bean's reference name used in the code of the 
+        Deployment Component that's referencing the enterprise bean.
+        - the optional expected type of the referenced enterprise bean
+        - the optional expected local interface of the referenced 
+        enterprise bean or the local business interface of the 
+        referenced enterprise bean.
+        - the optional expected local home interface of the referenced 
+        enterprise bean. Not applicable if this ejb-local-ref refers
+        to the local business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the 
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise  
+        bean into a component field or property.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name" type="jakartaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type" type="jakartaee:ejb-ref-typeType" minOccurs="0"/>
+      <xsd:element name="local-home" type="jakartaee:local-homeType" minOccurs="0"/>
+      <xsd:element name="local" type="jakartaee:localType" minOccurs="0"/>
+      <xsd:element name="ejb-link" type="jakartaee:ejb-linkType" minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-ref-name element contains the name of an enterprise bean reference. 
+        The enterprise bean reference is an entry in the Deployment Component's 
+        environment and is relative to the java:comp/env context.  The name must 
+        be unique within the Deployment Component.
+        
+        It is recommended that name is prefixed with "ejb/".
+        
+        Example:
+        
+        <ejb-ref-name>ejb/Payroll</ejb-ref-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:jndi-nameType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-refType is used by ejb-ref elements for the
+        declaration of a reference to an enterprise bean's home or
+        to the remote business interface of a 3.0 bean.  
+        The declaration consists of:
+        
+        - an optional description
+        - the enterprise bean's reference name used in the code of
+        the Deployment Component that's referencing the enterprise
+        bean. 
+        - the optional expected type of the referenced enterprise bean
+        - the optional remote interface of the referenced enterprise bean
+        or the remote business interface of the referenced enterprise 
+        bean
+        - the optional expected home interface of the referenced 
+        enterprise bean.  Not applicable if this ejb-ref
+        refers to the remote business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise
+        bean into a component field or property
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name" type="jakartaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type" type="jakartaee:ejb-ref-typeType" minOccurs="0"/>
+      <xsd:element name="home" type="jakartaee:homeType" minOccurs="0"/>
+      <xsd:element name="remote" type="jakartaee:remoteType" minOccurs="0"/>
+      <xsd:element name="ejb-link" type="jakartaee:ejb-linkType" minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-ref-typeType contains the expected type of the
+        referenced enterprise bean.
+        
+        The ejb-ref-type designates a value
+        that must be one of the following:
+        
+        Entity
+        Session
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Entity"/>
+        <xsd:enumeration value="Session"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="emptyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is used to designate an empty
+        element when used. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The env-entryType is used to declare an application's
+        environment entry. The declaration consists of an optional
+        description, the name of the environment entry, a type
+        (optional if the value is injected, otherwise required), and
+        an optional value.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        If a value is not specified and injection is requested,
+        no injection will occur and no entry of the specified name
+        will be created.  This allows an initial value to be
+        specified in the source code without being incorrectly
+        changed when no override has been specified.
+        
+        If a value is not specified and no injection is requested,
+        a value must be supplied during deployment. 
+        
+        This type is used by env-entry elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="env-entry-name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-name element contains the name of a
+            Deployment Component's environment entry.  The name
+            is a JNDI name relative to the java:comp/env
+            context.  The name must be unique within a 
+            Deployment Component. The uniqueness
+            constraints must be defined within the declared
+            context.
+            
+            Example:
+            
+            <env-entry-name>minAmount</env-entry-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-type" type="jakartaee:env-entry-type-valuesType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-type element contains the Java language
+            type of the environment entry.  If an injection target
+            is specified for the environment entry, the type may
+            be omitted, or must match the type of the injection
+            target.  If no injection target is specified, the type
+            is required.
+            
+            Example:
+            
+            <env-entry-type>java.lang.Integer</env-entry-type>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-value" type="jakartaee:xsdStringType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-value designates the value of a
+            Deployment Component's environment entry. The value
+            must be a String that is valid for the
+            constructor of the specified type that takes a
+            single String parameter, or for java.lang.Character,
+            a single character.
+            
+            Example:
+            
+            <env-entry-value>100.00</env-entry-value>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entry-type-valuesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        This type contains the fully-qualified Java type of the
+        environment entry value that is expected by the
+        application's code.
+        
+        The following are the legal values of env-entry-type-valuesType:
+        
+        java.lang.Boolean
+        java.lang.Byte
+        java.lang.Character
+        java.lang.String
+        java.lang.Short
+        java.lang.Integer
+        java.lang.Long
+        java.lang.Float
+        java.lang.Double
+        		  java.lang.Class
+        		  any enumeration type (i.e. a subclass of java.lang.Enum)
+        
+        Examples:
+        
+        <env-entry-type>java.lang.Boolean</env-entry-type>
+        <env-entry-type>java.lang.Class</env-entry-type>
+        <env-entry-type>com.example.Color</env-entry-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="fully-qualified-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate the name of a
+        Java class or interface.  The name is in the form of a
+        "binary name", as defined in the JLS.  This is the form
+        of name used in Class.forName().  Tools that need the
+        canonical name (the name used in source code) will need
+        to convert this binary name to the canonical name.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="generic-booleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines four different values which can designate
+        boolean values. This includes values yes and no which are 
+        not designated by xsd:boolean
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+        <xsd:enumeration value="yes"/>
+        <xsd:enumeration value="no"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="iconType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The icon type contains small-icon and large-icon elements
+        that specify the file names for small and large GIF, JPEG,
+        or PNG icon images used to represent the parent element in a
+        GUI tool. 
+        
+        The xml:lang attribute defines the language that the
+        icon file names are provided in. Its value is "en" (English)
+        by default. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="small-icon" type="jakartaee:pathType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The small-icon element contains the name of a file
+            containing a small (16 x 16) icon image. The file
+            name is a relative path within the Deployment
+            Component's Deployment File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <small-icon>employee-service-icon16x16.jpg</small-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="large-icon" type="jakartaee:pathType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The large-icon element contains the name of a file
+            containing a large
+            (32 x 32) icon image. The file name is a relative 
+            path within the Deployment Component's Deployment
+            File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <large-icon>employee-service-icon32x32.jpg</large-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute ref="xml:lang"/>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="injection-targetType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        An injection target specifies a class and a name within
+        that class into which a resource should be injected.
+        
+        The injection target class specifies the fully qualified
+        class name that is the target of the injection.  The
+        Jakarta EE specifications describe which classes can be an
+        injection target.
+        
+        The injection target name specifies the target within
+        the specified class.  The target is first looked for as a
+        JavaBeans property name.  If not found, the target is
+        looked for as a field name.
+        
+        The specified resource will be injected into the target
+        during initialization of the class by either calling the
+        set method for the target property or by setting a value
+        into the named field.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="injection-target-class" type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="injection-target-name" type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="isolation-levelType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        	The following transaction isolation levels are allowed
+        	(see documentation for the java.sql.Connection interface):
+        TRANSACTION_READ_UNCOMMITTED
+        TRANSACTION_READ_COMMITTED
+        TRANSACTION_REPEATABLE_READ
+        TRANSACTION_SERIALIZABLE
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="TRANSACTION_READ_UNCOMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_READ_COMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_REPEATABLE_READ"/>
+      <xsd:enumeration value="TRANSACTION_SERIALIZABLE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-identifierType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The java-identifierType defines a Java identifier.
+        The users of this type should further verify that 
+        the content does not contain Java reserved keywords.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="($|_|\p{L})(\p{L}|\p{Nd}|_|$)*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a generic type that designates a Java primitive
+        type or a fully qualified name of a Java interface/type,
+        or an array of such types.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="[^\p{Z}]*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jdbc-urlType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The jdbc-urlType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 9.3 of the
+        JDBC Specification where the format is:
+        
+        jdbc:<subprotocol>:<subname>
+        
+        Example:
+        
+        <url>jdbc:mysql://localhost:3307/testdb</url>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="jdbc:(.*):(.*)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-connection-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Messaging Connection Factory.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Messaging Connection Factory.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            messaging connection factory being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging connection factory
+            interface.  Permitted values are jakarta.jms.ConnectionFactory,
+            jakarta.jms.QueueConnectionFactory, or 
+            jakarta.jms.TopicConnectionFactory.  If not specified,
+            jakarta.jms.ConnectionFactory will be used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging connection factory 
+            implementation class.  Ignored if a resource adapter  
+            is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-id" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Client id to use for connection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Messaging Connection Factory property.  This may be a vendor-specific
+            property or a less commonly used ConnectionFactory property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional" type="jakartaee:xsdBooleanType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size" type="jakartaee:xsdIntegerType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Messaging Destination.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Messaging Destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            messaging destination being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name" type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging destination interface.
+            Permitted values are jakarta.jms.Queue and jakarta.jms.Topic
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging destination implementation
+            class.  Ignored if a resource adapter is used unless the
+            resource adapter defines more than one destination implementation
+            class for the specified interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="destination-name" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of the queue or topic.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Messaging Destination property.  This may be a vendor-specific
+            property or a less commonly used Destination property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jndi-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jndi-nameType type designates a JNDI name in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  A JNDI name must be unique within the
+        Deployment Component.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The homeType defines the fully-qualified name of
+        an enterprise bean's home interface. 
+        
+        Example:
+        
+        <home>com.aardvark.payroll.PayrollHome</home>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="lifecycle-callbackType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The lifecycle-callback type specifies a method on a
+        class to be called when a lifecycle event occurs.
+        Note that each class may have only one lifecycle callback
+        method for any given event and that the method may not
+        be overloaded.
+        
+        If the lifefycle-callback-class element is missing then
+        the class defining the callback is assumed to be the
+        component class in scope at the place in the descriptor
+        in which the callback definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="lifecycle-callback-class" type="jakartaee:fully-qualified-classType" minOccurs="0"/>
+      <xsd:element name="lifecycle-callback-method" type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The listenerType indicates the deployment properties for a web
+        application listener bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="listener-class" type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The listener-class element declares a class in the
+            application must be registered as a web
+            application listener bean. The value is the fully
+            qualified classname of the listener class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="localType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localType defines the fully-qualified name of an
+        enterprise bean's local interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="local-homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The local-homeType defines the fully-qualified
+        name of an enterprise bean's local home interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mail-sessionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Mail Session resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Mail Session resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            Mail Session resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Storage protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol-class" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider store protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Transport protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol-class" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider transport protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="host" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server host name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server user name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Email address to indicate the message sender.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="param-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is a general type that can be used to declare
+        parameter/value lists.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="param-name" type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-name element contains the name of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="param-value" type="jakartaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-value element contains the value of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate either a relative
+        path or an absolute path starting with a "/".
+        
+        In elements that specify a pathname to a file within the
+        same Deployment File, relative filenames (i.e., those not
+        starting with "/") are considered relative to the root of
+        the Deployment File's namespace.  Absolute filenames (i.e.,
+        those starting with "/") also specify names in the root of
+        the Deployment File's namespace.  In general, relative names
+        are preferred.  The exception is .war files where absolute
+        names are preferred for consistency with the Servlet API.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-context-ref element contains a declaration
+        of Deployment Component's reference to a persistence context
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence context reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - an optional specification as to whether
+        the persistence context type is Transaction or
+        Extended.  If not specified, Transaction is assumed.
+        - an optional specification as to whether
+        the persistence context synchronization with the current
+        transaction is Synchronized or Unsynchronized. If not
+        specified, Synchronized is assumed.
+        - an optional list of persistence properties
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        </persistence-context-ref>
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        <persistence-context-type>Extended</persistence-context-type>
+        </persistence-context-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref-name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-context-ref-name element specifies
+            the name of a persistence context reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Jakarta EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-context-type" type="jakartaee:persistence-context-typeType" minOccurs="0"/>
+      <xsd:element name="persistence-context-synchronization" type="jakartaee:persistence-context-synchronizationType" minOccurs="0"/>
+      <xsd:element name="persistence-property" type="jakartaee:propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify properties for the container or persistence
+            provider.  Vendor-specific properties may be included in
+            the set of properties.  Properties that are not recognized
+            by a vendor must be ignored.  Entries that make use of the 
+            namespace jakarta.persistence and its subnamespaces must not
+            be used for vendor-specific properties.  The namespace
+            jakarta.persistence is reserved for use by the specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-synchronizationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-synchronizationType specifies 
+        whether a container-managed persistence context is automatically
+        synchronized with the current transaction.
+        
+        The value of the persistence-context-synchronization element 
+        must be one of the following:
+        Synchronized
+        Unsynchronized
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Synchronized"/>
+        <xsd:enumeration value="Unsynchronized"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-typeType specifies the transactional
+        nature of a persistence context reference.  
+        
+        The value of the persistence-context-type element must be
+        one of the following:
+        Transaction
+        Extended
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Transaction"/>
+        <xsd:enumeration value="Extended"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a name/value pair.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name" type="jakartaee:xsdStringType">
+      </xsd:element>
+      <xsd:element name="value" type="jakartaee:xsdStringType">
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-unit-ref element contains a declaration
+        of Deployment Component's reference to a persistence unit
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence unit reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        </persistence-unit-ref>
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        </persistence-unit-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref-name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-unit-ref-name element specifies
+            the name of a persistence unit reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name" type="jakartaee:string" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Jakarta EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="remoteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The remote element contains the fully-qualified name
+        of the enterprise bean's remote interface.
+        
+        Example:
+        
+        <remote>com.wombat.empl.EmployeeService</remote>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-env-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-env-refType is used to define
+        resource-env-ref elements.  It contains a declaration of a
+        Deployment Component's reference to an administered object
+        associated with a resource in the Deployment Component's
+        environment.  It consists of an optional description, the
+        resource environment reference name, and an optional
+        indication of the resource environment reference type
+        expected by the Deployment Component code.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The resource environment type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-env-ref>
+        <resource-env-ref-name>jms/StockQueue
+        </resource-env-ref-name>
+        <resource-env-ref-type>jakarta.jms.Queue
+        </resource-env-ref-type>
+        </resource-env-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref-name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-name element specifies the name
+            of a resource environment reference; its value is
+            the environment entry name used in
+            the Deployment Component code.  The name is a JNDI 
+            name relative to the java:comp/env context and must 
+            be unique within a Deployment Component.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-env-ref-type" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-type element specifies the type
+            of a resource environment reference.  It is the
+            fully qualified name of a Java language class or
+            interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-refType contains a declaration of a
+        Deployment Component's reference to an external resource. It
+        consists of an optional description, the resource manager
+        connection factory reference name, an optional indication of
+        the resource manager connection factory type expected by the
+        Deployment Component code, an optional type of authentication
+        (Application or Container), and an optional specification of
+        the shareability of connections obtained from the resource
+        (Shareable or Unshareable).
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The connection factory type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-ref>
+        <res-ref-name>jdbc/EmployeeAppDB</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+        </resource-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="res-ref-name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-ref-name element specifies the name of a
+            resource manager connection factory reference.
+            The name is a JNDI name relative to the
+            java:comp/env context.  
+            The name must be unique within a Deployment File. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-type" type="jakartaee:fully-qualified-classType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-type element specifies the type of the data
+            source. The type is specified by the fully qualified
+            Java language class or interface
+            expected to be implemented by the data source.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-auth" type="jakartaee:res-authType" minOccurs="0"/>
+      <xsd:element name="res-sharing-scope" type="jakartaee:res-sharing-scopeType" minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-authType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-authType specifies whether the Deployment Component
+        code signs on programmatically to the resource manager, or
+        whether the Container will sign on to the resource manager
+        on behalf of the Deployment Component. In the latter case,
+        the Container uses information that is supplied by the
+        Deployer.
+        
+        The value must be one of the two following:
+        
+        Application
+        Container
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Application"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-sharing-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-sharing-scope type specifies whether connections
+        obtained through the given resource manager connection
+        factory reference can be shared. The value, if specified,
+        must be one of the two following:
+        
+        Shareable
+        Unshareable
+        
+        The default value is Shareable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Shareable"/>
+        <xsd:enumeration value="Unshareable"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="run-asType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The run-asType specifies the run-as identity to be
+        used for the execution of a component. It contains an 
+        optional description, and the name of a security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="role-name" type="jakartaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="role-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The role-nameType designates the name of a security role.
+        
+        The name must conform to the lexical rules for a token.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-roleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The security-roleType contains the definition of a security
+        role. The definition consists of an optional description of
+        the security role, and the security role name.
+        
+        Example:
+        
+        <security-role>
+        <description>
+        This role includes all employees who are authorized
+        to access the employee service application.
+        </description>
+        <role-name>employee</role-name>
+        </security-role>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="role-name" type="jakartaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-role-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-role-refType contains the declaration of a
+        security role reference in a component's or a
+        Deployment Component's code. The declaration consists of an
+        optional description, the security role name used in the
+        code, and an optional link to a security role. If the
+        security role is not specified, the Deployer must choose an
+        appropriate security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="role-name" type="jakartaee:role-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The value of the role-name element must be the String used
+            as the parameter to the 
+            EJBContext.isCallerInRole(String roleName) method or the
+            HttpServletRequest.isUserInRole(String role) method.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="role-link" type="jakartaee:role-nameType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The role-link element is a reference to a defined
+            security role. The role-link element must contain
+            the name of one of the security roles defined in the
+            security-role elements.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdQNameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:QName.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:QName">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdBooleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:boolean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNMTOKENType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NMTOKEN">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdAnyURIType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:anyURI.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:anyURI">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:integer.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:integer">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdPositiveIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:positiveInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:positiveInteger">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNonNegativeIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:nonNegativeInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:nonNegativeInteger">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:string.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="string">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a special string datatype that is defined by Jakarta EE as
+        a base type for defining collapsed strings. When schemas
+        require trailing/leading space elimination as well as
+        collapsing the existing whitespace, this base type may be
+        used.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:token">
+        <xsd:attribute name="id" type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="true-falseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This simple type designates a boolean with only two
+        permissible values
+        
+        - true
+        - false
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdBooleanType">
+        <xsd:pattern value="(true|false)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="url-patternType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The url-patternType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 11.2 of the
+        Servlet API Specification. This pattern is assumed to be in
+        URL-decoded form and must not contain CR(#xD) or LF(#xA).
+        If it contains those characters, the container must inform
+        the developer with a descriptive error message.
+        The container must preserve all characters including whitespaces.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destinationType specifies a message
+        destination. The logical destination described by this
+        element is mapped to a physical destination by the Deployer.
+        
+        The message destination element contains: 
+        
+        - an optional description
+        - an optional display-name
+        - an optional icon
+        - a message destination name which must be unique
+        among message destination names within the same 
+        Deployment File. 
+        - an optional mapped name
+        - an optional lookup name
+        
+        Example: 
+        
+        <message-destination>
+        <message-destination-name>CorporateStocks
+        </message-destination-name>
+        </message-destination>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="message-destination-name" type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-name element specifies a
+            name for a message destination.  This name must be
+            unique among the names of message destinations
+            within the Deployment File.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mapped-name" type="jakartaee:xsdStringType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this message destination
+            should be mapped to.  Each message-destination-ref
+            element that references this message destination will
+            define a name in the namespace of the referencing
+            component or in one of the other predefined namespaces. 
+            Many application servers provide a way to map these
+            local names to names of resources known to the
+            application server.  This mapped name is often a global
+            JNDI name, but may be a name of any form.  Each of the
+            local names should be mapped to this same global name.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lookup-name" type="jakartaee:xsdStringType" minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve the message destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-ref element contains a declaration
+        of Deployment Component's reference to a message destination
+        associated with a resource in Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the message destination reference name
+        - an optional message destination type
+        - an optional specification as to whether
+        the destination is used for 
+        consuming or producing messages, or both.
+        if not specified, "both" is assumed.
+        - an optional link to the message destination
+        - optional injection targets
+        
+        The message destination type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Examples:
+        
+        <message-destination-ref>
+        <message-destination-ref-name>jms/StockQueue
+        </message-destination-ref-name>
+        <message-destination-type>jakarta.jms.Queue
+        </message-destination-type>
+        <message-destination-usage>Consumes
+        </message-destination-usage>
+        <message-destination-link>CorporateStocks
+        </message-destination-link>
+        </message-destination-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description" type="jakartaee:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref-name" type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-ref-name element specifies
+            the name of a message destination reference; its
+            value is the environment entry name used in
+            Deployment Component code.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination-type" type="jakartaee:message-destination-typeType" minOccurs="0"/>
+      <xsd:element name="message-destination-usage" type="jakartaee:message-destination-usageType" minOccurs="0"/>
+      <xsd:element name="message-destination-link" type="jakartaee:message-destination-linkType" minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-usageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-usageType specifies the use of the
+        message destination indicated by the reference.  The value
+        indicates whether messages are consumed from the message
+        destination, produced for the destination, or both.  The
+        Assembler makes use of this information in linking producers
+        of a destination with its consumers.
+        
+        The value of the message-destination-usage element must be
+        one of the following:
+        Consumes
+        Produces
+        ConsumesProduces
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Consumes"/>
+        <xsd:enumeration value="Produces"/>
+        <xsd:enumeration value="ConsumesProduces"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-typeType specifies the type of
+        the destination. The type is specified by the Java interface
+        expected to be implemented by the destination.
+        
+        Example: 
+        
+        <message-destination-type>jakarta.jms.Queue
+        </message-destination-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-linkType is used to link a message
+        destination reference or message-driven bean to a message
+        destination.
+        
+        The Assembler sets the value to reflect the flow of messages
+        between producers and consumers in the application.
+        
+        The value must be the message-destination-name of a message
+        destination in the same Deployment File or in another
+        Deployment File in the same Jakarta EE application unit.
+        
+        Alternatively, the value may be composed of a path name
+        specifying a Deployment File containing the referenced
+        message destination with the message-destination-name of the
+        destination appended and separated from the path name by
+        "#". The path name is relative to the Deployment File
+        containing Deployment Component that is referencing the
+        message destination.  This allows multiple message
+        destinations with the same name to be uniquely identified.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-supportType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transaction-supportType specifies the level of
+        transaction support provided by the resource adapter. It is
+        used by transaction-support elements.
+        
+        The value must be one of the following:
+        
+        NoTransaction
+        LocalTransaction
+        XATransaction
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NoTransaction"/>
+        <xsd:enumeration value="LocalTransaction"/>
+        <xsd:enumeration value="XATransaction"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/permissions_10.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/permissions_10.xsd
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="10">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application or module declared permissions 10.
+      The declared permissions file must be named "META-INF/permissions.xml" in the
+      application's ear file, or in a module's META-INF/permissions.xml if
+      the module is deployed standalone.  All declared permissions must indicate
+      the declared permissions schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd"
+      version="10">
+      ...
+      </permisssions>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/permissions_10.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_10.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="permissions">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The permissions element is the root element in a
+        declared permissions file. The declared permissions file
+        declares the code based permissions granted to classes and libraries 
+        packaged in the application archive, or in a module if the module is
+        deployed standalone.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+
+<!-- **************************************************** -->
+
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="permission"
+                     maxOccurs="unbounded"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Each permission element declares a permission.  If no permission
+              elements are declared, the application or module needs no special
+              permissions, and the Jakarta EE product may deploy it with no
+              permissions beyond those necessary for the operation of the
+              container.
+              
+              For details on the definition of the 'name' and 'actions'
+              elements, refer to the Java API documentation for the class
+              java.security.Permission, and its derived classes.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+
+<!-- **************************************************** -->
+
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element type="jakartaee:fully-qualified-classType"
+                           name="class-name"/>
+              <xsd:element type="jakartaee:string"
+                           name="name"
+                           minOccurs="0"/>
+              <xsd:element type="jakartaee:string"
+                           name="actions"
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="jakartaee:dewey-versionType"
+                     fixed="10"
+                     use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The required value for the version is 10.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
Adds new schemas for EE 10 from https://jakarta.ee/xml/ns/jakartaee/#10

Needed in order to deploy test applications for the Jakarta Platform TCK.

Recreated https://github.com/eclipse-ee4j/glassfish/pull/23812 against the master branch.