### PR TITLE
#23455: javaee.jar should be renamed to jakartaee.jar

### DIFF
--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2021 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -264,7 +264,7 @@
         <fileSet>
             <directory>${temp.dir}</directory>
             <includes>
-                <include>javaee.jar</include>
+                <include>jakartaee.jar</include>
                 <include>appserv-rt.jar</include>
                 <include>gf-client.jar</include>
                 <include>grizzly-npn-api.jar</include>

--- a/appserver/distributions/web/src/main/assembly/web.xml
+++ b/appserver/distributions/web/src/main/assembly/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -170,7 +170,7 @@
         <fileSet>
             <directory>${temp.dir}</directory>
             <includes>
-                <include>javaee.jar</include>
+                <include>jakartaee.jar</include>
                 <include>appserv-rt.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/lib</outputDirectory>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2021 Contributors to Eclipse Foundation.
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -1594,7 +1594,7 @@
 
         <dependency>
             <groupId>org.glassfish.main.extras</groupId>
-            <artifactId>javaee-frag</artifactId>
+            <artifactId>jakartaee-frag</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2021 Contributors to Eclipse Foundation.
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -546,7 +546,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.extras</groupId>
-            <artifactId>javaee-frag</artifactId>
+            <artifactId>jakartaee-frag</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <optional>true</optional>

--- a/appserver/extras/jakartaee/dist-frag/pom.xml
+++ b/appserver/extras/jakartaee/dist-frag/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,11 +22,11 @@
 
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
-        <artifactId>javaee-pom</artifactId>
+        <artifactId>jakartaee-pom</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>javaee-frag</artifactId>
+    <artifactId>jakartaee-frag</artifactId>
     <packaging>distribution-fragment</packaging>
 
     <name>GlassFish javaee.jar distribution fragment</name>
@@ -34,7 +34,7 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.extras</groupId>
-            <artifactId>javaee</artifactId>
+            <artifactId>jakartaee</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>

--- a/appserver/extras/jakartaee/manifest-jar/pom.xml
+++ b/appserver/extras/jakartaee/manifest-jar/pom.xml
@@ -22,11 +22,11 @@
 
     <parent>
         <groupId>org.glassfish.main.extras</groupId>
-        <artifactId>javaee-pom</artifactId>
+        <artifactId>jakartaee-pom</artifactId>
         <version>7.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>javaee</artifactId>
+    <artifactId>jakartaee</artifactId>
 
     <name>GlassFish javaee.jar </name>
 

--- a/appserver/extras/jakartaee/pom.xml
+++ b/appserver/extras/jakartaee/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>javaee-pom</artifactId>
+    <artifactId>jakartaee-pom</artifactId>
     <packaging>pom</packaging>
 
     <name>GlassFish JavaEE Manifest pom</name>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@
     <name>GlassFish Extras modules</name>
 
     <modules>
-        <module>javaee</module>
+        <module>jakartaee</module>
         <module>appserv-rt</module>
     </modules>
 

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2021, 2022 Contributors to Eclipse Foundation.
-    Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -523,7 +523,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.extras</groupId>
-            <artifactId>javaee</artifactId>
+            <artifactId>jakartaee</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection-with-resource-declaration-in-another-jar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-component-resources/em-resource-injection-with-resource-declaration-in-another-jar/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +49,7 @@
             <param name="src" value="war"/>
         </antcall>
 
-            <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+            <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
         </javac>
     </target>
 
@@ -120,7 +120,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="${contextroot}"/>
            <arg line="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/bean-in-lib-dir-used-by-ejb-in-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/bean-in-lib-dir-used-by-ejb-in-ear/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,7 +52,7 @@
                 </antcall>
 
 
-                <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+                <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
                 </javac>
         </target>
 
@@ -113,7 +113,7 @@
         </target>
 
         <target name="run" depends="init-common">
-                <java fork="on" failonerror="true" classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" classname="${se.client}">
+                <java fork="on" failonerror="true" classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" classname="${se.client}">
                         <arg line="${contextroot}" />
                         <arg line="${http.host}" />
                         <arg line="${http.port}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/normal-bean-injection-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/normal-bean-injection-ear/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@
             <param name="src" value="ejb"/>
         </antcall>
 
-        <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+        <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
 
         </javac>
 <!--
@@ -72,7 +72,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="${contextroot}"/>
            <arg line="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/programmatic-lookup-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/javaee-integration/programmatic-lookup-ear/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@
             <param name="src" value="ejb"/>
         </antcall>
 
-        <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+        <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
 
         </javac>
 <!--
@@ -72,7 +72,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="${contextroot}"/>
            <arg line="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/scopes/request-and-application-scope-ejb-mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/scopes/request-and-application-scope-ejb-mdb/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -79,7 +79,7 @@
   <target name="run_standaloneclient" depends="init-common">
     <java fork="on"
           failonerror="true"
-          classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/jakarta.jms-api.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+          classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/jakarta.jms-api.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
           classname="${simple.client}"
     >
       <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ear/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@
             <param name="src" value="ejb"/>
         </antcall>
 
-        <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+        <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
 
         </javac>
 <!--
@@ -72,7 +72,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="${contextroot}"/>
            <arg line="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ejb-cdi/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ejb-cdi/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@
 
         <target name="run_standaloneclient" depends="init-common">
                 <java fork="on" failonerror="true"
-                        classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+                        classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
                         classname="${simple.client}">
                         <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}" />
                         <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
@@ -74,7 +74,7 @@
 
         <target name="run_standaloneclient2" depends="init-common">
                 <java fork="on" failonerror="true"
-                        classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+                        classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
                         classname="${simple.client2}">
                         <jvmarg value="-Djava.naming.factory.initial=org.glassfish.jndi.cosnaming.CNCtxFactory" />
                         <jvmarg value="-Djava.naming.provider.url=iiop://localhost:${orb.port}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ejb-singleton/hello/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-ejb-singleton/hello/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
   <target name="run_se" depends="init-common">
     <java fork="on"
           failonerror="true"
