### PR TITLE
Fix provider tests in CDI TCK

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -253,6 +253,11 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     }
 
     @Override
+    public Collection<String> getKnownClasses() {
+        return moduleClassNames;
+    }
+
+    @Override
     public BeansXml getBeansXml() {
         WeldBootstrap weldBootstrap = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class);
         if (beansXmlURLs.size() == 1) {

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -320,7 +320,7 @@ public class DeploymentImpl implements CDI11Deployment {
 
         for (BeanDeploymentArchive beanDeploymentArchive : beanDeploymentArchives) {
             BeanDeploymentArchiveImpl beanDeploymentArchiveImpl = (BeanDeploymentArchiveImpl) beanDeploymentArchive;
-            if (beanDeploymentArchiveImpl.getBeanClassObjects().contains(beanClass)) {
+            if (beanDeploymentArchiveImpl.getKnownClasses().contains(beanClass.getName())) {
                 return beanDeploymentArchive;
             }
         }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/RootBeanDeploymentArchive.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/RootBeanDeploymentArchive.java
@@ -99,7 +99,7 @@ public class RootBeanDeploymentArchive extends BeanDeploymentArchiveImpl {
 
     @Override
     public BeansXml getBeansXml() {
-        return getModuleBda().getBeansXml();
+        return null;
     }
 
     @Override

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/weld/RootBeanDeploymentArchiveTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/weld/RootBeanDeploymentArchiveTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -115,6 +116,7 @@ public class RootBeanDeploymentArchiveTest {
         assertEquals(WeldUtils.BDAType.UNKNOWN, rootBeanDeploymentArchive.getBDAType());
         assertEquals(0, rootBeanDeploymentArchive.getBeanClasses().size());
         assertEquals(0, rootBeanDeploymentArchive.getBeanClassObjects().size());
+        assertNull(rootBeanDeploymentArchive.getBeansXml());
 
         BeanDeploymentArchiveImpl moduleBda = (BeanDeploymentArchiveImpl) rootBeanDeploymentArchive.getModuleBda();
         assertNotNull(moduleBda);


### PR DESCRIPTION
This fix allows the follwing CDI TCK tests to pass:

- CDIProviderInitTest.testAccessingBeanManager
- CDIProviderRuntimeTest.testGetBeanManager
- CDIProviderRuntimeTest.testLookup

See also #23961
