### PR TITLE
Revert "Revert "Updated and reactivated Krazo for MVC 2.0 support""

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -256,7 +256,6 @@
         </dependency>
 
         <!-- Jakarta MVC -->
-        <!-- TMP disable until EE 10 versions
         <dependency>
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
@@ -287,7 +286,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        -->
 
         <!-- glassfish-grizzly-full -->
         <dependency>


### PR DESCRIPTION
This reverts commit 8aa0f20071015d78350b9bf911bf95d7fb183ce6.

Things changed, now GF passed CDI even with this change.

See #23988 for the original PR