### PR TITLE
Logging fixes

### DIFF
--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/config/branding/glassfish-version.properties
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/config/branding/glassfish-version.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
 # Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,7 +16,6 @@
 #
 
 product_name=${product.name}
-brief_product_name=${brief_product_name}
 abbrev_product_name=${abbrev_product_name}
 major_version=${major_version}
 minor_version=${minor_version}

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -182,8 +182,7 @@
         <!-- Settings -->
 
         <product.name>Eclipse GlassFish</product.name>
-        <brief_product_name>GlassFish</brief_product_name>
-        <abbrev_product_name>glassfish</abbrev_product_name>
+        <abbrev_product_name>GlassFish</abbrev_product_name>
         <admin_client_command_name>asadmin</admin_client_command_name>
         <default_domain_template>appserver-domain.jar</default_domain_template>
         <version_prefix />
@@ -322,7 +321,7 @@
                 <artifactId>mq-distribution</artifactId>
                 <version>${openmq.version}</version>
             </dependency>
-             <dependency>
+            <dependency>
                 <groupId>com.sun.messaging.mq</groupId>
                 <artifactId>imqjmx</artifactId>
                 <version>4.6-b01</version>
@@ -658,7 +657,7 @@
             </dependency>
 
 
-            <!--  Derby - embedded database -->
+            <!-- Derby - embedded database -->
             <dependency>
                 <groupId>org.glassfish.external</groupId>
                 <artifactId>derby</artifactId>

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/LoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/LoggingITest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.logging.Level;
+
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.main.admin.test.tool.asadmin.Asadmin;
+import org.glassfish.main.admin.test.tool.asadmin.AsadminResult;
+import org.glassfish.main.admin.test.tool.asadmin.GlassFishTestEnvironment;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.commons.lang3.StringUtils.replaceChars;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
+import static org.glassfish.main.admin.test.tool.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * @author David Matejcek
+ */
+public class LoggingITest {
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @Test
+    public void collectLogFiles() {
+        AsadminResult result = ASADMIN.exec("collect-log-files");
+        assertThat(result, asadminOK());
+        String path = StringUtils.substringBetween(result.getStdOut(), "Created Zip file under ", ".\n");
+        assertNotNull(path, () -> "zip file path parsed from " + result.getStdOut());
+        assertThat(new File(path).length(), greaterThan(2_000L));
+    }
+
+
+    @Test
+    public void listLogLevels() {
+        AsadminResult result = ASADMIN.exec("list-log-levels");
+        assertThat(result, asadminOK());
+        String[] lines = substringBefore(result.getStdOut(), "Command list-log-levels executed successfully.").split("\n");
+        assertThat(lines, arrayWithSize(greaterThan(75)));
+        Arrays.stream(lines).forEach(line -> {
+            String[] pair = line.split("\\s+");
+            assertAll(
+                () -> assertNotNull(pair[0]),
+                () -> assertDoesNotThrow(() -> Level.parse(replaceChars(pair[1], "<>", "")))
+            );
+        });
+    }
+}

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test.rest;
+
+import jakarta.ws.rs.core.MediaType;
+
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.HttpURLConnection;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONObject;
+import org.glassfish.main.admin.test.tool.asadmin.GlassFishTestEnvironment;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author David Matejcek
+ */
+public class LoggingRestITest {
+
+    @Test
+    public void logFileNames() throws Exception {
+        HttpURLConnection connection = GlassFishTestEnvironment
+            .openConnection("/management/domain/view-log/details/lognames?instanceName=server");
+        try {
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            connection.setDoOutput(true);
+            assertEquals(200, connection.getResponseCode());
+            try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
+                StringWriter buffer = new StringWriter();
+                reader.transferTo(buffer);
+                JSONObject json = new JSONObject(buffer.toString());
+                JSONArray array = json.getJSONArray("InstanceLogFileNames");
+                assertAll(
+                    () -> assertThat("InstanceLogFileNames", array.length(), equalTo(1)),
+                    () -> assertThat(array.get(0), equalTo("server.log"))
+                );
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    @Test
+    public void viewLogDetails() throws Exception {
+        HttpURLConnection connection = GlassFishTestEnvironment.openConnection("/management/domain/view-log/details");
+        try {
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", MediaType.APPLICATION_JSON);
+            assertEquals(200, connection.getResponseCode());
+            try (InputStreamReader reader = new InputStreamReader(connection.getInputStream())) {
+                StringWriter buffer = new StringWriter();
+                reader.transferTo(buffer);
+                JSONObject json = new JSONObject(buffer.toString());
+                JSONArray array = json.getJSONArray("records");
+                assertThat(array.length(), greaterThan(15));
+            }
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,8 +18,9 @@
 package org.glassfish.admin.rest.logviewer;
 
 import java.io.StringWriter;
+import java.time.OffsetDateTime;
 import java.util.Date;
-import java.util.logging.Level;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -31,9 +33,9 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.glassfish.admin.rest.RestLogging;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -46,7 +48,7 @@ import org.w3c.dom.Node;
 public class LogRecord {
 
     long recordNumber;
-    Date loggedDateTime;
+    OffsetDateTime loggedDateTime;
     String loggedLevel;
     String productName;
     String loggerName;
@@ -62,11 +64,11 @@ public class LogRecord {
         this.message = Message;
     }
 
-    public Date getLoggedDateTime() {
+    public OffsetDateTime getLoggedDateTime() {
         return loggedDateTime;
     }
 
-    public void setLoggedDateTime(Date loggedDateTime) {
+    public void setLoggedDateTime(OffsetDateTime loggedDateTime) {
         this.loggedDateTime = loggedDateTime;
     }
 
@@ -122,13 +124,13 @@ public class LogRecord {
         JSONObject obj = new JSONObject();
         try {
             obj.put("recordNumber", recordNumber);
-            obj.put("loggedDateTimeInMS", (loggedDateTime != null) ? loggedDateTime.getTime() : null);
+            obj.put("loggedDateTimeInMS", loggedDateTime == null ? null : loggedDateTime.toInstant().toEpochMilli());
             obj.put("loggedLevel", loggedLevel);
             obj.put("productName", productName);
             obj.put("loggerName", loggerName);
             obj.put("nameValuePairs", nameValuePairs);
             obj.put("messageID", messageID);
-            obj.put("Message", message); //.replaceAll("\n", Matcher.quoteReplacement("\\\n")).replaceAll("\"", Matcher.quoteReplacement("\\\"")));
+            obj.put("Message", message);
         } catch (JSONException ex) {
             throw new RuntimeException(ex);
         }
@@ -144,8 +146,9 @@ public class LogRecord {
             Document d = db.newDocument();
 
             Element result = d.createElement("record");
-            result.setAttribute("recordNumber", "" + recordNumber);
-            result.setAttribute("loggedDateTimeInMS", (loggedDateTime != null) ? ("" + loggedDateTime.getTime()) : "");
+            result.setAttribute("recordNumber", Long.toString(recordNumber));
+            result.setAttribute("loggedDateTimeInMS",
+                loggedDateTime == null ? "" : Long.toString(loggedDateTime.toInstant().toEpochMilli()));
             result.setAttribute("loggedLevel", loggedLevel);
             result.setAttribute("productName", productName);
             result.setAttribute("loggerName", loggerName);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
@@ -30,9 +30,9 @@ import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
@@ -63,34 +63,44 @@ public class StructuredLogViewerResource {
     }
 
     @GET
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON })
-    public String getJson(@QueryParam("logFileName") @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log") String logFileName,
-            @QueryParam("startIndex") @DefaultValue("-1") long startIndex,
-            @QueryParam("searchForward") @DefaultValue("false") boolean searchForward,
-            @QueryParam("maximumNumberOfResults") @DefaultValue("40") int maximumNumberOfResults,
-            @QueryParam("onlyLevel") @DefaultValue("false") boolean onlyLevel, @QueryParam("fromTime") @DefaultValue("-1") long fromTime,
-            @QueryParam("toTime") @DefaultValue("-1") long toTime, @QueryParam("logLevel") @DefaultValue("INFO") String logLevel,
-            @QueryParam("anySearch") @DefaultValue("") String anySearch, @QueryParam("listOfModules") String listOfModules, //default value is empty for List
-            @QueryParam("instanceName") @DefaultValue("") String instanceName) throws IOException {
+    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
+    public String getJson(
+        @QueryParam("logFileName") @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log") String logFileName,
+        @QueryParam("startIndex") @DefaultValue("-1") long startIndex,
+        @QueryParam("searchForward") @DefaultValue("false") boolean searchForward,
+        @QueryParam("maximumNumberOfResults") @DefaultValue("40") int maximumNumberOfResults,
+        @QueryParam("onlyLevel") @DefaultValue("false") boolean onlyLevel,
+        @QueryParam("fromTime") @DefaultValue("-1") long fromTime,
+        @QueryParam("toTime") @DefaultValue("-1") long toTime,
+        @QueryParam("logLevel") @DefaultValue("INFO") String logLevel,
+        @QueryParam("anySearch") @DefaultValue("") String anySearch,
+        @QueryParam("listOfModules") String listOfModules, //default value is empty for List
+        @QueryParam("instanceName") @DefaultValue("") String instanceName)
+        throws IOException {
 
-        return getWithType(logFileName, startIndex, searchForward, maximumNumberOfResults, fromTime, toTime, logLevel, onlyLevel, anySearch,
-                listOfModules, instanceName, "json");
+        return getWithType(logFileName, startIndex, searchForward, maximumNumberOfResults, fromTime, toTime, logLevel,
+            onlyLevel, anySearch, listOfModules, instanceName, "json");
 
     }
 
     @GET
-    @Produces({ MediaType.APPLICATION_XML })
-    public String getXML(@QueryParam("logFileName") @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log") String logFileName,
-            @QueryParam("startIndex") @DefaultValue("-1") long startIndex,
-            @QueryParam("searchForward") @DefaultValue("false") boolean searchForward,
-            @QueryParam("maximumNumberOfResults") @DefaultValue("40") int maximumNumberOfResults,
-            @QueryParam("onlyLevel") @DefaultValue("true") boolean onlyLevel, @QueryParam("fromTime") @DefaultValue("-1") long fromTime,
-            @QueryParam("toTime") @DefaultValue("-1") long toTime, @QueryParam("logLevel") @DefaultValue("INFO") String logLevel,
-            @QueryParam("anySearch") @DefaultValue("") String anySearch, @QueryParam("listOfModules") String listOfModules, //default value is empty for List,
-            @QueryParam("instanceName") @DefaultValue("") String instanceName) throws IOException {
+    @Produces({MediaType.APPLICATION_XML})
+    public String getXML(
+        @QueryParam("logFileName") @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log") String logFileName,
+        @QueryParam("startIndex") @DefaultValue("-1") long startIndex,
+        @QueryParam("searchForward") @DefaultValue("false") boolean searchForward,
+        @QueryParam("maximumNumberOfResults") @DefaultValue("40") int maximumNumberOfResults,
+        @QueryParam("onlyLevel") @DefaultValue("true") boolean onlyLevel,
+        @QueryParam("fromTime") @DefaultValue("-1") long fromTime,
+        @QueryParam("toTime") @DefaultValue("-1") long toTime,
+        @QueryParam("logLevel") @DefaultValue("INFO") String logLevel,
+        @QueryParam("anySearch") @DefaultValue("") String anySearch,
+        @QueryParam("listOfModules") String listOfModules, //default value is empty for List,
+        @QueryParam("instanceName") @DefaultValue("") String instanceName)
+        throws IOException {
 
-        return getWithType(logFileName, startIndex, searchForward, maximumNumberOfResults, fromTime, toTime, logLevel, onlyLevel, anySearch,
-                listOfModules, instanceName, "xml");
+        return getWithType(logFileName, startIndex, searchForward, maximumNumberOfResults, fromTime, toTime, logLevel,
+            onlyLevel, anySearch, listOfModules, instanceName, "xml");
 
     }
 
@@ -98,15 +108,13 @@ public class StructuredLogViewerResource {
             long toTime, String logLevel, boolean onlyLevel, String anySearch, String listOfModules, String instanceName, String type)
             throws IOException {
         if (habitat.getService(LogManager.class) == null) {
-            //the logger service is not install, so we cannot rely on it.
-            //return an error
+            // the logger service is not install, so we cannot rely on it.
             throw new IOException("The GlassFish LogManager Service is not available. Not installed?");
         }
 
         List<String> modules = new ArrayList<>();
-        if ((listOfModules != null) && !listOfModules.isEmpty()) {
+        if (listOfModules != null && !listOfModules.isEmpty()) {
             modules.addAll(Arrays.asList(listOfModules.split(",")));
-
         }
 
         Properties nameValueMap = new Properties();
@@ -122,13 +130,12 @@ public class StructuredLogViewerResource {
                 toTime == -1 ? null : Instant.ofEpochMilli(toTime), logLevel, onlyLevel, modules, nameValueMap,
                 anySearch);
             return convertQueryResult(result, type);
-        } else {
-            final AttributeList result = logFilter.getLogRecordsUsingQuery(logFileName, startIndex, searchForward,
-                sortAscending, maximumNumberOfResults, fromTime == -1 ? null : Instant.ofEpochMilli(fromTime),
-                toTime == -1 ? null : Instant.ofEpochMilli(toTime), logLevel, onlyLevel, modules, nameValueMap,
-                anySearch, instanceName);
-            return convertQueryResult(result, type);
         }
+        final AttributeList result = logFilter.getLogRecordsUsingQuery(logFileName, startIndex, searchForward,
+            sortAscending, maximumNumberOfResults, fromTime == -1 ? null : Instant.ofEpochMilli(fromTime),
+            toTime == -1 ? null : Instant.ofEpochMilli(toTime), logLevel, onlyLevel, modules, nameValueMap,
+            anySearch, instanceName);
+        return convertQueryResult(result, type);
 
     }
 
@@ -136,9 +143,6 @@ public class StructuredLogViewerResource {
         return List.class.cast(list);
     }
 
-    /*    private String quoted(String s) {
-        return "\"" + s + "\"";
-    }*/
 
     private String convertQueryResult(final AttributeList queryResult, String type) {
         // extract field descriptions into a String[]
@@ -168,7 +172,7 @@ public class StructuredLogViewerResource {
                 LogRecord rec = new LogRecord();
                 int fieldIdx = 0;
                 rec.setRecordNumber(((Long) record.get(fieldIdx++)).longValue());
-                rec.setLoggedDateTime((Date) record.get(fieldIdx++));
+                rec.setLoggedDateTime((OffsetDateTime) record.get(fieldIdx++));
                 rec.setLoggedLevel((String) record.get(fieldIdx++));
                 rec.setProductName((String) record.get(fieldIdx++));
                 rec.setLoggerName((String) record.get(fieldIdx++));

--- a/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/appserv/server/util/Version.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -29,16 +30,13 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- *
  * This class provides static methods to make accessible the version as well as
  * the individual parts that make up the version
- *
-*/
+ */
 public class Version {
 
     private static final String INSTALL_ROOT_PROP_NAME = "com.sun.aas.installRoot";
     private static final String PRODUCT_NAME_KEY = "product_name";
-    private static final String BRIEF_PRODUCT_NAME_KEY = "brief_product_name";
     private static final String ABBREV_PRODUCT_NAME_KEY = "abbrev_product_name";
     private static final String MAJOR_VERSION_KEY = "major_version";
     private static final String MINOR_VERSION_KEY = "minor_version";
@@ -51,8 +49,8 @@ public class Version {
     private static final String DEFAULT_DOMAIN_TEMPLATE_JAR = "nucleus-domain.jar";
     private static final String ADMIN_CLIENT_COMMAND_NAME_KEY = "admin_client_command_name";
     private static final String INITIAL_ADMIN_GROUPS_KEY = "initial_admin_user_groups";
-    private static List<Properties> versionProps = new ArrayList<Properties>();
-    private static Map<String,Properties> versionPropsMap = new HashMap<String,Properties>();
+    private static List<Properties> versionProps = new ArrayList<>();
+    private static Map<String,Properties> versionPropsMap = new HashMap<>();
     private static Properties versionProp = getVersionProp();
 
     private static Properties getVersionProp() {
@@ -222,13 +220,6 @@ public class Version {
     public static String getProductName() {
         return getProperty(PRODUCT_NAME_KEY,
                 "Undefined Product Name - define product and version info in config/branding");
-    }
-
-    /**
-     * Returns Brief Product Name (used in manual pages)
-     */
-    public static String getBriefProductName() {
-        return getProperty(BRIEF_PRODUCT_NAME_KEY, "Undefined Product Name");
     }
 
     /**

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/VersionInfo.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/VersionInfo.java
@@ -20,7 +20,6 @@ import org.jvnet.hk2.annotations.Contract;
 
 /**
  * Service interface to define the version info for an installed product.
- *
  */
 @Contract
 public interface VersionInfo {

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/LogFacade.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/LogFacade.java
@@ -186,12 +186,12 @@ public class LogFacade {
 
     @LogMessageInfo(
             message = "Registered {0} as OSGi service registration: {1}.",
-            level = "INFO")
+            level = "CONFIG")
     public static final String SERVICE_REGISTERED = "NCLS-BOOTSTRAP-00027";
 
     @LogMessageInfo(
             message = "Unregistered {0} from service registry.",
-            level = "INFO")
+            level = "CONFIG")
     public static final String SERVICE_UNREGISTERED = "NCLS-BOOTSTRAP-00028";
 
     @LogMessageInfo(

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishImpl.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishImpl.java
@@ -59,14 +59,14 @@ public class EmbeddedOSGiGlassFishImpl extends GlassFishDecorator {
 
     private void registerService() {
         reg = getBundleContext().registerService(GlassFish.class.getName(), this, null);
-        logger.log(Level.INFO, LogFacade.SERVICE_REGISTERED, new Object[]{this, reg});
+        logger.log(Level.CONFIG, LogFacade.SERVICE_REGISTERED, new Object[]{this, reg});
     }
 
     private void unregisterService() {
         if (getBundleContext() != null) { // bundle is still active
             try {
                 reg.unregister();
-                logger.log(Level.INFO, LogFacade.SERVICE_UNREGISTERED, this);
+                logger.log(Level.CONFIG, LogFacade.SERVICE_UNREGISTERED, this);
             } catch (IllegalStateException e) {
                 LogFacade.log(logger, Level.WARNING, LogFacade.SERVICE_UNREGISTRATION_EXCEPTION, e, e);
             }

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/parser/LogParser.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/parser/LogParser.java
@@ -55,7 +55,8 @@ public interface LogParser {
     DateTimeFormatter ISO_OFFSET_DATE_TIME_PARSER = new DateTimeFormatterBuilder()
         .parseCaseInsensitive()
         .append(ISO_LOCAL_DATE_TIME_PARSER)
-        .appendPattern("X")
+        .optionalStart().appendOffsetId().optionalEnd()
+        .optionalStart().appendOffset("+HHMMss", "Z").optionalEnd()
         .toFormatter(Locale.ROOT);
 
     /**

--- a/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/parser/LogParserTest.java
+++ b/nucleus/core/logging/src/test/java/com/sun/enterprise/server/logging/parser/LogParserTest.java
@@ -68,6 +68,22 @@ public class LogParserTest {
             () -> assertEquals("RunLevelControllerThread-1656622655238", record.getThreadName()),
             () -> assertEquals("jakarta.enterprise.logging", record.getLogger())
         );
+        ParsedLogRecord oldRecord = listener.records.get(listener.records.size() - 2);
+        assertAll(
+            () -> assertEquals("NCLS-CORE-00087", oldRecord.getMessageKey()),
+            () -> assertEquals("Grizzly Framework 4.0.0 started in: 2ms - bound to [/0.0.0.0:7676]", oldRecord.getMessage()),
+            () -> assertEquals("glassfish 7.0", oldRecord.getProductId()),
+            () -> assertEquals(LocalDate.of(2022, 06, 30), oldRecord.getDate()),
+            () -> assertEquals(LocalTime.of(22, 57, 36, 381_000_000), oldRecord.getTime()),
+            () -> assertEquals(OffsetDateTime.of(oldRecord.getDate(), oldRecord.getTime(), ZoneOffset.of("+01:00")), oldRecord.getTimestamp()),
+            () -> assertEquals("INFO", oldRecord.getLevel()),
+            () -> assertEquals(800, oldRecord.getLevelValue()),
+            () -> assertThat(oldRecord.getSupplementalAttributes(), aMapWithSize(1)),
+            () -> assertEquals(43L, oldRecord.getThreadId()),
+            () -> assertEquals("RunLevelControllerThread-1656622655235", oldRecord.getThreadName()),
+            () -> assertEquals("jakarta.enterprise.system.core", oldRecord.getLogger())
+        );
+
     }
 
 

--- a/nucleus/core/logging/src/test/resources/com/sun/enterprise/server/logging/parser/odl-server.log
+++ b/nucleus/core/logging/src/test/resources/com/sun/enterprise/server/logging/parser/odl-server.log
@@ -25,8 +25,8 @@ Authorization Service has successfully initialized.]]
 [2022-06-29T19:55:58.736+0200] [glassfish 7.0] [INFO] [NCLS-CORE-00087] [jakarta.enterprise.system.core] [tid: _ThreadID=43 _ThreadName=RunLevelControllerThread-1656525357793] [timeMillis: 1656525358736] [levelValue: 800] [[
 Grizzly Framework 4.0.0 started in: 71ms - bound to [/0.0.0.0:8080]]]
 
-[2022-06-29T19:55:58.798+0200] [glassfish 7.0] [INFO] [NCLS-CORE-00087] [jakarta.enterprise.system.core] [tid: _ThreadID=43 _ThreadName=RunLevelControllerThread-1656525357793] [timeMillis: 1656525358798] [levelValue: 800] [[
-Grizzly Framework 4.0.0 started in: 2ms - bound to [/0.0.0.0:8181]]]
+[2022-06-29T19:55:58.798993+02:00] [GlassFish 7.0] [INFO] [NCLS-CORE-00087] [jakarta.enterprise.system.core] [tid: _ThreadID=43 _ThreadName=RunLevelControllerThread-1656525357793] [levelValue: 800] [[
+Grizzly Framework 4.0.0 started in: 1ms - bound to [/0.0.0.0:8181]]]
 
 [2022-06-29T19:55:58.806+0200] [glassfish 7.0] [INFO] [NCLS-CORE-00087] [jakarta.enterprise.system.core] [tid: _ThreadID=43 _ThreadName=RunLevelControllerThread-1656525357793] [timeMillis: 1656525358806] [levelValue: 800] [[
 Grizzly Framework 4.0.0 started in: 1ms - bound to [/0.0.0.0:4848]]]

--- a/nucleus/core/logging/src/test/resources/com/sun/enterprise/server/logging/parser/uniform-server.log
+++ b/nucleus/core/logging/src/test/resources/com/sun/enterprise/server/logging/parser/uniform-server.log
@@ -1,47 +1,47 @@
-[#|2022-06-30T22:57:35.349+0200|INFO|glassfish 7.0|jakarta.enterprise.logging|_ThreadID=44;_ThreadName=RunLevelControllerThread-1656622655238;_TimeMillis=1656622655349;_LevelValue=800;_MessageID=NCLS-LOGGING-00009;|
+[#|2022-06-30T22:57:35.349000+02:00|INFO|glassfish 7.0|jakarta.enterprise.logging|_ThreadID=44;_ThreadName=RunLevelControllerThread-1656622655238;_TimeMillis=1656622655349;_LevelValue=800;_MessageID=NCLS-LOGGING-00009;|
 Running GlassFish Version: Eclipse GlassFish  7.0.0  (build master-b736-g2cdfe0f 2022-06-29T19:33:55+0200)|#]
 
-[#|2022-06-30T22:57:35.351+0200|INFO|glassfish 7.0|jakarta.enterprise.logging|_ThreadID=44;_ThreadName=RunLevelControllerThread-1656622655238;_TimeMillis=1656622655351;_LevelValue=800;_MessageID=NCLS-LOGGING-00010;|
+[#|2022-06-30T22:57:35.351000+02:00|INFO|glassfish 7.0|jakarta.enterprise.logging|_ThreadID=44;_ThreadName=RunLevelControllerThread-1656622655238;_TimeMillis=1656622655351;_LevelValue=800;_MessageID=NCLS-LOGGING-00010;|
 Server log file is using Formatter class: com.sun.enterprise.server.logging.ODLLogFormatter|#]
 
-[#|2022-06-30T22:57:35.495+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core.security|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655495;_LevelValue=800;_MessageID=NCLS-SECURITY-01115;|
+[#|2022-06-30T22:57:35.495000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core.security|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655495;_LevelValue=800;_MessageID=NCLS-SECURITY-01115;|
 Realm [admin-realm] of classtype [com.sun.enterprise.security.auth.realm.file.FileRealm] successfully created.|#]
 
-[#|2022-06-30T22:57:35.497+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core.security|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655497;_LevelValue=800;_MessageID=NCLS-SECURITY-01115;|
+[#|2022-06-30T22:57:35.497000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core.security|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655497;_LevelValue=800;_MessageID=NCLS-SECURITY-01115;|
 Realm [file] of classtype [com.sun.enterprise.security.auth.realm.file.FileRealm] successfully created.|#]
 
-[#|2022-06-30T22:57:35.503+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core.security|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655503;_LevelValue=800;_MessageID=NCLS-SECURITY-01115;|
+[#|2022-06-30T22:57:35.503000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core.security|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655503;_LevelValue=800;_MessageID=NCLS-SECURITY-01115;|
 Realm [certificate] of classtype [com.sun.enterprise.security.auth.realm.certificate.CertificateRealm] successfully created.|#]
 
-[#|2022-06-30T22:57:35.554+0200|INFO|glassfish 7.0|org.glassfish.ha.store.spi.BackingStoreFactoryRegistry|_ThreadID=46;_ThreadName=RunLevelControllerThread-1656622655244;_TimeMillis=1656622655554;_LevelValue=800;|
+[#|2022-06-30T22:57:35.554000+02:00|INFO|glassfish 7.0|org.glassfish.ha.store.spi.BackingStoreFactoryRegistry|_ThreadID=46;_ThreadName=RunLevelControllerThread-1656622655244;_TimeMillis=1656622655554;_LevelValue=800;|
 Registered org.glassfish.ha.store.adapter.cache.ShoalBackingStoreProxy for persistence-type = replicated in BackingStoreFactoryRegistry|#]
 
-[#|2022-06-30T22:57:35.643+0200|INFO|glassfish 7.0|jakarta.enterprise.security.services|_ThreadID=46;_ThreadName=RunLevelControllerThread-1656622655244;_TimeMillis=1656622655643;_LevelValue=800;_MessageID=SEC-SVCS-00100;|
+[#|2022-06-30T22:57:35.643000+02:00|INFO|glassfish 7.0|jakarta.enterprise.security.services|_ThreadID=46;_ThreadName=RunLevelControllerThread-1656622655244;_TimeMillis=1656622655643;_LevelValue=800;_MessageID=SEC-SVCS-00100;|
 Authorization Service has successfully initialized.|#]
 
-[#|2022-06-30T22:57:35.740+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655740;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
+[#|2022-06-30T22:57:35.740000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655740;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
 Grizzly Framework 4.0.0 started in: 11ms - bound to [/0.0.0.0:8080]|#]
 
-[#|2022-06-30T22:57:35.757+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655757;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
+[#|2022-06-30T22:57:35.757000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655757;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
 Grizzly Framework 4.0.0 started in: 1ms - bound to [/0.0.0.0:8181]|#]
 
-[#|2022-06-30T22:57:35.763+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655763;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
+[#|2022-06-30T22:57:35.763000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622655763;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
 Grizzly Framework 4.0.0 started in: 1ms - bound to [/0.0.0.0:4848]|#]
 
-[#|2022-06-30T22:57:35.786+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=44;_ThreadName=RunLevelControllerThread-1656622655238;_TimeMillis=1656622655786;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
+[#|2022-06-30T22:57:35.786000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=44;_ThreadName=RunLevelControllerThread-1656622655238;_TimeMillis=1656622655786;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
 Grizzly Framework 4.0.0 started in: 1ms - bound to [/0.0.0.0:3700]|#]
 
-[#|2022-06-30T22:57:35.787+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=1;_ThreadName=main;_TimeMillis=1656622655787;_LevelValue=800;_MessageID=NCLS-CORE-00017;|
-Eclipse GlassFish  7.0.0  (webappCL-b736-g2cdfe0f 2022-06-29T19:33:55+0200) startup time : Felix (1 395ms), startup services(556ms), total(1 951ms)|#]
+[#|2022-06-30T22:57:35.787000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=1;_ThreadName=main;_TimeMillis=1656622655787;_LevelValue=800;_MessageID=NCLS-CORE-00017;|
+Eclipse GlassFish  7.0.0  (master-b736-g2cdfe0f 2022-06-29T19:33:55+0200) startup time : Felix (1 395ms), startup services(556ms), total(1 951ms)|#]
 
-[#|2022-06-30T22:57:36.027+0200|INFO|glassfish 7.0|jakarta.enterprise.system.jmx|_ThreadID=81;_ThreadName=Thread-13;_TimeMillis=1656622656027;_LevelValue=800;_MessageID=NCLS-JMX-00005;|
+[#|2022-06-30T22:57:36.027000+02:00|INFO|glassfish 7.0|jakarta.enterprise.system.jmx|_ThreadID=81;_ThreadName=Thread-13;_TimeMillis=1656622656027;_LevelValue=800;_MessageID=NCLS-JMX-00005;|
 JMXStartupService has started JMXConnector on JMXService URL service:jmx:rmi://dmatej-P7740:8686/jndi/rmi://dmatej-P7740:8686/jmxrmi|#]
 
-[#|2022-06-30T22:57:36.046+0200|INFO|glassfish 7.0|org.hibernate.validator.internal.util.Version|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622656046;_LevelValue=800;|
+[#|2022-06-30T22:57:36.046000+02:00|INFO|glassfish 7.0|org.hibernate.validator.internal.util.Version|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622656046;_LevelValue=800;|
 HV000001: Hibernate Validator 8.0.0.Alpha3|#]
 
-[#|2022-06-30T22:57:36.381+0200|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622656381;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
+[#|2022-06-30T22:57:36.381+0100|INFO|glassfish 7.0|jakarta.enterprise.system.core|_ThreadID=43;_ThreadName=RunLevelControllerThread-1656622655235;_TimeMillis=1656622656381;_LevelValue=800;_MessageID=NCLS-CORE-00087;|
 Grizzly Framework 4.0.0 started in: 2ms - bound to [/0.0.0.0:7676]|#]
 
-[#|2022-06-30T22:57:36.385+0200|INFO|glassfish 7.0|jakarta.enterprise.bootstrap|_ThreadID=1;_ThreadName=main;_TimeMillis=1656622656385;_LevelValue=800;_MessageID=NCLS-BOOTSTRAP-00027;|
+[#|2022-07-24T14:21:57.058597+02:00|INFO|glassfish 7.0|jakarta.enterprise.bootstrap|_ThreadID=1;_ThreadName=main;_TimeMillis=1656622656385;_LevelValue=800;_MessageID=NCLS-BOOTSTRAP-00027;|
 Registered com.sun.enterprise.glassfish.bootstrap.osgi.EmbeddedOSGiGlassFishImpl@286b39c2 as OSGi service registration: org.apache.felix.framework.ServiceRegistrationImpl@5432050b.|#]

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/LogFormatDetector.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/LogFormatDetector.java
@@ -44,9 +44,9 @@ public class LogFormatDetector {
      */
     public static final String P_TIME = "\\d\\d:\\d\\d:\\d\\d\\.[\\d]{3,9}";
     /**
-     * {@link Pattern} string for usual time zone format: 02:00, 0200 or Z
+     * {@link Pattern} string for usual time zone format: +02:00, +0200 or Z
      */
-    public static final String P_TIMEZONE = "([0-9:+-]{5,6}|Z)";
+    public static final String P_TIMEZONE = "([0-9:+-]{5,8}|Z)";
     /**
      * {@link Pattern} string for usual ISO-8601 timestamp format: 2021-05-20T12:45:33.123456Z
      */

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/ODLLogFormatter.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/ODLLogFormatter.java
@@ -39,7 +39,7 @@ import static org.glassfish.main.jul.tracing.GlassFishLoggingTracer.error;
  * The specified format is
  *
  * <pre>
- * [[timestamp] [organization ID] [Message Type/Level] [Message ID] [Logger Name] [Thread ID] [User ID] [ECID] [Extra Attributes] [Message]]\n
+ * [[Timestamp] [Product ID] [Level] [Message ID] [Logger Name] [Thread ID] [Extra Attributes] [Message]]\n
  * </pre>
  *
  * @author Naman Mehta

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/UniformLogFormatter.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/UniformLogFormatter.java
@@ -25,7 +25,6 @@ import org.glassfish.main.jul.cfg.LogProperty;
 import org.glassfish.main.jul.env.LoggingSystemEnvironment;
 import org.glassfish.main.jul.formatter.ExcludeFieldsSupport.SupplementalAttribute;
 import org.glassfish.main.jul.record.GlassFishLogRecord;
-import org.glassfish.main.jul.record.MessageResolver;
 
 import static java.lang.System.lineSeparator;
 import static org.glassfish.main.jul.formatter.UniformLogFormatter.UniformFormatterProperty.EXCLUDED_FIELDS;

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogCollectorHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogCollectorHandler.java
@@ -64,6 +64,9 @@ public class LogCollectorHandler extends Handler {
     }
 
 
+    /**
+     * Unattaches the handler from the logger and drops all collected log records.
+     */
     @Override
     public void close() throws SecurityException {
         this.logger.removeHandler(this);

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/Syslog.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/Syslog.java
@@ -25,7 +25,6 @@ import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.logging.Level;
 
-import org.glassfish.main.jul.env.LoggingSystemEnvironment;
 import org.glassfish.main.jul.tracing.GlassFishLoggingTracer;
 
 /**

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SyslogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SyslogHandler.java
@@ -21,7 +21,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.time.format.DateTimeFormatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -45,7 +44,6 @@ import static org.glassfish.main.jul.handler.SyslogHandlerProperty.PORT;
  */
 public class SyslogHandler extends Handler {
     private static final MessageResolver MSG_RESOLVER = new MessageResolver();
-    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("MMM dd HH:mm:ss");
 
     private final LogRecordBuffer pendingRecords;
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLogManagerLifeCycleTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLogManagerLifeCycleTest.java
@@ -278,11 +278,6 @@ public class GlassFishLogManagerLifeCycleTest {
 
         private final AtomicBoolean blocker = new AtomicBoolean(true);
 
-        public void reset() {
-            blocker.set(true);
-        }
-
-
         public void unblock() throws InterruptedException {
             blocker.set(false);
             // in this time the log manager thread finishes the action and changes state

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/HandlerConfigurationHelperTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/HandlerConfigurationHelperTest.java
@@ -21,7 +21,6 @@ import java.util.logging.FileHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
-import java.util.logging.SimpleFormatter;
 
 import org.glassfish.main.jul.formatter.HandlerId;
 import org.glassfish.main.jul.formatter.ODLLogFormatter;

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/rotation/LogFileManagerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/rotation/LogFileManagerTest.java
@@ -17,11 +17,8 @@
 package org.glassfish.main.jul.rotation;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/rotation/MeteredStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/rotation/MeteredStreamTest.java
@@ -30,12 +30,12 @@ public class MeteredStreamTest {
 
     @Test
     public void test() throws Exception {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        final MeteredStream stream = new MeteredStream(bytes, 0);
-        stream.write(16);
-        assertEquals(1, stream.getBytesWritten());
-        stream.write("příšera z jezera".getBytes(UTF_8));
-        assertEquals(20, stream.getBytesWritten());
+        try (MeteredStream stream = new MeteredStream(new ByteArrayOutputStream(), 0)) {
+            stream.write(16);
+            assertEquals(1, stream.getBytesWritten());
+            stream.write("příšera z jezera".getBytes(UTF_8));
+            assertEquals(20, stream.getBytesWritten());
+        }
     }
 
 }


### PR DESCRIPTION
As I started updating the documentation I started also writing some integration tests for GF features. And they detected some bugs.

### Bugs

- log viewer sometimes wasn't able to parse server.log
  - there IS still mistake in indexing, but it is hard do reproduce it -> unit tests and refactoring would be helpful
  - parser is now more robust and can handle that
- timestamps from older versions could not be parsed for timestamps with offset (+0200) 

### Related Changes

- Removed unused imports
- Added some javadocs
- brief_product_name removed and abbrev_product_name is GlassFish now
  - affects productId in server.log
