### PR TITLE
Fix null pointer in ComponentDefinition

### DIFF
--- a/appserver/common/annotation-framework/src/main/java/org/glassfish/apf/impl/ComponentDefinition.java
+++ b/appserver/common/annotation-framework/src/main/java/org/glassfish/apf/impl/ComponentDefinition.java
@@ -142,7 +142,11 @@ public class ComponentDefinition implements ComponentInfo {
         if (clazz.getPackage().getName().startsWith("java.lang")) {
             return true;
         }
-        return EXCLUDED_FROM_ANNOTATION_PROCESSING.contains(clazz.getCanonicalName());
+        if (clazz.getCanonicalName() == null) {
+            return false;
+        } else {
+            return EXCLUDED_FROM_ANNOTATION_PROCESSING.contains(clazz.getCanonicalName());
+        }
     }
 
 


### PR DESCRIPTION
Fixes an exception in case of scanning nested classes and some other types of classes. 

Reproducible with a nested class in an app, deployed on GF embedded using ScatteredArchive pointed to target/classes. Here's an example app: https://github.com/OmniFish-EE/Presentation-Piranha-from-GlassFish/tree/main/embedded-glassfish-app

Here's an exception when running the reproducer - it's not clear from Javadoc but calling `contains` with a null argument on an unmodifiable Set results in an exception, at least on OpenJDK:

```
SEVERE: Exception during lifecycle processing
java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:208)
        at java.base/java.util.ImmutableCollections$SetN.contains(ImmutableCollections.java:937)
        at org.glassfish.apf.impl.ComponentDefinition.isExcludedFromAnnotationProcessing(ComponentDefinition.java:145)
        at org.glassfish.apf.impl.ComponentDefinition.constructClassList(ComponentDefinition.java:87)
        at org.glassfish.apf.impl.ComponentDefinition.<init>(ComponentDefinition.java:60)
        at org.glassfish.apf.impl.JavaEEScanner.getComponentInfo(JavaEEScanner.java:46)
        at org.glassfish.apf.impl.AnnotationProcessorImpl.process(AnnotationProcessorImpl.java:155)
        at org.glassfish.apf.impl.AnnotationProcessorImpl.process(AnnotationProcessorImpl.java:115)
        at com.sun.enterprise.deployment.archivist.Archivist.processAnnotations(Archivist.java:614)
        at com.sun.enterprise.deployment.archivist.Archivist.readAnnotations(Archivist.java:462)
        at com.sun.enterprise.deployment.archivist.Archivist.readAnnotations(Archivist.java:448)
        at com.sun.enterprise.deployment.archivist.Archivist.readRestDeploymentDescriptors(Archivist.java:421)
        at com.sun.enterprise.deployment.archivist.Archivist.readDeploymentDescriptors(Archivist.java:397)
        at com.sun.enterprise.deployment.archivist.Archivist.open(Archivist.java:274)
        at com.sun.enterprise.deployment.archivist.Archivist.open(Archivist.java:283)
        at com.sun.enterprise.deployment.archivist.Archivist.open(Archivist.java:244)
        at com.sun.enterprise.deployment.archivist.ApplicationFactory.openArchive(ApplicationFactory.java:131)
        at org.glassfish.javaee.core.deployment.DolProvider.processDOL(DolProvider.java:186)
        at org.glassfish.javaee.core.deployment.DolProvider.load(DolProvider.java:209)
        at org.glassfish.javaee.core.deployment.DolProvider.load(DolProvider.java:79)
        at com.sun.enterprise.v3.server.ApplicationLifecycle.loadDeployer(ApplicationLifecycle.java:944)
        at com.sun.enterprise.v3.server.ApplicationLifecycle.setupContainerInfos(ApplicationLifecycle.java:883)
        at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:413)
        at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:259)
        at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:467)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:529)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:525)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:376)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:524)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:555)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:547)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/javax.security.auth.Subject.doAs(Subject.java:376)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:546)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1456)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1825)
        at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1701)
        at com.sun.enterprise.admin.cli.embeddable.DeployerImpl.deploy(DeployerImpl.java:108)
        at com.sun.enterprise.admin.cli.embeddable.DeployerImpl.deploy(DeployerImpl.java:84)
        at ee.omnifish.piranhafromgf.embeddedgf.EmbeddedGlassfishApp.main(EmbeddedGlassfishApp.java:25)
```