### PR TITLE
Update Jakarta Tags API & IMPL to 3.0.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -142,8 +142,8 @@
         <stax2-api.version>4.2.1</stax2-api.version>
 
         <!-- Jakarta Standard Tag Library -->
-        <jstl-api.version>3.0.0-RC1</jstl-api.version>
-        <jstl-impl.version>3.0.0-M1</jstl-impl.version>
+        <jstl-api.version>3.0.0</jstl-api.version>
+        <jstl-impl.version>3.0.0</jstl-impl.version>
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.0.0</jakarta.cdi-api.version>


### PR DESCRIPTION
Both have been staged.

api:
https://jakarta.oss.sonatype.org/content/repositories/staging/jakarta/servlet/jsp/jstl/jakarta.servlet.jsp.jstl-api/3.0.0/

Impl:
https://jakarta.oss.sonatype.org/content/repositories/staging/org/glassfish/web/jakarta.servlet.jsp.jstl/3.0.0/

We just need TCK to verify. 