### PR TITLE
Re-integrate fixed MVC and Krazo artifacts

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -254,10 +254,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <!-- Jakarta MVC -->
-        <!--
-        <dependency>
+	
+	<!-- Jakarta MVC -->
+	<dependency>
             <groupId>jakarta.mvc</groupId>
             <artifactId>jakarta.mvc-api</artifactId>
             <exclusions>
@@ -287,8 +286,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        -->
-
+	
         <!-- glassfish-grizzly-full -->
         <dependency>
             <groupId>org.glassfish.main.grizzly</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -152,8 +152,8 @@
         <jboss.classfilewriter.version>1.2.5.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->
-        <jakarta.mvc-api.version>2.0.1</jakarta.mvc-api.version>
-        <krazo.version>2.0.2</krazo.version>
+        <jakarta.mvc-api.version>2.1.0.RC1</jakarta.mvc-api.version>
+        <krazo.version>3.0.0.RC1</krazo.version>
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.0.1</microprofile.config-api.version>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.5</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.7</cdi.tck-4-0.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.5</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.7</cdi.tck-4-0.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>


### PR DESCRIPTION
This commit re-enables MVC and Krazo with the Jakarta EE 10 compliant versions. Also
it updates the CDI TCK which received some fixes (see: https://github.com/jakartaee/cdi-tck/issues/400).

I tested the fixes by running `mvn clean install -Pfastest,staging -T4C && mvn clean install -Pstaging,tck -pl :glassfish-external-tck-cdi` on my local machine.