### PR TITLE
Asciidoctor plugin now supports JDK17 too

### DIFF
--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -35,7 +35,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.3</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <jruby.version>9.3.2.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <pdf.fileName>${project.artifactId}.pdf</pdf.fileName>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -39,7 +39,7 @@
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <pdf.fileName>${project.artifactId}.pdf</pdf.fileName>
-        <pdf.toclevels>2</pdf.toclevels>
+        <pdf.toclevels>3</pdf.toclevels>
         <productName>Eclipse GlassFish</productName>
         <bookDirectory>${project.build.directory}/book</bookDirectory>
     </properties>
@@ -116,7 +116,7 @@
                             <attributes>
                                 <linkcss>true</linkcss>
                                 <toc>left</toc>
-                                <toclevels>1</toclevels>
+                                <toclevels>3</toclevels>
                                 <embedAssets>false</embedAssets>
                             </attributes>
                         </configuration>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -32,10 +32,10 @@
     <properties>
         <maven.site.skip>true</maven.site.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <asciidoctor.maven.plugin.version>2.2.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.2</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
-        <jruby.version>9.3.2.0</jruby.version>
+        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.5.3</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
+        <jruby.version>9.2.20.1</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <pdf.fileName>${project.artifactId}.pdf</pdf.fileName>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -71,7 +71,7 @@
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -80,8 +80,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8</message>
+                                    <version>[11,)</version>
+                                    <message>You need JDK11+</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
1. Updated dependencies
2. Set the TOC level from 1 for HTML and 2 for PDF to 3 for both - until we add some indexing service able to search in documentation it is easier to find something just by rolling through the TOC menu.

Tested both with JDK11 and JDK17. 

After the merge I will visit yet [Jenkins](https://ci.eclipse.org/glassfish/view/all/job/glassfish-docs-publish/configure) as it uses JDK8 which was mandatory before this PR.