### PR TITLE
Fix of default context root with a generated suffix.

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ApplicationITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ApplicationITest.java
@@ -18,6 +18,7 @@
 package org.glassfish.main.admin.test.rest;
 
 import jakarta.ws.rs.core.Response;
+import java.io.File;
 
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -66,6 +67,26 @@ public class ApplicationITest extends RestTestBase {
         }
     }
 
+    @Test
+    public void testApplicationDeploymentWithDefaultContextRoot() throws URISyntaxException {
+        try {
+            final File war = getWar("test");
+            String expectedContextRoot = getFileNameWithoutSuffix(war.getName());
+            Map<String, String> deployedApp = deployApp(war, null, appName);
+            assertEquals(appName, deployedApp.get("name"));
+            assertEquals("/" + expectedContextRoot, deployedApp.get("contextRoot"));
+        } finally {
+            undeployApp(appName);
+        }
+    }
+
+    private static String getFileNameWithoutSuffix(final String filename) {
+        if (filename.contains(".")) {
+            return filename.substring(0, filename.lastIndexOf("."));
+        } else {
+            return filename;
+        }
+    }
 
     @Test
     public void testApplicationDisableEnable() throws URISyntaxException {

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
@@ -175,15 +175,24 @@ public class RestTestBase {
         assertEquals(404, response.getStatus());
     }
 
+    /*
+     * Arguments contextRoot and name can be null, then they are not set in the deploy command
+     */
     public Map<String, String> deployApp(final File archive, final String contextRoot, final String name) {
-        Map<String, Object> app = Map.of(
-            "id", archive,
-            "contextroot", contextRoot,
-            "name", name
-        );
+        Map<String, Object> app = new HashMap<>();
+        app.put("id", archive);
+        putIfNotNull("contextroot", contextRoot, app);
+        putIfNotNull("name", name, app);
+        
         Response response = managementClient.postWithUpload(URL_APPLICATION_DEPLOY, app);
         assertThat(response.getStatus(), equalTo(200));
         return getEntityValues(managementClient.get(URL_APPLICATION_DEPLOY + "/" + app.get("name")));
+    }
+
+    private void putIfNotNull(final String key, Object value, Map<String, Object> app) {
+        if (value != null) {
+            app.put(key, value);
+        }
     }
 
     public void addAppRef(final String applicationName, final String targetName){

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
@@ -183,7 +183,7 @@ public class RestTestBase {
         app.put("id", archive);
         putIfNotNull("contextroot", contextRoot, app);
         putIfNotNull("name", name, app);
-        
+
         Response response = managementClient.postWithUpload(URL_APPLICATION_DEPLOY, app);
         assertThat(response.getStatus(), equalTo(200));
         return getEntityValues(managementClient.get(URL_APPLICATION_DEPLOY + "/" + app.get("name")));

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/Util.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/Util.java
@@ -43,6 +43,8 @@ import javax.security.auth.Subject;
 import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.HttpHeaders;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.glassfish.admin.rest.Constants;
 import org.glassfish.admin.rest.RestLogging;
 import org.glassfish.admin.rest.utils.xml.RestActionReporter;
@@ -468,8 +470,7 @@ public class Util {
     public static File saveTemporaryFile(String fileName, InputStream fileStream) {
         File file;
         try {
-            String[] parts = getNameAndSuffix(fileName);
-            file = File.createTempFile(parts[0], parts[1]);
+            file = Files.createTempDirectory("gf_uploads").resolve(fileName).toFile();
         } catch (IOException e) {
             throw new IllegalStateException("Could not create a temp file for " + fileName, e);
         }
@@ -479,6 +480,7 @@ public class Util {
             while ((bytesRead = fileStream.read(buffer)) != -1) {
                 out.write(buffer, 0, bytesRead);
             }
+            file.deleteOnExit();
             return file;
         } catch (IOException e) {
             throw new IllegalStateException("Could not write to a temp file " + file, e);


### PR DESCRIPTION
This is caused by commit 8262ac43857d14c6186bd27009517a977df2073e which saves the uploaded deployment file to a temporary file, which automatically generates a suffix.

This also fixes Jakarta Security TCK tests that are failing with GlassFish 7.0.0-M5