### PR TITLE
Revert "Updated and reactivated Krazo for MVC 2.0 support"

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -256,6 +256,7 @@
         </dependency>
 
         <!-- Jakarta MVC -->
+        <!-- TMP disable until EE 10 versions
         <dependency>
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
@@ -286,6 +287,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        -->
 
         <!-- glassfish-grizzly-full -->
         <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -152,8 +152,8 @@
         <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->
-        <jakarta.mvc-api.version>2.0.1</jakarta.mvc-api.version>
-        <krazo.version>2.0.2</krazo.version>
+        <jakarta.mvc-api.version>2.0.0</jakarta.mvc-api.version>
+        <krazo.version>2.0.1</krazo.version>
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.0.1</microprofile.config-api.version>


### PR DESCRIPTION
This reverts PR #23988 due to incorrect osgi dependencies which in result broke the CDI TCK tests.

I tried to update MVC-API to 2.1.0.M1, but even that refers to CDI 3 while we need CDI 4.0.1 (Jakarta EE 10).
I had to rebuild Krazo from master too, that updated some dependencies, but it wasn't enough.

