### PR TITLE
Reverting Jersey back to M5 as the update broke 4 TCK tests

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -105,7 +105,7 @@
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>3.1.0</jakarta.rest-api.version>
-        <jersey.version>3.1.0-M6</jersey.version>
+        <jersey.version>3.1.0-M5</jersey.version>
 
         <!-- Jakarta Mail -->
         <jakarta.mail-api.version>2.1.0</jakarta.mail-api.version>


### PR DESCRIPTION
- fixes jaxrs/platform/container/completioncallback/JAXRSClient.java#argumentContainsException* tests

See:

- https://github.com/eclipse-ee4j/jersey/pull/5073
- https://github.com/eclipse-ee4j/jersey/issues/5072
- https://github.com/eclipse-ee4j/jakartaee-tck/issues/1052