### PR TITLE
Website updates (follow-up to PR 24130)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,45 @@ version.
 The `website/src/main/resources/docs/README.md` file needs to be updated
 to add the previous versions to a "previous versions" section.
 
+## Preview the website in a forked Github repository
+
+1. Run the following from this directory to build documentation and website modules:
+
+```
+mvn install
+```
+
+2. Then run the following to stage the Github pages resources:
+
+```
+mvn -pl website,distribution,publish -Ppublish-site install
+```
+
+3. Check out the `gh-pages` branch to a separate directory:
+
+```
+git clone --branch gh-pages https://github.com/eclipse-ee4j/glassfish.git /separate/directory
+```
+
+4. Copy the files from publish/target/staging to the other repository:
+
+```
+ cp -r publish/target/staging/* /separate/directory
+```
+
+5. Push to a forked repository
+
+* create a fork in GitHub
+* add the fork as a new remote to the other repository
+* commit the changes to the `gh-pages` branch
+* (force) push the `gh-pages` beanch: `git -C /separate/directory push --force https://github.com/myfork/glassfish.git refs/heads/gh-pages:refs/heads/gh-pages` (replace myfork with your GitHub username)
+
+6. Preview the website
+
+After some time, the preview will be available at (replace myfork with your GitHub username):
+
+https://myfork.github.io/glassfish
+
 ## To Do
 
 * Add a Jenkins job that waits for changes and publishes the web site.

--- a/docs/website/src/main/resources/README.md
+++ b/docs/website/src/main/resources/README.md
@@ -118,3 +118,9 @@ Please review the following links:
 * [Contribute](CONTRIBUTING)
 * [Pull Request Acceptance Workflow](pr_workflow)
 * [License](LICENSE)
+
+## Professional Services and Enterprise Support for Eclipse GlassFish
+
+There are companies that provide enterprise support for Eclipse GlassFish and other professional services related to Eclipse GlassFish. 
+
+There's a list of those companies on the [Professional Services and Enterprise Support](support.md) page.

--- a/docs/website/src/main/resources/_config.yml
+++ b/docs/website/src/main/resources/_config.yml
@@ -12,7 +12,7 @@ links:
   mailinglist: https://accounts.eclipse.org/mailing-list/glassfish-dev
   #javadocs:
   docs: documentation
-  #faq:
+  faq: faq
   hide_issuetracker: false #set explicitly to 'true' if you don't want to have the issue tracker link displayed
 
 include:


### PR DESCRIPTION
I forgot to commit a few things into https://github.com/eclipse-ee4j/glassfish/pull/24130 to make it complete:
 - Show FAQ page in sidebar
 - Info about support on the front page