### PR TITLE
Fixed another few CDI TCK tests

### DIFF
--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -361,7 +361,6 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <argLine>-Xmx768m</argLine>
-
                     <!-- Surefire / TestNG Properties -->
                     <!-- The suite, the exclude and the test dependencies together determine which tests are being run -->
                     <suiteXmlFiles>
@@ -385,11 +384,10 @@
                         <glassfish.enableDerby>true</glassfish.enableDerby>
                         <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
                         <glassfish.enableAssertions>:org.jboss.cdi.tck...</glassfish.enableAssertions>
-                        
                         <glassfish.systemProperties>
                             cdiTckExcludeDummy=true
+                            glassfish.servlet.loadAllOnStartup=true
                         </glassfish.systemProperties>
-
                         <glassfish.postBootCommands>
                             create-jms-resource --restype jakarta.jms.Queue --property Name=queue_test queue_test
                             create-jms-resource --restype jakarta.jms.Topic --property Name=topic_test topic_test
@@ -398,7 +396,6 @@
                             create-file-user --groups printer --passwordfile ${project.build.directory}/test-classes/password.txt printer
                             create-file-user --groups student:alarm --passwordfile ${project.build.directory}/test-classes/password.txt alarm
                         </glassfish.postBootCommands>
-
                         <libPath>${project.build.outputDirectory}</libPath>
                         <org.jboss.cdi.tck.libraryDirectory>${project.build.directory}/dependency/lib</org.jboss.cdi.tck.libraryDirectory>
                         <debugMode>true</debugMode>

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Wrapper.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Wrapper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -16,7 +17,6 @@
  */
 
 package org.apache.catalina;