-          classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+          classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
           classname="${se.client}"
     >
       <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}" />

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/simple-mdb/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -79,7 +79,7 @@
     <target name="run_standaloneclient" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/jakarta.jms-api.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/jakarta.jms-api.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
          <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
        </java>

--- a/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/singleton-startup/hello/build.xml
+++ b/appserver/tests/appserv-tests/devtests/cdi/smoke-tests/singleton-startup/hello/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/connector/v3/ejb32-mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/connector/v3/ejb32-mdb/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,7 +85,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/connector/v3/jpa-tx-propagation-gf-resources-xml/build.xml
+++ b/appserver/tests/appserv-tests/devtests/connector/v3/jpa-tx-propagation-gf-resources-xml/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -126,7 +126,7 @@
     <target name="runclient-standalone" depends="clean-db">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
               <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
               <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/config/common.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -138,7 +138,7 @@
     </path>
 
     <path id="test.compile.classpath">
-        <pathelement location="${inst}/lib/javaee.jar"/>
+        <pathelement location="${inst}/lib/jakartaee.jar"/>
         <pathelement location="${java.home}/lib/tools.jar"/>
     </path>
 
@@ -1184,7 +1184,7 @@ AS_ADMIN_MASTERPASSWORD=changeit
         <jvmarg value="-Djava.library.path=${inst}/lib"/>
         <jvmarg value="-Dcom.sun.aas.configRoot=${inst}/config"/>
         <classpath>
-            <pathelement path="${build}:${inst}/lib/javaee.jar:${inst}/lib/appserv-rt.jar"/>
+            <pathelement path="${build}:${inst}/lib/jakartaee.jar:${inst}/lib/appserv-rt.jar"/>
         </classpath>
         <arg value="${deployablearchive}"/>
         <arg value="${deploymentplan}"/>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/libClassPath/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/libClassPath/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -94,7 +94,7 @@
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
 
             <classpath>
-                <path location="${inst}/lib/javaee.jar"/>
+                <path location="${inst}/lib/jakartaee.jar"/>
                 <path location="${build}"/>
             </classpath>
 

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/libClassPath/misc/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/libClassPath/misc/build.xml
@@ -2,7 +2,7 @@
  <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,7 @@
         <target name="compile" depends="prepare">
                 <javac srcdir="samples" destdir="${build}">
                     <classpath>
-                      <pathelement location="${inst}/lib/javaee.jar"/>
+                      <pathelement location="${inst}/lib/jakartaee.jar"/>
                       <pathelement location="${inst}/lib/appserv-rt.jar"/>
                       <pathelement location="${build}/WEB-INF/lib/library.jar"/>
                     </classpath>

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/manifestClassPath/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/manifestClassPath/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -94,7 +94,7 @@
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
 
             <classpath>
-                <path location="${inst}/lib/javaee.jar"/>
+                <path location="${inst}/lib/jakartaee.jar"/>
                 <path location="${build}"/>
             </classpath>
 

--- a/appserver/tests/appserv-tests/devtests/deployment/ear/manifestClassPath/misc/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ear/manifestClassPath/misc/build.xml
@@ -2,7 +2,7 @@
  <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,7 @@
         <target name="compile" depends="prepare">
                 <javac srcdir="samples" destdir="${build}">
                     <classpath>
-                      <pathelement location="${inst}/lib/javaee.jar"/>
+                      <pathelement location="${inst}/lib/jakartaee.jar"/>
                       <pathelement location="${inst}/lib/appserv-rt.jar"/>
                       <pathelement location="${build}/WEB-INF/lib/library.jar"/>
                     </classpath>

--- a/appserver/tests/appserv-tests/devtests/deployment/ejb30/ear/mdb/webclient/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/ejb30/ear/mdb/webclient/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -90,7 +90,7 @@
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${depltest.orbport}"/>
 
             <classpath>
-                <path location="${inst}/lib/javaee.jar"/>
+                <path location="${inst}/lib/jakartaee.jar"/>
                 <path location="${build}"/>
             </classpath>
 

--- a/appserver/tests/appserv-tests/devtests/deployment/osgi/simple/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/osgi/simple/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -113,7 +113,7 @@
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
 
             <classpath>
-                <path location="${inst}/lib/javaee.jar"/>
+                <path location="${inst}/lib/jakartaee.jar"/>
                 <path location="${build}"/>
             </classpath>
 

--- a/appserver/tests/appserv-tests/devtests/deployment/war/deploydir/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/deploydir/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -129,7 +129,7 @@
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
 
             <classpath>
-                <path location="${inst}/lib/javaee.jar"/>
+                <path location="${inst}/lib/jakartaee.jar"/>
                 <path location="${build}/${testName}/WEB-INF/classes"/>
             </classpath>
 

--- a/appserver/tests/appserv-tests/devtests/deployment/war/virtualserver/build.xml
+++ b/appserver/tests/appserv-tests/devtests/deployment/war/virtualserver/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -132,7 +132,7 @@
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
 
             <classpath>
-                <path location="${inst}/lib/javaee.jar"/>
+                <path location="${inst}/lib/jakartaee.jar"/>
                 <path location="${build}"/>
             </classpath>
 

--- a/appserver/tests/appserv-tests/devtests/ejb/cli/negative/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/cli/negative/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,7 +39,7 @@
         <echo message="deploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="deploy"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ee/timer/autotimer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ee/timer/autotimer/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,7 +50,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
         </java>
@@ -60,7 +60,7 @@
         <echo message="deploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="deploy"/>
@@ -80,7 +80,7 @@
         <echo message="Stopping cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="clean"/>
         </java>
@@ -90,7 +90,7 @@
         <echo message="undeploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="undeploy"/>
            <arg line="${appname}-web"/>
@@ -148,7 +148,7 @@
         <echo message="Verifying timeouts"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify2"/>
            <arg line="${appname}-web"/>
