### PR TITLE
Generate missing config when asadmin set is called (2nd attempt)

### DIFF
--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/GetSetModularityHelper.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/GetSetModularityHelper.java
@@ -63,6 +63,10 @@ public class GetSetModularityHelper {
         return null;
     }
 
+    public Class getClassFor(String serviceName) {
+        return configModularityUtils.getClassFor(serviceName);
+    }
+
     /**
      * @param string the entire . separated string
      * @param position starts with one

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -176,6 +176,10 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
         </dependency>

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/SetCommand.java
@@ -195,6 +195,7 @@ public class SetCommand extends V2DottedNameSupport implements AdminCommand, Pos
             return dottedNameForResourceName.toString().replace('.', '/');
         }
 
+        // Methods and variables used within a call to the execute method
         private class ExecutionContext {
             String pattern = SetOperation.this.pattern;
             String attrName = SetOperation.this.attrName;
@@ -354,21 +355,21 @@ public class SetCommand extends V2DottedNameSupport implements AdminCommand, Pos
                 try {
                     // it's possible they are trying to create a property object.. lets check this.
                     // strip out the property name
-                    String parentPattern = getParentFromDottedPattern(this.target);
+                    String parentPattern = getParentFromDottedPattern(target);
                     if (parentPattern.endsWith("property")) {
                         ctx.pattern = parentPattern;
                         return ctx.setAsPropertyObject(dottedNames, context, targetName);
                     }
 
                 // attempt to create missing nodes and search for a matching node again
-                    ctx.createMissingNodes(dottedNames, this.pattern);
+                    ctx.createMissingNodes(dottedNames, ctx.pattern);
                 } catch (TransactionFailure ex) {
                     fail(context, localStrings.getLocalString("admin.set.badelement", "Cannot change the element: {0}",
                             ex.getMessage()), ex);
                     return false;
                 }
-                dottedNames = ctx.findDottedNames(parentNodes, this.pattern);
-                matchingNodes = getMatchingNodes(dottedNames, this.pattern);
+                dottedNames = ctx.findDottedNames(parentNodes, ctx.pattern);
+                matchingNodes = getMatchingNodes(dottedNames, ctx.pattern);
             }
 
             Map<ConfigBean, Map<String, String>> changes = new HashMap<>();

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/admin/ConfigAttributeSetTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/admin/ConfigAttributeSetTest.java
@@ -14,7 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package com.sun.enterprise.v3.admin;
 
 import com.sun.enterprise.v3.common.PlainTextActionReporter;
@@ -39,9 +38,13 @@ import org.jvnet.hk2.config.ObservableBean;
 import org.jvnet.hk2.config.Transactions;
 import org.jvnet.hk2.config.UnprocessedChangeEvents;
 import jakarta.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayWithSize;
+import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -51,10 +54,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * test the set command
+ *
  * @author Jerome Dochez
  */
 @ExtendWith(KernelJUnitExtension.class)
