### PR TITLE
Logging final cleanup

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -140,7 +140,7 @@ public class AsadminLoggingITest {
             .map(line -> line.replaceFirst("=.*", "")).collect(Collectors.toList());
         assertAll(
             () -> assertThat(keys.get(0), equalTo(".level")),
-            () -> assertThat(keys.get(keys.size() - 1), equalTo("systemRootLoggerLevel")),
+            () -> assertThat(keys.get(keys.size() - 1), equalTo("systemRootLogger.level")),
             () -> {
                 String previousKey = "";
                 for (String key : keys) {

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/PEAccessLogValve.java
@@ -43,7 +43,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -872,7 +871,7 @@ public final class PEAccessLogValve
      * file, and false if we have rotated
      */
     private synchronized void open(String dateStamp, boolean firstAccessLogFile) throws IOException {
-        _logger.log(Level.WARNING, "open(dateStamp={0}, firstAccessLogFile={1}",
+        _logger.log(Level.CONFIG, "open(dateStamp={0}, firstAccessLogFile={1}",
             new Object[] {dateStamp, firstAccessLogFile});
         // Create the directory if necessary
         File dir = new File(directory);
@@ -999,7 +998,7 @@ public final class PEAccessLogValve
         if (fileDateFormat == null) {
             fileDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         }
-        _logger.log(Level.SEVERE, "Using fileDateFormat: {0}", fileDateFormat);
+        _logger.log(Level.CONFIG, "Using fileDateFormat: {0}", fileDateFormat);
 
         final long systime = System.currentTimeMillis();
         try {

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/accesslog/CommonAccessLogFormatterImpl.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/accesslog/CommonAccessLogFormatterImpl.java
@@ -127,7 +127,7 @@ public class CommonAccessLogFormatterImpl extends AccessLogFormatter {
      */
     private void appendCurrentDate(CharBuffer cb) {
         cb.put("[");
-
+        cb.put(getPattern().getDateTimeFormatter().format(getTimestamp()));
         cb.put("]");
     }
 

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
 # Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -17,8 +18,9 @@
 # Handler settings
 
 handlers=\
+org.glassfish.main.jul.handler.GlassFishLogHandler,\
 org.glassfish.main.jul.handler.SimpleLogHandler,\
-org.glassfish.main.jul.handler.GlassFishLogHandler
+org.glassfish.main.jul.handler.SyslogHandler
 
 org.glassfish.main.jul.handler.GlassFishLogHandler.buffer.capacity=10000
 org.glassfish.main.jul.handler.GlassFishLogHandler.buffer.timeoutInSeconds=0
@@ -26,8 +28,8 @@ org.glassfish.main.jul.handler.GlassFishLogHandler.enabled=true
 org.glassfish.main.jul.handler.GlassFishLogHandler.encoding=UTF-8
 org.glassfish.main.jul.handler.GlassFishLogHandler.file=${com.sun.aas.instanceRoot}/logs/server.log
 org.glassfish.main.jul.handler.GlassFishLogHandler.flushFrequency=1
-org.glassfish.main.jul.handler.GlassFishLogHandler.formatter.excludedFields=
 org.glassfish.main.jul.handler.GlassFishLogHandler.formatter=org.glassfish.main.jul.formatter.ODLLogFormatter
+org.glassfish.main.jul.handler.GlassFishLogHandler.formatter.excludedFields=
 org.glassfish.main.jul.handler.GlassFishLogHandler.formatter.multiline=true
 org.glassfish.main.jul.handler.GlassFishLogHandler.formatter.printSource=false
 org.glassfish.main.jul.handler.GlassFishLogHandler.level=ALL
@@ -48,6 +50,14 @@ java.util.logging.FileHandler.count=1
 java.util.logging.FileHandler.formatter=java.util.logging.XMLFormatter
 java.util.logging.FileHandler.limit=50000
 java.util.logging.FileHandler.pattern=%h/java%u.log
+org.glassfish.main.jul.handler.SyslogHandler.buffer.capacity=5000
+org.glassfish.main.jul.handler.SyslogHandler.buffer.timeoutInSeconds=300
+org.glassfish.main.jul.handler.SyslogHandler.enabled=false
+org.glassfish.main.jul.handler.SyslogHandler.encoding=UTF-8
+org.glassfish.main.jul.handler.SyslogHandler.formatter=java.util.logging.SimpleFormatter
+org.glassfish.main.jul.handler.SyslogHandler.host=
+org.glassfish.main.jul.handler.SyslogHandler.level=SEVERE
+org.glassfish.main.jul.handler.SyslogHandler.port=514
 
 # Logger settings
 
@@ -134,7 +144,7 @@ jakarta.enterprise.system.tools.amx.level=INFO
 jakarta.enterprise.system.tools.amxee.level=INFO
 jakarta.enterprise.system.tools.backup.level=INFO
 jakarta.enterprise.system.tools.deployment.level=INFO
-jakarta.enterprise.system.tools.deployment.autodeploy
+jakarta.enterprise.system.tools.deployment.autodeploy.level=INFO
 jakarta.enterprise.system.tools.deployment.common.level=WARNING
 jakarta.enterprise.system.tools.deployment.dol.level=WARNING
 jakarta.enterprise.system.tools.deployment.javaeefull.level=INFO

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -46,10 +46,6 @@ org.glassfish.main.jul.handler.SimpleLogHandler.formatter.printSource=false
 org.glassfish.main.jul.handler.SimpleLogHandler.level=INFO
 org.glassfish.main.jul.handler.SimpleLogHandler.useErrorStream=true
 
-java.util.logging.FileHandler.count=1
-java.util.logging.FileHandler.formatter=java.util.logging.XMLFormatter
-java.util.logging.FileHandler.limit=50000
-java.util.logging.FileHandler.pattern=%h/java%u.log
 org.glassfish.main.jul.handler.SyslogHandler.buffer.capacity=5000
 org.glassfish.main.jul.handler.SyslogHandler.buffer.timeoutInSeconds=300
 org.glassfish.main.jul.handler.SyslogHandler.enabled=false

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -52,7 +52,7 @@ java.util.logging.FileHandler.pattern=%h/java%u.log
 # Logger settings
 
 .level=INFO
-systemRootLoggerLevel=INFO
+systemRootLogger.level=INFO
 
 com.sun.enterprise.glassfish.level=INFO
 com.sun.enterprise.glassfish.bootstrap.level=INFO

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -44,7 +44,7 @@ org.glassfish.main.jul.handler.SimpleLogHandler.formatter=org.glassfish.main.jul
 org.glassfish.main.jul.handler.SimpleLogHandler.formatter.excludedFields=
 org.glassfish.main.jul.handler.SimpleLogHandler.formatter.printSource=false
 org.glassfish.main.jul.handler.SimpleLogHandler.level=INFO
-org.glassfish.main.jul.handler.SimpleLogHandler.useErrorStream=false
+org.glassfish.main.jul.handler.SimpleLogHandler.useErrorStream=true
 
 java.util.logging.FileHandler.count=1
 java.util.logging.FileHandler.formatter=java.util.logging.XMLFormatter

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -24,12 +24,9 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.glassfish.embeddable.BootstrapProperties;
@@ -120,7 +117,7 @@ public class GlassFishMain {
         if ("true".equals(System.getenv(ENV_AS_TRACE_LOGGING))) {
             cfg.setProperty(KEY_TRACING_ENABLED, "true");
         }
-        cfg.setProperty("systemRootLoggerLevel", Level.INFO.getName());
+        cfg.setProperty("systemRootLogger.level", Level.INFO.getName());
         cfg.setProperty(".level", Level.INFO.getName());
         // better startup performance vs. losing log records.
         if ("true".equals(System.getenv(ENV_AS_TRACE_BOOTSTRAP))) {

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLogManagerProperty.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLogManagerProperty.java
@@ -33,7 +33,7 @@ public enum GlassFishLogManagerProperty implements LogProperty {
      * Property key for a level of system root logger. System root loggers children are not
      * configurable.
      */
-    KEY_SYS_ROOT_LOGGER_LEVEL("systemRootLoggerLevel"),
+    KEY_SYS_ROOT_LOGGER_LEVEL("systemRootLogger.level"),
     /**
      * Property key for a boolean value enabling forgetting log record parameters right after
      * the message is resolved. If false, parameters are set in the log record until the record

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/ODLLogFormatter.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/ODLLogFormatter.java
@@ -59,7 +59,7 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
     private static final String LABEL_RECORDNUMBER = "RECORDNUMBER";
 
     private final ExcludeFieldsSupport excludeFieldsSupport = new ExcludeFieldsSupport();
-    private String recordFieldSeparator = DEFAULT_FIELD_SEPARATOR;
+    private String fieldSeparator = DEFAULT_FIELD_SEPARATOR;
     private boolean multiline = true;
 
     public ODLLogFormatter(final HandlerId handlerId) {
@@ -80,7 +80,7 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
     private static void configure(final ODLLogFormatter formatter, final FormatterConfigurationHelper helper) {
         formatter.setExcludeFields(helper.getString(EXCLUDED_FIELDS, formatter.excludeFieldsSupport.toString()));
         formatter.multiline = helper.getBoolean(MULTILINE, formatter.multiline);
-        formatter.recordFieldSeparator = helper.getString(FIELD_SEPARATOR, formatter.recordFieldSeparator);
+        formatter.fieldSeparator = helper.getString(FIELD_SEPARATOR, formatter.fieldSeparator);
     }
 
 
@@ -148,7 +148,7 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
     private void appendTimestamp(final StringBuilder output, final OffsetDateTime timestamp) {
         output.append(FIELD_BEGIN_MARKER);
         output.append(getTimestampFormatter().format(timestamp));
-        output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+        output.append(FIELD_END_MARKER).append(fieldSeparator);
     }
 
     private void appendProductId(final StringBuilder output) {
@@ -157,13 +157,13 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
         if (productId != null) {
             output.append(productId);
         }
-        output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+        output.append(FIELD_END_MARKER).append(fieldSeparator);
     }
 
     private void appendLogLevel(final StringBuilder output, final Level logLevel) {
         output.append(FIELD_BEGIN_MARKER);
         output.append(logLevel.getName());
-        output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+        output.append(FIELD_END_MARKER).append(fieldSeparator);
     }
 
     private void appendMessageKey(final StringBuilder output, final String msgId) {
@@ -171,7 +171,7 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
         if (msgId != null) {
             output.append(msgId);
         }
-        output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+        output.append(FIELD_END_MARKER).append(fieldSeparator);
     }
 
     private void appendLoggerName(final StringBuilder output, final String loggerName) {
@@ -179,14 +179,14 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
         if (loggerName != null) {
             output.append(loggerName);
         }
-        output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+        output.append(FIELD_END_MARKER).append(fieldSeparator);
     }
 
     private void appendThread(final StringBuilder output, final int threadId, final String threadName) {
         if (!excludeFieldsSupport.isSet(SupplementalAttribute.TID)) {
             output.append(FIELD_BEGIN_MARKER);
             output.append("tid: ").append("_ThreadID=").append(threadId).append(" _ThreadName=").append(threadName);
-            output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+            output.append(FIELD_END_MARKER).append(fieldSeparator);
         }
     }
 
@@ -194,7 +194,7 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
         if (!excludeFieldsSupport.isSet(SupplementalAttribute.LEVEL_VALUE)) {
             output.append(FIELD_BEGIN_MARKER);
             output.append("levelValue: ").append(logLevel.intValue());
-            output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+            output.append(FIELD_END_MARKER).append(fieldSeparator);
         }
     }
 
@@ -202,7 +202,7 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
         if (isPrintSequenceNumber()) {
             output.append(FIELD_BEGIN_MARKER);
             output.append(LABEL_RECORDNUMBER).append(": ").append(sequenceNumber);
-            output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+            output.append(FIELD_END_MARKER).append(fieldSeparator);
         }
     }
 
@@ -213,12 +213,12 @@ public class ODLLogFormatter extends GlassFishLogFormatter {
         if (className != null) {
             output.append(FIELD_BEGIN_MARKER);
             output.append(LABEL_CLASSNAME).append(": ").append(className);
-            output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+            output.append(FIELD_END_MARKER).append(fieldSeparator);
         }
         if (methodName != null) {
             output.append(FIELD_BEGIN_MARKER);
             output.append(LABEL_METHODNAME).append(": ").append(methodName);
-            output.append(FIELD_END_MARKER).append(recordFieldSeparator);
+            output.append(FIELD_END_MARKER).append(fieldSeparator);
         }
     }
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SimpleLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SimpleLogHandler.java
@@ -33,7 +33,7 @@ import org.glassfish.main.jul.formatter.OneLineFormatter;
  * <p>
  * Similar to {@link java.util.logging.ConsoleHandler} except
  * <ul>
- * <li>it uses STDOUT instead of STDERR by default, but you can use also different {@link PrintStream}.
+ * <li>can be configured to use STDOUT instead of STDERR
  * <li>uses {@link OneLineFormatter} by default
  * </ul>
  *
@@ -46,7 +46,7 @@ public class SimpleLogHandler extends StreamHandler {
      */
     public SimpleLogHandler() {
         final HandlerConfigurationHelper helper = HandlerConfigurationHelper.forHandlerClass(getClass());
-        if (helper.getBoolean(SimpleLogHandlerProperty.USE_ERROR_STREAM, false)) {
+        if (helper.getBoolean(SimpleLogHandlerProperty.USE_ERROR_STREAM, true)) {
             setOutputStream(new UncloseablePrintStream(LoggingSystemEnvironment.getOriginalStdErr()));
         } else {
             setOutputStream(new UncloseablePrintStream(LoggingSystemEnvironment.getOriginalStdOut()));
@@ -106,7 +106,7 @@ public class SimpleLogHandler extends StreamHandler {
      */
     public enum SimpleLogHandlerProperty implements LogProperty {
 
-        /** Use STDERR instead of STDOUT */
+        /** Use STDERR or STDOUT? Default is true (STDERR). */
         USE_ERROR_STREAM("useErrorStream"),
         /** Class of the {@link Formatter} used with this handler */
         FORMATTER(HandlerConfigurationHelper.FORMATTER.getPropertyName()),

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/rotation/LogFileManager.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/rotation/LogFileManager.java
@@ -58,8 +58,8 @@ public class LogFileManager {
 
     private final File logFile;
     private final long maxFileSize;
-    private final boolean compressOldLogs;
-    private final int maxCountOfOldLogs;
+    private final boolean compressOldLogFiles;
+    private final int maxCountOfOldLogFiles;
     private final HandlerSetStreamMethod streamSetter;
     private final HandlerCloseStreamMethod streamCloser;
 
@@ -73,9 +73,9 @@ public class LogFileManager {
      * @param logFile - output logging file path
      * @param maxFileSize - if the size of the file crosses this value, the file is renamed to the
      *            logFile name with added suffix ie. <code>server.log_2020-05-01T16-28-27</code>
-     * @param compressOldLogs - if true, rolled file is packed to GZIP (so the file will have a name
+     * @param compressOldLogFiles - if true, rolled file is packed to GZIP (so the file will have a name
      *            ie. <code>server.log_2020-05-01T21-50-09.gz</code>)
-     * @param maxCountOfOldLogs - if the count of rolled files with logFile's file name prefix
+     * @param maxCountOfOldLogFiles - if the count of rolled files with logFile's file name prefix
      *            crosses this value, old files will be permanently deleted.
      * @param streamSetter - this should be a {@link StreamHandler#setOutputStream} method. This
      *            method will be called when we enable ouput.
@@ -83,13 +83,13 @@ public class LogFileManager {
      *            be called when we disable output.
      */
     public LogFileManager(final File logFile, //
-        final long maxFileSize, final boolean compressOldLogs, final int maxCountOfOldLogs, //
+        final long maxFileSize, final boolean compressOldLogFiles, final int maxCountOfOldLogFiles, //
         final HandlerSetStreamMethod streamSetter, final HandlerCloseStreamMethod streamCloser //
     ) {
         this.logFile = logFile;
         this.maxFileSize = maxFileSize;
-        this.compressOldLogs = compressOldLogs;
-        this.maxCountOfOldLogs = maxCountOfOldLogs;
+        this.compressOldLogFiles = compressOldLogFiles;
+        this.maxCountOfOldLogFiles = maxCountOfOldLogFiles;
         this.streamSetter = streamSetter;
         this.streamCloser = streamCloser;
     }
@@ -273,7 +273,7 @@ public class LogFileManager {
 
     // synchronized - it is executed in separate thread!
     private synchronized void cleanUpHistoryLogFiles(final File rotatedFile) {
-        if (this.compressOldLogs) {
+        if (this.compressOldLogFiles) {
             compressFile(rotatedFile);
         }
         deleteOldLogFiles();
@@ -304,7 +304,7 @@ public class LogFileManager {
 
 
     private void deleteOldLogFiles() {
-        if (this.maxCountOfOldLogs == 0) {
+        if (this.maxCountOfOldLogFiles == 0) {
             return;
         }
 
@@ -316,7 +316,7 @@ public class LogFileManager {
         final FileFilter filter = f -> f.isFile() && !f.getName().equals(logFileName)
             && f.getName().startsWith(logFileName);
         Arrays.stream(dir.listFiles(filter)).sorted(Comparator.comparing(File::getName).reversed())
-            .skip(this.maxCountOfOldLogs).forEach(this::deleteFile);
+            .skip(this.maxCountOfOldLogFiles).forEach(this::deleteFile);
     }
 
 


### PR DESCRIPTION
I am still going through all manual tests based on documentation (doc PR tomorrow) as a user.
This PR is a result ...

* SimpleLogHandler.useErrorStream is true by default. See https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)
* Added SyslogHandler to help users with configuration (disabled by default, requires OS configuration, tested on Kubuntu 22.04 with rsyslog)
* Renamed systemRootLoggerLevel to follow conventions
* Fixed CommonAccessLogFormatterImpl (recently removed old timestamp formatting, but I forgot to add new; wasn't visible in tests because by default is used different impl)
* Removed FileHandler settings. Obsoleted usage, now usually not used.
* Minor cleanup