### PR TITLE
Bump jakarta.resource-api

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -114,7 +114,7 @@
         <jakarta.transaction-api.version>2.0.1-RC1</jakarta.transaction-api.version>
 
         <!-- Jakarta Connectors -->
-        <jakarta.resource-api.version>2.1.0-RC1</jakarta.resource-api.version>
+        <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
 
         <!-- Jakarta Batch -->
         <jakarta.batch-api.version>2.1.0</jakarta.batch-api.version>


### PR DESCRIPTION
Fix https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_build-and-publish-to-eclipse-download/657
```
[ERROR] Failed to execute goal on project cciblackbox-tx: Could not resolve dependencies for project org.glassfish.main.tests.connectors:cciblackbox-tx:jar:7.0.0-SNAPSHOT: Could not find artifact jakarta.resource:jakarta.resource-api:jar:2.1.0-RC1 in sonatype-nexus-staging (https://jakarta.oss.sonatype.org/content/repositories/staging/) -> [Help 1]
```
as 2.1.0-RC1 was dropped from staging repository.