### PR TITLE
Fixes and updates based on playing with external Jenkins builds with TCK

### DIFF
--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -35,6 +35,7 @@
         <glassfish.version>${project.version}</glassfish.version>
         <tck.root>${project.build.directory}</tck.root>
         <maven.executable>${env._}</maven.executable>
+        <maven.settings.xml>${user.home}/.m2/settings.xml</maven.settings.xml>
     </properties>
 
     <dependencies>
@@ -87,13 +88,15 @@
                 <configuration>
                     <executable>${maven.executable}</executable>
                     <arguments>
-                        <argument>clean</argument>
-                        <argument>install</argument>
-                        <argument>-f</argument>
-                        <argument>${tck.root}/faces-tck-4.0.1/tck/pom.xml</argument>
-                        <argument>-Dglassfish.version=${glassfish.version}</argument>
                         <argument>-B</argument>
                         <argument>-e</argument>
+                        <argument>-s</argument>
+                        <argument>${maven.settings.xml}</argument>
+                        <argument>-f</argument>
+                        <argument>${tck.root}/faces-tck-4.0.1/tck/pom.xml</argument>
+                        <argument>clean</argument>
+                        <argument>install</argument>
+                        <argument>-Dglassfish.version=${glassfish.version}</argument>
                     </arguments>
                     <environmentVariables>
                         <LC_ALL>C</LC_ALL>

--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -27,290 +27,78 @@
     </parent>
 
     <artifactId>glassfish-external-tck-faces</artifactId>
-    <packaging>pom</packaging>
-
     <name>TCK: Faces</name>
 
+    <description>This verifies the compliance of Eclipse Glassfish using the Jakarta Faces standalone TCK</description>
+
     <properties>
-        <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
-        <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
-        <tck.home>${project.build.directory}/faces-tck</tck.home>
-        <tck.tests.home>${tck.home}/src/com/sun/ts/tests/jsf</tck.tests.home> 
-         
-        <glassfish.home>${project.build.directory}/glassfish6</glassfish.home>
         <glassfish.version>${project.version}</glassfish.version>
-        <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
-       
-        <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
-        
-        <port.admin>14848</port.admin>
-        <port.derby>11527</port.derby>
-        <port.http>18080</port.http>
-        <port.https>18181</port.https>
-        <port.jms>17676</port.jms>
-        <port.jmx>18686</port.jmx>
-        <port.orb>13700</port.orb>
-        <port.orb.mutual>13920</port.orb.mutual>
-        <port.orb.ssl>13820</port.orb.ssl>
-        <port.harness.log>12000</port.harness.log>
+        <tck.root>${project.build.directory}</tck.root>
+        <maven.executable>${env._}</maven.executable>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.main.distributions</groupId>
-            <artifactId>glassfish</artifactId>
-            <version>${glassfish.version}</version>
-            <type>zip</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.main.tests.tck</groupId>
             <artifactId>jakarta-faces-tck</artifactId>
-            <version>${project.version}</version>
             <type>zip</type>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>download-ant</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skip>${skipITs}</skip>
-                    <url>${ant.zip.url}</url>
-                    <unpack>true</unpack>
-                    <outputDirectory>${project.build.directory}</outputDirectory>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <skip>${skipITs}</skip>
-                </configuration>
                 <executions>
                     <execution>
