### PR TITLE
Update NOTICE.md

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -30,17 +30,28 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse-ee4j/glassfish-ha-api
-* https://github.com/eclipse-ee4j/glassfish-logging-annotation-processor
-* https://github.com/eclipse-ee4j/glassfish-shoal
-* https://github.com/eclipse-ee4j/glassfish-cdi-porting-tck
-* https://github.com/eclipse-ee4j/glassfish-jsftemplating
-* https://github.com/eclipse-ee4j/glassfish-hk2-extra
-* https://github.com/eclipse-ee4j/glassfish-hk2
-* https://github.com/eclipse-ee4j/glassfish-fighterfish
-* https://github.com/eclipse-ee4j/glassfish
-* https://github.com/eclipse-ee4j/glassfish-maven-embedded-plugin
 * https://github.com/eclipse-ee4j/bvtck-porting
+* https://github.com/eclipse-ee4j/cditck-porting
+* https://github.com/eclipse-ee4j/ditck-porting
+* https://github.com/eclipse-ee4j/glassfish-build-maven-plugin
+* https://github.com/eclipse-ee4j/glassfish-cdi-porting-tck
+* https://github.com/eclipse-ee4j/glassfish-copyright-plugin
+* https://github.com/eclipse-ee4j/glassfish-doc-plugin
+* https://github.com/eclipse-ee4j/glassfish-docs
+* https://github.com/eclipse-ee4j/glassfish-fighterfish
+* https://github.com/eclipse-ee4j/glassfish-ha-api
+* https://github.com/eclipse-ee4j/glassfish-hk2
+* https://github.com/eclipse-ee4j/glassfish-hk2-extra
+* https://github.com/eclipse-ee4j/glassfish-infra
+* https://github.com/eclipse-ee4j/glassfish-jsftemplating
+* https://github.com/eclipse-ee4j/glassfish-logging-annotation-processor
+* https://github.com/eclipse-ee4j/glassfish-maven-embedded-plugin
+* https://github.com/eclipse-ee4j/glassfish-repackaged
+* https://github.com/eclipse-ee4j/glassfish-samples
+* https://github.com/eclipse-ee4j/glassfish-security-plugin
+* https://github.com/eclipse-ee4j/glassfish-shoal
+* https://github.com/eclipse-ee4j/glassfish-spec-version-maven-plugin
+* https://github.com/eclipse-ee4j/glassfish-woodstock
 
 ## Third-party Content
 
@@ -52,7 +63,7 @@ Ant Contrib (1.0)
 * Project: http://ant-contrib.sourceforge.net/
 * Source: http://ant-contrib.sourceforge.net/
 
-Apache Ant (1.10.1)
+Apache Ant (1.10.12)
 
 * License: Apache License, 2.0, W3C License, Public Domain
 
@@ -96,28 +107,27 @@ Apache Log4j (1.2.17)
 
 * License: Apache License 2.0
 
-Apache XML Security (1.2.1)
+Apache XML Security (3.0.0)
 
-* License: Apache-2.0 AND W3C-19980720 AND Apache-1.1
-* Project: http://santuario.apache.org/java121releasenotes.html
+* License: Apache License 2.0
 
-ASM (6.0)
+ASM (9.4)
 
 * License: BSD-3-Clause
 
-classmate (1.3.3)
+classmate (1.5.1)
 
 * License: Apache-2.0
 
-com.ibm.jbatch.container (1.0.2)
+com.ibm.jbatch.container (2.1.1)
 
 * License: Apache-2.0
 
-com.ibm.jbatch.spi (1.0.2)
+com.ibm.jbatch.spi (2.1.1)
 
 * License: Apache-2.0
 
-commons-fileupload (1.3.3)
+commons-fileupload (1.4)
 
 * License: Apache-2.0
 
@@ -131,39 +141,39 @@ Emma (2.1.5320)
 * Project: http://emma.sourceforge.net/
 * Source: http://emma.sourceforge.net/
 
-hibernate-validator (6.0.10)
+hibernate-validator (8.0.0.Final)
 
-* License: Apache-2.0 AND LicenseRef-Public-Domain
+* License: Apache-2.0
 
 Jakarta Watchdog Version:4 (n/a)
 
 * License: Apache-1.1
 
-Java Native Access Platform (JNA Platform) (4.5.1)
+Java Native Access Platform (JNA Platform) (5.12.1)
 
 * License: Apache-2.0 OR LGPL-2.1-or-later
 
-javassist (3.22.0)
+javassist (3.29.2-GA)
 
 * License: Apache-2.0 OR LGPL -2.1+ OR MPL-1.1
 
-jboss-logging (3.3.1)
+jboss-logging (3.5.0.Final)
 
 * License: Apache-2.0
 
-Jettison (1.3.7)
+Jettison (1.5.1)
 
 * License: Apache-2.0
 
-jline (2.14.5)
+jline (3.21.0)
 
 * License: BSD-3-Clause
 
-JSch (0.1.54)
+JSch (0.1.56)
 
 * License: New BSD license
 
-JUnit (4.12)
+JUnit (5.9.1)
 
 * License: Eclipse Public License
 
@@ -171,23 +181,23 @@ org.apache.commons.collections (3.2.1)
 
 * License: Apache License 2.0
 
-OSGi Service Platform Core Companion Code (6.0)
+OSGi Service Platform Core Companion Code (8.0.0)
 
 * License: Apache License, 2.0
 
-slf4j-api (1.7.25)
+slf4j-api (1.7.26)
 
 * License: MIT
 
-slf4j-simple (1.7.25)
+slf4j-simple (1.7.26)
 
 * License: MIT
 
-stax2-api (3.1.4)
+stax2-api (4.2.1)
 
 * License: BSD-2-Clause
 
-TestNG (6.13.1)
+TestNG (7.4.0)
 
 * License: Apache-2.0 AND (MIT OR GPL-1.0+)
 * Project: http://testng.org/


### PR DESCRIPTION
* For: https://github.com/eclipse-ee4j/glassfish/issues/24088
  * add some glassfish repo's URLs from https://projects.eclipse.org/projects/ee4j.glassfish/developer
  * update third-party content's versions

* Note:
  * couldn't find any projects using them:
    * Apache Felix SCR (Declarative Services) (2.0.12)
    * Jakarta Watchdog Version:4 (n/a)
    * woodstox-core-asl (4.4.1)
  * seem to have mixed versions:
    * TestNG
    * OSGi Service Platform Core Companion Code
  * following contents are also suspected to be necessary:
    * antlr
    * fasterxml
    * mimepull
    * jmockit
    * findbugs