### PR TITLE
Add concurrency API JAR to the default JSP servlet config.

### DIFF
--- a/appserver/admin/template/src/main/resources/config/default-web.xml
+++ b/appserver/admin/template/src/main/resources/config/default-web.xml
@@ -327,6 +327,7 @@
         webservices-osgi.jar
         weld-osgi-bundle.jar
         jersey-mvc-jsp.jar
+        jakarta.enterprise.concurrent-api.jar
       </param-value>
     </init-param>
     <load-on-startup>3</load-on-startup>

--- a/appserver/tests/tck/concurrency/pom.xml
+++ b/appserver/tests/tck/concurrency/pom.xml
@@ -171,6 +171,14 @@
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${glassfish.root}/glassfish7/glassfish/lib</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.beust</groupId>
+                                    <artifactId>jcommander</artifactId>
+                                    <version>1.78</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${glassfish.root}/glassfish7/glassfish/lib</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fixes some issues when running the ContextPropagationTests.testSecurityPropagatedContext test in Concurrency 3.0 TCK.

Related to https://github.com/eclipse-ee4j/glassfish/pull/23999

Also copy missing test lib in the Concurrency TCK runner.

With this, stuck on getting "java.io.IOException: unexpected tag: 18" 
in the ContextPropagationTests.testSecurityPropagatedContext Concurrency TCK test.