@@ -187,7 +187,7 @@
         <loadfile property="port-fail" srcFile="error"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify1"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ee/timer/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ee/timer/cli/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -149,12 +149,12 @@
     <target name="compile" depends="init-common">
         <mkdir dir="${build.classes.dir}"/>
         <javac fork="true" includeAntRuntime="false" destdir="${build.classes.dir}" debug="true"
-               classpath="${build.classes.dir}:${env.S1AS_HOME}/lib/javaee.jar:${env.APS_HOME}/lib/reportbuilder.jar:${env.APS_HOME}/lib/reporter.jar"
+               classpath="${build.classes.dir}:${env.S1AS_HOME}/lib/jakartaee.jar:${env.APS_HOME}/lib/reportbuilder.jar:${env.APS_HOME}/lib/reporter.jar"
                srcdir="${env.APS_HOME}/devtests/admin/cli/src" includes="**/AdminBaseDevTest.java">
         </javac>
 
         <javac fork="true" includeAntRuntime="false"
-               classpath="${build.classes.dir}:${env.S1AS_HOME}/lib/javaee.jar:${env.APS_HOME}/lib/reportbuilder.jar:${env.APS_HOME}/lib/reporter.jar"
+               classpath="${build.classes.dir}:${env.S1AS_HOME}/lib/jakartaee.jar:${env.APS_HOME}/lib/reportbuilder.jar:${env.APS_HOME}/lib/reporter.jar"
                destdir="${build.classes.dir}" debug="true" srcdir="src" includes="**/*.java">
         </javac>
     </target>
@@ -175,7 +175,7 @@
         <attribute name="main-class" default="NOT_SET"/>
         <sequential>
             <java
-        classpath="${build.classes.dir}:${env.S1AS_HOME}/lib/javaee.jar:${env.APS_HOME}/lib/reportbuilder.jar:${env.APS_HOME}/lib/reporter.jar"
+        classpath="${build.classes.dir}:${env.S1AS_HOME}/lib/jakartaee.jar:${env.APS_HOME}/lib/reportbuilder.jar:${env.APS_HOME}/lib/reporter.jar"
         classname="@{main-class}" fork="true">
             <!--
             <jvmarg line="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=9009"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ee/timer/domaindeployment/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ee/timer/domaindeployment/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -83,7 +83,7 @@
         <echo message="Starting cluster ${cname}"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${cname}"/>
@@ -100,7 +100,7 @@
         <echo message="deploying application to ${dtarget}"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="deploy"/>
@@ -119,7 +119,7 @@
         <echo message="undeploying application from ${utarget}"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="undeploy"/>
            <arg line="${utarget}"/>
@@ -131,7 +131,7 @@
         <echo message="calling add-app-ref for application to ${cname}"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="add-app-ref"/>
            <arg line="${cname}"/>
@@ -156,7 +156,7 @@
         <echo message="Stopping cluster ${cname}"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="clean"/>
            <arg line="${cname}"/>
@@ -167,7 +167,7 @@
         <echo message="redeploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="redeploy"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -220,7 +220,7 @@
         <echo message="Verifying timeouts"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ee/timer/failover/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ee/timer/failover/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,7 +56,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
         </java>
@@ -66,7 +66,7 @@
         <echo message="deploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="deploy"/>
@@ -91,7 +91,7 @@
         <echo message="Stopping cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="clean"/>
         </java>
@@ -101,7 +101,7 @@
         <echo message="Stopping cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="undeploy"/>
            <arg line="${appname}-web"/>
@@ -159,7 +159,7 @@
         <echo message="Verifying timeouts"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify2"/>
            <arg line="${appname}-web"/>
@@ -190,7 +190,7 @@
         <loadfile property="port-fail" srcFile="error"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify1"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ee/timer/getalltimers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ee/timer/getalltimers/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,7 +56,7 @@
     <target name="setup-cluster" depends="init-common">
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
         </java>
@@ -65,7 +65,7 @@
     <target name="deploy-to-cluster" depends="init-common">
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="deploy"/>
@@ -76,7 +76,7 @@
     <target name="undeploy-from-cluster" depends="init-common">
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="undeploy"/>
            <arg line="${appname}-web"/>
@@ -94,7 +94,7 @@
     <target name="unsetup-cluster" depends="init-common">
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="clean"/>
         </java>
@@ -146,7 +146,7 @@
         <echo message="Verifying"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/clientview/adapted/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/clientview/adapted/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
         <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/clientview/core/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/clientview/core/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
         <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/clientview/exceptions/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/clientview/exceptions/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
         <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/hello/mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/hello/mdb/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -79,7 +79,7 @@
     <target name="run_standaloneclient" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/jakarta.jms-api.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/jakarta.jms-api.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
        </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/hello/session/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/hello/session/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
   <target name="run_standaloneclient" depends="init-common">
     <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
       <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
       <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
@@ -83,7 +83,7 @@
   <target name="run_standaloneclient2" depends="init-common">
     <java fork="on"
           failonerror="true"
-          classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+          classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
           classname="${simple.client2}"
     >
       <jvmarg value="-Djava.naming.factory.initial=org.glassfish.jndi.cosnaming.CNCtxFactory" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb30/persistence/tx_propagation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb30/persistence/tx_propagation/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -122,7 +122,7 @@
     <target name="runclient-standalone" depends="clean-db">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
               <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
               <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/asynchronous/localandremote/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/asynchronous/localandremote/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/asynchronous/remote/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/asynchronous/remote/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/asynchronous/threadpoolconfig/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/asynchronous/threadpoolconfig/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,7 +66,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/generics/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/generics/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/javamodule/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/javamodule/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/jaxrs/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/jaxrs/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/managedbean/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/managedbean/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/sinitcallejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/ejblite/sinitcallejb/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/disable_nonportable_jndi/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/disable_nonportable_jndi/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,7 +66,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/ear/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/ear/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@
             <param name="src" value="ejb"/>
         </antcall>
 
-        <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+        <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
 
         </javac>
 <!--
