### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -103,7 +103,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.3.0-M3</openmq.version>
+        <openmq.version>6.3.0-RC1</openmq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0-RC2</jakarta.persistence-api.version>


### PR DESCRIPTION
This version was [tested with the newest TCK](https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/39/), and all tests, including signature test, passed this time:
```
[javatest.batch] Number of Tests Passed      = 904
[javatest.batch] Number of Tests Failed      = 0
[javatest.batch] Number of Tests with Errors = 0
```