### PR TITLE
Test bean attributes for session bean

### DIFF
--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -394,6 +394,7 @@
                         
                         <libPath>${project.build.outputDirectory}</libPath>
                         <org.jboss.cdi.tck.libraryDirectory>target/dependency/lib</org.jboss.cdi.tck.libraryDirectory>
+                        <debugMode>true</debugMode>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Install support for delegating some EJB tasks to the right bean archive.

Without this, when the a bean manager for the root bean archive is used,
it will not find the EJB definitions in a sub-archive, and will treat
the bean as a normal CDI bean.

For EJB beans a few special rules have to be taken into account, and
without applying these rules
CreateBeanAttributesTest#testBeanAttributesForSessionBean fails.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>
