### PR TITLE
Fix the Issue Tracker link in website

### DIFF
--- a/docs/website/src/main/resources/_config.yml
+++ b/docs/website/src/main/resources/_config.yml
@@ -1,5 +1,3 @@
-github: [metadata]
-
 remote_theme: eclipsefdn/jekyll-theme-eclipsefdn
 
 title: [Eclipse GlassFish]


### PR DESCRIPTION
The link in the sidebar now points to https://glassfish.org instead of https://github.com/eclipse-ee4j/glassfish/issues

I removed the `github` section in the site config, because it should be automatically populated by the [github-metadata](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins) plugin by GitHub Pages. If the section is present, it's not automatically populated and the Eclipse Jekyll theme doesn't find the metadata for the link.

The `github` section was previously set in the https://github.com/eclipse-ee4j/glassfish/pull/22965 PR. @ivargrimstad , do you remember why you added it? Would removing it break something?