### PR TITLE
Fixes for the TCK

### DIFF
--- a/appserver/common/annotation-framework/src/main/java/org/glassfish/apf/impl/ComponentDefinition.java
+++ b/appserver/common/annotation-framework/src/main/java/org/glassfish/apf/impl/ComponentDefinition.java
@@ -137,7 +137,7 @@ public class ComponentDefinition implements ComponentInfo {
      */
     private boolean isExcludedFromAnnotationProcessing(Class<?> clazz) {
         if (clazz.getPackage() == null) {
-            return true;
+            return false;
         }
         if (clazz.getPackage().getName().startsWith("java.lang")) {
             return true;

--- a/appserver/tests/tck/tck-runner/pom.xml
+++ b/appserver/tests/tck/tck-runner/pom.xml
@@ -120,6 +120,9 @@
                             <sources>
                                 <source>src/main/resources/junit-results.xsd</source>
                             </sources>
+                            <xjbSources>
+                                <xjbSource>src/main/resources/junit-results.xjb</xjbSource>
+                            </xjbSources>
                             <packageName>org.glassfish.main.tests.tck.ant.junit.generated</packageName>
                         </configuration>
                     </execution>

--- a/appserver/tests/tck/tck-runner/pom.xml
+++ b/appserver/tests/tck/tck-runner/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.glassfish.main.distributions</groupId>
             <artifactId>glassfish</artifactId>
-            <version>${project.version}</version>
+            <version>${glassfish.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -236,6 +236,7 @@ public class TckRunner {
     private String toReport(Testsuite suite) {
         StringBuilder report = new StringBuilder();
         report.append("Test suite ").append(suite.getName());
+        report.append(" finished at ").append(suite.getTimestamp());
         report.append(" failed with ").append(suite.getFailures()).append(" failures and ");
         report.append(suite.getErrors()).append(" errors.");
         List<Testcase> tests = suite.getTestcase();

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -190,6 +190,7 @@ public class TckRunner {
 
     private void configureEnvironment(Map<String, String> env) {
         env.put("LC_ALL", "en_US.UTF-8");
+        env.put("LANG", "en");
         env.put("WORKSPACE", cfg.getTargetDir().getAbsolutePath());
         env.put("JAVA_HOME", cfg.getJdkDirectory().getAbsolutePath());
         env.put("JDK17_HOME", cfg.getJdkDirectory().getAbsolutePath());

--- a/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/xml/TimestampAdapter.java
+++ b/appserver/tests/tck/tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/xml/TimestampAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.tests.tck.ant.xml;
+
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.regex.Pattern;
+
+/**
+ * @author David Matejcek
+ */
+public class TimestampAdapter extends XmlAdapter<String, LocalDateTime> {
+    private static final Pattern P_LDT = Pattern.compile("[0-9T:\\-.]+");
+
+    @Override
+    public LocalDateTime unmarshal(final String value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() < 11) {
+            return LocalDate.parse(value).atStartOfDay();
+        }
+        if (P_LDT.matcher(value).matches()) {
+            return LocalDateTime.parse(value);
+        }
+        return ZonedDateTime.parse(value).withZoneSameLocal(ZoneId.systemDefault()).toLocalDateTime();
+    }
+
+
+    @Override
+    public String marshal(final LocalDateTime value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/appserver/tests/tck/tck-runner/src/main/resources/junit-results.xjb
+++ b/appserver/tests/tck/tck-runner/src/main/resources/junit-results.xjb
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<!--
+Note that this XSD file reflects just TCK results and should not be used to parse generic JUnit reports.
+-->
+<jaxb:bindings
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+    version="3.0"
+>
+    <jaxb:bindings schemaLocation="junit-results.xsd" node="/xsd:schema">
+        <jaxb:bindings node="//xsd:element[@name='testsuite']/xsd:complexType/xsd:attribute[@name='timestamp']">
+            <jaxb:property>
+                <jaxb:baseType>
+                    <xjc:javaType
+                        name="java.time.LocalDateTime"
+                        adapter="org.glassfish.main.tests.tck.ant.xml.TimestampAdapter"
+                     />
+                </jaxb:baseType>
+            </jaxb:property>
+        </jaxb:bindings>
+    </jaxb:bindings>
+</jaxb:bindings>

--- a/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/xml/TimestampAdapterTest.java
+++ b/appserver/tests/tck/tck-runner/src/test/java/org/glassfish/main/tests/tck/ant/xml/TimestampAdapterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.tests.tck.ant.xml;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * @author David Matejcek
+ */
+public class TimestampAdapterTest {
+
+    private final TimestampAdapter adapter = new TimestampAdapter();
+
+    @Test
+    public void unmarshall() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = now.toLocalDate();
+        ZonedDateTime zoned = now.atZone(ZoneId.systemDefault());
+        OffsetDateTime offsetNow = now.atOffset(ZoneOffset.of("+05:00"));
+        assertAll(
+            () -> assertEquals(now, adapter.unmarshal(now.toString())),
+            () -> assertEquals(now, adapter.unmarshal(offsetNow.toString())),
+            () -> assertEquals(now, adapter.unmarshal(zoned.toString())),
+            () -> assertEquals(today.atStartOfDay(), adapter.unmarshal(today.toString())),
+            () -> assertEquals(LocalDateTime.of(2022, 9, 20, 10, 42, 0), adapter.unmarshal("2022-09-20T10:42")),
+            () -> assertNull(adapter.unmarshal(null))
+        );
+    }
+
+
+    @Test
+    public void marshall() {
+        LocalDateTime now = LocalDateTime.now();
+        assertAll(
+            () -> assertEquals(now.toString(), adapter.marshal(now)),
+            () -> assertNull(adapter.marshal(null))
+        );
+    }
+}


### PR DESCRIPTION
- fixes "tz" tests failed in https://ci.eclipse.org/jakartaee-tck/job/10/job/eftl-jakartaeetck-run-100/142/ 
  - broken in https://github.com/eclipse-ee4j/glassfish/pull/24082
- fixes random failure on partin junit results
  - XmlGregorianCalendar cannot parse Instant.toString() on round minutes - seconds and micros are not printed then
- fixes LANG related issues - on systems with different language
- fixes handling of different glassfish.version set from commandline