-                        <id>unpack-glassfish</id>
+                        <id>unpack</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>unpack</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>glassfish</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.tests.tck</groupId>
+                                    <artifactId>jakarta-faces-tck</artifactId>
+                                    <type>zip</type>
+                                    <version>${project.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${tck.root}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
-                    <!-- 
-                    <execution>
-                        <id>unpack-tck</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeArtifactIds>jakarta-faces-tck</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                    -->
                 </executions>
             </plugin>
-
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant</artifactId>
-                        <version>${ant.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>ant-contrib</groupId>
-                        <artifactId>ant-contrib</artifactId>
-                        <version>1.0b3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>ant</groupId>
-                                <artifactId>ant</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <skip>${skipITs}</skip>
-                </configuration>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
-                        <id>prepare-tck-and-glassfish</id>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
-                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
-                                         classpathref="maven.plugin.classpath" />
-                                         
-                               <macrodef name="tck-setting">
-                                    <attribute name="key" /> <attribute name="value" />
-                                    <sequential>
-                                      <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
-                                        match="@{key}=.*" replace="@{key}=@{value}" />
-                                    </sequential>
-                                </macrodef>
-
-                                <!-- Change configuration -->
-                                <copy file="${tck.home}/bin/ts.jte.jdk11" tofile="${tck.home}/bin/ts.jte" overwrite="true"  />
-                                
-                                <tck-setting key="webServerHost" value="localhost"/>
-                                <tck-setting key="webServerPort" value="${port.http}"/>
-                                <tck-setting key="securedWebServicePort" value="${port.https}"/>
-                                <tck-setting key="s1as.admin.port" value="${port.admin}"/>
-                                <tck-setting key="glassfish.admin.port" value="${port.admin}"/>
-                                <tck-setting key="orb.port" value="${port.orb}"/>
-                                <tck-setting key="database.port" value="${port.derby}"/>
-                                <tck-setting key="harness.log.port" value="${port.harness.log}"/>
-                                
-                                <tck-setting key="report.dir" value="${tck.home}/facesreport/faces"/>
-                                <tck-setting key="work.dir" value="${tck.home}/faceswork/faces"/>
-                                
-                                <tck-setting key="webServerHome" value="${glassfish.home}/glassfish"/>
-                                
-                                <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
-                                    match="webServerHome=/ri/glassfish3/glassfish" replace="webServerHome=${glassfish.home}/glassfish" />
-                                 
-                                
-                                <tck-setting key="impl.vi" value="glassfish"/>
-                                <tck-setting key="impl.vi.deploy.dir" value="${webServerHome}/domains/domain1/autodeploy"/>
-                                <tck-setting key="impl.deploy.timeout.multiplier" value="960"/>
-                                
-                                <tck-setting key="jsf.classes" value="${webServerHome}/modules/jakarta.enterprise.cdi-api.jar;${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar;${webServerHome}/modules/jakarta.inject-api.jar;${webServerHome}/modules/jakarta.faces.jar;${webServerHome}/modules/jakarta.servlet.jsp-api.jar;${webServerHome}/modules/jakarta.servlet-api.jar;${webServerHome}/modules/expressly.jar"/>
-
-                                <limit maxwait="60">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="delete-domain"/>
-                                        <arg value="domain1" />
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="create-domain"/>
-                                        <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
-                                        <arg value="--user=admin" />
-                                        <arg value="--nopassword" />
-                                        <arg value="domain1" />
-                                    </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="start-domain"/>
-                                    </exec>
-
-                                    <if>
-                                        <isset property="jacoco.version" />
-                                        <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                                <arg value="create-jvm-options" />
-                                                <arg value="--port=${port.admin}" />
-                                                <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
-                                            </exec>
-                                        </then>
-                                    </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="stop-domain"/>
-                                        <arg value="domain1"/>
-                                    </exec>
-                                </limit>
-                                <mkdir dir="${tck.home}/facesreport"/>
-                                <mkdir dir="${tck.home}/facesreport/faces"/>
-                                
-                                <replace file="${tck.home}/bin/xml/ts.top.import.xml">
-                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m" />]]></replacetoken>
-                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m" />
-                                <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
-                                </replace>
-                                
-                                <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
-                                  <replacetoken><![CDATA[<jvmarg value="-Xmx512m" />]]></replacetoken>
-                                  <replacevalue><![CDATA[<jvmarg value="-Xmx512m" />
-                                <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008"/>]]></replacevalue>
-                                </replace>
-                                
-                                
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>configure-tck-tests</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
-                                         classpathref="maven.plugin.classpath" />
-                                <limit maxwait="20">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                        <arg value="start-domain"/>
-                                    </exec>
-                                </limit>
-                                
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
-                                    <arg value="-Dutil.dir=${tck.home}"  />
-                                    <arg value="deploy.all"  />
-                                </exec>
-                            </target>
-                        </configuration>
-                    </execution>
-      
-
-                     <execution>
-                        <id>run-tck-tests</id>
                         <phase>integration-test</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>exec</goal>
                         </goals>
-                        <configuration>
-                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
-                                <taskdef resource="net/sf/antcontrib/antcontrib.properties"
-                                         classpathref="maven.plugin.classpath" />
-
-                                <echo level="info" message="Start running all tests" unless:set="run.test"/>
-                                <echo level="info" message="Start running single test" if:set="run.test"/>
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" resultproperty="testResult">
-                                    <arg value="-Dutil.dir=${tck.home}"  />
-                                    <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
-                                    <arg value="runclient"/>
-                                    <env key="LC_ALL" value="C" />
-                                </exec>
-
-                                <if>
-                                    <not>
-                                        <equals arg1="${testResult}" arg2="0" />
-                                    </not>
-                                    <then>
-                                        <echo message="Running tests failed." />
-                                        <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
-                                    </then>
-                                </if>
-
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
-                            </target>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <executable>${maven.executable}</executable>
+                    <arguments>
+                        <argument>clean</argument>
+                        <argument>install</argument>
+                        <argument>-f</argument>
+                        <argument>${tck.root}/faces-tck-4.0.1/tck/pom.xml</argument>
+                        <argument>-Dglassfish.version=${glassfish.version}</argument>
+                        <argument>-B</argument>
+                        <argument>-e</argument>
+                    </arguments>
+                    <environmentVariables>
+                        <LC_ALL>C</LC_ALL>
+                    </environmentVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <glassfish.version>${project.version}</glassfish.version>
         <tck.root>${project.build.directory}</tck.root>
-        <maven.executable>${env._}</maven.executable>
+        <maven.executable>${maven.home}/bin/mvn</maven.executable>
         <maven.settings.xml>${user.home}/.m2/settings.xml</maven.settings.xml>
     </properties>
 

--- a/appserver/tests/tck/tck-download/jakarta-faces-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-faces-tck/pom.xml
@@ -32,7 +32,7 @@
     <name>TCK: Install Jakarta Faces TCK</name>
 
     <properties>
-        <tck.test.faces.file>jakarta-faces-tck-4.0.0.zip</tck.test.faces.file>
+        <tck.test.faces.file>jakarta-faces-tck-4.0.1.zip</tck.test.faces.file>
         <tck.test.faces.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/${tck.test.faces.file}</tck.test.faces.url>
     </properties>
 

--- a/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/EjbITest.java
+++ b/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/EjbITest.java
@@ -111,6 +111,9 @@ public class EjbITest {
     }
 
 
+    /**
+     * 230 tests, usual time 45 minutes.
+     */
     @Test
     public void ejb30LiteSingleton() throws Exception {
         tck.start(Path.of("ejb30", "lite", "singleton"));

--- a/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/EjbITest.java
+++ b/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/EjbITest.java
@@ -36,6 +36,7 @@ public class EjbITest {
 
     @Test
     public void ejb() throws Exception {
+        tck.startMailServer();
         tck.start(Path.of("ejb"));
     }
 

--- a/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/ServletITest.java
+++ b/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/ServletITest.java
@@ -39,6 +39,7 @@ public class ServletITest {
      */
     @Test
     public void servlet() throws Exception {
+        tck.startMailServer();
         tck.start(Path.of("servlet"));
     }
 }

--- a/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/WebsocketITest.java
+++ b/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/tests/WebsocketITest.java
@@ -38,7 +38,7 @@ public class WebsocketITest {
      * Usual time: ? minutes
      */
     @Test
-    public void jstl() throws Exception {
-        tck.start(Path.of("jstl"));
+    public void websocket() throws Exception {
+        tck.start(Path.of("websocket"));
     }
 }

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogCollectorHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogCollectorHandler.java
@@ -44,7 +44,7 @@ public class LogCollectorHandler extends Handler {
      * @param loggerToFollow this handler will be added to this logger.
      */
     public LogCollectorHandler(final Logger loggerToFollow) {
-        this.buffer = new LogRecordBuffer(100, 5);
+        buffer = new LogRecordBuffer(100, 5);
         logger = loggerToFollow;
         logger.addHandler(this);
     }

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -167,7 +167,8 @@ public class LoggingPrintStreamTest {
         assertSame(stream, stream.format("That %s", Level.ALL));
         assertSame(stream, stream.format(Locale.GERMAN, "Number: %f.", 8.7f));
 
-        Thread.yield();
+        // The internal buffer is managed by a thread, so we need to be sure it processed all records.
+        stream.close();
         List<String> list = handler.getAll(LogRecord::getMessage);
         assertAll(
             () -> assertThat(list,


### PR DESCRIPTION
This PR contains several commits fixing issues I have found on my private Jenkins.

1. LoggingPrintStreamTest started failing. It was because the global printstreams use internal buffers with an own thread to avoid blocking and locking and slowing down usages of these streams (used as STDOUT/STDERR in JVM). They translate each call to a LogRecord, then call logger, logger distributes the log record while original caller continues. And that was the issue in the test. Thread.yield is usually enough, but doesn't guarantee anything, the same thread can be scheduled again.
2. That and recent deadlock in TCK, repeated here, led me to reviewing that locking prevention in the LoggingPrintStream class. I think it was implemented yet for Java 1.4, but it did not work in JDK11+, because JUL internally changed, GF implementation changed, there is more locks in the path, while these locks are not an issue any more. So I removed the mechanism. Until now I executed around 200 000 tests and did not see any deadlock.
3. Fixed missing test dependencies - mail server, customized settings.xml
4. Upgraded Faces TCK execution to the maven based. Was still just inherited from GF6.