### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -106,7 +106,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.3.0-RC1</openmq.version>
+        <openmq.version>6.3.0</openmq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>


### PR DESCRIPTION
TCK results: https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/41/