### PR TITLE
Add REST JDBC management tests

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
@@ -85,7 +85,7 @@ public class DriverLoader implements ConnectorConstants {
             System.getProperty(ConnectorConstants.INSTALL_ROOT) + File.separator +
             "lib" + File.separator + "install" + File.separator + "databases" +
             File.separator + "dbvendormapping" + File.separator;
-    private final static String DS_PROPERTIES = "dataStructure.properties";
+    private final static String DS_PROPERTIES = "ds.properties";
     private final static String CPDS_PROPERTIES = "cpds.properties";
     private final static String XADS_PROPERTIES = "xads.properties";
     private final static String DRIVER_PROPERTIES = "driver.properties";

--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcAdminServiceImpl.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/service/JdbcAdminServiceImpl.java
@@ -71,7 +71,7 @@ public class JdbcAdminServiceImpl extends ConnectorService {
         "dbvendormapping" + File.separator;
 
     private final static String JDBC40_CONNECTION_VALIDATION = "org.glassfish.api.jdbc.validation.JDBC40ConnectionValidation";
-    private final static String DS_PROPERTIES = "dataStructure.properties";
+    private final static String DS_PROPERTIES = "ds.properties";
     private final static String CPDS_PROPERTIES = "cpds.properties";
     private final static String XADS_PROPERTIES = "xads.properties";
     private final static String DRIVER_PROPERTIES = "driver.properties";

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JdbcITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JdbcITest.java
@@ -22,21 +22,28 @@ import jakarta.ws.rs.core.Response;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.glassfish.main.admin.test.tool.RandomGenerator;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author jasonlee
  */
 public class JdbcITest extends RestTestBase {
+
+    private static final String URL_DATABASE_VENDOR_NAMES = "/domain/resources/get-database-vendor-names";
 
     @Test
     public void testReadingPoolEntity() {
@@ -105,5 +112,18 @@ public class JdbcITest extends RestTestBase {
             "org.apache.derby.jdbc.ClientDataSource");
         Response response = managementClient.post(URL_JDBC_CONNECTION_POOL, params);
         assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGetDatabaseVendorNames() {
+        Response response = managementClient.get(URL_DATABASE_VENDOR_NAMES);
+        assertEquals(200, response.getStatus());
+
+        Map<String, Object> extraProperties = getExtraProperties(response);
+        assertNotNull(extraProperties);
+
+        List<String> vendorNames = (List<String>) extraProperties.get("vendorNames");
+        assertThat(vendorNames, not(empty()));
     }
 }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JdbcITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JdbcITest.java
@@ -45,6 +45,10 @@ public class JdbcITest extends RestTestBase {
 
     private static final String URL_DATABASE_VENDOR_NAMES = "/domain/resources/get-database-vendor-names";
 
+    private static final String URL_JDBC_DRIVER_CLASS_NAMES = "/domain/resources/get-jdbc-driver-class-names";
+
+    private static final String DATABASE_VENDOR_ORACLE = "ORACLE";
+
     @Test
     public void testReadingPoolEntity() {
         Map<String, String> entity = getEntityValues(managementClient.get(URL_JDBC_CONNECTION_POOL + "/__TimerPool"));
@@ -125,5 +129,53 @@ public class JdbcITest extends RestTestBase {
 
         List<String> vendorNames = (List<String>) extraProperties.get("vendorNames");
         assertThat(vendorNames, not(empty()));
+    }
+
+    @Test
+    public void testGetJdbcDriverClassNames() {
+        List<String> driverClassNames = getJdbcResourceClassNames("java.sql.Driver");
+
+        assertNotNull(driverClassNames);
+        assertThat(driverClassNames, not(empty()));
+    }
+
+    @Test
+    public void testGetDataSourceClassNames() {
+        List<String> dataSourceClassNames = getJdbcResourceClassNames("javax.sql.DataSource");
+
+        assertNotNull(dataSourceClassNames);
+        assertThat(dataSourceClassNames, not(empty()));
+    }
+
+    @Test
+    public void testGetXADataSourceClassNames() {
+        List<String> dataSourceClassNames = getJdbcResourceClassNames("javax.sql.XADataSource");
+
+        assertNotNull(dataSourceClassNames);
+        assertThat(dataSourceClassNames, not(empty()));
+    }
+
+    @Test
+    public void testGetConnectionPoolDataSourceClassNames() {
+        List<String> dataSourceClassNames = getJdbcResourceClassNames("javax.sql.ConnectionPoolDataSource");
+
+        assertNotNull(dataSourceClassNames);
+        assertThat(dataSourceClassNames, not(empty()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getJdbcResourceClassNames(String resourceType) {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("dbVendor", DATABASE_VENDOR_ORACLE);
+        queryParams.put("restype", resourceType);
+        queryParams.put("introspect", "false");
+
+        Response response = managementClient.get(URL_JDBC_DRIVER_CLASS_NAMES, queryParams);
+
+        Map<String, Object> extraProperties = getExtraProperties(response);
+        if (extraProperties == null) {
+            return null;
+        }
+        return (List<String>) extraProperties.get("driverClassNames");
     }
 }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
@@ -266,6 +266,14 @@ public class RestTestBase {
         return new HashMap<>();
     }
 
+    @SuppressWarnings("unchecked")
+    protected Map<String, Object> getExtraProperties(Response response) {
+        Map<String, Object> responseEntity = MarshallingUtils.buildMapFromDocument(response.readEntity(String.class));
+        if (responseEntity == null) {
+            return null;
+        }
+        return (Map<String, Object>) responseEntity.get("extraProperties");
+    }
 
     protected List<Map<String, String>> getProperties(Response response) {
         Map responseMap = MarshallingUtils.buildMapFromDocument(response.readEntity(String.class));


### PR DESCRIPTION
Adds some tests for REST JDBC management interface and fixes a minor issue:

- Add test for `get-database-vendor-names`;
- Add tests for `get-jdbc-driver-class-names`;
- Fix retrieval issue for `javax.sql.DataSource` resource type.

This PR closes #24167 Issue.

Signed-off-by: Alexander Pinchuk <alexander.v.pinchuk@gmail.com>
