### PR TITLE
Rules for resource and class loading resolution aligned

### DIFF
--- a/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
+++ b/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
@@ -168,14 +168,8 @@ public class WarHandler extends AbstractArchiveHandler {
 
         } catch(XMLStreamException xse) {
             logger.log(Level.SEVERE, xse.getMessage(), xse);
-            if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, xse.getMessage(), xse);
-            }
         } catch(IOException ioe) {
             logger.log(Level.SEVERE, ioe.getMessage(), ioe);
-            if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, ioe.getMessage(), ioe);
-            }
         }
         cloader.start();
         return cloader;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Loader.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Loader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -19,6 +20,7 @@ package org.apache.catalina;
 
 
 import java.beans.PropertyChangeListener;
+import java.util.Set;
 
 
 /**
@@ -61,13 +63,13 @@ public interface Loader {
     /**
      * Return the Java class loader to be used by this Container.
      */
-    public ClassLoader getClassLoader();
+    ClassLoader getClassLoader();
 
 
     /**
      * Return the Container with which this Loader has been associated.
      */
-    public Container getContainer();
+    Container getContainer();
 
 
     /**
@@ -75,14 +77,14 @@ public interface Loader {
      *
      * @param container The associated Container
      */
-    public void setContainer(Container container);
+    void setContainer(Container container);
 
 
     /**
      * Return the "follow standard delegation model" flag used to configure
      * our ClassLoader.
      */
-    public boolean getDelegate();
+    boolean getDelegate();
 
 
     /**
@@ -91,7 +93,7 @@ public interface Loader {
      *
      * @param delegate The new flag
      */
-    public void setDelegate(boolean delegate);
+    void setDelegate(boolean delegate);
 
 
     /**
@@ -99,13 +101,13 @@ public interface Loader {
      * the corresponding version number, in the format
      * <code>&lt;description&gt;/&lt;version&gt;</code>.
      */
-    public String getInfo();
+    String getInfo();
 
 
     /**
      * Return the reloadable flag for this Loader.
      */
-    public boolean getReloadable();
+    boolean getReloadable();
 
 
     /**
@@ -113,7 +115,7 @@ public interface Loader {
      *
      * @param reloadable The new reloadable flag
      */
-    public void setReloadable(boolean reloadable);
+    void setReloadable(boolean reloadable);
 
 
     // --------------------------------------------------------- Public Methods
@@ -124,7 +126,7 @@ public interface Loader {
      *
      * @param listener The listener to add
      */
-    public void addPropertyChangeListener(PropertyChangeListener listener);
+    void addPropertyChangeListener(PropertyChangeListener listener);
 
 
     /**
@@ -132,21 +134,21 @@ public interface Loader {
      *
      * @param repository Repository to be added
      */
-    public void addRepository(String repository);
+    void addRepository(String repository);
 
 
     /**
      * Return the set of repositories defined for this class loader.
      * If none are defined, a zero-length array is returned.
      */
-    public String[] findRepositories();
+    String[] findRepositories();
 
 
     /**
      * Has the internal repository associated with this Loader been modified,
      * such that the loaded classes should be reloaded?
      */
-    public boolean modified();
+    boolean modified();
 
 
     /**
@@ -154,20 +156,18 @@ public interface Loader {
      *
      * @param listener The listener to remove
      */
-    public void removePropertyChangeListener(PropertyChangeListener listener);
+    void removePropertyChangeListener(PropertyChangeListener listener);
 
 
-    // START PE 4985680
     /**
-     * Adds the given package name to the list of packages that may always be
-     * overriden, regardless of whether they belong to a protected namespace
+     * Sets the given set of package names that may always be overriden, regardless of whether they
+     * belong to a protected namespace. Rules apply to subpackages too.
+     *
+     * @param packageNames
      */
-    public void addOverridablePackage(String packageName);
-    // END PE 4985680
+    void setOverridablePackages(Set<String> packageNames);
 
 
-    // START PWC 1.1 6314481
-    public void setIgnoreHiddenJarFiles(boolean ignoreHiddenJarFiles);
-    // END PWC 1.1 6314481
+    void setIgnoreHiddenJarFiles(boolean ignoreHiddenJarFiles);
 }
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/loader/WebappLoader.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/loader/WebappLoader.java
@@ -41,9 +41,9 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -110,9 +110,7 @@ public class WebappLoader
      * (so that the actual parent will be the system class loader).
      */
     public WebappLoader() {
-
         this(null);
-
     }
 
 
@@ -136,7 +134,7 @@ public class WebappLoader
     /**
      * The class loader being managed by this Loader component.
      */
-    private WebappClassLoader classLoader = null;
+    private WebappClassLoader classLoader;
 
 
     /**
@@ -199,9 +197,7 @@ public class WebappLoader
     /**
      * The string manager for this package.
      */
