### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -103,7 +103,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.3.0-M2</openmq.version>
+        <openmq.version>6.3.0-M3</openmq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0-RC2</jakarta.persistence-api.version>


### PR DESCRIPTION
This version is _almost_ JakartaEE 10 ready, and compared to M2 it has Messaging in v3.1.
Current TCK overall result:
```
[javatest.batch] Test results: passed: 903; failed: 1
```
- failed one, expected test: `JMSSigTest` (needs TCK update).
