### PR TITLE
Fixed comparison in JDK version requirement validation

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/FilteringClassLoader.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/FilteringClassLoader.java
@@ -102,7 +102,7 @@ class FilteringClassLoader extends ClassLoader {
         if (requiredMinVersion == null) {
             return true;
         }
-        return requiredMinVersion.compareTo(Runtime.version()) < 0;
+        return requiredMinVersion.compareTo(Runtime.version()) <= 0;
     }
 
 


### PR DESCRIPTION
- it did not cause any errors (yet), but it should be correct.
- see https://github.com/eclipse-ee4j/glassfish/pull/24076#discussion_r953517629 , thanks @pzygielo for the review!
