### PR TITLE
Try to eager load Servlets at startup.

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Wrapper.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Wrapper.java
@@ -341,6 +341,8 @@ public interface Wrapper extends Container {
      */
     public void load() throws ServletException;
 
+    public void tryLoad() throws ServletException;
+
 
     /**
      * Remove the specified initialization parameter from this servlet.

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardWrapper.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardWrapper.java
@@ -1114,6 +1114,23 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
         initServlet(instance);
     }
 
+    @Override
+    public synchronized void tryLoad() throws ServletException {
+        try {
+            instance = loadServlet();
+            initServlet(instance);
+        } catch (Throwable t) {
+            instance = null;
+            available = 0l;
+            classLoadTime = 0;
+            loadTime = 0l;
+            instanceInitialized = false;
+
+            throw t;
+        }
+    }
+
+
     /**
      * Creates an instance of the servlet, if there is not already at least one initialized instance.
      */


### PR DESCRIPTION
This will trigger all the required CDI events, with as side-effect that
we also created the Servlet in advance.

According to the Servlet spec, this is allowed, and the Servlet TCK
indeed passes with this change.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>
