### PR TITLE
Correcting results

### DIFF
--- a/docs/website/src/main/resources/certifications/jakarta-platform/10/TCK-Results-7.0.md
+++ b/docs/website/src/main/resources/certifications/jakarta-platform/10/TCK-Results-7.0.md
@@ -193,7 +193,7 @@ Stage Name: ejb30/lite/singleton
    [runcts] OUT => [javatest.batch] ********************************************************************************
    [runcts] OUT => [javatest.batch] Completed running 230 tests.
    [runcts] OUT => [javatest.batch] Number of Tests Passed      = 230
-   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 10
+   [runcts] OUT => [javatest.batch] Number of Tests Failed      = 0
    [runcts] OUT => [javatest.batch] Number of Tests with Errors = 0
    [runcts] OUT => [javatest.batch] ********************************************************************************
 


### PR DESCRIPTION
Taken from root/run_cts.log from:

https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/master/1898/artifact/ejb30_lite_singleton-results.tar.gz

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>
