### PR TITLE
Reduce dependency scope

### DIFF
--- a/appserver/jms/jmsra/pom.xml
+++ b/appserver/jms/jmsra/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,6 +47,7 @@
             <artifactId>mq-distribution</artifactId>
             <version>${openmq.version}</version>
             <type>zip</type>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I think that once `org.glassfish.main.jms:jmsra` is built/repackaged from `mq-jmsra`, `mq-distribution`:**`zip`** is not required in dependency tree.