### PR TITLE
Implementation of new Jakarta Authentication methods

### DIFF
--- a/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/singlemodule/DefaultAuthConfigProvider.java
+++ b/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/singlemodule/DefaultAuthConfigProvider.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jaspic.config.factory.singlemodule;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.config.AuthConfigFactory;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ClientAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+
+/**
+ * This class functions as a kind of factory-factory for {@link ServerAuthConfig} instances, which are by themselves factories
+ * for {@link ServerAuthContext} instances, which are delegates for the actual {@link ServerAuthModule} (SAM) that we're after.
+ *
+ * @author Arjan Tijms
+ */
+public class DefaultAuthConfigProvider implements AuthConfigProvider {
+
+    private static final String CALLBACK_HANDLER_PROPERTY_NAME = "authconfigprovider.client.callbackhandler";
+
+    private Map<String, String> providerProperties;
+    private ServerAuthModule serverAuthModule;
+
+    public DefaultAuthConfigProvider(ServerAuthModule serverAuthModule) {
+        this.serverAuthModule = serverAuthModule;
+    }
+
+    /**
+     * Constructor with signature and implementation that's required by API.
+     *
+     * @param properties provider properties
+     * @param factory the auth config factory
+     */
+    public DefaultAuthConfigProvider(Map<String, String> properties, AuthConfigFactory factory) {
+        this.providerProperties = properties;
+
+        // API requires self registration if factory is provided. Not clear
+        // where the "layer" (2nd parameter)
+        // and especially "appContext" (3rd parameter) values have to come from
+        // at this place.
+        if (factory != null) {
+            // If this method ever gets called, it may throw a SecurityException.
+            // Don't bother with a PrivilegedAction as we don't expect to ever be
+            // constructed this way.
+            factory.registerConfigProvider(this, null, null, "Auto registration");
+        }
+    }
+
+    /**
+     * The actual factory method that creates the factory used to eventually obtain the delegate for a SAM.
+     */
+    @Override
+    public ServerAuthConfig getServerAuthConfig(String layer, String appContext, CallbackHandler handler) throws AuthException,
+        SecurityException {
+        return new DefaultServerAuthConfig(layer, appContext, handler == null ? createDefaultCallbackHandler() : handler,
+            providerProperties, serverAuthModule);
+    }
+
+    @Override
+    public ClientAuthConfig getClientAuthConfig(String layer, String appContext, CallbackHandler handler) throws AuthException,
+        SecurityException {
+        return null;
+    }
+
+    @Override
+    public void refresh() {
+    }
+
+    /**
+     * Creates a default callback handler via the system property "authconfigprovider.client.callbackhandler", as seemingly
+     * required by the API (API uses wording "may" create default handler). TODO: Isn't
+     * "authconfigprovider.client.callbackhandler" JBoss specific?
+     *
+     * @return
+     * @throws AuthException
+     */
+    private CallbackHandler createDefaultCallbackHandler() throws AuthException {
+        String callBackClassName = System.getProperty(CALLBACK_HANDLER_PROPERTY_NAME);
+
+        if (callBackClassName == null) {
+            throw new AuthException("No default handler set via system property: " + CALLBACK_HANDLER_PROPERTY_NAME);
+        }
+
+        try {
+            return (CallbackHandler)
+                Thread.currentThread()
+                      .getContextClassLoader()
+                      .loadClass(callBackClassName)
+                      .getDeclaredConstructor()
+                      .newInstance();
+        } catch (Exception e) {
+            throw new AuthException(e.getMessage());
+        }
+    }
+
+}

