### PR TITLE
Fixed nightly and weekly builds which use gfbuild.sh

### DIFF
--- a/gfbuild.sh
+++ b/gfbuild.sh
@@ -72,7 +72,7 @@ dev_build(){
 
 build_re_dev(){
   if [ -f "${WORKSPACE}/snapshots/pom.xml" ]; then
-    mvn clean install -T2C -f "${WORKSPACE}/snapshots/pom.xml" ${MVN_EXTRA}
+    mvn clean install -T2C -s "${WORKSPACE}/snapshots/settings.xml" -f "${WORKSPACE}/snapshots/pom.xml" ${MVN_EXTRA}
   fi
   dev_build
   archive_bundles


### PR DESCRIPTION
Tested locally

This merges
- #23824
- #23829

for https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_build-and-publish-to-eclipse-download/ to continue with next build steps.
Per its https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_build-and-publish-to-eclipse-download/656/console - it is using
```
bash -xe ./gfbuild.sh build_re_dev
```
so this might help.