@@ -72,7 +72,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/jcdifull/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/jcdifull/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,7 +37,7 @@
 
     <target name="compile" depends="clean">
       <mkdir dir="${build.classes.dir}"/>
-      <javac classpath="${env.S1AS_HOME}/modules/weld-osgi-bundle.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="ejb" destdir="${build.classes.dir}" debug="on" failonerror="true" includeantruntime="false" >
+      <javac classpath="${env.S1AS_HOME}/modules/weld-osgi-bundle.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="ejb" destdir="${build.classes.dir}" debug="on" failonerror="true" includeantruntime="false" >
         </javac>
     </target>
 
@@ -71,7 +71,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/passact/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/passact/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,7 +66,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/remote1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/remote1/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -66,7 +66,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/remote2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/remote2/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/schema/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/schema/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/sfsbscnc/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/sfsbscnc/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/webandejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/full/webandejb/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/security/simple/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/security/simple/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,7 +40,7 @@
         <antcall target="compile-common">
             <param name="src" value="ejb"/>
         </antcall>
-        <javac classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
+        <javac classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar" srcdir="client" destdir="${build.classes.dir}" debug="on" failonerror="true">
 
         </javac>
     </target>
@@ -116,7 +116,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/cache/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/cache/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/hello/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/hello/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/multi-module/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/multi-module/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -121,7 +121,7 @@
        <echo message="se.client: ${se.client}"/>
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/${appname}-ejb.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/${appname}-ejb.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/threemodules/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/singleton/threemodules/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -121,7 +121,7 @@
        <echo message="se.client: ${se.client}"/>
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/${appname}-ejb.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/${appname}-ejb.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/timer31/mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/timer31/mdb/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/timer31/methodintf/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/timer31/methodintf/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/ejblite/async/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/ejblite/async/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/ejblite/nonpersistenttimer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/ejblite/nonpersistenttimer/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="${contextroot}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/aroundconstruct/annotation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/aroundconstruct/annotation/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/aroundconstruct/descriptor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/aroundconstruct/descriptor/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,7 +60,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/constructor-level/annotation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/constructor-level/annotation/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/constructor-level/descriptor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/constructor-level/descriptor/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,7 +60,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/get_method_lc/annotation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/get_method_lc/annotation/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/get_method_lc/descriptor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/get_method_lc/descriptor/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,7 +60,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/interceptors-inheritance/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/interceptors-inheritance/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/lc-method-constructor-level/annotation/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/lc-method-constructor-level/annotation/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/lc-method-constructor-level/descriptor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/interceptors/lc-method-constructor-level/descriptor/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,7 +60,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/intfces/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/intfces/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -102,7 +102,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="${se.client}">
               <arg line="${client.type}"/>
               <arg line="${ejb.jar}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/mdb/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,7 +85,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/methodintf/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/methodintf/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -59,7 +59,7 @@
     <target name="run" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/sfsb/basic/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/sfsb/basic/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/sfsb/descriptor/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/sfsb/descriptor/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/sfsb/lifecycle_cb_txattr/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/sfsb/lifecycle_cb_txattr/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb32/timer/opallowed/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb32/timer/opallowed/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
   <target name="run-client">
     <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${test.client}">
       <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}" />
       <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/ejb/sfsb/stress/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/sfsb/stress/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -91,7 +91,7 @@
 
     <target name="runloadgenerator">
        <java  fork="true" failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${assemble.dir}/ejb-sfsb-stressAppClient.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${assemble.dir}/ejb-sfsb-stressAppClient.jar:${env.APS_HOME}/lib/reporter.jar"
            classname="${loadgenerator.client}">
            <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
            <arg value="ejb/ejb_sfsb_stress_StressSFSBHome"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/stubs/standaloneclient/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/stubs/standaloneclient/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,7 +48,7 @@
     <target name="runclient_nooverride" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/ejb-stubs-ejbappAppClient/ejb-stubs-ejbapp-clientClient.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/ejb-stubs-ejbappAppClient/ejb-stubs-ejbapp-clientClient.jar:${env.APS_HOME}/lib/reporter.jar"
            classname="${simple.client}">
            <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
            <jvmarg value="-Dorg.glassfish.gmbal.no.multipleUpperBoundsException=true" />
@@ -65,7 +65,7 @@
     <target name="runclient_setnothing" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/ejb-stubs-ejbappAppClient.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/ejb-stubs-ejbappAppClient.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
            <arg value="ejb/ejb_stubs_ejbapp_HelloBean"/>
         </java>
@@ -96,7 +96,7 @@
     <target name="runclient_withoverride" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/ejb-stubs-ejbappAppClient.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${assemble.dir}/ejb-stubs-ejbappAppClient.jar:${env.APS_HOME}/lib/reporter.jar"
            classname="${simple.client}">
             <jvmarg value="-Dorg.omg.CORBA.ORBInitialPort=${orb.port}"/>
              <jvmarg

--- a/appserver/tests/appserv-tests/devtests/ejb/stubs/stubser/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/stubs/stubser/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,7 +82,7 @@
     <target name="run_se_nohandle" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
         </java>
@@ -91,7 +91,7 @@
     <target name="run_se_handle" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
          <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
          <arg line="handle"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/util/methodmap/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/util/methodmap/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,7 +48,7 @@
   <target name="runclient" depends="init-common">
     <java  fork="on"
           failonerror="true"
-          classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+          classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
           classname="${simple.client}">
     </java>
   </target>
@@ -57,7 +57,7 @@
   <target name="perf" depends="init-common">
     <java  fork="on"
           failonerror="true"
-          classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+          classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
           classname="${perf.client}">
       <arg value="javax.xml.rpc.Service"/>
       <arg value="100000"/>