--- a/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/singlemodule/DefaultServerAuthConfig.java
+++ b/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/singlemodule/DefaultServerAuthConfig.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jaspic.config.factory.singlemodule;
+
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+
+/**
+ * This class functions as a kind of factory for {@link ServerAuthContext} instances, which are delegates for the actual
+ * {@link ServerAuthModule} (SAM) that we're after.
+ *
+ * @author Arjan Tijms
+ */
+public class DefaultServerAuthConfig implements ServerAuthConfig {
+
+    private String layer;
+    private String appContext;
+    private CallbackHandler handler;
+    private Map<String, String> providerProperties;
+    private ServerAuthModule serverAuthModule;
+
+    public DefaultServerAuthConfig(String layer, String appContext, CallbackHandler handler,
+        Map<String, String> providerProperties, ServerAuthModule serverAuthModule) {
+        this.layer = layer;
+        this.appContext = appContext;
+        this.handler = handler;
+        this.providerProperties = providerProperties;
+        this.serverAuthModule = serverAuthModule;
+    }
+
+    @Override
+    public ServerAuthContext getAuthContext(String authContextID, Subject serviceSubject,
+        @SuppressWarnings("rawtypes") Map properties) throws AuthException {
+        return new DefaultServerAuthContext(handler, serverAuthModule);
+    }
+
+    // ### The methods below mostly just return what has been passed into the
+    // constructor.
+    // ### In practice they don't seem to be called
+
+    @Override
+    public String getMessageLayer() {
+        return layer;
+    }
+
+    /**
+     * It's not entirely clear what the difference is between the "application context identifier" (appContext) and the
+     * "authentication context identifier" (authContext). In early iterations of the specification, authContext was called
+     * "operation" and instead of the MessageInfo it was obtained by something called an "authParam".
+     */
+    @Override
+    public String getAuthContextID(MessageInfo messageInfo) {
+        return appContext;
+    }
+
+    @Override
+    public String getAppContext() {
+        return appContext;
+    }
+
+    @Override
+    public void refresh() {
+    }
+
+    @Override
+    public boolean isProtected() {
+        return false;
+    }
+
+    public Map<String, String> getProviderProperties() {
+        return providerProperties;
+    }
+
+}

--- a/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/singlemodule/DefaultServerAuthContext.java
+++ b/appserver/security/jaspic-provider-framework/src/main/java/com/sun/jaspic/config/factory/singlemodule/DefaultServerAuthContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jaspic.config.factory.singlemodule;
+
+import java.util.Collections;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.ServerAuth;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+
+/**
+ * The Server Authentication Context is an extra (required) indirection between the Application Server and the actual Server
+ * Authentication Module (SAM). This can be used to encapsulate any number of SAMs and either select one at run-time, invoke
+ * them all in order, etc.
+ * <p>
+ * Since this simple example only has a single SAM, we delegate directly to that one. Note that this {@link ServerAuthContext}
+ * and the {@link ServerAuthModule} (SAM) share a common base interface: {@link ServerAuth}.
+ *
+ * @author Arjan Tijms
+ */
+public class DefaultServerAuthContext implements ServerAuthContext {
+
+    private final ServerAuthModule serverAuthModule;
+
+    public DefaultServerAuthContext(CallbackHandler handler, ServerAuthModule serverAuthModule) throws AuthException {
+        this.serverAuthModule = serverAuthModule;
+        serverAuthModule.initialize(null, null, handler, Collections.<String, Object> emptyMap());
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
+        throws AuthException {
+        return serverAuthModule.validateRequest(messageInfo, clientSubject, serviceSubject);
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject serviceSubject) throws AuthException {
+        return serverAuthModule.secureResponse(messageInfo, serviceSubject);
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+        serverAuthModule.cleanSubject(messageInfo, subject);
+    }
+
+}

--- a/appserver/security/jaspic-provider-framework/src/test/java/test/com/sun/jaspic/config/FactoryTest.java
+++ b/appserver/security/jaspic-provider-framework/src/test/java/test/com/sun/jaspic/config/FactoryTest.java
@@ -63,7 +63,6 @@ import jakarta.security.auth.message.config.ClientAuthContext;
 import jakarta.security.auth.message.config.RegistrationListener;
 import jakarta.security.auth.message.config.ServerAuthConfig;
 import jakarta.security.auth.message.config.ServerAuthContext;
-import jakarta.security.auth.message.module.ServerAuthModule;
 
 /**
  * @author Ron Monzillo
@@ -282,17 +281,6 @@ public class FactoryTest {
             }
         }
 
-        @Override
-        public String registerServerAuthModule(ServerAuthModule serverAuthModule, Object context) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void removeServerAuthModule(Object context) {
-            // TODO Auto-generated method stub
-
-        }
     }
 
     static class _Extends_ExtendsAuthConfigFactory extends _ExtendsBaseAuthConfigFactory {


### PR DESCRIPTION
This implements the two new methods to add and remove a single ServerAuthModule.

Note that TCK tests are still to be developed, and we need to add spec text for servlet profile specific elements, such as removing any ServerAuthModule when the application is undeployed.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>

