### PR TITLE
Remove empty volumeMounts

### DIFF
--- a/etc/PruneMavenCache.groovy
+++ b/etc/PruneMavenCache.groovy
@@ -20,7 +20,6 @@ spec:
   - name: jnlp
     image: jenkins/jnlp-slave:alpine
     imagePullPolicy: IfNotPresent
-    volumeMounts:
     env:
       - name: JAVA_TOOL_OPTIONS
         value: -Xmx1G


### PR DESCRIPTION
Remove the empty volumeMounts. This line causes the Jenkins job not to start on Eclipse Infra.  
Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>
