### PR TITLE
#24159 - Load scripts eagerly in Admin Console.

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -19,6 +19,13 @@
  * Common utility
  */
 
+require(['webui/suntheme/field']);
+require(['webui/suntheme/dropDown']);
+require(['webui/suntheme/upload']);
+require(['webui/suntheme/jumpDropDown']);
+require(['webui/suntheme/hyperlink']);
+require(['webui/suntheme/props']);
+
 function checkPSWInCommon(secureAdminEnabled, id1, id2, alert1, alert2, confirmMessage) {
 	var ps1 = document.getElementById(id1); 
 	var ps2 =  document.getElementById(id2); 
@@ -119,18 +126,20 @@ function getField(theForm, fieldName) {
 // FIXME: suntheme should not be used -- prevents theme from changing
 function getTextElement(componentName) {
 
+	var el;
+
 	require(['webui/suntheme/field'], function (field) {		
 		if(field === "undefined"){
 			return  document.getElementById(componentName);
 		}
 		
 	    var el = field.getInputElement(componentName);
-	    if (el == null) {
-	        el = document.getElementById(componentName); // This may get too deep inside WS, but it should work as a fall back
-	    }
-	    return el; 
 	});	
 
+        if (el == null) {
+            el = document.getElementById(componentName); // This may get too deep inside WS, but it should work as a fall back
+        }
+        return el; 
 }
 
 function getSelectElement(componentName) {

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -157,9 +157,9 @@
 
         <!-- Admin console components -->
 
-        <jsftemplating.version>4.0.0-SNAPSHOT</jsftemplating.version>
+        <jsftemplating.version>4.0.0-M1</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.0.0-SNAPSHOT</woodstock.version>
+        <woodstock.version>6.0.0-M1</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
         <woodstock-dojo-ajax-nodemo.version>1.12.4</woodstock-dojo-ajax-nodemo.version>
         <woodstock-json.version>2.0</woodstock-json.version>


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/24159.
And fix the getTextElement method to return a valid value instead of undefined 
The Javascript methods are blocking, but they depend on another JS module, which is often loaded asynchronously when it's needed for the first time. Loading the JS modules eagerly makes them immediately available later, without executing asynchronous task.