### PR TITLE
Fix appclient parsing error due to trailing spaces in windows

### DIFF
--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/common/ClassPathUtils.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/common/ClassPathUtils.java
@@ -136,7 +136,7 @@ public class ClassPathUtils {
         final List<Path> result = new ArrayList<>();
         try {
             for (String classPathElement : classPath.split(File.pathSeparator)) {
-                result.add(new File(classPathElement).toPath());
+                result.add(new File(classPathElement.trim()).toPath());
             }
             return result;
         } catch (Exception e) {


### PR DESCRIPTION
* Fix #23953

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>
