### PR TITLE
Eagerly create MDBs on startup

### DIFF
--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/MdbContainer.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/MdbContainer.java
@@ -42,7 +42,7 @@ public interface MdbContainer extends ConfigBeanProxy, PropertyBag, ConfigExtens
      *
      * @return possible object is {@link String }
      */
-    @Attribute(defaultValue = "0")
+    @Attribute(defaultValue = "1")
     @Min(value = 0)
     String getSteadyPoolSize();
 

--- a/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/MdbContainer.java
+++ b/appserver/ejb/ejb-connector/src/main/java/org/glassfish/ejb/config/MdbContainer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,123 +17,106 @@
 
 package org.glassfish.ejb.config;
 
-import org.jvnet.hk2.config.Attribute;
-import org.jvnet.hk2.config.Element;
-import org.jvnet.hk2.config.Configured;
-import org.jvnet.hk2.config.ConfigBeanProxy;
-import org.jvnet.hk2.config.types.Property;
-import org.jvnet.hk2.config.types.PropertyBag;
-
 import java.beans.PropertyVetoException;
 import java.util.List;
 
-import org.glassfish.config.support.datatypes.NonNegativeInteger;
 import org.glassfish.api.admin.config.ConfigExtension;
 import org.glassfish.api.admin.config.PropertiesDesc;
 import org.glassfish.api.admin.config.PropertyDesc;
+import org.glassfish.config.support.datatypes.NonNegativeInteger;
+import org.jvnet.hk2.config.Attribute;
+import org.jvnet.hk2.config.ConfigBeanProxy;
+import org.jvnet.hk2.config.Configured;
+import org.jvnet.hk2.config.Element;
+import org.jvnet.hk2.config.types.Property;
+import org.jvnet.hk2.config.types.PropertyBag;
 
 import jakarta.validation.constraints.Min;