-    protected static final StringManager sm =
-        StringManager.getManager(WebappLoader.class.getPackage().getName());
-
+    protected static final StringManager sm = StringManager.getManager(WebappLoader.class.getPackage().getName());
 
     /**
      * Has this component been started?
@@ -221,19 +217,14 @@ public class WebappLoader
     private String classpath = null;
 
 
-    // START PE 4985680`
     /**
-     * List of packages that may always be overridden, regardless of whether
+     * Set of packages that may always be overridden, regardless of whether
      * they belong to a protected namespace (i.e., a namespace that may never
      * be overridden by a webapp)
      */
-    private ArrayList<String> overridablePackages;
-    // END PE 4985680
+    private Set<String> overridablePackages = Set.of();
 
-
-    // START PWC 1.1 6314481
     private boolean ignoreHiddenJarFiles;
-    // END PWC 1.1 6314481
 
     private boolean useMyFaces;
 
@@ -285,7 +276,7 @@ public class WebappLoader
 
 
     /**
-     * Return the debugging detail level for this component.
+     * @return the debugging detail level for this component.
      */
     public int getDebug() {
         return (this.debug);
@@ -300,8 +291,7 @@ public class WebappLoader
     public void setDebug(int debug) {
         int oldDebug = this.debug;
         this.debug = debug;
-        support.firePropertyChange("debug", Integer.valueOf(oldDebug),
-                                   Integer.valueOf(this.debug));
+        support.firePropertyChange("debug", Integer.valueOf(oldDebug), Integer.valueOf(this.debug));
     }
 
 
@@ -325,8 +315,7 @@ public class WebappLoader
     public void setDelegate(boolean delegate) {
         boolean oldDelegate = this.delegate;
         this.delegate = delegate;
-        support.firePropertyChange("delegate", Boolean.valueOf(oldDelegate),
-                                   Boolean.valueOf(this.delegate));
+        support.firePropertyChange("delegate", Boolean.valueOf(oldDelegate), Boolean.valueOf(this.delegate));
     }
 
 
@@ -379,9 +368,7 @@ public class WebappLoader
         // Process this property change
         boolean oldReloadable = this.reloadable;
         this.reloadable = reloadable;
-        support.firePropertyChange("reloadable",
-                                   Boolean.valueOf(oldReloadable),
-                                   Boolean.valueOf(this.reloadable));
+        support.firePropertyChange("reloadable", Boolean.valueOf(oldReloadable), Boolean.valueOf(this.reloadable));
     }
 
 
@@ -654,14 +641,7 @@ public class WebappLoader
                 classLoader.addRepository(element);
             }
 
-            // START OF PE 4985680
-            if (overridablePackages != null){
-                for (String overridablePackage : overridablePackages) {
-                    classLoader.addOverridablePackage(overridablePackage);
-                }
-                overridablePackages = null;
-            }
-            // END OF PE 4985680
+            classLoader.setOverridablePackages(overridablePackages);
 
             // Configure our repositories
             setRepositories();
@@ -1293,26 +1273,14 @@ public class WebappLoader
         this.controller = controller;
     }
 
-    // START OF PE 4985680
-    /**
-     * Adds the given package name to the list of packages that may always be
-     * overriden, regardless of whether they belong to a protected namespace
-     */
     @Override
-    public void addOverridablePackage(String packageName){
-        if (overridablePackages == null) {
-            overridablePackages = new ArrayList<>();
-        }
-        overridablePackages.add(packageName);
+    public void setOverridablePackages(Set<String> packageNames){
+        overridablePackages = packageNames;
     }
-    // END OF PE 4985680
 
 
-    // START PWC 1.1 6314481
     @Override
     public void setIgnoreHiddenJarFiles(boolean ignoreHiddenJarFiles) {
         this.ignoreHiddenJarFiles = ignoreHiddenJarFiles;
     }
-    // END PWC 1.1 6314481
-
 }


### PR DESCRIPTION
- overridablePackages are not added, but set, and then just used. Because it is just configured and then read, we don't need ConcurrentLinkedQueue
- useMyFaces now affects both classes and resources
- org.apache.commons.logging doesn't exist in GlassFish - removed
- com.sun.enterprise.overrideablejavaxpackages renamed to org.glassfish.main.webappCL.overridablePackages
  - I don't think anyone used it for years, but it really could be useful.
  - overridable packages are now set only by this system property.
- removed redundant log
- removed synchronized on setOverridablePackages as it is set just from a single thread which creates the instance.
- based on review from @hs536 : 
  - https://github.com/eclipse-ee4j/glassfish/pull/23973#pullrequestreview-1019545385
  - https://github.com/eclipse-ee4j/glassfish/pull/23973#pullrequestreview-1021094261

