### PR TITLE
Fixes to be able to run the TCK on custom Jenkins instance

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -35,20 +35,16 @@ import static org.apache.commons.lang3.StringUtils.replaceChars;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.glassfish.main.admin.test.tool.AsadminResultMatcher.asadminOK;
 import static org.glassfish.main.admin.test.tool.asadmin.GlassFishTestEnvironment.getDomain1Directory;
-import static org.glassfish.tests.utils.junit.matcher.TextFileMatchers.getterMatches;
 import static org.glassfish.tests.utils.junit.matcher.TextFileMatchers.hasLineCount;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -119,8 +115,8 @@ public class AsadminLoggingITest {
             .collect(Collectors.toMap(pair -> pair[0], pair -> pair[1]));
         assertAll(
             () -> assertThat(map.get("handlers"),
-                equalTo("<org.glassfish.main.jul.handler.GlassFishLogHandler,"
-                + "org.glassfish.main.jul.handler.SimpleLogHandler,"
+                equalTo("<org.glassfish.main.jul.handler.SimpleLogHandler,"
+                + "org.glassfish.main.jul.handler.GlassFishLogHandler,"
                 + "org.glassfish.main.jul.handler.SyslogHandler>")),
             () -> assertThat(map.get("org.glassfish.main.jul.handler.GlassFishLogHandler.file"),
                 equalTo("<${com.sun.aas.instanceRoot}/logs/server.log>"))

--- a/appserver/tests/tck/tck-download/jakarta-ant-based-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-ant-based-tck/pom.xml
@@ -44,7 +44,7 @@
                 <artifactId>download-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>download-pages-tck</id>
+                        <id>download-tck</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>wget</goal>

--- a/appserver/tests/tck/tck-runner/pom.xml
+++ b/appserver/tests/tck/tck-runner/pom.xml
@@ -35,6 +35,7 @@
         <ant.home>${env.ANT_HOME}</ant.home>
         <jdk.home>${env.JAVA_HOME}</jdk.home>
         <glassfish.version>${project.version}</glassfish.version>
+        <maven.repo.local>${user.home}/.m2/repository</maven.repo.local>
         <tck.version>${project.version}</tck.version>
     </properties>
 
@@ -42,7 +43,7 @@
         <dependency>
             <groupId>org.glassfish.main.tests.tck</groupId>
             <artifactId>jakarta-ant-based-tck</artifactId>
-            <version>${project.version}</version>
+            <version>${tck.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
@@ -96,6 +97,7 @@
                 <directory>src/test/resources</directory>
                 <includes>
                     <include>**/*.properties</include>
+                    <include>**/*.xml</include>
                 </includes>
                 <filtering>true</filtering>
             </testResource>

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckConfiguration.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckConfiguration.java
@@ -133,6 +133,14 @@ public class TckConfiguration {
 
 
     /**
+     * @return configured maven settings.xml file.
+     */
+    public File getSettingsXml() {
+        return new File(cfg.getProperty("settingsXmlFile"));
+    }
+
+
+    /**
      * @return version of the GlassFish zip artifact.
      */
     public String getGlassFishVersion() {
@@ -169,5 +177,14 @@ public class TckConfiguration {
      */
     public boolean isAsadminLoggingEnabled() {
         return Boolean.parseBoolean(cfg.getProperty("log.asadmin"));
+    }
+
+
+    /**
+     * Prints internal properties to string.
+     */
+    @Override
+    public String toString() {
+        return this.cfg.toString();
     }
 }

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -195,6 +195,7 @@ public class TckRunner {
         env.put("JDK17_HOME", cfg.getJdkDirectory().getAbsolutePath());
         env.put("JDK", "JDK17");
         if (mailServer != null) {
+            env.put("MAIL_HOST", mailServer.getHost());
             env.put("SMTP_PORT", String.valueOf(mailServer.getMappedPort(MAIL_SMTP_PORT)));
             env.put("IMAP_PORT", String.valueOf(mailServer.getMappedPort(MAIL_IMAP_PORT)));
         }

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -61,6 +61,7 @@ public class TckRunner {
      */
     public TckRunner(final TckConfiguration cfg) {
         this.cfg = cfg;
+        LOG.log(Level.INFO, "TckRunner configuration: \n{0}", cfg);
     }
 
 
@@ -69,12 +70,17 @@ public class TckRunner {
      */
     public void prepareWorkspace() {
         LOG.log(Level.INFO, "Preparing workspace at {0}", cfg.getTargetDir());
-        ZipResolver zipResolver = new ZipResolver(cfg.getTargetDir());
+        ZipResolver zipResolver = new ZipResolver(cfg.getTargetDir(), cfg.getSettingsXml());
         if (cfg.getJakartaeeDir().exists()) {
             LOG.log(Level.INFO, "Jakarta EE was already installed, unzipping to {0} skipped.", cfg.getJakartaeeDir());
         } else {
             zipResolver.unzipDependency("org.glassfish.main.tests.tck", "jakarta-ant-based-tck", cfg.getTckVersion());
-            cfg.getJakartaeetckCommand().toFile().setExecutable(true);
+            File command = cfg.getJakartaeetckCommand().toFile();
+            if (command.exists()) {
+                command.setExecutable(true);
+            } else {
+                throw new IllegalStateException("The TCK runnable doesn't exist: " + command);
+            }
         }
         glassfishZip = zipResolver.getZipFile("org.glassfish.main.distributions", "glassfish", cfg.getGlassFishVersion());
     }

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/io/ZipResolver.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/io/ZipResolver.java
@@ -19,6 +19,8 @@ package org.glassfish.main.tests.tck.ant.io;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -35,6 +37,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.MavenResolverSystem;
  * @author David Matejcek
  */
 public class ZipResolver {
+    private static final Logger LOG = System.getLogger(ZipResolver.class.getName());
 
     private final MavenResolverSystem resolver;
     private final File targetDirectory;
@@ -43,10 +46,11 @@ public class ZipResolver {
      * Initializes the resolver.
      *
      * @param targetDirectory - this directory will be used for the output.
+     * @param settingsXml - Maven configuration
      */
-    public ZipResolver(final File targetDirectory) {
-        this.resolver = Maven.configureResolver().withMavenCentralRepo(false).workOffline()
-            .fromClassloaderResource("settings.xml");
+    public ZipResolver(final File targetDirectory, final File settingsXml) {
+        LOG.log(Level.DEBUG, "ZipResolver(targetDirectory={0}, settingsXml={1})", targetDirectory, settingsXml);
+        this.resolver = Maven.configureResolver().withMavenCentralRepo(false).workOffline().fromFile(settingsXml);
         this.targetDirectory = targetDirectory;
     }
 
@@ -55,6 +59,7 @@ public class ZipResolver {
      * @return the artifact ZIP file in user's default local Maven repository.
      */
     public File getZipFile(String groupId, String artifactId, String version) {
+        LOG.log(Level.INFO, "getZipFile(groupId={0}, artifactId={1}, version={2})", groupId, artifactId, version);
         return resolve(groupId, artifactId, version).asSingleFile();
     }
 
@@ -63,6 +68,7 @@ public class ZipResolver {
      * Resolves the ZIP dependency and unzips it to the target directory given in constructor.
      */
     public void unzipDependency(String groupId, String artifactId, String version) {
+        LOG.log(Level.INFO, "unzipDependency(groupId={0}, artifactId={1}, version={2})", groupId, artifactId, version);
         MavenFormatStage tckZip = resolve(groupId, artifactId, version);
         try (ZipInputStream zis = new ZipInputStream(tckZip.asSingleInputStream())) {
             try {

--- a/appserver/tests/tck/tck-runner/src/test/resources/settings.xml
+++ b/appserver/tests/tck/tck-runner/src/test/resources/settings.xml
@@ -6,4 +6,6 @@
   It is possible because all required dependencies should be already downloaded
   by the tck-download maven submodules.
   -->
+  <interactiveMode>false</interactiveMode>
+  <localRepository>${maven.repo.local}</localRepository>
 </settings>

--- a/appserver/tests/tck/tck-runner/src/test/resources/tck.properties
+++ b/appserver/tests/tck/tck-runner/src/test/resources/tck.properties
@@ -3,6 +3,7 @@ tck.version=${tck.version}
 
 target.directory=${project.build.directory}
 pomFile=${basedir}/pom.xml
+settingsXmlFile=${project.build.testOutputDirectory}/settings.xml
 
 ant.directory=${ant.home}
 jdk.directory=${jdk.home}

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -18,8 +18,8 @@
 # Handler settings
 
 handlers=\
-org.glassfish.main.jul.handler.GlassFishLogHandler,\
 org.glassfish.main.jul.handler.SimpleLogHandler,\
+org.glassfish.main.jul.handler.GlassFishLogHandler,\
 org.glassfish.main.jul.handler.SyslogHandler
 
 org.glassfish.main.jul.handler.GlassFishLogHandler.buffer.capacity=10000

--- a/runtests.sh
+++ b/runtests.sh
@@ -34,7 +34,7 @@ install_glassfish() {
 
 install_jacoco() {
   mvn -N org.apache.maven.plugins:maven-dependency-plugin:3.2.0:copy \
-  -Dartifact=org.jacoco:org.jacoco.agent:0.8.7:jar:runtime \
+  -Dartifact=org.jacoco:org.jacoco.agent:0.8.8:jar:runtime \
   -Dmdep.stripVersion=true \
   -Dmdep.stripClassifier=true \
   -DoutputDirectory=${WORKSPACE}/bundles
@@ -70,7 +70,9 @@ if [ -z "${JAVA_HOME}" ]; then
 fi
 export PATH="${JAVA_HOME}/bin:${PATH}"
 
-export MVN_REPOSITORY="${HOME}/.m2/repository"
+if [ -z "${MVN_REPOSITORY}" ]; then
+  export MVN_REPOSITORY="${HOME}/.m2/repository"
+fi
 export M2_HOME="${M2_HOME=$(realpath $(dirname $(realpath $(which mvn)))/..)}"
 export APS_HOME="$(pwd)/appserver/tests/appserv-tests"
 


### PR DESCRIPTION
- old authentication TCK 3.0.0 is based on Ant and it still steals logging.properties from GlassFish and uses them on clients. That leads to a deadlock on client, but not when we switch the order of handlers.
- settings.xml on Jenkins redefines path to the local m2 cache, so we respect it inside the runner to avoid redundant downloads.
- added hostname configuration for the mail server.
- Tested locally and on private Jenkins instance
- Execution on the private Jenkins depends on rebuilt JEE 10 zip including these two:
  - https://github.com/eclipse-ee4j/jakartaee-tck/pull/1115
  - https://github.com/eclipse-ee4j/jakartaee-tck/pull/1118
  - However the Eclipse's Jenkins doesn't depend on these changes.
- seems the TCK wasn't rebuilt for some time ... https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/master/