### PR TITLE
Updated jakarta.el-api, removed hack to clear cache

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/LogFacade.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/LogFacade.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -23,8 +24,6 @@ import org.glassfish.logging.annotation.LogMessagesResourceBundle;
 import java.util.logging.Logger;
 
 /**
-/**
- *
  * Provides the logging facilities.
  *
  * @author Shing Wai Chan
@@ -186,11 +185,6 @@ public class LogFacade {
             message = "Unable to read data for class with name [{0}]",
             level = "WARNING")
     public static final String READ_CLASS_ERROR = prefix + "00025";
-
-    @LogMessageInfo(
-            message = "Unable to purge bean classes from BeanELResolver",
-            level = "WARNING")
-    public static final String UNABLE_PURGE_BEAN_CLASSES = prefix + "00026";
 
     @LogMessageInfo(
             message = "extra-class-path component [{0}] is not a valid pathname",

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -1615,24 +1615,16 @@ public class WebappClassLoader extends URLClassLoader
     /**
      * Stop the class loader.
      *
-     * @exception LifecycleException if a lifecycle error occurs
+     * @throws LifecycleException if a lifecycle error occurs
      */
     public void stop() throws Exception {
-
         if (!started) {
             return;
         }
 
-        // START GlassFish Issue 587
-        purgeELBeanClasses();
-        // END GlassFish Issue 587
-
-        /*
-         * Clearing references should be done before setting started to
-         * false, due to possible side effects.
-         * In addition, set this classloader as the Thread's context
-         * classloader, see IT 9894 for details
-         */
+        // Clearing references should be done before setting started to
+        // false, due to possible side effects.
+        // In addition, set this classloader as the Thread's context classloader
         ClassLoader curCl = null;
         try {
             curCl = Thread.currentThread().getContextClassLoader();
@@ -1644,9 +1636,7 @@ public class WebappClassLoader extends URLClassLoader
             }
         }
 
-        // START SJSAS 6258619
         close();
-        // END SJSAS 6258619
 
         started = false;
 
@@ -3001,80 +2991,23 @@ public class WebappClassLoader extends URLClassLoader
 
     }
 
-    // START SJSAS 6344989
     public void addByteCodePreprocessor(BytecodePreprocessor preprocessor) {
         byteCodePreprocessors.add(preprocessor);
     }
-    // END SJSAS 6344989
 
 
-    // START GlassFish Issue 587
-    /*
-     * Purges all bean classes that were loaded by this WebappClassLoader
-     * from the caches maintained by jakarta.el.BeanELResolver, in order to
-     * avoid this WebappClassLoader from leaking.
-     */
-    private void purgeELBeanClasses() {
-
-        Field fieldlist[] = jakarta.el.BeanELResolver.class.getDeclaredFields();
-        for (Field fld : fieldlist) {
-            if (fld.getName().equals("properties")) {
-                purgeELBeanClasses(fld);
-                break;
-            }
-        }
-    }
-
-    /*
-     * Purges all bean classes that were loaded by this WebappClassLoader
-     * from the cache represented by the given reflected field.
-     *
-     * @param fld The reflected field from which to remove the bean classes
-     * that were loaded by this WebappClassLoader
-     */
-    private void purgeELBeanClasses(final Field fld) {
-
-        setAccessible(fld);
-
-        Map<Class, ?> m = null;
-        try {
-            m = getBeanELResolverProperties(fld);
-        } catch (IllegalAccessException iae) {
-            logger.log(Level.WARNING, LogFacade.UNABLE_PURGE_BEAN_CLASSES, iae);
-            return;
-        }
-
-        if (m.size() == 0) {
-            return;
-        }
-
-        Iterator<Class> iter = m.keySet().iterator();
-        while (iter.hasNext()) {
-            Class<?> mbeanClass = iter.next();
-            if (this.equals(mbeanClass.getClassLoader())) {
-                iter.remove();
-            }
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<Class, ?> getBeanELResolverProperties(Field fld) throws IllegalAccessException {
-        return (Map<Class, ?>)fld.get(null);
-    }
-    // END GlassFish Issue 587
-
-     /**
+    /**
      * Create and return a temporary loader with the same visibility
-      * as this loader. The temporary loader may be used to load
-      * resources or any other application classes for the purposes of
-      * introspecting them for annotations. The persistence provider
-      * should not maintain any references to the temporary loader,
-      * or any objects loaded by it.
-      *
-      * @return A temporary classloader with the same classpath as this loader
-      */
-     @Override
-     public ClassLoader copy() {
+     * as this loader. The temporary loader may be used to load
+     * resources or any other application classes for the purposes of
+     * introspecting them for annotations. The persistence provider
+     * should not maintain any references to the temporary loader,
+     * or any objects loaded by it.
+     *
+     * @return A temporary classloader with the same classpath as this loader
+     */
+    @Override
+    public ClassLoader copy() {
          logger.entering("WebModuleListener$InstrumentableWebappClassLoader", "copy");
          // set getParent() as the parent of the cloned class loader
          return AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ResourceLocator.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/loader/ResourceLocator.java
@@ -61,7 +61,7 @@ public class ResourceLocator {
      * @return true if the resource present in the current classloader can shadow parent's resource.
      */
     public boolean isOverridableResource(String name) {
-        if (name.startsWith("META-INF/services/jakarta.json.spi.JsonProvider")) {
+        if ("META-INF/services/jakarta.json.spi.JsonProvider".equals(name)) {
             return true;
         }
         return false;

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -73,7 +73,7 @@
         <!-- Jakarta API Versions -->
 
         <!-- Jakarta Expression Language -->
-        <jakarta.el-api.version>5.0.0</jakarta.el-api.version>
+        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
         <expressly.version>5.0.0-M2</expressly.version>
 
         <!-- Jakarta Servlet -->


### PR DESCRIPTION
el-api 5.0.1 now avoids memory leaks
- see https://github.com/jakartaee/expression-language/compare/5.0.0-RELEASE-api...5.0.1-RELEASE-api   and https://github.com/jakartaee/expression-language/commit/3ec9258dd20ebedb76e1a72a63c69bf71b14775b
- now there is no need to use the reflection to clear the cache
- also it would not work any more as the field is not static any more

