### PR TITLE
Fix ServletContext.getResource() to resolve to a file path instead of a jndi url 

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -186,6 +186,7 @@ import static org.apache.catalina.startup.Constants.WebDtdPublicId_22;
 import static org.apache.catalina.util.RequestUtil.urlDecode;
 import static org.apache.naming.resources.ProxyDirContext.CONTEXT;
 import static org.apache.naming.resources.ProxyDirContext.HOST;
+import org.apache.naming.resources.UrlResource;
 import static org.glassfish.web.loader.ServletContainerInitializerUtil.getInitializerList;
 import static org.glassfish.web.loader.ServletContainerInitializerUtil.getInterestList;
 
@@ -6651,10 +6652,14 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
         }
 
         if (resources != null) {
-            String fullPath = getName() + path;
-            String hostName = getParent().getName();
             try {
-                resources.lookup(path);
+                Object resource = resources.lookup(path);
+                if (resource instanceof UrlResource) {
+                    UrlResource urlResource = (UrlResource)resource;
+                    return urlResource.getUrl();
+                }
+                String fullPath = getName() + path;
+                String hostName = getParent().getName();
                 return new URL("jndi", "", 0, getJNDIUri(hostName, fullPath),
                     new DirContextURLStreamHandler(resources));
             } catch (Exception e) {

--- a/appserver/web/web-core/src/test/java/org/apache/catalina/core/StandardContextTest.java
+++ b/appserver/web/web-core/src/test/java/org/apache/catalina/core/StandardContextTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.apache.catalina.core;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+
+import org.apache.catalina.LifecycleException;
+import org.apache.naming.resources.FileDirContext;
+import org.apache.naming.resources.Resource;
+import org.apache.naming.resources.UrlResource;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+
+public class StandardContextTest {
+
+    /**
+     * Covers the fix for https://github.com/eclipse-ee4j/glassfish/issues/24083
+     */
+    @Test
+    public void testServletContextGetResource() throws MalformedURLException, NamingException, LifecycleException, IOException {
+        final String RESOURCE_RELATIVE_PATH = "file.txt";
+        final String RESOURCE_PATH = "/" + RESOURCE_RELATIVE_PATH;
+        final URL RESOURCE_URL = new File(RESOURCE_PATH).toURI().toURL();
+
+        final StandardContext standardContext = new StandardContext();
+        standardContext.setName("testContext");
+
+        final Path realDirectory = Files.createTempDirectory("glassfish-test");
+        Path realFile = Files.createFile(realDirectory.resolve(RESOURCE_RELATIVE_PATH));
+        try {
+            standardContext.setDocBase(realDirectory.toString());
+
+            DirContext testDirContext = mockDirContext(RESOURCE_URL, RESOURCE_PATH);
+
+            standardContext.setResources(testDirContext);
+            standardContext.resourcesStart();
+            try {
+                assertNotNull(standardContext.getServletContext().getRealPath(RESOURCE_PATH));
+                assertEquals(RESOURCE_URL, standardContext.getResource(RESOURCE_PATH));
+            } finally {
+                standardContext.resourcesStop();
+            }
+        } finally {
+            Files.deleteIfExists(realFile);
+            Files.deleteIfExists(realDirectory);
+        }
+    }
+
+    private DirContext mockDirContext(URL resourceUrl, String resourcePath) throws NamingException {
+        FileDirContext resultDirContext = createNiceMock(FileDirContext.class);
+
+        class TestResource extends Resource implements UrlResource {
+
+            @Override
+            public URL getUrl() throws MalformedURLException {
+                return resourceUrl;
+            }
+
+        }
+
+        expect(resultDirContext.lookup(resourcePath)).andReturn(new TestResource());
+        replay(resultDirContext);
+
+        return resultDirContext;
+    }
+
+}

--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/FileDirContext.java
@@ -26,6 +26,8 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 import javax.naming.Binding;
 import javax.naming.NameClassPair;
@@ -991,7 +993,7 @@ public class FileDirContext extends BaseDirContext {
      * This specialized resource implementation avoids opening the InputStream
      * to the file right away (which would put a lock on the file).
      */
-    protected static class FileResource extends Resource {
+    protected static class FileResource extends Resource implements UrlResource {
 
 
         // -------------------------------------------------------- Constructor
@@ -1027,6 +1029,11 @@ public class FileDirContext extends BaseDirContext {
                 return fin;
             }
             return super.streamContent();
+        }
+
+        @Override
+        public URL getUrl() throws MalformedURLException {
+            return file.toURI().toURL();
         }
 
 

--- a/appserver/web/web-naming/src/main/java/org/apache/naming/resources/UrlResource.java
+++ b/appserver/web/web-naming/src/main/java/org/apache/naming/resources/UrlResource.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.apache.naming.resources;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public interface UrlResource {
+    URL getUrl() throws MalformedURLException ;
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/24083

When I debugged, the file path was available in the result of ` resources.lookup(path);`. But, surprisingly, the return value of this method wasn't used at all. Instead a new URL with the `jndi` prefix was created, ingoring the looked up object.

However, the file path was available only through a protected class, so I added an interface to that class to retrieve the URL.

I also added a unit test. I hope it makes sense because it relies on some internals. For example, the behavior is invoked only if the dirContext extends a `FileDirContext` and the looked up resource extends `Resource`.  

I'd like to add an integration test that contains a Servlet, which calls `request.getServletContext().getResource(String)` and verifies that the returned URL is a file URL and not a jndi URL. But I need help with where to put it and how to create it. Maybe it's good to create a test with GF Embedded in [appserver/tests/embedded/web/web-api](https://github.com/eclipse-ee4j/glassfish/tree/078f1b6e081101d36b9a7e6e7653561fb8d1d1cc/appserver/tests/embedded/web/web-api)?