### PR TITLE
Fixed maven compiler annotation processing

### DIFF
--- a/appserver/jdbc/jdbc-ra/jdbc40/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc40/pom.xml
@@ -54,12 +54,5 @@
                 </excludes>
             </resource>
         </resources>
-        <plugins>
-            <plugin><!--
-                  Use JDBC 4.0 API regardless of which JDK we are building with.
-                -->
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -662,13 +662,6 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <version>2.1</version>

--- a/appserver/tests/appserv-tests/util/reportbuilder/pom.xml
+++ b/appserver/tests/appserv-tests/util/reportbuilder/pom.xml
@@ -21,18 +21,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0</version>
+        <groupId>org.glassfish.main.tests</groupId>
+        <artifactId>ant-tests</artifactId>
+        <version>6.2.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.devtests</groupId>
-        <version>4.0-SNAPSHOT</version>
     <artifactId>report-builder</artifactId>
     <packaging>jar</packaging>
     <name>report-builder</name>
     <build>
-        <finalName>${artifactId}</finalName>
+        <finalName>${project.artifactId}</finalName>
         <defaultGoal>install</defaultGoal>
         <plugins>
             <plugin>
@@ -42,7 +41,7 @@
                         <phase>install</phase>
                         <configuration>
                             <tasks>
-                                <copy file="target/${artifactId}.jar" tofile="../../lib/reportbuilder.jar"/>
+                                <copy file="target/${project.artifactId}.jar" tofile="../../lib/reportbuilder.jar"/>
                             </tasks>
                         </configuration>
                         <goals>

--- a/appserver/tests/gftest.sh
+++ b/appserver/tests/gftest.sh
@@ -54,8 +54,11 @@ if [ ! -z "${JENKINS_HOME}" ] ; then
   fi
   echo "Removing old glassfish directory: ${S1AS_HOME}";
   rm -rf "${S1AS_HOME}";
+  if [ -z "${MVN_EXTRA}" ]; then
+    export MVN_EXTRA="";
+  fi
   if [ -z "${GF_VERSION}" ]; then
-    export GF_VERSION="$(mvn help:evaluate -f \"${APS_HOME}/pom.xml\" -Dexpression=project.version -q -DforceStdout)"
+    export GF_VERSION="$(mvn help:evaluate -f \"${APS_HOME}/pom.xml\" -Dexpression=project.version -q -DforceStdout ${MVN_EXTRA})"
   fi
   if [ -z "${MVN_REPOSITORY}" ]; then
     export MVN_REPOSITORY="${HOME}/.m2/repository";

--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0</version>
+        <version>1.0.7</version>
         <relativePath/>
     </parent>
     <groupId>org.glassfish.quicklook</groupId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -70,7 +70,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -33,6 +33,7 @@
     <description>Rest Interface for GlassFish Management and Monitoring</description>
 
     <dependencies>
+
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2</artifactId>
@@ -145,19 +146,6 @@
 
     <build>
         <plugins>
-            <plugin><!-- The services directory must be processed after compilation,
-                     it would be used in compilation otherwise and the build would fail  -->
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-resources</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>resources</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Test classes from this module are used elsewhere -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath />
     </parent>
 
@@ -955,7 +955,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -701,6 +701,28 @@
                             <testExclude>**/.ade_path/**</testExclude>
                         </testExcludes>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>default-compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <proc>none</proc>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>process-annotations</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <proc>only</proc>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.main</groupId>
     <artifactId>glassfish-main-aggregator</artifactId>
-    <version>6.2.6-SNAPSHOT-brekeke</version>
+    <version>6.2.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GlassFish Project</name>
@@ -73,7 +73,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
     </parent>
 
     <groupId>org.glassfish.main</groupId>
     <artifactId>glassfish-main-aggregator</artifactId>
-    <version>6.2.6-SNAPSHOT</version>
+    <version>6.2.6-SNAPSHOT-brekeke</version>
     <packaging>pom</packaging>
 
     <name>GlassFish Project</name>
@@ -134,9 +134,9 @@
                 <module>appserver</module>
                 <module>nucleus/hk2/config-generator</module>
                 <module>docs</module>
-                <module>appserver/admingui/devtests</module>
                 <module>appserver/extras/embedded/common</module>
-                <module>nucleus/tests</module>
+                <module>appserver/tests/appserv-tests/util/reportbuilder</module>
+                <module>appserver/tests/tck</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
* after running `mvn clean install -Pfastest -T4C` should be possible to run also `mvn package` without failures.
* updated eclipse project artifact version
* updated set-version-id profile
