### PR TITLE
Upgrade jbatch to v2.1.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -120,7 +120,7 @@
 
         <!-- Jakarta Batch -->
         <jakarta.batch-api.version>2.1.0</jakarta.batch-api.version>
-        <jbatch.version>2.1.0-M2</jbatch.version>
+        <jbatch.version>2.1.0</jbatch.version>
 
         <!-- Jakarta Enterprise beans -->
         <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

There shouldn't be any functional change here.   We had just been waiting for Weld & the CDI API dependencies to release final versions, and now that they have, we've released 2.1.0.