### PR TITLE
Helidon Config - CDI TCK Fix 2

### DIFF
--- a/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -142,19 +142,15 @@ public class ConfigCdiExtension implements Extension {
 
         AnnotatedMethod<X> annotatedMethod = event.getAnnotatedMethod();
         List<AnnotatedParameter<X>> annotatedParameters = annotatedMethod.getParameters();
+
         if (annotatedParameters != null) {
             for (AnnotatedParameter<?> annotatedParameter : annotatedParameters) {
                 if ((annotatedParameter != null)
-                        && !annotatedParameter.isAnnotationPresent(Observes.class)) {
-                    InjectionPoint injectionPoint = beanManager.createInjectionPoint(annotatedParameter);
-                    Set<Annotation> qualifiers = injectionPoint.getQualifiers();
-                    assert qualifiers != null;
-                    for (Annotation qualifier : qualifiers) {
-                        if (qualifier instanceof ConfigProperty) {
-                            ips.add(injectionPoint);
-                            break;
-                        }
-                    }
+                        && !annotatedParameter.isAnnotationPresent(Observes.class)
+                        && annotatedParameter.isAnnotationPresent(ConfigProperty.class)) {
+
+                    final var injectionPoint = beanManager.createInjectionPoint(annotatedParameter);
+                    ips.add(injectionPoint);
                 }
             }
         }


### PR DESCRIPTION
Injection points were being created by the Config CDI extension regardless of if an `@ConfigProperty` annotation was present, which was causing the CDI TCK to fail unexpectedly. This change just checks for an annotation before creating an injection point.