-
 
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
@@ -59,7 +59,7 @@ public interface Wrapper extends Container {
      * the servlet is currently available.  A value equal to Long.MAX_VALUE
      * is considered to mean that unavailability is permanent.
      */
-    public long getAvailable();
+    long getAvailable();
 
 
     /**
@@ -70,13 +70,13 @@ public interface Wrapper extends Container {
      *
      * @param available The new available date/time
      */
-    public void setAvailable(long available);
+    void setAvailable(long available);
 
 
     /**
      * Return the context-relative URI of the JSP file for this servlet.
      */
-    public String getJspFile();
+    String getJspFile();
 
 
     /**
@@ -84,14 +84,14 @@ public interface Wrapper extends Container {
      *
      * @param jspFile JSP file URI
      */
-    public void setJspFile(String jspFile);
+    void setJspFile(String jspFile);
 
 
     /**
      * Return the load-on-startup order value (negative value means
      * load on first call).
      */
-    public int getLoadOnStartup();
+    int getLoadOnStartup();
 
 
     /**
@@ -100,13 +100,13 @@ public interface Wrapper extends Container {
      *
      * @param value New load-on-startup value
      */
-    public void setLoadOnStartup(int value);
+    void setLoadOnStartup(int value);
 
 
     /**
      * Return the run-as identity for this servlet.
      */
-    public String getRunAs();
+    String getRunAs();
 
 
     /**
@@ -114,19 +114,19 @@ public interface Wrapper extends Container {
      *
      * @param runAs New run-as identity value
      */
-    public void setRunAs(String runAs);
+    void setRunAs(String runAs);
 
 
     /**
      * Return the fully qualified servlet class name for this servlet.
      */
-    public String getServletClassName();
+    String getServletClassName();
 
 
     /**
      * Gets the name of the wrapped servler.
      */
-    public String getServletName();
+    String getServletName();
 
 
     /**
@@ -134,7 +134,7 @@ public interface Wrapper extends Container {
      *
      * @param className Servlet class name
      */
-    public void setServletClassName(String className);
+    void setServletClassName(String className);
 
 
     /**
@@ -143,7 +143,7 @@ public interface Wrapper extends Container {
      * @param servletClass the class object from which the servlet will be
      * instantiated
      */
-    public void setServletClass(Class <? extends Servlet> servletClass);
+    void setServletClass(Class <? extends Servlet> servletClass);
 
 
     /**
@@ -156,73 +156,73 @@ public interface Wrapper extends Container {
      * @return Array of names of the methods supported by the underlying
      * servlet
      */
-    public String[] getServletMethods() throws ServletException;
+    String[] getServletMethods() throws ServletException;
 
 
     /**
      * Is this servlet currently unavailable?
      */
-    public boolean isUnavailable();
+    boolean isUnavailable();
 
 
     /**
      * Sets the description of this servlet.
      */
-    public void setDescription(String description);
+    void setDescription(String description);
 
 
     /**
      * Gets the description of this servlet.
      */
-    public String getDescription();
+    String getDescription();
 
 
     /**
      * Sets the multipart location
      */
-    public void setMultipartLocation(String location);
+    void setMultipartLocation(String location);
 
 
     /**
      * Gets the multipart location
      */
-    public String getMultipartLocation();
+    String getMultipartLocation();
 
 
     /**
      * Sets the multipart max-file-size
      */
-    public void setMultipartMaxFileSize(long maxFileSize);
+    void setMultipartMaxFileSize(long maxFileSize);
 
 
     /**
      * Gets the multipart max-file-size
      */
-    public long getMultipartMaxFileSize();
+    long getMultipartMaxFileSize();
 
 
     /**
      * Sets the multipart max-request-size
      */
-    public void setMultipartMaxRequestSize(long maxRequestSize);
+    void setMultipartMaxRequestSize(long maxRequestSize);
 
 
     /**
      * Gets the multipart max-request-Size
      */
-    public long getMultipartMaxRequestSize();
+    long getMultipartMaxRequestSize();
 
 
     /**
      * Sets the multipart file-size-threshold
      */
-    public void setMultipartFileSizeThreshold(int fileSizeThreshold);
+    void setMultipartFileSizeThreshold(int fileSizeThreshold);
 
 
     /**
      * Gets the multipart file-size-threshol
      */
-    public int getMultipartFileSizeThreshold();
+    int getMultipartFileSizeThreshold();
 
 
     // --------------------------------------------------------- Public Methods
@@ -234,7 +234,7 @@ public interface Wrapper extends Container {
      * @param name Name of this initialization parameter to add
      * @param value Value of this initialization parameter to add
      */
-    public void addInitParameter(String name, String value);
+    void addInitParameter(String name, String value);
 
 
     /**
@@ -242,7 +242,7 @@ public interface Wrapper extends Container {
      *
      * @param listener The new listener
      */
-    public void addInstanceListener(InstanceListener listener);
+    void addInstanceListener(InstanceListener listener);
 
 
     /**
@@ -250,7 +250,7 @@ public interface Wrapper extends Container {
      *
      * @param mapping The new wrapper mapping
      */
-    public void addMapping(String mapping);
+    void addMapping(String mapping);
 
 
     /**
@@ -260,7 +260,7 @@ public interface Wrapper extends Container {
      * @param name Role name used within this servlet
      * @param link Role name used within the web application
      */
-    public void addSecurityReference(String name, String link);
+    void addSecurityReference(String name, String link);
 
 
     /**
@@ -272,11 +272,11 @@ public interface Wrapper extends Container {
      * that this instance is not allocated again until it is deallocated by a
      * call to <code>deallocate()</code>.
      *
-     * @exception ServletException if the servlet init() method threw
+     * @throws ServletException if the servlet init() method threw
      *  an exception
-     * @exception ServletException if a loading error occurs
+     * @throws ServletException if a loading error occurs
      */
-    public Servlet allocate() throws ServletException;
+    Servlet allocate() throws ServletException;
 
 
     /**
@@ -286,9 +286,9 @@ public interface Wrapper extends Container {
      *
      * @param servlet The servlet to be returned
      *
-     * @exception ServletException if a deallocation error occurs
+     * @throws ServletException if a deallocation error occurs
      */
-    public void deallocate(Servlet servlet) throws ServletException;
+    void deallocate(Servlet servlet) throws ServletException;
 
 
     /**
@@ -297,20 +297,20 @@ public interface Wrapper extends Container {
      *
      * @param name Name of the requested initialization parameter
      */
-    public String findInitParameter(String name);
+    String findInitParameter(String name);
 
 
     /**
      * Return the names of all defined initialization parameters for this
      * servlet.
      */
-    public String[] findInitParameters();
+    String[] findInitParameters();
 
 
     /**
      * Return the mappings associated with this wrapper.
      */
-    public String[] findMappings();
+    String[] findMappings();
 
 
     /**
@@ -319,29 +319,26 @@ public interface Wrapper extends Container {
      *
      * @param name Security role reference used within this servlet
      */
-    public String findSecurityReference(String name);
+    String findSecurityReference(String name);
 
 
     /**
      * Return the set of security role reference names associated with
      * this servlet, if any; otherwise return a zero-length array.
      */
-    public String[] findSecurityReferences();
+    String[] findSecurityReferences();
 
 
     /**
      * Load and initialize an instance of this servlet, if there is not already
-     * at least one initialized instance.  This can be used, for example, to
+     * at least one initialized instance. This can be used, for example, to
      * load servlets that are marked in the deployment descriptor to be loaded
      * at server startup time.
      *
-     * @exception ServletException if the servlet init() method threw
-     *  an exception
-     * @exception ServletException if some other loading problem occurs
+     * @throws ServletException if the servlet init() method threw an exception
+     * @throws ServletException if some other loading problem occurs
      */
-    public void load() throws ServletException;
-
-    public void tryLoad() throws ServletException;
+    void load() throws ServletException;
 
 
     /**
@@ -349,7 +346,7 @@ public interface Wrapper extends Container {
      *
      * @param name Name of the initialization parameter to remove
      */
-    public void removeInitParameter(String name);
+    void removeInitParameter(String name);
 
 
     /**
@@ -357,7 +354,7 @@ public interface Wrapper extends Container {
      *
      * @param listener The listener to remove
      */
-    public void removeInstanceListener(InstanceListener listener);
+    void removeInstanceListener(InstanceListener listener);
 
 
     /**
@@ -365,7 +362,7 @@ public interface Wrapper extends Container {
      *
      * @param mapping The pattern to remove
      */
-    public void removeMapping(String mapping);
+    void removeMapping(String mapping);
 
 
     /**
@@ -373,7 +370,7 @@ public interface Wrapper extends Container {
      *
      * @param name Security role used within this servlet to be removed
      */
-    public void removeSecurityReference(String name);
+    void removeSecurityReference(String name);
 
 
     /**
@@ -383,7 +380,7 @@ public interface Wrapper extends Container {
      * @param unavailable The exception that occurred, or <code>null</code>
      *  to mark this servlet as permanently unavailable
      */
-    public void unavailable(UnavailableException unavailable);
+    void unavailable(UnavailableException unavailable);
 
 
     /**
@@ -393,9 +390,9 @@ public interface Wrapper extends Container {
      * prior to reloading all of the classes from the Loader associated with
      * our Loader's repository.
      *
-     * @exception ServletException if an unload error occurs
+     * @throws ServletException if an unload error occurs
      */
-    public void unload() throws ServletException;
+    void unload() throws ServletException;
 
 
     /**
@@ -405,7 +402,7 @@ public interface Wrapper extends Container {
      * @param isAsyncSupported true if the wrapped servlet supports
      * asynchronous operations, false otherwise
      */
-    public void setIsAsyncSupported(boolean isAsyncSupported);
+    void setIsAsyncSupported(boolean isAsyncSupported);
 
 
     /**
@@ -415,5 +412,5 @@ public interface Wrapper extends Container {
      * @return true if the wrapped servlet supports async operations, and
      * false otherwise
      */
-    public boolean isAsyncSupported();
+    boolean isAsyncSupported();
 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -4980,16 +4980,13 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
         // Collect "load on startup" servlets that need to be initialized
         Map<Integer, List<Wrapper>> loadOnStartupServlets = new TreeMap<>();
         List<Wrapper> nonLoadOnStartupServlets = new ArrayList<>();
-
         for (Container aChildren : children) {
             Wrapper wrapper = (Wrapper) aChildren;
-
             int loadOnStartup = wrapper.getLoadOnStartup();
             if (loadOnStartup < 0) {
                 nonLoadOnStartupServlets.add(wrapper);
             } else {
-                loadOnStartupServlets.computeIfAbsent(loadOnStartup, e -> new ArrayList<>())
-                                     .add(wrapper);
+                loadOnStartupServlets.computeIfAbsent(loadOnStartup, e -> new ArrayList<>()).add(wrapper);
             }
         }
 
@@ -5004,36 +5001,34 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
 
         // Load the collected "load on startup" servlets
         for (Wrapper wrapper : allServlets) {
-            try {
-                wrapper.load();
-            } catch (ServletException e) {
-                getServletContext().log(
-                    format(rb.getString(SERVLET_LOAD_EXCEPTION), neutralizeForLog(getName())),
-                    StandardWrapper.getRootCause(e));
-
-                    // NOTE: load errors (including a servlet that throws
-                    // UnavailableException from the init() method) are NOT
-                    // fatal to application startup
-                    throw new LifecycleException(StandardWrapper.getRootCause(e));
-            }
+            loadServlet(wrapper);
         }
 
-        if (Boolean.parseBoolean(System.getProperty("glassfish.try.preload.servlets", "true"))) {
+        if (Boolean.parseBoolean(System.getProperty("glassfish.servlet.loadAllOnStartup", "false"))) {
             // Also load the other servlets, which is one way to pass the CDI TCK, specifically
             // ContainerEventTest#testProcessInjectionTargetEventFiredForServlet and adhere to the rule
             // that injection points for Servlets have to be processed during start.
             for (Wrapper wrapper : nonLoadOnStartupServlets) {
-                try {
-                    wrapper.tryLoad();
-                } catch (Throwable t) {
-                    // Only log errors, don't fail anything.
-                    getServletContext().log(
-                            format(rb.getString(SERVLET_LOAD_EXCEPTION), neutralizeForLog(getName())),
-                            t);
-                }
+                loadServlet(wrapper);
             }
         }
     }
+
+
+    private void loadServlet(Wrapper wrapper) throws LifecycleException {
+        try {
+            wrapper.load();
+        } catch (ServletException e) {
+            getServletContext().log(
+                format(rb.getString(SERVLET_LOAD_EXCEPTION), neutralizeForLog(getName())),
+                StandardWrapper.getRootCause(e));
+            // NOTE: load errors (including a servlet that throws
+            // UnavailableException from the init() method) are NOT
+            // fatal to application startup
+            throw new LifecycleException(StandardWrapper.getRootCause(e));
+        }
+    }
+
 
     /**
      * Starts the session manager of this Context.

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -5004,7 +5004,7 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
             loadServlet(wrapper);
         }
 
-        if (Boolean.parseBoolean(System.getProperty("glassfish.servlet.loadAllOnStartup", "false"))) {
+        if (Boolean.getBoolean("glassfish.servlet.loadAllOnStartup")) {
             // Also load the other servlets, which is one way to pass the CDI TCK, specifically
             // ContainerEventTest#testProcessInjectionTargetEventFiredForServlet and adhere to the rule
             // that injection points for Servlets have to be processed during start.

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardWrapper.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardWrapper.java
@@ -18,24 +18,17 @@
 
 package org.apache.catalina.core;
 
-import static com.sun.logging.LogCleanerUtil.neutralizeForLog;
-import static java.text.MessageFormat.format;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableList;
-import static java.util.logging.Level.FINEST;
-import static org.apache.catalina.InstanceEvent.EventType.AFTER_DESTROY_EVENT;
-import static org.apache.catalina.InstanceEvent.EventType.AFTER_INIT_EVENT;
-import static org.apache.catalina.InstanceEvent.EventType.AFTER_SERVICE_EVENT;
-import static org.apache.catalina.InstanceEvent.EventType.BEFORE_DESTROY_EVENT;
-import static org.apache.catalina.InstanceEvent.EventType.BEFORE_INIT_EVENT;
-import static org.apache.catalina.InstanceEvent.EventType.BEFORE_SERVICE_EVENT;
-import static org.apache.catalina.LogFacade.CANNOT_ALLOCATE_SERVLET_EXCEPTION;
-import static org.apache.catalina.LogFacade.CANNOT_FIND_SERVLET_CLASS_EXCEPTION;
-import static org.apache.catalina.LogFacade.ERROR_ALLOCATE_SERVLET_INSTANCE_EXCEPTION;
-import static org.apache.catalina.LogFacade.ERROR_LOADING_INFO;
-import static org.apache.catalina.LogFacade.PARENT_CONTAINER_MUST_BE_CONTEXT_EXCEPTION;
-import static org.apache.catalina.LogFacade.WRAPPER_CONTAINER_NO_CHILD_EXCEPTION;
-import static org.apache.catalina.core.Constants.JSP_SERVLET_CLASS;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.UnavailableException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+// END GlassFish 1343
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -72,17 +65,24 @@ import org.apache.catalina.util.Enumerator;
 import org.apache.catalina.util.InstanceSupport;
 import org.glassfish.web.valve.GlassFishValve;
 
-import jakarta.servlet.Servlet;
-import jakarta.servlet.ServletConfig;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.UnavailableException;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-// END GlassFish 1343
+import static com.sun.logging.LogCleanerUtil.neutralizeForLog;
+import static java.text.MessageFormat.format;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableList;
+import static java.util.logging.Level.FINEST;
+import static org.apache.catalina.InstanceEvent.EventType.AFTER_DESTROY_EVENT;
+import static org.apache.catalina.InstanceEvent.EventType.AFTER_INIT_EVENT;
+import static org.apache.catalina.InstanceEvent.EventType.AFTER_SERVICE_EVENT;
+import static org.apache.catalina.InstanceEvent.EventType.BEFORE_DESTROY_EVENT;
+import static org.apache.catalina.InstanceEvent.EventType.BEFORE_INIT_EVENT;
+import static org.apache.catalina.InstanceEvent.EventType.BEFORE_SERVICE_EVENT;
+import static org.apache.catalina.LogFacade.CANNOT_ALLOCATE_SERVLET_EXCEPTION;
+import static org.apache.catalina.LogFacade.CANNOT_FIND_SERVLET_CLASS_EXCEPTION;
+import static org.apache.catalina.LogFacade.ERROR_ALLOCATE_SERVLET_INSTANCE_EXCEPTION;
+import static org.apache.catalina.LogFacade.ERROR_LOADING_INFO;
+import static org.apache.catalina.LogFacade.PARENT_CONTAINER_MUST_BE_CONTEXT_EXCEPTION;
+import static org.apache.catalina.LogFacade.WRAPPER_CONTAINER_NO_CHILD_EXCEPTION;
+import static org.apache.catalina.core.Constants.JSP_SERVLET_CLASS;
 
 /**
  * Standard implementation of the <b>Wrapper</b> interface that represents an individual servlet definition. No child
@@ -125,7 +125,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
      * The count of allocations that are currently active (even if they are for the same instance, as will be true on a
      * non-STM servlet).
      */
-    private AtomicInteger countAllocated = new AtomicInteger(0);
+    private final AtomicInteger countAllocated = new AtomicInteger(0);
 
     /**
      * The debugging detail level for this component.
@@ -135,7 +135,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
     /**
      * The facade associated with this wrapper.
      */
-    private StandardWrapperFacade facade = new StandardWrapperFacade(this);
+    private final StandardWrapperFacade facade = new StandardWrapperFacade(this);
 
     /**
      * The descriptive information string for this implementation.
@@ -155,7 +155,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
     /**
      * The support object for our instance listeners.
      */
-    private InstanceSupport instanceSupport = new InstanceSupport(this);
+    private final InstanceSupport instanceSupport = new InstanceSupport(this);
 
     /**
      * The context-relative URI of the JSP file for this servlet.
@@ -170,18 +170,18 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
     /**
      * Mappings associated with the wrapper.
      */
-    private ArrayList<String> mappings = new ArrayList<String>();
+    private final ArrayList<String> mappings = new ArrayList<>();
 
     /**
      * The initialization parameters for this servlet, keyed by parameter name.
      */
-    private Map<String, String> parameters = new HashMap<String, String>();
+    private final Map<String, String> parameters = new HashMap<>();
 
     /**
      * The security role references for this servlet, keyed by role name used in the servlet. The corresponding value is the
      * role name of the web application itself.
      */
-    private HashMap<String, String> references = new HashMap<String, String>();
+    private final HashMap<String, String> references = new HashMap<>();
 
     /**
      * The run-as identity for this servlet.
@@ -240,7 +240,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
 
 
     // To support jmx attributes
-    private StandardWrapperValve swValve;
+    private final StandardWrapperValve swValve;
     private long loadTime = 0;
     private int classLoadTime = 0;
 
@@ -652,7 +652,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
             return DEFAULT_SERVLET_METHODS;
         }
 
-        HashSet<String> allow = new HashSet<String>();
+        HashSet<String> allow = new HashSet<>();
         allow.add("TRACE");
         allow.add("OPTIONS");
 
@@ -788,8 +788,9 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
         do {
             loops++;
             rootCauseCheck = rootCause.getCause();
-            if (rootCauseCheck != null)
+            if (rootCauseCheck != null) {
                 rootCause = rootCauseCheck;
+            }
         } while (rootCauseCheck != null && (loops < 20));
         return rootCause;
     }
@@ -864,7 +865,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
 
                 if (parameters.containsKey(e.getKey())) {
                     if (conflicts == null) {
-                        conflicts = new HashSet<String>();
+                        conflicts = new HashSet<>();
                     }
                     conflicts.add(e.getKey());
                 }
@@ -1105,29 +1106,13 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
      * current web application. This gives such classes access to Catalina internals, which are prevented for classes loaded
      * for web applications.
      *
-     * @exception ServletException if the servlet init() method threw an exception
-     * @exception ServletException if some other loading problem occurs
+     * @throws ServletException if the servlet init() method threw an exception
+     * @throws ServletException if some other loading problem occurs
      */
     @Override
     public synchronized void load() throws ServletException {
         instance = loadServlet();
         initServlet(instance);
-    }
-
-    @Override
-    public synchronized void tryLoad() throws ServletException {
-        try {
-            instance = loadServlet();
-            initServlet(instance);
-        } catch (Throwable t) {
-            instance = null;
-            available = 0l;
-            classLoadTime = 0;
-            loadTime = 0l;
-            instanceInitialized = false;
-
-            throw t;
-        }
     }
 
 
@@ -1160,8 +1145,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
             throw new ServletException(msg, e);
         }
 
-        // Check if loading the servlet in this web application should be
-        // allowed
+        // Check if loading the servlet in this web application should be allowed
         if (!isServletAllowed(servlet)) {
             String msg = format(rb.getString(LogFacade.PRIVILEGED_SERVLET_CANNOT_BE_LOADED_EXCEPTION),
                     servletClass.getName());
@@ -1519,14 +1503,15 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
     public void unavailable(UnavailableException unavailable) {
         String msg = format(rb.getString(LogFacade.MARK_SERVLET_UNAVAILABLE), neutralizeForLog(getName()));
         getServletContext().log(msg);
-        if (unavailable == null)
+        if (unavailable == null) {
             setAvailable(Long.MAX_VALUE);
-        else if (unavailable.isPermanent())
+        } else if (unavailable.isPermanent()) {
             setAvailable(Long.MAX_VALUE);
-        else {
+        } else {
             int unavailableSeconds = unavailable.getUnavailableSeconds();
-            if (unavailableSeconds <= 0)
+            if (unavailableSeconds <= 0) {
                 unavailableSeconds = 60; // Arbitrary default
+            }
             setAvailable(System.currentTimeMillis() + (unavailableSeconds * 1000L));
         }
 
@@ -1543,8 +1528,9 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
     public synchronized void unload() throws ServletException {
 
         // Nothing to do if we have never loaded the instance
-        if (!singleThreadModel && (instance == null))
+        if (!singleThreadModel && instance == null) {
             return;
+        }
         unloading = true;
 
         // Loaf a while if the current instance is allocated
@@ -1552,11 +1538,11 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
         if (countAllocated.get() > 0) {
             int nRetries = 0;
             long delay = unloadDelay / 20;
-            while ((nRetries < 21) && (countAllocated.get() > 0)) {
+            while (nRetries < 21 && countAllocated.get() > 0) {
                 if ((nRetries % 10) == 0) {
                     if (log.isLoggable(Level.FINE)) {
                         log.log(Level.FINE, LogFacade.WAITING_INSTANCE_BE_DEALLOCATED,
-                                new Object[] { countAllocated.toString(), instance.getClass().getName() });
+                            new Object[] {countAllocated.toString(), instance.getClass().getName()});
                     }
                 }
                 try {
@@ -1665,7 +1651,7 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
     @Override
     public Enumeration<String> getInitParameterNames() {
         synchronized (parameters) {
-            return (new Enumerator<String>(parameters.keySet()));
+            return new Enumerator<>(parameters.keySet());
         }
     }
 
@@ -1809,8 +1795,9 @@ public class StandardWrapper extends ContainerBase implements ServletConfig, Wra
         // Start up this component
         super.start();
 
-        if (oname != null)
+        if (oname != null) {
             registerJMX((StandardContext) getParent());
+        }
 
         // Load and initialize an instance of this servlet if requested
         // MOVED TO StandardContext START() METHOD


### PR DESCRIPTION
- some CDI TCK tests rely on loadOnStartup for servlets, so we made it a feature
- it is now possible to use a system property to enforce that all servlets will load on application startup: `glassfish.servlet.loadAllOnStartup=true`
- the default value is false, then servlets which don't have loadOnStartup attribute will load on the first request just like in previous GlassFish versions.
- thrown exceptions are always propagated

