### PR TITLE
Fix for #23922 - EAR with multiple WAR logs many false ClassNotFound warnings

### DIFF
--- a/appserver/deployment/jakartaee-full/src/main/java/org/glassfish/javaee/full/deployment/EarHandler.java
+++ b/appserver/deployment/jakartaee-full/src/main/java/org/glassfish/javaee/full/deployment/EarHandler.java
@@ -373,6 +373,9 @@ public class EarHandler extends AbstractArchiveHandler implements CompositeHandl
         for (ModuleDescriptor<BundleDescriptor> md : holder.app.getModules()) {
             String moduleUri = md.getArchiveUri();
             try (ReadableArchive sub = archive.getSubArchive(moduleUri)) {
+                if (sub == null) {
+                    throw new IllegalArgumentException(strings.get("noSubModuleArchiveFound", moduleUri));
+                }
                 if (sub instanceof InputJarArchive) {
                     throw new IllegalArgumentException(strings.get("wrongArchType", moduleUri));
                 }

--- a/appserver/deployment/jakartaee-full/src/main/resources/org/glassfish/javaee/full/deployment/LocalStrings.properties
+++ b/appserver/deployment/jakartaee-full/src/main/resources/org/glassfish/javaee/full/deployment/LocalStrings.properties
@@ -17,5 +17,6 @@
 
 errAddLibs=Error in adding libraries in library directory
 wrongArchType=Expected to find an expanded directory for submodule {0} but found a JAR.  If this is a directory deployment be sure to expand all submodules.
+noSubModuleArchiveFound=Expected to find an expanded directory for submodule {0} but didn''t find it. Check that the submodule file or expanded directory is in the root of the EAR being deployed and its name matches the name in META-INF/application.xml descriptor in the EAR.
 noClassLoader=Cannot find a class loader for submodule {0}
 errReadMetadata=Cannot read application metadata

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
@@ -49,6 +49,13 @@ public class ServletContainerInitializerUtil {
     private static final Logger log = LogFacade.getLogger();
 
     private static final ResourceBundle rb = log.getResourceBundle();
+    
+    public static interface LogContext {
+
+        public default Level getNonCriticalClassloadingErrorLogLevel() {
+            return Level.WARNING;
+        }
+    }
 
     /**
      * Given a class loader, check for ServletContainerInitializer
@@ -201,7 +208,7 @@ public class ServletContainerInitializerUtil {
             Iterable<ServletContainerInitializer> initializers,
             Map<Class<?>, List<Class<? extends ServletContainerInitializer>>> interestList,
             Types types,
-            ClassLoader cl) {
+            ClassLoader cl, LogContext logContext) {
 
         if (interestList == null) {
             return null;
@@ -304,9 +311,9 @@ public class ServletContainerInitializerUtil {
                     }
                 }
 
-                initializerList = checkAgainstInterestList(classInfo, interestList, initializerList, cl);
+                initializerList = checkAgainstInterestList(classInfo, interestList, initializerList, cl, logContext);
             } else {
-                initializerList = checkAgainstInterestList(types, interestList, initializerList, cl);
+                initializerList = checkAgainstInterestList(types, interestList, initializerList, cl, logContext);
             }
         }
 
@@ -396,7 +403,7 @@ public class ServletContainerInitializerUtil {
                                 Types classInfo,
                                 Map<Class<?>, List<Class<? extends ServletContainerInitializer>>> interestList,
                                 Map<Class<? extends ServletContainerInitializer>, Set<Class<?>>> initializerList,
-                                ClassLoader cl) {
+                                ClassLoader cl, LogContext logContext) {
 
         if (classInfo==null) {
             return initializerList;
@@ -421,8 +428,8 @@ public class ServletContainerInitializerUtil {
                         try {
                             resultSet.add(cl.loadClass(ae.getName()));
                         } catch (Throwable t) {
-                            if (log.isLoggable(Level.WARNING)) {
-                                log.log(Level.WARNING,
+                            if (log.isLoggable(logContext.getNonCriticalClassloadingErrorLogLevel())) {
+                                log.log(logContext.getNonCriticalClassloadingErrorLogLevel(),
                                     LogFacade.CLASS_LOADING_ERROR,
                                     new Object[] {ae.getName(), t.toString()});
                             }
@@ -440,8 +447,8 @@ public class ServletContainerInitializerUtil {
                     try {
                         resultSet.add(cl.loadClass(classModel.getName()));
                     } catch (Throwable t) {
-                        if (log.isLoggable(Level.WARNING)) {
-                            log.log(Level.WARNING,
+                        if (log.isLoggable(logContext.getNonCriticalClassloadingErrorLogLevel())) {
+                            log.log(logContext.getNonCriticalClassloadingErrorLogLevel(),
                                 LogFacade.CLASS_LOADING_ERROR,
                                 new Object[] {classModel.getName(), t.toString()});
                         }
@@ -479,7 +486,7 @@ public class ServletContainerInitializerUtil {
                                 ClassDependencyBuilder classInfo,
                                 Map<Class<?>, List<Class<? extends ServletContainerInitializer>>> interestList,
                                 Map<Class<? extends ServletContainerInitializer>, Set<Class<?>>> initializerList,
-                                ClassLoader cl) {
+                                ClassLoader cl, LogContext logContext) {
         for(Map.Entry<Class<?>, List<Class<? extends ServletContainerInitializer>>> e :
                 interestList.entrySet()) {
 
@@ -495,8 +502,8 @@ public class ServletContainerInitializerUtil {
                     Class aClass = cl.loadClass(className);
                     resultSet.add(aClass);
                 } catch (Throwable t) {
-                    if (log.isLoggable(Level.WARNING)) {
-                        log.log(Level.WARNING,
+                    if (log.isLoggable(logContext.getNonCriticalClassloadingErrorLogLevel())) {
+                        log.log(logContext.getNonCriticalClassloadingErrorLogLevel(),
                             LogFacade.CLASS_LOADING_ERROR,
                             new Object[] {className, t.toString()});
                     }

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
@@ -49,7 +49,7 @@ public class ServletContainerInitializerUtil {
     private static final Logger log = LogFacade.getLogger();
 
     private static final ResourceBundle rb = log.getResourceBundle();
-    
+
     public static interface LogContext {
 
         public default Level getNonCriticalClassloadingErrorLogLevel() {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -807,7 +807,7 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
     protected boolean showArchivedRealPathEnabled = true;
 
     protected int servletReloadCheckSecs = 1;
-    
+
     // Fine tune log levels for ServletContainerInitializerUtil to avoid spurious or too verbose logging
     protected ServletContainerInitializerUtil.LogContext logContext
             = new ServletContainerInitializerUtil.LogContext() {
@@ -5291,7 +5291,7 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
     protected Types getTypes() {
         return null;
     }
-    
+
     protected boolean isStandaloneModule() {
         return true;
     }

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -1164,6 +1164,10 @@ public class WebModule extends PwcWebModule implements Context {
     boolean isStandalone() {
         return isStandalone;
     }
+    
+    protected boolean isStandaloneModule() {
+        return isStandalone;
+    }
 
     /**
      * Sets the WebBundleDescriptor (web.xml) for this WebModule.

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -1164,7 +1164,7 @@ public class WebModule extends PwcWebModule implements Context {
     boolean isStandalone() {
         return isStandalone;
     }
-    
+
     protected boolean isStandaloneModule() {
         return isStandalone;
     }


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/23922 

Also gives a meaningful message instead of exception if WAR in EAR has an unexpected name or doesn't exist (e.g. when application.xml states the module name is app.war, but the EAR includes app-1.0.war file instead).