-public class ConfigAttributeSetTest implements ConfigListener {
+public class ConfigAttributeSetTest {
 
     @Inject
     private ServiceLocator locator;
@@ -70,15 +74,23 @@ public class ConfigAttributeSetTest implements ConfigListener {
 
     @ParameterizedTest(name = "{index}: Test setting {0}")
     @CsvSource({
-        "a direct property,"
+        "a direct attribute,"
+        + "PORT,"
         + "configs.config.server-config.network-config.network-listeners.network-listener.http-listener-1.port,"
-        + "8090",
-        "an aliased property,"
+        + "8090"
+        ,
+        "an aliased attribute,"
+        + "PORT,"
         + "server.network-config.network-listeners.network-listener.http-listener-1.port,"
         + "8090"
-            
+        ,
+        "a property,"
+        + "PROPERTY,"
+        + "server.network-config.network-listeners.network-listener.http-listener-1.property.a,"
+        + "b"
+
     })
-    public void setListenerPortNumber(String testDescription, String propertyName, String propertyValue) {
+    public void setListenerAttribute(String testDescription, ListenerAttributeType attributeType, String propertyName, String propertyValue) {
         CommandRunnerImpl runner = locator.getService(CommandRunnerImpl.class);
         assertNotNull(runner);
 
@@ -92,45 +104,93 @@ public class ConfigAttributeSetTest implements ConfigListener {
             }
         }
         assertNotNull(listener);
-        
-        String oldPortValue = listener.getPort();
+
+        String oldAttributeValue = attributeType.getAttributeValue(listener);
 
         // Let's register a listener
         ObservableBean bean = (ObservableBean) ConfigSupport.getImpl(listener);
-        bean.addListener(this);
+        final PropertyChangeListener beanListener = new PropertyChangeListener(attributeType.getEventPropertyName());
+        bean.addListener(beanListener);
 
-        // parameters to the command
-        ParameterMap parameters = new ParameterMap();
-        parameters.set("DEFAULT", propertyName + "=" + propertyValue);
-        // execute the set command.
-        PlainTextActionReporter reporter = new PlainTextActionReporter();
-        CommandInvocation invocation = runner.getCommandInvocation("set", reporter, adminSubject).parameters(parameters);
-        invocation.execute();
+        try {
+            // parameters to the command
+            ParameterMap parameters = new ParameterMap();
+            parameters.set("DEFAULT", propertyName + "=" + propertyValue);
+            // execute the set command.
+            PlainTextActionReporter reporter = new PlainTextActionReporter();
+            CommandInvocation invocation = runner.getCommandInvocation("set", reporter, adminSubject).parameters(parameters);
+            invocation.execute();
 
-        assertEquals(ExitCode.SUCCESS, reporter.getActionExitCode());
-        assertEquals("", reporter.getMessage());
+            assertEquals(ExitCode.SUCCESS, reporter.getActionExitCode());
+            assertEquals("", reporter.getMessage());
 
-        // ensure events are delivered.
-        locator.<Transactions>getService(Transactions.class).waitForDrain();
+            // ensure events are delivered.
+            locator.<Transactions>getService(Transactions.class).waitForDrain();
 
-        // check the result.
-        String port = listener.getPort();
-        assertEquals(propertyValue, port);
+            // check the result.
+            String newAttributeValue = attributeType.getAttributeValue(listener);
+            assertEquals(propertyValue, newAttributeValue);
 
-        // check we recevied the event
-        assertNotNull(event);
-        assertAll(
-            () -> assertEquals(oldPortValue, event.getOldValue()),
-            () -> assertEquals(propertyValue, event.getNewValue()),
-            () -> assertEquals("port", event.getPropertyName())
-        );
+            // check we recevied the event
+            assertNotNull(event);
+            assertAll(
+                    () -> assertEquals(oldAttributeValue, event.getOldValue()),
+                    () -> assertEquals(propertyValue, event.getNewValue()),
+                    () -> assertEquals(attributeType.getEventPropertyName(), event.getPropertyName())
+            );
+        } finally {
+            bean.removeListener(beanListener);
+        }
 
     }
 
-    @Override
-    public UnprocessedChangeEvents changed(PropertyChangeEvent[] propertyChangeEvents) {
-        assertThat(propertyChangeEvents, arrayWithSize(1));
-        event = propertyChangeEvents[0];
-        return null;
+    private enum ListenerAttributeType {
+        PORT {
+            @Override
+            String getAttributeValue(NetworkListener listener) {
+                return listener.getPort();
+            }
+
+            @Override
+            String getEventPropertyName() {
+                return "port";
+            }
+
+        },
+        PROPERTY {
+            @Override
+            String getAttributeValue(NetworkListener listener) {
+                return listener.getPropertyValue("a");
+            }
+
+            @Override
+            String getEventPropertyName() {
+                return "value";
+            }
+
+        };
+
+        abstract String getAttributeValue(NetworkListener listener);
+
+        abstract String getEventPropertyName();
+    }
+
+    private class PropertyChangeListener implements ConfigListener {
+        
+        private String propertyName;
+
+        public PropertyChangeListener(String propertyName) {
+            this.propertyName = propertyName;
+        }
+        
+        @Override
+        public UnprocessedChangeEvents changed(PropertyChangeEvent[] propertyChangeEvents) {
+            List<PropertyChangeEvent> events = Arrays.stream(propertyChangeEvents)
+                    .filter(event -> propertyName.equals(event.getPropertyName()))
+                    .collect(Collectors.toList());
+            assertThat(events, hasSize(1));
+            event = events.get(0);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/24158. Automatically creates missing config nodes in the `set` command, if they aren't present in domain.xml.

Added tests to cover multiple scenarios:

* setting an attribute directly (this test was already present)
* setting an attribute through an alias (a different dotted name leading to the same config node)
* seting a custom property `a=b`
* setting an attribute on a node which isn't in the current configuration and which will be created before setting the attribute (this is the new feature implemented)

This is a fix of https://github.com/eclipse-ee4j/glassfish/pull/24160, which was reverted by https://github.com/eclipse-ee4j/glassfish/pull/24170 to pass the tests.