### PR TITLE
Fixes #24136 - Exception when enabling a Monitoring Service

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -218,6 +218,9 @@
         <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</jvm-options>
+        
+        <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
+        <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -411,6 +414,9 @@
              <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED</jvm-options>
+
+             <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
+             <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
          </java-config>
          <availability-service>
              <web-container-availability/>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -177,6 +177,9 @@
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
+        
+        <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
+        <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -332,6 +335,8 @@
              <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
+             <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
+             <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
          </java-config>
          <availability-service/>
          <network-config>

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/FlashlightLoggerInfo.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/FlashlightLoggerInfo.java
@@ -95,7 +95,7 @@ public class FlashlightLoggerInfo {
     public static final String MISSING_AGENT_JAR_DIR = LOGMSG_PREFIX + "-00503";
 
     @LogMessageInfo(
-            message = "Encountered exception during agent attach",
+            message = "Encountered exception during agent attach: {0}",
             level = "WARNING")
     public static final String ATTACH_AGENT_EXCEPTION = LOGMSG_PREFIX + "-00504";
 


### PR DESCRIPTION
Since OpenJDK 9, attaching of an agent to the current JVM has to be enabled by a system property. See https://bugs.openjdk.org/browse/JDK-8180425