--- a/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jdbc/jpa-dsd/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -133,7 +133,7 @@
     <target name="runclient-standalone" depends="clean-db">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${simple.client}">
               <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
               <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB1/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.jmsxdeliverycount.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB2/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.jmsxdeliverycount.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB3/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB3/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.jmsxdeliverycount.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB4/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/MDB4/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.jmsxdeliverycount.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/sessionBean1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/sessionBean1/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.jmsxdeliverycount.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/sessionBean2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/JMSXDeliveryCount/sessionBean2/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.jmsxdeliverycount.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/durableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/durableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/ClusterScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/durableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/durableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/InstanceScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/durableNoClientIdWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/durableNoClientIdWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableNotSharedWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableNotSharedWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableNotSharedWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableNotSharedWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/cluster/noScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -92,7 +92,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${deploy.clusterinstance1.orbport}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/durableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/durableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/ClusterScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/durableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/durableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/InstanceScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/durableNoClientIdWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/durableNoClientIdWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/embedded/noScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/durableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/durableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/ClusterScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/durableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/durableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/InstanceScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/durableNoClientIdWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/durableNoClientIdWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/durableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/durableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/nondurableWithName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/nondurableWithName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/nondurableWithoutName/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/activationProperties/subscriptionScope/standalone/local/noScope/nondurableWithoutName/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.activationproperties.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB1/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,7 +58,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.annotation.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB2/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,7 +58,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.annotation.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/MDB3/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/MDB3/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,7 +58,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.annotation.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/annotation/sessionBean/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,7 +40,7 @@
         <echo message="common.xml: Compiling test source files" level="verbose"/>
         <javac srcdir="ejb"
             destdir="${build.classes.dir}"
-            classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar"
+            classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar"
             debug="on"
             includeantruntime="false"
             failonerror="true">
@@ -64,7 +64,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.annotation.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/defaultCF/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/defaultCF/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,7 +40,7 @@
         <echo message="common.xml: Compiling test source files" level="verbose"/>
         <javac srcdir="ejb"
             destdir="${build.classes.dir}"
-            classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar"
+            classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar"
             debug="on"
             includeantruntime="false"
             failonerror="true">
@@ -79,7 +79,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.defaultcf.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/ejbInterceptorRequestScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/ejbInterceptorRequestScoped/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/ejbInterceptorTransactionScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/ejbInterceptorTransactionScoped/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jsfRequestScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jsfRequestScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WebTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jsfTransactionScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jsfTransactionScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WebTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jspRequestScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jspRequestScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WebTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jspTransactionScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/jspTransactionScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WebTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/servletRequestScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/servletRequestScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WebTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/servletTransactionScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/servletTransactionScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -131,7 +131,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WebTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/sessionBeanRequestScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/sessionBeanRequestScoped/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/sessionBeanTransactionScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/sessionBeanTransactionScoped/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/wsRequestScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/wsRequestScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -153,7 +153,7 @@
     <target name="generateWSConfig" depends="compile-ejb">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="org.glassfish.test.jms.injection.ejb.GenerateWSConfig">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="config.xml"/>
@@ -165,7 +165,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WsTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/wsTransactionScoped/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/basic/wsTransactionScoped/build.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -153,7 +153,7 @@
     <target name="generateWSConfig" depends="compile-ejb">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="org.glassfish.test.jms.injection.ejb.GenerateWSConfig">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="config.xml"/>
@@ -165,7 +165,7 @@
     <target name="run" depends="init-common">
          <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar:${env.APS_HOME}/lib/reportbuilder.jar"
               classname="WsTest">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
             <arg value="${http.host}"/>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextDefaultInjection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextDefaultInjection/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionA/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionA/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionB/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionB/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionC/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionC/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionD/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionD/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionE/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionE/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionF/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionF/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionG/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionG/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionH/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionH/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionJ/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionJ/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionK/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/injection/jmsContext/mixedScoped/jmsContextInjectionK/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.injection.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/jms/mdbDest/build.xml
+++ b/appserver/tests/appserv-tests/devtests/jms/mdbDest/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +73,7 @@
     <target name="run" depends="init-common">
         <java fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${assemble.dir}/${appname}-client.jar:${env.APS_HOME}/lib/reporter.jar"
               classname="org.glassfish.test.jms.mdbdest.client.Client">
             <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/naming/injection/build.xml
+++ b/appserver/tests/appserv-tests/devtests/naming/injection/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -75,7 +75,7 @@
     <target name="run_se" depends="init-common">
        <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />

--- a/appserver/tests/appserv-tests/devtests/security/container-auth/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/container-auth/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,7 +61,7 @@
         <java classname="AuthConfigTest" fork="yes">
         <classpath>
                 <pathelement path="${env.S1AS_HOME}/lib/appserv-rt.jar:${build.classes.dir}"/>
-                <pathelement path="${env.S1AS_HOME}/lib/javaee.jar"/>
+                <pathelement path="${env.S1AS_HOME}/lib/jakartaee.jar"/>
                 <pathelement path="${env.S1AS_HOME}/lib/dtds"/>
                 <pathelement path="${env.S1AS_HOME}/lib/schemas"/>
                 <pathelement path="${env.APS_HOME}/lib/reporter.jar"/>

--- a/appserver/tests/appserv-tests/devtests/security/jmac/soap/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jmac/soap/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -137,7 +137,7 @@
             <replacefilter token="@PORT@" value="${http.port}"/>
         </replace>
         <javac srcdir="client" destdir="${build.classes.dir}/client"
-          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
+          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
           debug="on" failonerror="true"/>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/security/jmac/soapDefault/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jmac/soapDefault/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -152,7 +152,7 @@
             <replacefilter token="@PORT@" value="${http.port}"/>
         </replace>
         <javac srcdir="client" destdir="${build.classes.dir}/client"
-          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-api-osgi.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
+          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-api-osgi.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
           debug="on" failonerror="true"/>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/security/jmac/soapEmbedded/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jmac/soapEmbedded/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -124,7 +124,7 @@
     </replace>
     <javac srcdir="webclient"
            destdir="${build.classes.dir}/webclient"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/webclient"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/webclient"
            debug="on"
            failonerror="true"
     />

