### PR TITLE
Updated and reactivated Krazo for MVC 2.0 support

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -256,7 +256,6 @@
         </dependency>
 
         <!-- Jakarta MVC -->
-        <!-- TMP disable until EE 10 versions
         <dependency>
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
@@ -287,7 +286,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        -->
 
         <!-- glassfish-grizzly-full -->
         <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -152,8 +152,8 @@
         <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->
-        <jakarta.mvc-api.version>2.0.0</jakarta.mvc-api.version>
-        <krazo.version>2.0.1</krazo.version>
+        <jakarta.mvc-api.version>2.0.1</jakarta.mvc-api.version>
+        <krazo.version>2.0.2</krazo.version>
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.0.1</microprofile.config-api.version>


### PR DESCRIPTION
As part of preparing Glassfish for Jakarta EE 10, @arjantijms disabled support for [Jakarta MVC 2.0](https://jakarta.ee/specifications/mvc/2.0/) due to some issues with the spec's and implementation's OSGi manifests. See [here](https://github.com/eclipse-ee4j/glassfish/blob/ba05d6db61aa02ccdf0fdae4e506e78b2f0b7f99/appserver/featuresets/web/pom.xml#L258-L290).

These OSGi issues have been fixed on the MVC + Krazo side and updated artifacts are available in the staging repository.

The TCK report of running the Jakarta MVC TCK 2.0.1 against this branch can be found here:

https://eclipse-ee4j.github.io/krazo/reports/2.0.2-glassfish-integration/surefire-report.html

To run the TCK yourself, just start Glassfish (web or full distribution) and run the following commands:

```
$ git clone https://github.com/eclipse-ee4j/krazo.git && cd krazo
$ git checkout 2.0.2
$ mvn -Pstaging -pl tck -Dtck-env=glassfish-module verify
```

Let me know if you have any questions.