-
-/* @XmlType(name = "", propOrder = {
-    "property"
-}) */
 
 @Configured
 public interface MdbContainer extends ConfigBeanProxy, PropertyBag, ConfigExtension {
 
-
     /**
-     * Gets the value of the steadyPoolSize property.
-     * Minimum and initial number of message driven beans in pool.
-     * An integer in the range [0, max-pool-size].
+     * Gets the value of the steadyPoolSize property. Minimum and initial number of message driven beans in pool. An integer
+     * in the range [0, max-pool-size].
      *
-     * @return possible object is
-     *         {@link String }
+     * @return possible object is {@link String }
      */
-    @Attribute (defaultValue="0")
-    @Min(value=0)
+    @Attribute(defaultValue = "0")
+    @Min(value = 0)
     String getSteadyPoolSize();
 
     /**
      * Sets the value of the steadyPoolSize property.
      *
-     * @param value allowed object is
-     *              {@link String }
+     * @param value allowed object is {@link String }
      */
     void setSteadyPoolSize(String value) throws PropertyVetoException;
 
     /**
      * Gets the value of the poolResizeQuantity property.
      *
-     * Quantum of increase/decrease, when the size of pool grows/shrinks.
-     * An integer in the range [0, max-pool-size].
+     * Quantum of increase/decrease, when the size of pool grows/shrinks. An integer in the range [0, max-pool-size].
      *
-     * @return possible object is
-     *         {@link String }
+     * @return possible object is {@link String }
      */
-    @Attribute (defaultValue="8")
-    @Min(value=0)
+    @Attribute(defaultValue = "8")
+    @Min(value = 0)
     String getPoolResizeQuantity();
 
     /**
      * Sets the value of the poolResizeQuantity property.
      *
-     * @param value allowed object is
-     *              {@link String }
+     * @param value allowed object is {@link String }
      */
     void setPoolResizeQuantity(String value) throws PropertyVetoException;
 
     /**
-     * Gets the value of the maxPoolSize property.
-     * maximum size, pool can grow to. A non-negative integer.
+     * Gets the value of the maxPoolSize property. maximum size, pool can grow to. A non-negative integer.
      *
-     * @return possible object is
-     *         {@link String }
+     * @return possible object is {@link String }
      */
-    @Attribute (defaultValue="32")
-    @Min(value=0)
+    @Attribute(defaultValue = "32")
+    @Min(value = 0)
     String getMaxPoolSize();
 
     /**
      * Sets the value of the maxPoolSize property.
      *
-     * @param value allowed object is
-     *              {@link String }
+     * @param value allowed object is {@link String }
      */
     void setMaxPoolSize(String value) throws PropertyVetoException;
 
     /**
      * Gets the value of the idleTimeoutInSeconds property.
      *
-     * Idle bean instance in pool becomes a candidate for deletion, when this
-     * timeout expires
+     * Idle bean instance in pool becomes a candidate for deletion, when this timeout expires
      *
-     * @return possible object is
-     *         {@link String }
+     * @return possible object is {@link String }
      */
-    @Attribute (defaultValue="600")
-    @Min(value=0)
+    @Attribute(defaultValue = "600")
+    @Min(value = 0)
     String getIdleTimeoutInSeconds();
 
     /**
      * Sets the value of the idleTimeoutInSeconds property.
      *
-     * @param value allowed object is
-     *              {@link String }
+     * @param value allowed object is {@link String }
      */
     void setIdleTimeoutInSeconds(String value) throws PropertyVetoException;
 
-
     /**
-       Properties.
+     * Properties.
      */
-@PropertiesDesc(
-    props={
-        @PropertyDesc(name="cmt-max-runtime-exceptions", defaultValue="1", dataType=NonNegativeInteger.class,
-            description="Deprecated. Specifies the maximum number of RuntimeException occurrences allowed from a message-driven bean's " +
-                "method when container-managed transactions are used")
-    }
-    )
+    @Override
+    @PropertiesDesc(props = {
+        @PropertyDesc(
+            name = "cmt-max-runtime-exceptions",
+            defaultValue = "1",
+            dataType = NonNegativeInteger.class,
+            description =
+                "Deprecated. Specifies the maximum number of RuntimeException occurrences allowed from a message-driven bean's " +
+                "method when container-managed transactions are used") })
     @Element
     List<Property> getProperty();
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/util/pool/ObjectFactory.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/util/pool/ObjectFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,8 +23,6 @@
 
 package com.sun.ejb.containers.util.pool;
 
-import java.util.Properties;
-
 /**
  * An object factory that 'knows' how to create / destroy objects
  */
@@ -32,12 +31,11 @@ public interface ObjectFactory {
     /**
      * Create an object. Called from Pool.getObject(param)
      */
-    public Object create(Object param)
-        throws PoolException;
+    Object create(Object param) throws PoolException;
 
     /**
      * Destroy an object. Called from Pool.destroyObject.
      */
-    public void destroy(Object object);
+    void destroy(Object object);
 
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/util/pool/Pool.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/util/pool/Pool.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -23,56 +24,38 @@
 package com.sun.ejb.containers.util.pool;
 
 /**
- * Pool defines the methods that can be used by the application to access
- * pooled objects. The basic assumption is that all objects in the pool are
- * identical (homogeneous). This interface defines methods for a) getting an
- * object from the pool, b) returning an object back to the pool
- * and, c) destroying (instead of reusing) an object. In addition to these
- * methods, the Pool has methods for adding and removing PoolEventListeners.
- * There are six overloaded methods for getting objects from a pool.
+ * Pool defines the methods that can be used by the application to access pooled objects. The basic assumption is that
+ * all objects in the pool are identical (homogeneous). This interface defines methods for a) getting an object from the
+ * pool, b) returning an object back to the pool and, c) destroying (instead of reusing) an object. In addition to these
+ * methods, the Pool has methods for adding and removing PoolEventListeners. There are six overloaded methods for
+ * getting objects from a pool.
  *
  */
 public interface Pool {
 
     /**
-       @deprecated
-    */
-    public Object getObject(boolean canWait, Object param)
-        throws PoolException;
-
-    /**
-       @deprecated
-    */
-    public Object getObject(long maxWaitTime, Object param)
-        throws PoolException;
-
-    /**
      * Get an object from the pool within the specified time.
+     *
      * @param The amount of time the calling thread agrees to wait.
      * @param Some value that might be used while creating the object
-     * @return an Object or null if an object could not be returned in
-     *   'waitForMillis' millisecond.
+     * @return an Object or null if an object could not be returned in 'waitForMillis' millisecond.
      * @exception Throws PoolException if an object cannot be created
      */
-    public Object getObject(Object param)
-        throws PoolException;
+    Object getObject(Object param) throws PoolException;
 
     /**
-     * Return an object back to the pool. An object that is obtained through
-     *    getObject() must always be returned back to the pool using either
-     *    returnObject(obj) or through destroyObject(obj).
+     * Return an object back to the pool. An object that is obtained through getObject() must always be returned back to the
+     * pool using either returnObject(obj) or through destroyObject(obj).
      */
-    public void returnObject(Object obj);
+    void returnObject(Object obj);
 
     /**
-     * Destroys an Object. Note that applications should not ignore the
-     * reference to the object that they got from getObject(). An object
-     * that is obtained through getObject() must always be returned back to
-     * the pool using either returnObject(obj) or through destroyObject(obj).
-     * This method tells that the object should be destroyed and cannot be
+     * Destroys an Object. Note that applications should not ignore the reference to the object that they got from
+     * getObject(). An object that is obtained through getObject() must always be returned back to the pool using either
+     * returnObject(obj) or through destroyObject(obj). This method tells that the object should be destroyed and cannot be
      * reused.
      *
      */
-    public void destroyObject(Object obj);
+    void destroyObject(Object obj);
 
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/util/pool/PoolException.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/util/pool/PoolException.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,10 +26,10 @@ package com.sun.ejb.containers.util.pool;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-public class PoolException
-    extends RuntimeException
-{
-    Throwable throwable = null;
+public class PoolException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    Throwable throwable;
 
     public PoolException() {
         super();
@@ -47,14 +48,17 @@ public class PoolException
         return this.throwable;
     }
 
+    @Override
     public void printStackTrace() {
         printStackTrace(new PrintWriter(System.err));
     }
 
+    @Override
     public void printStackTrace(PrintStream ps) {
         printStackTrace(new PrintWriter(ps));
     }
 
+    @Override
     public void printStackTrace(PrintWriter pw) {
         if (throwable != null) {
             pw.println("PoolException: " + getMessage());

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -901,7 +901,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
             if (addedAsyncTask) {
                 synchronized (task) {
                     if (!task.isDone()) {
-                        _logger.log(FINE, "[MDBContainer] " + "Going to wait for a maximum of " + timeout + " mili-seconds.");
+                        _logger.log(FINE, "[MDBContainer] Going to wait for a maximum of {0} mili-seconds.", timeout);
                         long maxWaitTime = System.currentTimeMillis() + timeout;
                         // wait in loop to guard against spurious wake-up
                         do {

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -880,7 +880,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
                                           .getService(ConnectorRuntime.class)
                                           .getShutdownTimeout();
         } catch (Throwable th) {
-            _logger.log(WARNING, "[MDBContainer] Got exception while trying " + " to get shutdown timeout", th);
+            _logger.log(WARNING, "[MDBContainer] Got exception while trying to get shutdown timeout", th);
         }
 
         try {

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -1091,7 +1091,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
 
         if (invocation == null && _logger.isLoggable(FINEST)) {
             if (containerState != CONTAINER_STARTED) {
-                _logger.log(FINEST, "No invocation in onMessage " + " (container closing)");
+                _logger.log(FINEST, "No invocation in onMessage (container closing)");
             } else {
                 _logger.log(FINEST, "No invocation in onMessage : ");
             }

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -914,7 +914,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
 
                     if (!task.isDone()) {
                         _logger.log(WARNING,
-                                "[MDBContainer] ASync task has not finished. " + "Giving up after " + timeout + " mili-seconds.");
+                                "[MDBContainer] ASync task has not finished. Giving up after {0} mili-seconds.", timeout);
                     } else {
                         _logger.log(FINE, "[MDBContainer] ASync task has completed");
                     }

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -126,7 +126,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     private static final String DEFAULT_MESSAGE_BEAN_CLIENT_FACTORY = ConnectorConstants.CONNECTOR_MESSAGE_BEAN_CLIENT_FACTORY;
 
     private static final int DEFAULT_RESIZE_QUANTITY = 8;
-    private static final int DEFAULT_STEADY_SIZE = 0;
+    private static final int DEFAULT_STEADY_SIZE = 1;
     private static final int DEFAULT_MAX_POOL_SIZE = 32;
     private static final int DEFAULT_IDLE_TIMEOUT = 600;
 
@@ -250,6 +250,11 @@ public final class MessageBeanContainer extends BaseContainer implements Message
     @Override
     public void startApplication(boolean deploy) {
         super.startApplication(deploy);
+
+        if (messageBeanPool instanceof NonBlockingPool) {
+            NonBlockingPool nonBlockingPool = (NonBlockingPool) messageBeanPool;
+            nonBlockingPool.prepopulate(beanPoolDescriptor.getSteadyPoolSize());
+        }
 
         // Start delivery of messages to message bean instances.
         try {

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +17,17 @@
 
 package org.glassfish.ejb.mdb;
 
+import static com.sun.ejb.containers.EJBContextImpl.BeanState.DESTROYED;
+import static com.sun.ejb.containers.EJBContextImpl.BeanState.POOLED;
+import static com.sun.enterprise.deployment.LifecycleCallbackDescriptor.CallbackType.POST_CONSTRUCT;
+import static com.sun.enterprise.util.Utility.setContextClassLoader;
+import static jakarta.transaction.Status.STATUS_MARKED_ROLLBACK;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+import static javax.transaction.xa.XAResource.TMSUCCESS;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -23,18 +35,6 @@ import java.lang.reflect.Proxy;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import jakarta.ejb.CreateException;
-import jakarta.ejb.EJBException;
-import jakarta.ejb.EJBHome;
-import jakarta.ejb.MessageDrivenBean;
-import jakarta.ejb.RemoveException;
-import jakarta.resource.spi.endpoint.MessageEndpoint;
-import jakarta.transaction.Status;
-import javax.transaction.xa.XAResource;
-
-import com.sun.ejb.spi.container.OptionalLocalInterfaceProvider;
-import com.sun.enterprise.config.serverbeans.Config;
-import com.sun.enterprise.deployment.EjbBundleDescriptor;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
@@ -44,6 +44,7 @@ import org.glassfish.ejb.api.ResourcesExceededException;
 import org.glassfish.ejb.config.MdbContainer;
 import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
 import org.glassfish.ejb.deployment.descriptor.EjbMessageBeanDescriptor;
+import org.glassfish.ejb.mdb.monitoring.stats.MessageDrivenBeanStatsProvider;
 import org.glassfish.ejb.spi.MessageBeanClient;
 import org.glassfish.ejb.spi.MessageBeanClientFactory;
 
@@ -54,20 +55,22 @@ import com.sun.appserv.connectors.internal.api.TransactedPoolManager;
 import com.sun.ejb.ComponentContext;
 import com.sun.ejb.EjbInvocation;
 import com.sun.ejb.containers.BaseContainer;
-import com.sun.ejb.containers.EjbContainerUtilImpl;
 import com.sun.ejb.containers.EJBContextImpl;
 import com.sun.ejb.containers.EJBContextImpl.BeanState;
 import com.sun.ejb.containers.EJBLocalRemoteObject;
 import com.sun.ejb.containers.EJBObjectImpl;
 import com.sun.ejb.containers.EJBTimerService;
+import com.sun.ejb.containers.EjbContainerUtilImpl;
 import com.sun.ejb.containers.RuntimeTimerState;
 import com.sun.ejb.containers.util.pool.AbstractPool;
 import com.sun.ejb.containers.util.pool.NonBlockingPool;
 import com.sun.ejb.containers.util.pool.ObjectFactory;
 import com.sun.ejb.monitoring.stats.EjbMonitoringStatsProvider;
 import com.sun.ejb.monitoring.stats.EjbPoolStatsProvider;
-import org.glassfish.ejb.mdb.monitoring.stats.MessageDrivenBeanStatsProvider;
+import com.sun.ejb.spi.container.OptionalLocalInterfaceProvider;
 import com.sun.enterprise.admin.monitor.callflow.ComponentType;
+import com.sun.enterprise.config.serverbeans.Config;
+import com.sun.enterprise.deployment.EjbBundleDescriptor;
 import com.sun.enterprise.deployment.LifecycleCallbackDescriptor.CallbackType;
 import com.sun.enterprise.deployment.MethodDescriptor;
 import com.sun.enterprise.deployment.runtime.BeanPoolDescriptor;
@@ -76,71 +79,69 @@ import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.Utility;
 import com.sun.logging.LogDomains;
 
+import jakarta.ejb.CreateException;
+import jakarta.ejb.EJBException;
+import jakarta.ejb.EJBHome;
+import jakarta.ejb.MessageDrivenBean;
+import jakarta.ejb.RemoveException;
+import jakarta.resource.spi.endpoint.MessageEndpoint;
+
 /**
- * This class provides container functionality specific to message-driven EJBs.
- * At deployment time, one instance of the MessageDrivenBeanContainer is created
- * for each message-driven bean in an application.
+ * This class provides container functionality specific to message-driven EJBs. At deployment time, one instance of the
+ * MessageDrivenBeanContainer is created for each message-driven bean in an application.
  * <P>
- * The 3 states of a Message-driven EJB (an EJB can be in only 1 state at a
- * time): 1. POOLED : ready for invocations, no transaction in progress 2.
- * INVOKING : processing an invocation 3. DESTROYED : does not exist
+ * The 3 states of a Message-driven EJB (an EJB can be in only 1 state at a time):
+ * <pre>
+ * 1. POOLED : ready for invocations, no transaction in progress
+ * 2. INVOKING : processing an invocation
+ * 3. DESTROYED : does not exist
+ * </pre>
  *
- * A Message-driven Bean can hold open DB connections across invocations. It's
- * assumed that the Resource Manager can handle multiple incomplete transactions
- * on the same connection.
+ * A Message-driven Bean can hold open DB connections across invocations. It's assumed that the Resource Manager can
+ * handle multiple incomplete transactions on the same connection.
  *
  * @author Kenneth Saks
  */
-public final class MessageBeanContainer extends BaseContainer implements
-        MessageBeanProtocolManager { //, MessageDrivenBeanStatsProvider {
-    private static final Logger _logger = LogDomains.getLogger(
-            MessageBeanContainer.class, LogDomains.MDB_LOGGER);
+public final class MessageBeanContainer extends BaseContainer implements MessageBeanProtocolManager { // , MessageDrivenBeanStatsProvider {
+    private static final Logger _logger = LogDomains.getLogger(MessageBeanContainer.class, LogDomains.MDB_LOGGER);
 
     private String appEJBName_;
 
-    private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(
-            MessageBeanContainer.class);
+    private static LocalStringManagerImpl localStrings = new LocalStringManagerImpl(MessageBeanContainer.class);
 
-    // Message-bean instance states
-    private static final int POOLED = 1, INVOKING = 2, DESTROYED = 3;
+    private MessageBeanClient messageBeanClient;
 
-    private MessageBeanClient messageBeanClient_ = null;
+    private AbstractPool messageBeanPool;
 
-    private AbstractPool messageBeanPool_ = null;
-
-    private BeanPoolDescriptor beanPoolDesc_ = null;
+    private BeanPoolDescriptor beanPoolDescriptor;
     private int maxMessageBeanListeners_;
     private int numMessageBeanListeners_;
-    private Class messageBeanInterface_;
-    private Class messageBeanSubClass_;
+    private Class<?> messageBeanInterface;
+    private Class<?> messageBeanSubClass;
 
     // Property used to bootstrap message bean client factory for inbound
     // message delivery.
     private static final String MESSAGE_BEAN_CLIENT_FACTORY_PROP = "com.sun.enterprise.MessageBeanClientFactory";
 
-    private static final String DEFAULT_MESSAGE_BEAN_CLIENT_FACTORY =
-            ConnectorConstants.CONNECTOR_MESSAGE_BEAN_CLIENT_FACTORY;
+    private static final String DEFAULT_MESSAGE_BEAN_CLIENT_FACTORY = ConnectorConstants.CONNECTOR_MESSAGE_BEAN_CLIENT_FACTORY;
 
     private static final int DEFAULT_RESIZE_QUANTITY = 8;
     private static final int DEFAULT_STEADY_SIZE = 0;
     private static final int DEFAULT_MAX_POOL_SIZE = 32;
     private static final int DEFAULT_IDLE_TIMEOUT = 600;
 
-        //issue 4629. 0 means a bean can remain idle indefinitely.
+    // issue 4629. 0 means a bean can remain idle indefinitely.
     private static final int MIN_IDLE_TIMEOUT = 0;
 
-        // TODO : remove
-    private int statMessageCount = 0;
-
-    private TransactedPoolManager poolMgr;
+    private TransactedPoolManager transactedPoolManager;
     private final Class<?> messageListenerType_;
 
-    MessageBeanContainer(EjbDescriptor desc, ClassLoader loader, SecurityManager sm)
-            throws Exception {
-        super(ContainerType.MESSAGE_DRIVEN, desc, loader, sm);
+    MessageBeanContainer(EjbDescriptor ejbDescriptor, ClassLoader classLoader, SecurityManager securityManager) throws Exception {
+        super(ContainerType.MESSAGE_DRIVEN, ejbDescriptor, classLoader, securityManager);
 
         // Instantiate the ORB and Remote naming manager
         // to allow client lookups of JMS queues/topics/connectionfactories
+        //
         // TODO - implement the sniffer for DAS/cluster instance - listening on the naming port that will
         // instantiate the orb/remote naming service on demand upon initial access.
         // Once that's available, this call can be removed.
@@ -148,39 +149,38 @@ public final class MessageBeanContainer extends BaseContainer implements
 
         isMessageDriven = true;
 
-        appEJBName_ = desc.getApplication().getRegistrationName() + ":"
-                + desc.getName();
+        appEJBName_ = ejbDescriptor.getApplication().getRegistrationName() + ":" + ejbDescriptor.getName();
 
-        EjbMessageBeanDescriptor msgBeanDesc = (EjbMessageBeanDescriptor) desc;
+        EjbMessageBeanDescriptor msgBeanDesc = (EjbMessageBeanDescriptor) ejbDescriptor;
 
         ComponentInvocation componentInvocation = null;
         try {
 
-            Class<?> beanClass = loader.loadClass(desc.getEjbClassName());
-            messageListenerType_ = loader.loadClass(msgBeanDesc.getMessageListenerType());
+            Class<?> beanClass = classLoader.loadClass(ejbDescriptor.getEjbClassName());
+            messageListenerType_ = classLoader.loadClass(msgBeanDesc.getMessageListenerType());
 
             Class<?> messageListenerType_1 = messageListenerType_;
             if (isModernMessageListener(messageListenerType_1)) {
                 // Generate interface and subclass for EJB 3.2 No-interface MDB VIew
-                MessageBeanInterfaceGenerator generator = new MessageBeanInterfaceGenerator(loader);
-                messageBeanInterface_ = generator.generateMessageBeanInterface(beanClass);
-                messageBeanSubClass_ = generator.generateMessageBeanSubClass(beanClass, messageBeanInterface_);
+                MessageBeanInterfaceGenerator generator = new MessageBeanInterfaceGenerator(classLoader);
+                messageBeanInterface = generator.generateMessageBeanInterface(beanClass);
+                messageBeanSubClass = generator.generateMessageBeanSubClass(beanClass, messageBeanInterface);
             }
 
             // Register the tx attribute for each method on MessageListener
-            // interface. NOTE : These method objects MUST come from the
+            // interface.
+            //
+            // NOTE : These method objects MUST come from the
             // MessageListener interface, NOT the bean class itself. This
             // is because the message bean container clients do not have
             // access to the message bean class.
-            Method[] msgListenerMethods = msgBeanDesc
-                    .getMessageListenerInterfaceMethods(loader);
+            Method[] msgListenerMethods = msgBeanDesc.getMessageListenerInterfaceMethods(classLoader);
 
-            for (int i = 0; i < msgListenerMethods.length; i++) {
-                Method next = msgListenerMethods[i];
-                addInvocationInfo(next, MethodDescriptor.EJB_BEAN, null);
+            for (Method msgListenerMethod : msgListenerMethods) {
+                addInvocationInfo(msgListenerMethod, MethodDescriptor.EJB_BEAN, null);
             }
 
-            poolMgr = ejbContainerUtilImpl.getServices().getService(TransactedPoolManager.class);
+            transactedPoolManager = ejbContainerUtilImpl.getServices().getService(TransactedPoolManager.class);
 
             // NOTE : No need to register tx attribute for ejbTimeout. It's
             // done in BaseContainer intialization.
@@ -194,17 +194,14 @@ public final class MessageBeanContainer extends BaseContainer implements
             // implementation is ready.
             String factoryClassName = System.getProperty(MESSAGE_BEAN_CLIENT_FACTORY_PROP);
             MessageBeanClientFactory clientFactory = null;
-            if(factoryClassName != null){
-                Class clientFactoryClass = loader.loadClass(factoryClassName);
-                clientFactory = (MessageBeanClientFactory) clientFactoryClass
-                        .newInstance();
+            if (factoryClassName != null) {
+                Class clientFactoryClass = classLoader.loadClass(factoryClassName);
+                clientFactory = (MessageBeanClientFactory) clientFactoryClass.newInstance();
             } else {
-                clientFactory = ejbContainerUtilImpl.getServices().getService(
-                        MessageBeanClientFactory.class, DEFAULT_MESSAGE_BEAN_CLIENT_FACTORY );
+                clientFactory = ejbContainerUtilImpl.getServices().getService(MessageBeanClientFactory.class,
+                        DEFAULT_MESSAGE_BEAN_CLIENT_FACTORY);
             }
-            _logger.log(Level.FINE, "Using " + clientFactory.getClass().getName()
-                    + " for message bean client factory in " + appEJBName_);
-
+            _logger.log(FINE, "Using " + clientFactory.getClass().getName() + " for message bean client factory in " + appEJBName_);
 
             // Create message bean pool before calling setup on
             // Message-bean client, since pool properties can be retrieved
@@ -215,51 +212,73 @@ public final class MessageBeanContainer extends BaseContainer implements
             // Protocol Manager. For now, just use max pool size. However,
             // we might want to bump this up once the ejb timer service is
             // integrated.
-            maxMessageBeanListeners_ = beanPoolDesc_.getMaxPoolSize();
+            maxMessageBeanListeners_ = beanPoolDescriptor.getMaxPoolSize();
             numMessageBeanListeners_ = 0;
 
-            messageBeanClient_ = clientFactory
-                    .createMessageBeanClient(msgBeanDesc);
+            messageBeanClient = clientFactory.createMessageBeanClient(msgBeanDesc);
 
             componentInvocation = createComponentInvocation();
             componentInvocation.container = this;
             invocationManager.preInvoke(componentInvocation);
-            messageBeanClient_.setup(this);
+            messageBeanClient.setup(this);
 
             registerMonitorableComponents(msgListenerMethods);
 
             createCallFlowAgent(ComponentType.MDB);
         } catch (Exception ex) {
-
-            if (messageBeanClient_ != null) {
-                messageBeanClient_.close();
+            if (messageBeanClient != null) {
+                messageBeanClient.close();
             }
 
-            _logger.log(Level.SEVERE,
-                    "containers.mdb.create_container_exception", new Object[] {
-                            desc.getName(), ex.toString() });
-            _logger.log(Level.SEVERE, ex.getClass().getName(), ex);
+            _logger.log(SEVERE, "containers.mdb.create_container_exception", new Object[] { ejbDescriptor.getName(), ex.toString() });
+            _logger.log(SEVERE, ex.getClass().getName(), ex);
             throw ex;
         } finally {
-            if(componentInvocation != null) {
+            if (componentInvocation != null) {
                 invocationManager.postInvoke(componentInvocation);
             }
         }
     }
 
-    protected void registerMonitorableComponents(Method[] msgListenerMethods) {
-        super.registerMonitorableComponents();
-                poolProbeListener = new EjbPoolStatsProvider(messageBeanPool_,
-                        getContainerId(), containerInfo.appName, containerInfo.modName,
-                        containerInfo.ejbName);
-                poolProbeListener.register();
-        // registryMediator.registerProvider(messageBeanPool_);
-        // super.setMonitorOn(mdbc.isMonitoringEnabled());
-        _logger.log(Level.FINE, "[MessageBeanContainer] registered monitorable");
+    /**
+     * Called when the application containing this message-bean has successfully gotten through the initial load phase of
+     * each module. Now we can "turn on the spigot" and allow incoming requests, which could result in the creation of
+     * message-bean instances.
+     *
+     * @param deploy true if this method is called during application deploy
+     */
+    @Override
+    public void startApplication(boolean deploy) {
+        super.startApplication(deploy);
+
+        // Start delivery of messages to message bean instances.
+        try {
+            messageBeanClient.start();
+        } catch (Exception e) {
+            _logger.log(FINE, e.getClass().getName(), e);
+
+            throw new RuntimeException("MessageBeanContainer.start failure for app " + appEJBName_, e);
+        }
     }
 
-    protected EjbMonitoringStatsProvider getMonitoringStatsProvider(
-            String appName, String modName, String ejbName) {
+    protected void registerMonitorableComponents(Method[] msgListenerMethods) {
+        super.registerMonitorableComponents();
+
+        poolProbeListener =
+            new EjbPoolStatsProvider(
+                messageBeanPool,
+                getContainerId(),
+                containerInfo.appName,
+                containerInfo.modName,
+                containerInfo.ejbName);
+
+        poolProbeListener.register();
+
+        _logger.log(FINE, "[MessageBeanContainer] registered monitorable");
+    }
+
+    @Override
+    protected EjbMonitoringStatsProvider getMonitoringStatsProvider(String appName, String modName, String ejbName) {
         return new MessageDrivenBeanStatsProvider(getContainerId(), appName, modName, ejbName);
     }
 
@@ -284,75 +303,68 @@ public final class MessageBeanContainer extends BaseContainer implements
     }
 
     private void createMessageBeanPool(EjbMessageBeanDescriptor descriptor) {
+        beanPoolDescriptor = descriptor.getIASEjbExtraDescriptors().getBeanPool();
 
-        beanPoolDesc_ = descriptor.getIASEjbExtraDescriptors().getBeanPool();
-
-        if (beanPoolDesc_ == null) {
-            beanPoolDesc_ = new BeanPoolDescriptor();
+        if (beanPoolDescriptor == null) {
+            beanPoolDescriptor = new BeanPoolDescriptor();
         }
 
-        MdbContainer mdbc = ejbContainerUtilImpl.getServices()
-                        .<Config>getService(Config.class, ServerEnvironment.DEFAULT_INSTANCE_NAME).getExtensionByType(MdbContainer.class);
-        int maxPoolSize = beanPoolDesc_.getMaxPoolSize();
+        MdbContainer mdbContainer =
+            ejbContainerUtilImpl.getServices()
+                                .getService(Config.class, ServerEnvironment.DEFAULT_INSTANCE_NAME)
+                                .getExtensionByType(MdbContainer.class);
+
+        int maxPoolSize = beanPoolDescriptor.getMaxPoolSize();
         if (maxPoolSize < 0) {
-            maxPoolSize = stringToInt(mdbc.getMaxPoolSize(), appEJBName_,
-                    _logger);
+            maxPoolSize = stringToInt(mdbContainer.getMaxPoolSize(), appEJBName_, _logger);
         }
-        maxPoolSize = validateValue(maxPoolSize, 1, -1, DEFAULT_MAX_POOL_SIZE,
-                "max-pool-size", appEJBName_, _logger);
-        beanPoolDesc_.setMaxPoolSize(maxPoolSize);
+        maxPoolSize = validateValue(maxPoolSize, 1, -1, DEFAULT_MAX_POOL_SIZE, "max-pool-size", appEJBName_, _logger);
+        beanPoolDescriptor.setMaxPoolSize(maxPoolSize);
 
-        int value = beanPoolDesc_.getSteadyPoolSize();
+        int value = beanPoolDescriptor.getSteadyPoolSize();
         if (value < 0) {
-            value = stringToInt(mdbc.getSteadyPoolSize(), appEJBName_, _logger);
+            value = stringToInt(mdbContainer.getSteadyPoolSize(), appEJBName_, _logger);
         }
-        value = validateValue(value, 0, maxPoolSize, DEFAULT_STEADY_SIZE,
-                "steady-pool-size", appEJBName_, _logger);
-        beanPoolDesc_.setSteadyPoolSize(value);
+        value = validateValue(value, 0, maxPoolSize, DEFAULT_STEADY_SIZE, "steady-pool-size", appEJBName_, _logger);
+        beanPoolDescriptor.setSteadyPoolSize(value);
 
-        value = beanPoolDesc_.getPoolResizeQuantity();
+        value = beanPoolDescriptor.getPoolResizeQuantity();
         if (value < 0) {
-            value = stringToInt(mdbc.getPoolResizeQuantity(), appEJBName_,
-                    _logger);
+            value = stringToInt(mdbContainer.getPoolResizeQuantity(), appEJBName_, _logger);
         }
-        value = validateValue(value, 1, maxPoolSize, DEFAULT_RESIZE_QUANTITY,
-                "pool-resize-quantity", appEJBName_, _logger);
-        beanPoolDesc_.setPoolResizeQuantity(value);
+        value = validateValue(value, 1, maxPoolSize, DEFAULT_RESIZE_QUANTITY, "pool-resize-quantity", appEJBName_, _logger);
+        beanPoolDescriptor.setPoolResizeQuantity(value);
 
-                //if ejb pool idle-timeout-in-seconds is not explicitly set in
-                //glassfish-ejb-jar.xml, returned value is -1
-        value = beanPoolDesc_.getPoolIdleTimeoutInSeconds();
+        // If ejb pool idle-timeout-in-seconds is not explicitly set in
+        // glassfish-ejb-jar.xml, returned value is -1
+        value = beanPoolDescriptor.getPoolIdleTimeoutInSeconds();
         if (value < MIN_IDLE_TIMEOUT) {
-            value = stringToInt(mdbc.getIdleTimeoutInSeconds(), appEJBName_,
-                    _logger);
+            value = stringToInt(mdbContainer.getIdleTimeoutInSeconds(), appEJBName_, _logger);
         }
-        value = validateValue(value, MIN_IDLE_TIMEOUT, -1,
-                DEFAULT_IDLE_TIMEOUT, "idle-timeout-in-seconds", appEJBName_,
-                _logger);
-        beanPoolDesc_.setPoolIdleTimeoutInSeconds(value);
+        value = validateValue(value, MIN_IDLE_TIMEOUT, -1, DEFAULT_IDLE_TIMEOUT, "idle-timeout-in-seconds", appEJBName_, _logger);
+        beanPoolDescriptor.setPoolIdleTimeoutInSeconds(value);
 
-        if (_logger.isLoggable(Level.FINE)) {
-            _logger.log(Level.FINE, appEJBName_
-                    + ": Setting message-driven bean pool max-pool-size="
-                    + beanPoolDesc_.getMaxPoolSize() + ", steady-pool-size="
-                    + beanPoolDesc_.getSteadyPoolSize()
-                    + ", pool-resize-quantity="
-                    + beanPoolDesc_.getPoolResizeQuantity()
-                    + ", idle-timeout-in-seconds="
-                    + beanPoolDesc_.getPoolIdleTimeoutInSeconds());
-        }
+        _logger.log(FINE, () ->
+            appEJBName_ + ": Setting message-driven bean pool max-pool-size=" + beanPoolDescriptor.getMaxPoolSize() +
+            ", steady-pool-size=" + beanPoolDescriptor.getSteadyPoolSize() +
+            ", pool-resize-quantity=" + beanPoolDescriptor.getPoolResizeQuantity() +
+            ", idle-timeout-in-seconds=" + beanPoolDescriptor.getPoolIdleTimeoutInSeconds());
 
         // Create a non-blocking pool of message bean instances.
         // The protocol manager implementation enforces a limit
         // on message bean resources independent of the pool.
-        ObjectFactory objFactory = new MessageBeanContextFactory();
-                String val = descriptor.getEjbBundleDescriptor().getEnterpriseBeansProperty(SINGLETON_BEAN_POOL_PROP);
-        messageBeanPool_ = new NonBlockingPool(getContainerId(), appEJBName_, objFactory,
-                beanPoolDesc_.getSteadyPoolSize(), beanPoolDesc_
-                        .getPoolResizeQuantity(), beanPoolDesc_
-                        .getMaxPoolSize(), beanPoolDesc_
-                        .getPoolIdleTimeoutInSeconds(), loader,
-                                                Boolean.parseBoolean(val));
+
+        messageBeanPool =
+            new NonBlockingPool(
+                getContainerId(),
+                appEJBName_,
+                new MessageBeanContextFactory(),
+                beanPoolDescriptor.getSteadyPoolSize(),
+                beanPoolDescriptor.getPoolResizeQuantity(),
+                beanPoolDescriptor.getMaxPoolSize(),
+                beanPoolDescriptor.getPoolIdleTimeoutInSeconds(),
+                loader,
+                Boolean.parseBoolean(descriptor.getEjbBundleDescriptor().getEnterpriseBeansProperty(SINGLETON_BEAN_POOL_PROP)));
     }
 
     protected static int stringToInt(String val, String appName, Logger logger) {
@@ -360,27 +372,21 @@ public final class MessageBeanContainer extends BaseContainer implements
         try {
             value = Integer.parseInt(val);
         } catch (Exception e) {
-            _logger.log(Level.WARNING, "containers.mdb.invalid_value",
-                    new Object[] { appName, val, e.toString(),
-                            "0" });
-            _logger.log(Level.WARNING, "", e);
+            _logger.log(WARNING, "containers.mdb.invalid_value", new Object[] { appName, val, e.toString(), "0" });
+            _logger.log(WARNING, "", e);
         }
         return value;
     }
 
     // deft should always >= lowLimit
-    protected int validateValue(int value, int lowLimit, int highLimit,
-            int deft, String emsg, String appName, Logger logger) {
-
+    protected int validateValue(int value, int lowLimit, int highLimit, int deft, String emsg, String appName, Logger logger) {
         if (value < lowLimit) {
-            _logger.log(Level.WARNING, "containers.mdb.invalid_value",
-                    new Object[] { appName, value, emsg, deft });
+            _logger.log(WARNING, "containers.mdb.invalid_value", new Object[] { appName, value, emsg, deft });
             value = deft;
         }
 
         if ((highLimit >= 0) && (value > highLimit)) {
-            _logger.log(Level.WARNING, "containers.mdb.invalid_value",
-                    new Object[] { appName, value, emsg, highLimit });
+            _logger.log(WARNING, "containers.mdb.invalid_value", new Object[] { appName, value, emsg, highLimit });
             value = highLimit;
         }
 
@@ -390,8 +396,7 @@ public final class MessageBeanContainer extends BaseContainer implements
     private boolean containerStartsTx(Method method) {
         int txMode = getTxAttr(method, MethodDescriptor.EJB_BEAN);
 
-        return isEjbTimeoutMethod(method) ? ((txMode == TX_REQUIRES_NEW) || (txMode == TX_REQUIRED))
-                : (txMode == TX_REQUIRED);
+        return isEjbTimeoutMethod(method) ? ((txMode == TX_REQUIRES_NEW) || (txMode == TX_REQUIRED)) : (txMode == TX_REQUIRED);
     }
 
     public String getMonitorAttributeValues() {
@@ -399,20 +404,22 @@ public final class MessageBeanContainer extends BaseContainer implements
         sbuf.append("MESSAGEDRIVEN ");
         sbuf.append(appEJBName_);
 
-        sbuf.append(messageBeanPool_.getAllAttrValues());
+        sbuf.append(messageBeanPool.getAllAttrValues());
         sbuf.append("]");
         return sbuf.toString();
     }
 
+    @Override
     public boolean userTransactionMethodsAllowed(ComponentInvocation inv) {
         boolean utMethodsAllowed = false;
         if (isBeanManagedTran) {
             if (inv instanceof EjbInvocation) {
                 EjbInvocation ejbInvocation = (EjbInvocation) inv;
                 MessageBeanContextImpl mdc = (MessageBeanContextImpl) ejbInvocation.context;
-                utMethodsAllowed = (mdc.operationsAllowed()) ? true: false;
+                utMethodsAllowed = mdc.operationsAllowed();
             }
         }
+
         return utMethodsAllowed;
     }
 
@@ -420,43 +427,41 @@ public final class MessageBeanContainer extends BaseContainer implements
         throw new Exception("Can't set EJB Home on Message-driven bean");
     }
 
+    @Override
     public EJBObjectImpl getEJBObjectImpl(byte[] instanceKey) {
         throw new EJBException("No EJBObject for message-driven beans");
     }
 
+    @Override
     public EJBObjectImpl createEJBObjectImpl() throws CreateException {
         throw new EJBException("No EJBObject for message-driven beans");
     }
 
-    protected void removeBean(EJBLocalRemoteObject ejbo, Method removeMethod,
-            boolean local) throws RemoveException, EJBException {
+    @Override
+    protected void removeBean(EJBLocalRemoteObject ejbo, Method removeMethod, boolean local) throws RemoveException, EJBException {
         throw new EJBException("not used in message-driven beans");
     }
 
     /**
-     * Override callEJBTimeout from BaseContainer since delivery to message
-     * driven beans is a bit different from session/entity.
+     * Override callEJBTimeout from BaseContainer since delivery to message driven beans is a bit different from
+     * session/entity.
      */
     @Override
-    protected boolean callEJBTimeout(RuntimeTimerState timerState,
-            EJBTimerService timerService) throws Exception {
-
+    protected boolean callEJBTimeout(RuntimeTimerState timerState, EJBTimerService timerService) throws Exception {
         boolean redeliver = false;
 
         // There is no resource associated with the delivery of the timeout.
         try {
 
-            Method method = getTimeoutMethod(timerState);
+            Method timeoutMethod = getTimeoutMethod(timerState);
 
             // Do pre-invoke logic for message bean with tx import = false
             // and a null resource handle.
-            beforeMessageDelivery(method, MessageDeliveryType.Timer,
-                    false, null);
+            beforeMessageDelivery(timeoutMethod, MessageDeliveryType.Timer, false, null);
 
             ComponentInvocation componentInvocation = invocationManager.getCurrentInvocation();
             if (componentInvocation instanceof EjbInvocation) {
-                prepareEjbTimeoutParams((EjbInvocation) componentInvocation,
-                        timerState, timerService);
+                prepareEjbTimeoutParams((EjbInvocation) componentInvocation, timerState, timerService);
             }
 
             // Method arguments had been set already
@@ -469,13 +474,12 @@ public final class MessageBeanContainer extends BaseContainer implements
             // exception will be destroyed, as per the EJB spec.
             redeliver = true;
 
-            _logger.log(Level.FINE, "ejbTimeout threw Runtime exception", t);
+            _logger.log(FINE, "ejbTimeout threw Runtime exception", t);
 
         } finally {
-            if (!isBeanManagedTran
-                    && (transactionManager.getStatus() == Status.STATUS_MARKED_ROLLBACK)) {
+            if (!isBeanManagedTran && transactionManager.getStatus() == STATUS_MARKED_ROLLBACK) {
                 redeliver = true;
-                _logger.log(Level.FINE, "ejbTimeout called setRollbackOnly");
+                _logger.log(FINE, "ejbTimeout called setRollbackOnly");
             }
 
             // Only call postEjbTimeout if there are no errors so far.
@@ -497,29 +501,31 @@ public final class MessageBeanContainer extends BaseContainer implements
     }
 
     /**
-     * Force destroy the EJB. Called from postInvokeTx. Note: EJB2.0 section
-     * 18.3.1 says that discarding an EJB means that no methods other than
-     * finalize() should be invoked on it.
+     * Force destroy the EJB. Called from postInvokeTx. Note: EJB2.0 section 18.3.1 says that discarding an EJB means that
+     * no methods other than finalize() should be invoked on it.
      */
-    protected void forceDestroyBean(EJBContextImpl sc) {
-        MessageBeanContextImpl mbc = (MessageBeanContextImpl)sc;
+    @Override
+    protected void forceDestroyBean(EJBContextImpl ejbContext) {
+        MessageBeanContextImpl messageBeanContext = (MessageBeanContextImpl) ejbContext;
 
-        if (mbc.isInState(BeanState.DESTROYED))
+        if (messageBeanContext.isInState(DESTROYED)) {
             return;
+        }
 
-        // mark context as destroyed
-        mbc.setState(BeanState.DESTROYED);
+        // Mark context as destroyed
+        messageBeanContext.setState(DESTROYED);
 
-        messageBeanPool_.destroyObject(sc);
+        messageBeanPool.destroyObject(ejbContext);
     }
 
     // This particular preInvoke signature not used
+    @Override
     public void preInvoke(EjbInvocation inv) {
         throw new EJBException("preInvoke(Invocation) not supported");
     }
 
     private class MessageBeanContextFactory implements ObjectFactory {
-
+        @Override
         public Object create(Object param) {
             try {
                 return createMessageDrivenEJB();
@@ -528,43 +534,39 @@ public final class MessageBeanContainer extends BaseContainer implements
             }
         }
 
+        @Override
         public void destroy(Object obj) {
-
             MessageBeanContextImpl beanContext = (MessageBeanContextImpl) obj;
 
             Object ejb = beanContext.getEJB();
 
-            if (!beanContext.isInState(BeanState.DESTROYED)) {
+            if (!beanContext.isInState(DESTROYED)) {
 
                 // Called from pool implementation to reduce the pool size.
-                // So we need to call ejb.ejbRemove() and
-                // mark context as destroyed.
-                EjbInvocation inv = null;
+                // So we need to call ejb.ejbRemove() and mark context as destroyed.
+                EjbInvocation ejbInvocation = null;
 
                 try {
                     // NOTE : Context class-loader is already set by Pool
 
-                    inv = createEjbInvocation(ejb, beanContext);
+                    ejbInvocation = createEjbInvocation(ejb, beanContext);
 
-                    inv.isMessageDriven = true;
-                    invocationManager.preInvoke(inv);
+                    ejbInvocation.isMessageDriven = true;
+                    invocationManager.preInvoke(ejbInvocation);
 
                     beanContext.setInEjbRemove(true);
                     intercept(CallbackType.PRE_DESTROY, beanContext);
 
                     cleanupInstance(beanContext);
-                    ejbProbeNotifier.ejbBeanDestroyedEvent(getContainerId(),
-                                                containerInfo.appName, containerInfo.modName,
-                                                containerInfo.ejbName);
+                    ejbProbeNotifier.ejbBeanDestroyedEvent(getContainerId(), containerInfo.appName, containerInfo.modName,
+                            containerInfo.ejbName);
                 } catch (Throwable t) {
-                    _logger.log(Level.SEVERE,
-                            "containers.mdb_preinvoke_exception_indestroy",
-                            new Object[] { appEJBName_, t.toString() });
-                    _logger.log(Level.SEVERE, t.getClass().getName(), t);
+                    _logger.log(SEVERE, "containers.mdb_preinvoke_exception_indestroy", new Object[] { appEJBName_, t.toString() });
+                    _logger.log(SEVERE, t.getClass().getName(), t);
                 } finally {
                     beanContext.setInEjbRemove(false);
-                    if (inv != null) {
-                        invocationManager.postInvoke(inv);
+                    if (ejbInvocation != null) {
+                        invocationManager.postInvoke(ejbInvocation);
                     }
                 }
 
@@ -572,38 +574,39 @@ public final class MessageBeanContainer extends BaseContainer implements
 
             }
 
-            // tell the TM to release resources held by the bean
+            // Tell the TM to release resources held by the bean
             transactionManager.componentDestroyed(beanContext);
 
-            // Message-driven beans can't have transactions across
-            // invocations.
+            // Message-driven beans can't have transactions across invocations.
             beanContext.setTransaction(null);
         }
-
     }
 
+    @Override
     protected ComponentContext _getContext(EjbInvocation inv) {
-        MessageBeanContextImpl context = null;
+        MessageBeanContextImpl messageBeanContext = null;
         try {
-            context = (MessageBeanContextImpl) messageBeanPool_.getObject(null);
-            context.setState(BeanState.INVOKING);
+            messageBeanContext = (MessageBeanContextImpl) messageBeanPool.getObject(null);
+            messageBeanContext.setState(BeanState.INVOKING);
         } catch (Exception e) {
             throw new EJBException(e);
         }
-        return context;
+
+        return messageBeanContext;
     }
 
     /**
      * Return instance to a pooled state.
      */
+    @Override
     public void releaseContext(EjbInvocation inv) {
         MessageBeanContextImpl beanContext = (MessageBeanContextImpl) inv.context;
 
-        if (beanContext.isInState(BeanState.DESTROYED)) {
+        if (beanContext.isInState(DESTROYED)) {
             return;
         }
 
-        beanContext.setState(BeanState.POOLED);
+        beanContext.setState(POOLED);
 
         // Message-driven beans can't have transactions across invocations.
         beanContext.setTransaction(null);
@@ -611,33 +614,21 @@ public final class MessageBeanContainer extends BaseContainer implements
         // Update last access time so pool's time-based logic will work best
         beanContext.touch();
 
-        messageBeanPool_.returnObject(beanContext);
+        messageBeanPool.returnObject(beanContext);
     }
-
-/** TODO
-    public void appendStats(StringBuffer sbuf) {
-        sbuf.append("\nMessageBeanContainer: ").append("CreateCount=").append(
-                statCreateCount).append("; ").append("RemoveCount=").append(
-                statRemoveCount).append("; ").append("MsgCount=").append(
-                statMessageCount).append("; ");
-        sbuf.append("]");
-    }
-**/
 
     // This particular postInvoke signature not used
+    @Override
     public void postInvoke(EjbInvocation inv) {
-        throw new EJBException("postInvoke(Invocation) not supported "
-                + "in message-driven bean container");
+        throw new EJBException("postInvoke(Invocation) not supported " + "in message-driven bean container");
     }
 
     /****************************************************************
-     * The following are implementation for methods required by the *
-     * MessageBeanProtocalManager interface. *
+     * The following are implementation for methods required by the * MessageBeanProtocalManager interface. *
      ****************************************************************/
 
-    public MessageBeanListener createMessageBeanListener(ResourceHandle resource)
-            throws ResourcesExceededException {
-
+    @Override
+    public MessageBeanListener createMessageBeanListener(ResourceHandle resource) throws ResourcesExceededException {
         boolean resourcesExceeded = false;
 
         synchronized (this) {
@@ -650,10 +641,8 @@ public final class MessageBeanContainer extends BaseContainer implements
 
         if (resourcesExceeded) {
             ResourcesExceededException ree = new ResourcesExceededException(
-                    "Message Bean Resources " + "exceeded for message bean "
-                            + appEJBName_);
-            _logger.log(Level.FINE, "exceeded max of "
-                    + maxMessageBeanListeners_, ree);
+                    "Message Bean Resources " + "exceeded for message bean " + appEJBName_);
+            _logger.log(FINE, "exceeded max of " + maxMessageBeanListeners_, ree);
             throw ree;
         }
 
@@ -679,6 +668,7 @@ public final class MessageBeanContainer extends BaseContainer implements
         return new MessageBeanListenerImpl(this, resource);
     }
 
+    @Override
     public void destroyMessageBeanListener(MessageBeanListener listener) {
         synchronized (this) {
             numMessageBeanListeners_--;
@@ -686,18 +676,18 @@ public final class MessageBeanContainer extends BaseContainer implements
     }
 
     /**
-     * @param method
-     *            One of the methods used to deliver messages, e.g. onMessage
-     *            method for jakarta.jms.MessageListener. Note that if the
-     *            <code>method</code> is not one of the methods for message
-     *            delivery, the behavior of this method is not defined.
+     * @param method One of the methods used to deliver messages, e.g. onMessage method for jakarta.jms.MessageListener.
+     * Note that if the <code>method</code> is not one of the methods for message delivery, the behavior of this method is
+     * not defined.
      */
+    @Override
     public boolean isDeliveryTransacted(Method method) {
         return containerStartsTx(method);
     }
 
+    @Override
     public BeanPoolDescriptor getPoolDescriptor() {
-        return beanPoolDesc_;
+        return beanPoolDescriptor;
     }
 
     /**
@@ -707,21 +697,20 @@ public final class MessageBeanContainer extends BaseContainer implements
      * @return an object implementing MessageEndpoint and the appropriate MDB view
      * @throws Exception
      */
+    @Override
     public Object createMessageBeanProxy(InvocationHandler handler) throws Exception {
-
         if (isModernMessageListener(messageListenerType_)) {
             // EJB 3.2 No-interface MDB View
 
-            Proxy proxy = (Proxy) Proxy.newProxyInstance(loader, new Class[]{messageBeanInterface_}, handler);
-            OptionalLocalInterfaceProvider provider = (OptionalLocalInterfaceProvider) messageBeanSubClass_.newInstance();
+            Proxy proxy = (Proxy) Proxy.newProxyInstance(loader, new Class[] { messageBeanInterface }, handler);
+            OptionalLocalInterfaceProvider provider = (OptionalLocalInterfaceProvider) messageBeanSubClass.getDeclaredConstructor().newInstance();
             provider.setOptionalLocalIntfProxy(proxy);
 
             return provider;
-        } else {
-
-            // EJB 3.1 - 2.0 Interface View
-            return Proxy.newProxyInstance(loader, new Class[]{messageListenerType_, MessageEndpoint.class}, handler);
         }
+
+        // EJB 3.1 - 2.0 Interface View
+        return Proxy.newProxyInstance(loader, new Class[] { messageListenerType_, MessageEndpoint.class }, handler);
     }
 
     /**
@@ -729,65 +718,56 @@ public final class MessageBeanContainer extends BaseContainer implements
      *
      * In the future this method could potentially just return:
      *
-     *   <pre>
+     * <pre>
      *     return Annotation.class.isAssignableFrom(messageListenerType)
-     *   </pre>
+     * </pre>
      *
      * @param messageListenerType
      * @return true of the specified interface has no methods
      */
     private static boolean isModernMessageListener(Class<?> messageListenerType) {
         // DMB: In the future, this can just return 'Annotation.class.isAssignableFrom(messageListenerType)'
-
         return messageListenerType.getMethods().length == 0;
     }
 
     @Override
     protected EJBContextImpl _constructEJBContextImpl(Object instance) {
-    return new MessageBeanContextImpl(instance, this);
+        return new MessageBeanContextImpl(instance, this);
     }
 
     /**
      * Instantiate and initialize a message-driven bean instance.
      */
-    private MessageBeanContextImpl createMessageDrivenEJB()
-            throws CreateException {
-
-        EjbInvocation inv = null;
-        MessageBeanContextImpl context = null;
+    private MessageBeanContextImpl createMessageDrivenEJB() throws CreateException {
+        EjbInvocation ejbInvocation = null;
+        MessageBeanContextImpl messageBeanContext = null;
         ClassLoader originalClassLoader = null;
-        boolean methodCalled = false;
-        boolean methodCallFailed = false;
 
         try {
             // Set application class loader before invoking instance.
-            originalClassLoader = Utility
-                    .setContextClassLoader(getClassLoader());
+            originalClassLoader = setContextClassLoader(getClassLoader());
 
-            context = (MessageBeanContextImpl)
-                createEjbInstanceAndContext();
+            messageBeanContext = (MessageBeanContextImpl) createEjbInstanceAndContext();
 
-            Object ejb = context.getEJB();
-
+            Object ejb = messageBeanContext.getEJB();
 
             // java:comp/env lookups are allowed from here on...
-            inv = createEjbInvocation(ejb, context);
+            ejbInvocation = createEjbInvocation(ejb, messageBeanContext);
 
-            inv.isMessageDriven = true;
-            invocationManager.preInvoke(inv);
+            ejbInvocation.isMessageDriven = true;
+            invocationManager.preInvoke(ejbInvocation);
 
             if (ejb instanceof MessageDrivenBean) {
                 // setMessageDrivenContext will be called without a Tx
                 // as required by the spec
-                ((MessageDrivenBean) ejb).setMessageDrivenContext(context);
+                ((MessageDrivenBean) ejb).setMessageDrivenContext(messageBeanContext);
             }
 
             // Perform injection right after where setMessageDrivenContext
             // would be called. This is important since injection methods
             // have the same "operations allowed" permissions as
             // setMessageDrivenContext.
-            injectEjbInstance(context);
-
+            injectEjbInstance(messageBeanContext);
 
             // Set flag in context so UserTransaction can
             // be used from ejbCreate. Didn't want to add
@@ -795,76 +775,74 @@ public final class MessageBeanContainer extends BaseContainer implements
             // require either changing lots of code in
             // EJBContextImpl or re-implementing all the
             // context methods within MessageBeanContextImpl.
-            context.setContextCalled();
+            messageBeanContext.setContextCalled();
 
             // Call ejbCreate OR @PostConstruct on the bean.
-            intercept(CallbackType.POST_CONSTRUCT, context);
+            intercept(POST_CONSTRUCT, messageBeanContext);
 
-            ejbProbeNotifier.ejbBeanCreatedEvent(getContainerId(),
-                                containerInfo.appName, containerInfo.modName,
-                                containerInfo.ejbName);
+            ejbProbeNotifier.ejbBeanCreatedEvent(getContainerId(), containerInfo.appName, containerInfo.modName, containerInfo.ejbName);
 
             // Set the state to POOLED after ejbCreate so that
             // EJBContext methods not allowed will throw exceptions
-            context.setState(BeanState.POOLED);
+            messageBeanContext.setState(POOLED);
         } catch (Throwable t) {
-            _logger.log(Level.SEVERE, "containers.mdb.ejb_creation_exception",
-                    new Object[] { appEJBName_, t.toString() });
-            if (t instanceof InvocationTargetException) {
-                _logger.log(Level.SEVERE, t.getClass().getName(), t.getCause());
-            }
-            _logger.log(Level.SEVERE, t.getClass().getName(), t);
+            _logger.log(SEVERE, "containers.mdb.ejb_creation_exception", new Object[] { appEJBName_, t.toString() });
 
-            CreateException ce = new CreateException(
-                    "Could not create Message-Driven EJB");
+            if (t instanceof InvocationTargetException) {
+                _logger.log(SEVERE, t.getClass().getName(), t.getCause());
+            }
+            _logger.log(SEVERE, t.getClass().getName(), t);
+
+            CreateException ce = new CreateException("Could not create Message-Driven EJB");
             ce.initCause(t);
             throw ce;
 
         } finally {
             if (originalClassLoader != null) {
-                Utility.setContextClassLoader(originalClassLoader);
+                setContextClassLoader(originalClassLoader);
             }
-            if (inv != null) {
-                invocationManager.postInvoke(inv);
+            if (ejbInvocation != null) {
+                invocationManager.postInvoke(ejbInvocation);
             }
         }
 
-        return context;
+        return messageBeanContext;
     }
 
     /**
-     * Make the work performed by a message-bean instance's associated XA
-     * resource part of any global transaction
+     * Make the work performed by a message-bean instance's associated XA resource part of any global transaction
      */
-    private void registerMessageBeanResource(ResourceHandle resourceHandle)
-            throws Exception {
+    private void registerMessageBeanResource(ResourceHandle resourceHandle) throws Exception {
         if (resourceHandle != null) {
-            poolMgr.registerResource(resourceHandle);
+            transactedPoolManager.registerResource(resourceHandle);
         }
     }
 
     private void unregisterMessageBeanResource(ResourceHandle resourceHandle) {
-
         // resource handle may be null if preInvokeTx error caused
         // ResourceAllocator.destroyResource()
         if (resourceHandle != null) {
-            poolMgr.unregisterResource(resourceHandle, XAResource.TMSUCCESS);
+            transactedPoolManager.unregisterResource(resourceHandle, TMSUCCESS);
         }
     }
 
+    @Override
     protected void afterBegin(EJBContextImpl context) {
         // Message-driven Beans cannot implement SessionSynchronization!!
     }
 
+    @Override
     protected void beforeCompletion(EJBContextImpl context) {
         // Message-driven beans cannot implement SessionSynchronization!!
     }
 
+    @Override
     protected void afterCompletion(EJBContextImpl ctx, int status) {
         // Message-driven Beans cannot implement SessionSynchronization!!
     }
 
     // default
+    @Override
     public boolean passivateEJB(ComponentContext context) {
         return false;
     }
@@ -873,59 +851,33 @@ public final class MessageBeanContainer extends BaseContainer implements
     public void activateEJB(Object ctx, Object instanceKey) {
     }
 
-    /**
-     * Called when the application containing this message-bean has
-     * successfully gotten through the initial load phase of each
-     * module.  Now we can "turn on the spigot" and allow incoming
-     * requests, which could result in the creation of message-bean
-     * instances.
-     * @param deploy true if this method is called during application deploy
-     */
-    public void startApplication(boolean deploy) {
-        super.startApplication(deploy);
-
-        // Start delivery of messages to message bean instances.
-        try {
-
-            messageBeanClient_.start();
-
-        } catch (Exception e) {
-
-            _logger.log(Level.FINE, e.getClass().getName(), e);
-
-            throw new RuntimeException("MessageBeanContainer.start failure for app " +
-                appEJBName_, e);
-
-        }
-    }
-
     private ComponentInvocation createComponentInvocation() {
         EjbBundleDescriptor ejbBundleDesc = getEjbDescriptor().getEjbBundleDescriptor();
-        ComponentInvocation newInv = new ComponentInvocation(
+
+        return new
+            ComponentInvocation(
                 getComponentId(),
                 ComponentInvocation.ComponentInvocationType.SERVLET_INVOCATION,
                 this,
                 ejbBundleDesc.getApplication().getAppName(),
-                ejbBundleDesc.getModuleName()
-        );
-        //newInv.setJNDIEnvironment(getJNDIEnvironment());   ???
-        return newInv;
+                ejbBundleDesc.getModuleName());
     }
 
     private void cleanupResources() {
         ComponentInvocation componentInvocation = createComponentInvocation();
 
-        ASyncClientShutdownTask task = new ASyncClientShutdownTask(appEJBName_,
-                messageBeanClient_, loader, messageBeanPool_, componentInvocation);
+        ASyncClientShutdownTask task =
+            new ASyncClientShutdownTask(appEJBName_, messageBeanClient, loader, messageBeanPool, componentInvocation);
         long timeout = 0;
+
         try {
-                    ConnectorRuntime cr = ejbContainerUtilImpl.getServices()
-                            .getService(ConnectorRuntime.class);
-                    timeout = cr.getShutdownTimeout();
-                } catch (Throwable th) {
-                    _logger.log(Level.WARNING, "[MDBContainer] Got exception while trying " +
-                     " to get shutdown timeout", th);
-                }
+            timeout = ejbContainerUtilImpl.getServices()
+                                          .getService(ConnectorRuntime.class)
+                                          .getShutdownTimeout();
+        } catch (Throwable th) {
+            _logger.log(WARNING, "[MDBContainer] Got exception while trying " + " to get shutdown timeout", th);
+        }
+
         try {
             boolean addedAsyncTask = false;
             if (timeout > 0) {
@@ -933,61 +885,45 @@ public final class MessageBeanContainer extends BaseContainer implements
                     ejbContainerUtilImpl.addWork(task);
                     addedAsyncTask = true;
                 } catch (Throwable th) {
-                    // Since we got an exception while trying to add the async
-                    // task
-                    // we will have to do the cleanup in the current thread
-                    // itself.
+                    // Since we got an exception while trying to add the async task
+                    // we will have to do the cleanup in the current thread itself.
                     addedAsyncTask = false;
-                    _logger
-                            .log(
-                                    Level.WARNING,
-                                    "[MDBContainer] Got exception while trying "
-                                            + "to add task to ContainerWorkPool. Will execute "
-                                            + "cleanupResources on current thread",
-                                    th);
+                    _logger.log(WARNING, "[MDBContainer] Got exception while trying "
+                            + "to add task to ContainerWorkPool. Will execute " + "cleanupResources on current thread", th);
                 }
             }
 
             if (addedAsyncTask) {
                 synchronized (task) {
                     if (!task.isDone()) {
-                        _logger.log(Level.FINE, "[MDBContainer] "
-                                + "Going to wait for a maximum of " + timeout
-                                + " mili-seconds.");
+                        _logger.log(FINE, "[MDBContainer] " + "Going to wait for a maximum of " + timeout + " mili-seconds.");
                         long maxWaitTime = System.currentTimeMillis() + timeout;
                         // wait in loop to guard against spurious wake-up
                         do {
                             long timeTillTimeout = maxWaitTime - System.currentTimeMillis();
-                            if (timeTillTimeout <= 0) break;
+                            if (timeTillTimeout <= 0)
+                                break;
                             task.wait(timeTillTimeout);
                         } while (!task.isDone());
                     }
 
                     if (!task.isDone()) {
-                        _logger.log(Level.WARNING,
-                                "[MDBContainer] ASync task has not finished. "
-                                        + "Giving up after " + timeout
-                                        + " mili-seconds.");
+                        _logger.log(WARNING,
+                                "[MDBContainer] ASync task has not finished. " + "Giving up after " + timeout + " mili-seconds.");
                     } else {
-                        _logger.log(Level.FINE,
-                                "[MDBContainer] ASync task has completed");
+                        _logger.log(FINE, "[MDBContainer] ASync task has completed");
                     }
                 }
             } else {
                 // Execute in the same thread
-                _logger
-                        .log(Level.FINE,
-                                "[MDBContainer] Attempting to do cleanup()in current thread...");
+                _logger.log(FINE, "[MDBContainer] Attempting to do cleanup()in current thread...");
                 task.run();
-                _logger.log(Level.FINE,
-                        "[MDBContainer] Current thread done cleanup()... ");
+                _logger.log(FINE, "[MDBContainer] Current thread done cleanup()... ");
             }
         } catch (InterruptedException inEx) {
-            _logger.log(Level.SEVERE, "containers.mdb.cleanup_exception",
-                    new Object[] { appEJBName_, inEx.toString() });
+            _logger.log(SEVERE, "containers.mdb.cleanup_exception", new Object[] { appEJBName_, inEx.toString() });
         } catch (Exception ex) {
-            _logger.log(Level.SEVERE, "containers.mdb.cleanup_exception",
-                    new Object[] { appEJBName_, ex.toString() });
+            _logger.log(SEVERE, "containers.mdb.cleanup_exception", new Object[] { appEJBName_, ex.toString() });
         }
     }
 
@@ -995,48 +931,49 @@ public final class MessageBeanContainer extends BaseContainer implements
         private boolean done = false;
 
         String appName;
-        MessageBeanClient mdbClient;
-        ClassLoader clsLoader;
+        MessageBeanClient messageBeanClient;
+        ClassLoader classLoader;
         AbstractPool mdbPool;
         ComponentInvocation componentInvocation;
 
-        ASyncClientShutdownTask(String appName, MessageBeanClient mdbClient,
-                ClassLoader loader, AbstractPool mdbPool, ComponentInvocation componentInvocation) {
+        ASyncClientShutdownTask(String appName, MessageBeanClient mdbClient, ClassLoader loader, AbstractPool mdbPool,  ComponentInvocation componentInvocation) {
             this.appName = appName;
-            this.mdbClient = mdbClient;
-            this.clsLoader = loader;
+            this.messageBeanClient = mdbClient;
+            this.classLoader = loader;
             this.mdbPool = mdbPool;
             this.componentInvocation = componentInvocation;
         }
 
+        @Override
         public void run() {
             ClassLoader previousClassLoader = null;
             InvocationManager invocationManager = EjbContainerUtilImpl.getInstance().getInvocationManager();
             try {
-                previousClassLoader = Utility.setContextClassLoader(clsLoader);
+                previousClassLoader = setContextClassLoader(classLoader);
+
                 invocationManager.preInvoke(componentInvocation);
                 // Cleanup the message bean client resources.
-                mdbClient.close();
-                _logger
-                        .log(Level.FINE,
-                                "[MDBContainer] ASync thread done with mdbClient.close()");
+                messageBeanClient.close();
+
+                _logger.log(FINE, "[MDBContainer] ASync thread done with mdbClient.close()");
             } catch (Exception e) {
-                _logger.log(Level.SEVERE, "containers.mdb.cleanup_exception",
-                        new Object[] { appName, e.toString() });
-                _logger.log(Level.SEVERE, e.getClass().getName(), e);
+                _logger.log(SEVERE, "containers.mdb.cleanup_exception", new Object[] { appName, e.toString() });
+                _logger.log(SEVERE, e.getClass().getName(), e);
             } finally {
                 synchronized (this) {
                     this.done = true;
                     this.notifyAll();
                 }
+
                 try {
                     mdbPool.close();
                 } catch (Exception ex) {
-                    _logger.log(Level.FINE, "Exception while closing pool", ex);
+                    _logger.log(FINE, "Exception while closing pool", ex);
                 }
                 invocationManager.postInvoke(componentInvocation);
+
                 if (previousClassLoader != null) {
-                    Utility.setContextClassLoader(previousClassLoader);
+                    setContextClassLoader(previousClassLoader);
                 }
             }
         }
@@ -1049,43 +986,35 @@ public final class MessageBeanContainer extends BaseContainer implements
     /**
      * Called by BaseContainer during container shutdown sequence
      */
+    @Override
     protected void doConcreteContainerShutdown(boolean appBeingUndeployed) {
-        _logger.log(Level.FINE, "containers.mdb.shutdown_cleanup_start",
-                appEJBName_);
+        _logger.log(FINE, "containers.mdb.shutdown_cleanup_start", appEJBName_);
         monitorOn = false;
         cleanupResources();
-        _logger.log(Level.FINE, "containers.mdb.shutdown_cleanup_end",
-                appEJBName_);
+        _logger.log(FINE, "containers.mdb.shutdown_cleanup_end", appEJBName_);
     }
 
     /**
      * Actual message delivery happens in three steps :
      *
-     * 1) beforeMessageDelivery(Message, MessageListener) This is our chance to
-     * make the message delivery itself part of the instance's global
-     * transaction.
+     * 1) beforeMessageDelivery(Message, MessageListener) This is our chance to make the message delivery itself part of the
+     * instance's global transaction.
      *
-     * 2) onMessage(Message, MessageListener) This is where the container
-     * delegates to the actual ejb instance's onMessage method.
+     * 2) onMessage(Message, MessageListener) This is where the container delegates to the actual ejb instance's onMessage
+     * method.
      *
-     * 3) afterMessageDelivery(Message, MessageListener) Perform transaction
-     * cleanup and error handling.
+     * 3) afterMessageDelivery(Message, MessageListener) Perform transaction cleanup and error handling.
      *
-     * We use the EjbInvocation manager's thread-specific state to track the
-     * invocation across these three calls.
+     * We use the EjbInvocation manager's thread-specific state to track the invocation across these three calls.
      *
      */
 
-    public void beforeMessageDelivery(Method method, MessageDeliveryType deliveryType,
-                                      boolean txImported, ResourceHandle resourceHandle) {
-
+    public void beforeMessageDelivery(Method method, MessageDeliveryType deliveryType, boolean txImported, ResourceHandle resourceHandle) {
         if (containerState != CONTAINER_STARTED) { // i.e. no invocation
-            String errorMsg = localStrings
-                    .getLocalString(
-                            "containers.mdb.invocation_closed",
-                            appEJBName_
-                                    + ": Message-driven bean invocation closed by container",
-                            new Object[] { appEJBName_ });
+            String errorMsg =
+                localStrings.getLocalString(
+                    "containers.mdb.invocation_closed",
+                    appEJBName_ + ": Message-driven bean invocation closed by container", new Object[] { appEJBName_ });
 
             throw new EJBException(errorMsg);
         }
@@ -1096,7 +1025,7 @@ public final class MessageBeanContainer extends BaseContainer implements
 
             MessageBeanContextImpl context = (MessageBeanContextImpl) getContext(invocation);
 
-            if( deliveryType == MessageDeliveryType.Timer ) {
+            if (deliveryType == MessageDeliveryType.Timer) {
                 invocation.isTimerCallback = true;
             }
 
@@ -1106,8 +1035,7 @@ public final class MessageBeanContainer extends BaseContainer implements
             // The previous context class loader will be restored in
             // afterMessageDelivery.
 
-            invocation.setOriginalContextClassLoader(
-                    Utility.setContextClassLoader(getClassLoader()));
+            invocation.setOriginalContextClassLoader(Utility.setContextClassLoader(getClassLoader()));
             invocation.isMessageDriven = true;
             invocation.method = method;
 
@@ -1143,41 +1071,35 @@ public final class MessageBeanContainer extends BaseContainer implements
 
         } catch (Throwable c) {
             if (containerState != CONTAINER_STARTED) {
-                _logger.log(Level.SEVERE, "containers.mdb.preinvoke_exception",
-                        new Object[] { appEJBName_, c.toString() });
-                _logger.log(Level.SEVERE, c.getClass().getName(), c);
+                _logger.log(SEVERE, "containers.mdb.preinvoke_exception", new Object[] { appEJBName_, c.toString() });
+                _logger.log(SEVERE, c.getClass().getName(), c);
             }
             invocation.exception = c;
         }
     }
 
     public Object deliverMessage(Object[] params) throws Throwable {
-
         EjbInvocation invocation = null;
-        boolean methodCalled = false; // for monitoring
         Object result = null;
 
         invocation = (EjbInvocation) invocationManager.getCurrentInvocation();
 
-        if (invocation == null && _logger.isLoggable(Level.FINEST)) {
+        if (invocation == null && _logger.isLoggable(FINEST)) {
             if (containerState != CONTAINER_STARTED) {
-                _logger.log(Level.FINEST, "No invocation in onMessage "
-                        + " (container closing)");
+                _logger.log(FINEST, "No invocation in onMessage " + " (container closing)");
             } else {
-                _logger.log(Level.FINEST, "No invocation in onMessage : ");
+                _logger.log(FINEST, "No invocation in onMessage : ");
             }
         }
 
-        if ((invocation != null) && (invocation.exception == null)) {
+        if (invocation != null && invocation.exception == null) {
 
             try {
 
                 // NOTE : Application classloader already set in
                 // beforeMessageDelivery
 
-                methodCalled = true;
-                if (isTimedObject()
-                        && isEjbTimeoutMethod(invocation.method)) {
+                if (isTimedObject() && isEjbTimeoutMethod(invocation.method)) {
                     invocation.beanMethod = invocation.method;
                     intercept(invocation);
                 } else {
@@ -1188,11 +1110,13 @@ public final class MessageBeanContainer extends BaseContainer implements
                     // method itself. This info is also returned from the
                     // interceptor context info.
 
-                        invocation.methodParams = params;
+                    invocation.methodParams = params;
 
-                    invocation.beanMethod = invocation.ejb.getClass()
-                            .getMethod(invocation.method.getName(),
-                                    invocation.method.getParameterTypes());
+                    invocation.beanMethod =
+                        invocation.ejb.getClass()
+                                      .getMethod(
+                                          invocation.method.getName(),
+                                          invocation.method.getParameterTypes());
 
                     result = super.intercept(invocation);
                 }
@@ -1229,43 +1153,35 @@ public final class MessageBeanContainer extends BaseContainer implements
                 invocation.exception = cause;
 
                 if (isSystemUncheckedException(cause)) {
-                    EJBException ejbEx = new EJBException(
-                            "message-driven bean method " + invocation.method
-                                    + " system exception");
+                    EJBException ejbEx = new EJBException("message-driven bean method " + invocation.method + " system exception");
                     ejbEx.initCause(cause);
                     cause = ejbEx;
                 }
                 throw cause;
             } catch (Throwable t) {
-                EJBException ejbEx = new EJBException(
-                        "message-bean container dispatch error");
+                EJBException ejbEx = new EJBException("message-bean container dispatch error");
                 ejbEx.initCause(t);
                 invocation.exception = ejbEx;
                 throw ejbEx;
             } finally {
                 /*
-                 * FIXME if ( AppVerification.doInstrument() ) {
-                 * AppVerification.getInstrumentLogger().doInstrumentForEjb
-                 * (getEjbDescriptor(), invocation.method,
-                 * invocation.exception); }
+                 * FIXME if ( AppVerification.doInstrument() ) { AppVerification.getInstrumentLogger().doInstrumentForEjb
+                 * (getEjbDescriptor(), invocation.method, invocation.exception); }
                  */
             }
 
         } // End if -- invoke instance's onMessage method
         else {
             if (invocation == null) {
-                String errorMsg = localStrings.getLocalString(
-                        "containers.mdb.invocation_closed", appEJBName_
-                                + ": Message-driven bean invocation "
-                                + "closed by container",
-                        new Object[] { appEJBName_ });
+                String errorMsg =
+                    localStrings.getLocalString(
+                        "containers.mdb.invocation_closed",
+                        appEJBName_ + ": Message-driven bean invocation " + "closed by container", new Object[] { appEJBName_ });
                 throw new EJBException(errorMsg);
             } else {
-                _logger.log(Level.SEVERE,
-                        "containers.mdb.invocation_exception", new Object[] {
-                                appEJBName_, invocation.exception.toString() });
-                _logger.log(Level.SEVERE, invocation.exception.getClass()
-                        .getName(), invocation.exception);
+                _logger.log(SEVERE, "containers.mdb.invocation_exception",
+                        new Object[] { appEJBName_, invocation.exception.toString() });
+                _logger.log(SEVERE, invocation.exception.getClass().getName(), invocation.exception);
                 EJBException ejbEx = new EJBException();
                 ejbEx.initCause(invocation.exception);
                 throw ejbEx;
@@ -1287,8 +1203,7 @@ public final class MessageBeanContainer extends BaseContainer implements
 
         invocation = (EjbInvocation) invocationManager.getCurrentInvocation();
         if (invocation == null) {
-            _logger.log(Level.SEVERE, "containers.mdb.no_invocation",
-                    new Object[] { appEJBName_, "" });
+            _logger.log(SEVERE, "containers.mdb.no_invocation", new Object[] { appEJBName_, "" });
         } else {
             try {
                 if (invocation.isContainerStartsTx()) {
@@ -1308,50 +1223,39 @@ public final class MessageBeanContainer extends BaseContainer implements
                 success = true;
 
                 // TODO: Check if Tx existed / committed
-                                ejbProbeNotifier.messageDeliveredEvent(getContainerId(),
-                                        containerInfo.appName, containerInfo.modName,
-                                        containerInfo.ejbName);
+                ejbProbeNotifier.messageDeliveredEvent(getContainerId(), containerInfo.appName, containerInfo.modName,
+                        containerInfo.ejbName);
 
             } catch (Throwable ce) {
-                _logger.log(Level.SEVERE,
-                        "containers.mdb.postinvoke_exception", new Object[] {
-                                appEJBName_, ce.toString() });
-                _logger.log(Level.SEVERE, ce.getClass().getName(), ce);
+                _logger.log(SEVERE, "containers.mdb.postinvoke_exception", new Object[] { appEJBName_, ce.toString() });
+                _logger.log(SEVERE, ce.getClass().getName(), ce);
             } finally {
                 releaseContext(invocation);
             }
 
             // Reset original class loader
-            Utility.setContextClassLoader(
-                    invocation.getOriginalContextClassLoader());
+            setContextClassLoader(invocation.getOriginalContextClassLoader());
 
             if (invocation.exception != null) {
-
                 if (isSystemUncheckedException(invocation.exception)) {
                     success = false;
                 }
 
                 // Log system exceptions by default and application exceptions
                 // only when log level is FINE or higher.
-                Level exLogLevel = isSystemUncheckedException(invocation.exception) ? Level.WARNING
-                        : Level.FINE;
+                Level exLogLevel = isSystemUncheckedException(invocation.exception) ? WARNING : FINE;
 
                 _logger.log(exLogLevel, "containers.mdb.invocation_exception",
-                        new Object[] { appEJBName_,
-                                invocation.exception.toString() });
-                _logger.log(exLogLevel, invocation.exception.getClass()
-                        .getName(), invocation.exception);
+                        new Object[] { appEJBName_, invocation.exception.toString() });
+                _logger.log(exLogLevel, invocation.exception.getClass().getName(), invocation.exception);
             }
         }
 
         return success;
     }
 
-        // TODO : remove
-    public long getMessageCount() {
-        return statMessageCount;
-    }
-
-    public enum MessageDeliveryType { Message, Timer };
+    public enum MessageDeliveryType {
+        Message, Timer
+    };
 
 }

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainer.java
@@ -894,7 +894,7 @@ public final class MessageBeanContainer extends BaseContainer implements Message
                     // we will have to do the cleanup in the current thread itself.
                     addedAsyncTask = false;
                     _logger.log(WARNING, "[MDBContainer] Got exception while trying "
-                            + "to add task to ContainerWorkPool. Will execute " + "cleanupResources on current thread", th);
+                            + "to add task to ContainerWorkPool. Will execute cleanupResources on current thread", th);
                 }
             }
 

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainerFactory.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContainerFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,24 +17,22 @@
 
 package org.glassfish.ejb.mdb;
 
-import com.sun.ejb.containers.BaseContainerFactory;
-import jakarta.inject.Singleton;
 import org.glassfish.api.deployment.DeploymentContext;
-import com.sun.enterprise.security.SecurityManager;
+import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
 import org.jvnet.hk2.annotations.Service;
+
 import com.sun.ejb.Container;
 import com.sun.ejb.ContainerFactory;
-import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
+import com.sun.ejb.containers.BaseContainerFactory;
+
+import jakarta.inject.Singleton;
 
 @Service(name = "MessageBeanContainerFactory")
 @Singleton
 public final class MessageBeanContainerFactory extends BaseContainerFactory implements ContainerFactory {
 
     @Override
-    public Container createContainer(EjbDescriptor ejbDescriptor, ClassLoader loader, DeploymentContext deployContext)
-        throws Exception {
-        SecurityManager sm = getSecurityManager(ejbDescriptor);
-        MessageBeanContainer mdbContainer = new MessageBeanContainer(ejbDescriptor, loader, sm);
-        return mdbContainer;
+    public Container createContainer(EjbDescriptor ejbDescriptor, ClassLoader loader, DeploymentContext deployContext) throws Exception {
+        return new MessageBeanContainer(ejbDescriptor, loader, getSecurityManager(ejbDescriptor));
     }
 }

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContextImpl.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanContextImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +17,8 @@
 
 package org.glassfish.ejb.mdb;
 
+import org.glassfish.api.invocation.ComponentInvocation;
+
 import com.sun.ejb.EjbInvocation;
 import com.sun.ejb.containers.BaseContainer;
 import com.sun.ejb.containers.EJBContextImpl;
@@ -23,8 +26,6 @@ import com.sun.ejb.containers.EJBObjectImpl;
 import com.sun.ejb.containers.EJBTimerService;
 import com.sun.ejb.containers.EJBTimerServiceWrapper;
 import com.sun.ejb.containers.EjbContainerUtilImpl;
-
-import org.glassfish.api.invocation.ComponentInvocation;
 
 import jakarta.ejb.EJBHome;
 import jakarta.ejb.EJBObject;
@@ -38,34 +39,29 @@ import jakarta.transaction.UserTransaction;
  * @author Kenneth Saks
  */
 public final class MessageBeanContextImpl extends EJBContextImpl implements MessageDrivenContext {
-
-    private boolean afterSetContext = false;
+    private static final long serialVersionUID = 1L;
+    private boolean afterSetContext;
 
     MessageBeanContextImpl(Object ejb, BaseContainer container) {
         super(ejb, container);
     }
 
-
     void setEJBStub(EJBObject ejbStub) {
         throw new RuntimeException("No stubs for Message-driven beans");
     }
 
-
     void setEJBObjectImpl(EJBObjectImpl ejbo) {
         throw new RuntimeException("No EJB Object for Message-driven beans");
     }
-
 
     // FIXME later
     EJBObjectImpl getEJBObjectImpl() {
         throw new RuntimeException("No EJB Object for Message-driven beans");
     }
 
-
     public void setContextCalled() {
         this.afterSetContext = true;
     }
-
 
     /*****************************************************************
      * The following are implementations of EJBContext methods.
@@ -86,18 +82,14 @@ public final class MessageBeanContextImpl extends EJBContextImpl implements Mess
         return ((BaseContainer) getContainer()).getUserTransaction();
     }
 
-
     /**
-     * Doesn't make any sense to get EJBHome object for
-     * a message-driven ejb.
+     * Doesn't make any sense to get EJBHome object for a message-driven ejb.
      */
     @Override
     public EJBHome getEJBHome() {
-        RuntimeException exception = new java.lang.IllegalStateException(
-            "getEJBHome not allowed for message-driven beans");
+        RuntimeException exception = new java.lang.IllegalStateException("getEJBHome not allowed for message-driven beans");
         throw exception;
     }
-
 
     @Override
     protected void checkAccessToCallerSecurity() throws java.lang.IllegalStateException {
@@ -108,7 +100,6 @@ public final class MessageBeanContextImpl extends EJBContextImpl implements Mess
         }
 
     }
-
 
     @Override
     public boolean isCallerInRole(String roleRef) {
@@ -133,7 +124,6 @@ public final class MessageBeanContextImpl extends EJBContextImpl implements Mess
         return sm.isCallerInRole(roleRef);
     }
 
-
     @Override
     public TimerService getTimerService() throws java.lang.IllegalStateException {
         if (!afterSetContext) {
@@ -144,41 +134,33 @@ public final class MessageBeanContextImpl extends EJBContextImpl implements Mess
         return new EJBTimerServiceWrapper(timerService, this);
     }
 
-
     @Override
     public void checkTimerServiceMethodAccess() throws java.lang.IllegalStateException {
         // A message-driven ejb's state transitions past UNINITIALIZED
         // AFTER ejbCreate
         if (!operationsAllowed()) {
-            throw new java.lang.IllegalStateException(
-                "EJB Timer Service method calls cannot be called in " + " this context");
+            throw new java.lang.IllegalStateException("EJB Timer Service method calls cannot be called in " + " this context");
         }
     }
-
 
     boolean isInState(BeanState value) {
         return getState() == value;
     }
 
-
     void setState(BeanState s) {
         state = s;
     }
-
 
     void setInEjbRemove(boolean beingRemoved) {
         inEjbRemove = beingRemoved;
     }
 
-
     boolean operationsAllowed() {
         return !(isUnitialized() || inEjbRemove);
     }
 
-
     /**
-     * Returns true if this context has NOT progressed past its initial
-     * state.
+     * Returns true if this context has NOT progressed past its initial state.
      */
     private boolean isUnitialized() {
         return (state == EJBContextImpl.BeanState.CREATED);

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanListenerImpl.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanListenerImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,11 +17,13 @@
 
 package org.glassfish.ejb.mdb;
 
-import java.lang.reflect.Method;
-import com.sun.appserv.connectors.internal.api.ResourceHandle;
-import org.glassfish.ejb.api.MessageBeanListener;
-import org.glassfish.ejb.mdb.MessageBeanContainer.MessageDeliveryType;
+import static org.glassfish.ejb.mdb.MessageBeanContainer.MessageDeliveryType.Message;
 
+import java.lang.reflect.Method;
+
+import org.glassfish.ejb.api.MessageBeanListener;
+
+import com.sun.appserv.connectors.internal.api.ResourceHandle;
 
 /**
  *
@@ -29,39 +32,43 @@ import org.glassfish.ejb.mdb.MessageBeanContainer.MessageDeliveryType;
  */
 public class MessageBeanListenerImpl implements MessageBeanListener {
 
-    private MessageBeanContainer container_;
-    private ResourceHandle resourceHandle_;
+    private MessageBeanContainer messageBeanContainer;
+    private ResourceHandle resourceHandle;
 
-    MessageBeanListenerImpl(MessageBeanContainer container,
-                            ResourceHandle handle) {
-        container_ = container;
+    MessageBeanListenerImpl(MessageBeanContainer container, ResourceHandle handle) {
+        messageBeanContainer = container;
 
         // can be null
-        resourceHandle_ = handle;
+        resourceHandle = handle;
     }
 
+    @Override
     public void setResourceHandle(ResourceHandle handle) {
-        resourceHandle_ = handle;
+        resourceHandle = handle;
     }
 
+    @Override
     public ResourceHandle getResourceHandle() {
-        return resourceHandle_;
+        return resourceHandle;
     }
 
+    @Override
     public void beforeMessageDelivery(Method method, boolean txImported) {
-        container_.onEnteringContainer();   //Notify Callflow Agent
-        container_.beforeMessageDelivery(method, MessageDeliveryType.Message, txImported, resourceHandle_);
+        messageBeanContainer.onEnteringContainer(); // Notify Callflow Agent
+        messageBeanContainer.beforeMessageDelivery(method, Message, txImported, resourceHandle);
     }
 
+    @Override
     public Object deliverMessage(Object[] params) throws Throwable {
-        return container_.deliverMessage(params);
+        return messageBeanContainer.deliverMessage(params);
     }
 
+    @Override
     public void afterMessageDelivery() {
         try {
-            container_.afterMessageDelivery(resourceHandle_);
+            messageBeanContainer.afterMessageDelivery(resourceHandle);
         } finally {
-            container_.onLeavingContainer();    //Notify Callflow Agent
+            messageBeanContainer.onLeavingContainer(); // Notify Callflow Agent
         }
     }
 


### PR DESCRIPTION
The CDI TCK requires events for MDBs to be fired on startup. The easiest
way to satisfy that requirement is to eagerly load MDBs by default.
Users can still disable that if needed.

First commit is some refactoring, mostly formatting and some naming.
Second commmit will be the actual change.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>