--- a/appserver/tests/appserv-tests/devtests/security/wss/gartner/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/wss/gartner/build.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE project [
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -89,7 +89,7 @@
         </antcall>
 
         <javac srcdir="client" destdir="${build.classes.dir}/client"
-          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/ejbws:${build.classes.dir}/servletws/WEB-INF/classes:${build.classes.dir}/client"
+          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/ejbws:${build.classes.dir}/servletws/WEB-INF/classes:${build.classes.dir}/client"
           debug="on" failonerror="true"/>
     </target>
 

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/autorecovery/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/autorecovery/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -127,7 +127,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
            <arg line="verify_xa"/>
@@ -153,7 +153,7 @@
         <echo message="Executing test on in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/cli/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/cli/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -113,7 +113,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <sysproperty key="enableShoalLogger" value="${enableShoalLogger}"/>
            <arg line="prepare"/>
@@ -205,7 +205,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_default"/>
            <arg line="${appname}-web"/>
@@ -228,7 +228,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_default"/>
            <arg line="${appname}-web"/>
@@ -254,7 +254,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -290,7 +290,7 @@
         <echo message="Verifying xa results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -319,7 +319,7 @@
         <echo message="Executing test on instance ${instance}"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="${operation}"/>
            <arg line="${appname}-web"/>
@@ -332,7 +332,7 @@
         <echo message="Rolling back one transaction"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="rollback"/>
         </java>
@@ -343,7 +343,7 @@
         <echo message="Recover XA transaction"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="recover"/>
            <arg line="${log-dir}"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/dblogs/base/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/dblogs/base/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -102,7 +102,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -221,7 +221,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -276,7 +276,7 @@
         <echo message="Executing test on instance in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>
@@ -289,7 +289,7 @@
         <echo message="Recover XA transaction"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="recover"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/dblogs/mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/dblogs/mdb/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -185,7 +185,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${delegated}"/>
@@ -197,7 +197,7 @@
         <echo message="deploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="deploy"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -251,7 +251,7 @@
         <echo message="undeploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="undeploy"/>
            <arg line="${appname}-web"/>
@@ -326,7 +326,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -339,7 +339,7 @@
         <echo message="Executing test on in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>
@@ -359,7 +359,7 @@
         <echo message="Executing test on in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/ee.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/ee.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -114,7 +114,7 @@
     <echo message="Stopping cluster"/>
     <java  fork="on"
           failonerror="true"
-          classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+          classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
           classname="${se.client}">
        <arg line="clean"/>
        <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/mdb/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -120,7 +120,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <sysproperty key="enableShoalLogger" value="${enableShoalLogger}"/>
@@ -131,7 +131,7 @@
         <echo message="deploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="deploy"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -177,7 +177,7 @@
         <echo message="undeploying application"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="undeploy"/>
            <arg line="${appname}-web"/>
@@ -203,7 +203,7 @@
         <sleep seconds="25"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -218,7 +218,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -238,7 +238,7 @@
         <echo message="Executing test on in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/resendautorecovery/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/resendautorecovery/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -69,7 +69,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -162,7 +162,7 @@
 
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -193,7 +193,7 @@
         <echo message="Executing test in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/selfrecovery/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/selfrecovery/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -133,7 +133,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -154,7 +154,7 @@
         <echo message="Executing test on in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="insert_xa_data"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/transaction/ee/timer_with_autorecovery/build.xml
+++ b/appserver/tests/appserv-tests/devtests/transaction/ee/timer_with_autorecovery/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@
         <echo message="Starting cluster"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}:${env.APS_HOME}/lib/reporter.jar"
               classname="${se.client}">
            <arg line="prepare"/>
            <arg line="${assemble.dir}/${appname}-web.war"/>
@@ -143,7 +143,7 @@
         <echo message="Verifying results"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="verify_xa"/>
            <arg line="${appname}-web"/>
@@ -168,7 +168,7 @@
         <echo message="Executing test on in1"/>
         <java  fork="on"
               failonerror="true"
-              classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
+              classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/gf-client.jar:${env.APS_HOME}/lib/reportbuilder.jar:${build.classes.dir}"
               classname="${se.client}">
            <arg line="${operation}"/>
            <arg line="${appname}-web"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/annotations-common.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/annotations-common.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,7 +50,7 @@
 
 <target name="compile-client">
     <javac srcdir="." destdir="${env.APS_HOME}/build/module/classes"
-        classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
+        classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
         includes="${client-src-name}"/>
 </target>
 

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/async/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/async/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,7 +64,7 @@
                value="-keep -b custom-client.xml -d ${build.classes.dir}/client http://${http.host}:${http.port}/${appname}/webservice/AsyncService?WSDL"/>
       </antcall>
       <javac srcdir="." destdir="${build.classes.dir}/client"
-          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+          classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
           includes="client/**"
       />
     </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/multiport/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/multiport/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -70,7 +70,7 @@
                value="-keep -wsdllocation ${env.APS_HOME}/devtests/webservice/annotations/multiport/HttpTestService.wsdl -b customclient.xml -d ${build.classes.dir}/client HttpTestService.wsdl"/>
         </antcall>
         <javac srcdir="." destdir="${build.classes.dir}/client"
-            classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+            classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
             includes="client/**"
          />
     </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/prepkged-svc-1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/prepkged-svc-1/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -101,7 +101,7 @@
           value="-b custom-client.xml -keep -d ${build.classes.dir}/appclient ${env.APS_HOME}/devtests/webservice/annotations/prepkged-svc-1/AddNumbers.wsdl"/>
       </antcall>
       <javac srcdir="." destdir="${build.classes.dir}/appclient"
