### PR TITLE
Add glassfish-jul-extension dependency to glassfish-embedded-all

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -1667,6 +1667,7 @@
             <groupId>org.glassfish.main</groupId>
             <artifactId>glassfish-jul-extension</artifactId>
             <version>${project.version}</version>
+            <type>glassfish-jar</type>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -1705,7 +1706,7 @@
                             <excludeTransitive>true</excludeTransitive>
                             <includeScope>compile</includeScope>
                             <includeScope>runtime</includeScope>
-                            <includeTypes>jar</includeTypes>
+                            <includeTypes>jar,glassfish-jar</includeTypes>
                             <includes>**/*.class</includes>
                         </configuration>
                     </execution>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -1663,6 +1663,12 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
    <build>

--- a/appserver/extras/embedded/all/src/assembly/package.xml
+++ b/appserver/extras/embedded/all/src/assembly/package.xml
@@ -30,6 +30,7 @@
             </unpackOptions>
             <includes>
                 <include>*:*:jar:*</include>
+                <include>*:*:glassfish-jar:*</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
With 7.0.0-M8 I'm getting:
```
java.lang.NoClassDefFoundError: org/glassfish/main/jul/GlassFishLogger
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:555)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at com.sun.appserv.connectors.internal.api.AppSpecificConnectorClassLoaderUtil.
```

- #24046 seems to be introduced after M7