-            classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+            classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
             includes="appclient/**"/>
       <mkdir dir="${build.classes.dir}/appclient/META-INF/wsdl"/>
       <copy file="AddNumbers.wsdl" todir="${build.classes.dir}/appclient/META-INF/wsdl"/>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/restful-2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/restful-2/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,7 +61,7 @@
     <replace file="client/Client.java" value="${http.port}" token="HTTP_PORT" />
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/restful/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/restful/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,7 +60,7 @@
     <replace file="client/Client.java" value="${http.port}" token="HTTP_PORT" />
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/soap12/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/soap12/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -80,7 +80,7 @@
     <replace file="appclient/Client.java" value="${http.port}" token="HTTP_PORT" />
     <javac srcdir="."
            destdir="${build.classes.dir}/appclient"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="appclient/**"
     />
     <mkdir dir="${build.classes.dir}/appclient/META-INF/wsdl" />

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/soaptcp/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/soaptcp/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@
 
     <path id="client-classpath">
         <pathelement path="${env.APS_HOME}/lib/reporter.jar"/>
-        <pathelement path="${env.S1AS_HOME}/lib/javaee.jar"/>
+        <pathelement path="${env.S1AS_HOME}/lib/jakartaee.jar"/>
         <pathelement path="${env.S1AS_HOME}/lib/webservices-osgi.jar"/>
         <pathelement path="${env.S1AS_HOME}/lib/appserv-rt.jar"/>
     </path>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/webservicerefs/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/webservicerefs/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -86,7 +86,7 @@
 
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/annotations/wsdltojava/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/annotations/wsdltojava/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -75,7 +75,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/async/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/async/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,7 +64,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${build.classes.dir}/client"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/bigint/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/bigint/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/libdependent-2/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/libdependent-2/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/libdependent/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/libdependent/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@
     <javac verbose="true"
            srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${env.S1AS_HOME}/modules/jaxb-osgi.jar:${env.S1AS_HOME}/modules/jaxb-api-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${env.S1AS_HOME}/modules/jaxb-osgi.jar:${env.S1AS_HOME}/modules/jaxb-api-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/multiport/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/multiport/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -82,7 +82,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/restful-ejb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/restful-ejb/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,7 +61,7 @@
     <mkdir dir="${build.classes.dir}/client" />
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/singleton/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/singleton/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -76,7 +76,7 @@
     <javac verbose="true"
            srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${env.S1AS_HOME}/modules/jaxb-osgi.jar:${env.S1AS_HOME}/modules/jaxb-api-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${env.S1AS_HOME}/modules/jaxb-osgi.jar:${env.S1AS_HOME}/modules/jaxb-api-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/wsnameejbname/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/ejb_annotations/wsnameejbname/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -62,7 +62,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/bare_doc_literal/se_consumer_se_provider/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/bare_doc_literal/se_consumer_se_provider/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,7 +72,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar"
            includes="common/**, webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/client/web/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/client/web/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +67,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/ejb-jmsbc/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/ejb-jmsbc/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -110,7 +110,7 @@
     </antcall>
     <javac srcdir="consumer"
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            debug="on"
            includes="webclient/**"
     />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/inout-sample/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/inout-sample/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +67,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/oneway/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/oneway/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +67,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/rpc_literal/se_consumer_se_provider/bundled_wsdl/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/rpc_literal/se_consumer_se_provider/bundled_wsdl/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -103,7 +103,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar"
            includes="common/**,webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/rpc_literal/se_consumer_se_provider/generated_wsdl/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/rpc_literal/se_consumer_se_provider/generated_wsdl/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,7 +72,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar"
            includes="common/**, webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/security/jse_only/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/security/jse_only/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,7 +85,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            debug="on"
            includes="webclient/**"
     />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/server/ejb/hello/stress.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/server/ejb/hello/stress.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -61,7 +61,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${env.APS_HOME}/build/module/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${env.APS_HOME}/build/module/classes/client"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar:${env.APS_HOME}/build/module/classes/client"
            includes="${client-src-name}"
     >
     </javac>

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/add-numbers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/add-numbers/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,7 +85,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/compApp-client/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/compApp-client/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -81,7 +81,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/endpoint_mapping/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/endpoint_mapping/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -85,7 +85,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/endpoint_mapping_consumer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/endpoint_mapping_consumer/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -81,7 +81,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/enterprise_app/build.properties
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/service_unit/enterprise_app/build.properties
@@ -33,4 +33,4 @@ serviceengine.dir=${domain.dir}/jbi/components/sun-javaee-engine/install_root
 ejb.path=${domain.dir}/applications/j2ee-modules/${ejb.module}
 output.dir=${serviceengine.dir}/workspace
 asadmin.command=${server.dir}/bin/asadmin
-client.classpath=".:build:${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-api-osgi.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+client.classpath=".:build:${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-api-osgi.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/soapfault/se_consumer/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/soapfault/se_consumer/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +67,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/soapfault/se_consumerNprovider/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/soapfault/se_consumerNprovider/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +67,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/soapoverjms/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/soapoverjms/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -108,7 +108,7 @@
     </antcall>
     <javac srcdir="consumer"
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./consumer/client-web.xml"

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +67,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="webclient/**"
     />
     <copy file="./client-web.xml" tofile="${build.classes.dir}/webclient/WEB-INF/web.xml" />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbcommit/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbcommit/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            debug="on"
            includes="webclient/**"
     />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbcommit1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbcommit1/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            debug="on"
            includes="webclient/**"
     />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbrollback/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbrollback/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            debug="on"
            includes="webclient/**"
     />

--- a/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbrollback1/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/jbi-serviceengine/transactions/jse_only_ejbrollback1/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/webclient/WEB-INF/classes"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            debug="on"
            includes="webclient/**"
     />

--- a/appserver/tests/appserv-tests/devtests/webservice/wls_dd/service_endpoint_address/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/wls_dd/service_endpoint_address/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,7 +63,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/appserv-tests/devtests/webservice/wls_dd/wsdl_exposed_false/build.xml
+++ b/appserver/tests/appserv-tests/devtests/webservice/wls_dd/wsdl_exposed_false/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -78,7 +78,7 @@
     </antcall>
     <javac srcdir="."
            destdir="${build.classes.dir}/client"
-           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
+           classpath="${env.APS_HOME}/lib/reporter.jar:${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/modules/webservices-osgi.jar"
            includes="client/**"
     />
   </target>

--- a/appserver/tests/v2-tests/appserv-tests/devtests/admin/pe/build.xml
+++ b/appserver/tests/v2-tests/appserv-tests/devtests/admin/pe/build.xml
@@ -137,7 +137,7 @@
         <pathelement path="${s1astest.classpath}"/>
         <pathelement path="${classes.dir}"/>
         <pathelement path="${env.S1AS_HOME}/lib/appserv-rt.jar"/>
-        <pathelement path="${env.S1AS_HOME}/lib/javaee.jar"/>
+        <pathelement path="${env.S1AS_HOME}/lib/jakartaee.jar"/>
         <pathelement location="${env.APS_HOME}/lib/testng.jar"/>
         <pathelement location="${env.APS_HOME}/lib/reporter.jar"/>
     </path>

--- a/appserver/tests/v2-tests/appserv-tests/devtestsNG/common-build.xml
+++ b/appserver/tests/v2-tests/appserv-tests/devtestsNG/common-build.xml
@@ -415,7 +415,7 @@ Variables used:
     <mkdir dir="${env.APS_HOME}/build/util"/>
     <javac srcdir="${env.APS_HOME}/devtestsNG/common/src"
         destdir="${env.APS_HOME}/build/util"
-        classpath="${env.S1AS_HOME}/lib/javaee.jar:${env.S1AS_HOME}/lib/appserv-ext.jar">
+        classpath="${env.S1AS_HOME}/lib/jakartaee.jar:${env.S1AS_HOME}/lib/appserv-ext.jar">
     </javac>
     <delete file="${env.APS_HOME}/lib/myutil.jar"/>
     <jar destfile="${env.APS_HOME}/lib/myutil.jar"

--- a/appserver/tests/v2-tests/appserv-tests/sqetests/jsfcomponents/build.xml
+++ b/appserver/tests/v2-tests/appserv-tests/sqetests/jsfcomponents/build.xml
@@ -61,7 +61,7 @@
         <fileset dir="${jars.dir}">
              <include name="*.jar"/>
         </fileset>
-        <pathelement location="${env.S1AS_HOME}/lib/javaee.jar" />
+        <pathelement location="${env.S1AS_HOME}/lib/jakartaee.jar" />
         <pathelement location="${env.S1AS_HOME}/lib/appserv-jstl.jar" />
         <pathelement location="${classpath}" />
     </path>

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc
@@ -21,6 +21,6 @@ JSP_IMPL=$AS_INSTALL_LIB/wasp.jar
 EL_IMPL=$AS_INSTALL_LIB/expressly:$AS_INSTALL_LIB/jakarta.el-api.jar
 JSTL_IMPL=$AS_INSTALL_LIB/jakarta.servlet.jsp.jstl.jar
 AS_LIB=$AS_INSTALL/lib
-JAVAEE_API=$AS_lib/jakartaee.jar
+JAKARTAEE_API=$AS_lib/jakartaee.jar
 
-java -cp "$JSP_IMPL:$JAVAEE_API:$AS_LIB" org.apache.jasper.JspC -sysClasspath "$JSP_IMPL:$EL_IMPL:$JSTL_IMPL:$JAVAEE_API:$AS_LIB" -schemas "/schemas/" -dtds "/dtds/" "$@"
+java -cp "$JSP_IMPL:$JAKARTAEE_API:$AS_LIB" org.apache.jasper.JspC -sysClasspath "$JSP_IMPL:$EL_IMPL:$JSTL_IMPL:$JAKARTAEE_API:$AS_LIB" -schemas "/schemas/" -dtds "/dtds/" "$@"

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,6 +21,6 @@ JSP_IMPL=$AS_INSTALL_LIB/wasp.jar
 EL_IMPL=$AS_INSTALL_LIB/expressly:$AS_INSTALL_LIB/jakarta.el-api.jar
 JSTL_IMPL=$AS_INSTALL_LIB/jakarta.servlet.jsp.jstl.jar
 AS_LIB=$AS_INSTALL/lib
-JAVAEE_API=$AS_LIB/javaee.jar
+JAVAEE_API=$AS_lib/jakartaee.jar
 
 java -cp "$JSP_IMPL:$JAVAEE_API:$AS_LIB" org.apache.jasper.JspC -sysClasspath "$JSP_IMPL:$EL_IMPL:$JSTL_IMPL:$JAVAEE_API:$AS_LIB" -schemas "/schemas/" -dtds "/dtds/" "$@"

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
@@ -1,6 +1,6 @@
 @echo off
 REM
-REM  Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,6 @@ set JSP_IMPL=%AS_INSTALL_LIB%\wasp.jar
 set EL_IMPL=%AS_INSTALL_LIB%\expressly;%AS_INSTALL_LIB%\jakarta.el-api.jar
 set JSTL_IMPL=%AS_INSTALL_LIB%\jakarta.servlet.jsp.jstl.jar
 set AS_LIB=%~dp0..\lib
-set JAVAEE_API=%AS_LIB%\javaee.jar
+set JAKARTAEE_API=%AS_LIB%\jakartaee.jar
 
-java -cp "%JSP_IMPL%;%JAVAEE_API%;%AS_LIB%" org.apache.jasper.JspC -sysClasspath "%JSP_IMPL%;%EL_IMPL%;%JSTL_IMPL%;%JAVAEE_API%;%AS_LIB%" -schemas "/schemas/" -dtds "/dtds/" %*
+java -cp "%JSP_IMPL%;%JAKARTAEE_API%;%AS_LIB%" org.apache.jasper.JspC -sysClasspath "%JSP_IMPL%;%EL_IMPL%;%JSTL_IMPL%;%JAKARTAEE_API%;%AS_LIB%" -schemas "/schemas/" -dtds "/dtds/" %*


### PR DESCRIPTION
fixes #23455 

notes:
* I did not run tests on my end this time
* the jar is no longer in `/lib` but in `/modules` folder - don't think it's caused by this change