### PR TITLE
Authorization Constraints Ignored When Using Path Traversal Penetration Using Default Virtual Module

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -329,6 +329,13 @@ public class CoyoteAdapter extends HttpHandler {
             return false;
         }
 
+        // Normalize Decoded URI
+        if (!normalize(decodedURI)) {
+            res.setStatus(400);
+            res.setDetailMessage(("Invalid URI"));
+            return false;
+        }
+
         if (compatWithTomcat || !v3Enabled) {
 
             // Set the remote principal
@@ -490,19 +497,19 @@ public class CoyoteAdapter extends HttpHandler {
      * This method normalizes "\", "//", "/./" and "/../". This method will return false when trying to go above the root,
      * or if the URI contains a null byte.
      *
-     * @param uriMB URI to be normalized
+     * @param uriDataChunk URI to be normalized
      */
-    public static boolean normalize(MessageBytes uriMB) {
-        int type = uriMB.getType();
-        if (type == MessageBytes.T_CHARS) {
-            return normalizeChars(uriMB);
+    public static boolean normalize(DataChunk uriDataChunk) {
+        DataChunk.Type type = uriDataChunk.getType();
+        if (type == DataChunk.Type.Chars) {
+            return normalizeChars(uriDataChunk);
         }
 
-        return normalizeBytes(uriMB);
+        return normalizeBytes(uriDataChunk);
     }
 
-    private static boolean normalizeBytes(MessageBytes uriMB) {
-        ByteChunk uriBC = uriMB.getByteChunk();
+    private static boolean normalizeBytes(DataChunk uriDataChunk) {
+        ByteChunk uriBC = uriDataChunk.getByteChunk();
         byte[] b = uriBC.getBytes();
         int start = uriBC.getStart();
         int end = uriBC.getEnd();
@@ -606,8 +613,8 @@ public class CoyoteAdapter extends HttpHandler {
         return true;
     }
 
-    private static boolean normalizeChars(MessageBytes uriMessageBytes) {
-        CharChunk uriCharChunk = uriMessageBytes.getCharChunk();
+    private static boolean normalizeChars(DataChunk uriDataChunk) {
+        CharChunk uriCharChunk = uriDataChunk.getCharChunk();
         char[] c = uriCharChunk.getChars();
         int start = uriCharChunk.getStart();
         int end = uriCharChunk.getEnd();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -496,10 +496,10 @@ public class CoyoteAdapter extends HttpHandler {
     /**
      * Normalize URI.
      * <p>
-     * This method normalizes "\", "//", "/./" and "/../". This method will return false when trying to go above the root,
+     * This method normalizes "\", "//", "/./" and "/../". This method will throw an error when trying to go above the root,
      * or if the URI contains a null byte.
      *
-     * @param uriDataChunk URI to be normalized
+     * @param uriDataChunk URI DataChunk to be normalized
      */
     public static boolean normalize(DataChunk uriDataChunk) throws IOException {
         DataChunk.Type type = uriDataChunk.getType();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.ResourceBundle;
 import java.util.logging.Logger;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
 import org.apache.catalina.Globals;
@@ -333,8 +334,8 @@ public class CoyoteAdapter extends HttpHandler {
         try {
             normalize(decodedURI);
         } catch (IOException ioException) {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URI");
-            response.setDetailMessage(ioException.getMessage());
+            catalinaResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URI");
+            catalinaResponse.setDetailMessage(ioException.getMessage());
             return false;
         }
 
@@ -501,17 +502,17 @@ public class CoyoteAdapter extends HttpHandler {
      *
      * @param uriDataChunk URI DataChunk to be normalized
      */
-    public static boolean normalize(DataChunk uriDataChunk) throws IOException {
+    public static void normalize(DataChunk uriDataChunk) throws IOException {
         DataChunk.Type type = uriDataChunk.getType();
         if (type == DataChunk.Type.Chars) {
             normalizeChars(uriDataChunk);
-	    return;
+	        return;
         }
 
-        return normalizeBytes(uriDataChunk);
+        normalizeBytes(uriDataChunk);
     }
 
-    private static boolean normalizeBytes(DataChunk uriDataChunk) throws IOException {
+    private static void normalizeBytes(DataChunk uriDataChunk) throws IOException {
         ByteChunk uriBC = uriDataChunk.getByteChunk();
         byte[] b = uriBC.getBytes();
         int start = uriBC.getStart();
@@ -614,7 +615,7 @@ public class CoyoteAdapter extends HttpHandler {
         uriBC.setBytes(b, start, end);
     }
 
-    private static boolean normalizeChars(DataChunk uriDataChunk) throws IOException {
+    private static void normalizeChars(DataChunk uriDataChunk) throws IOException {
         CharChunk uriCharChunk = uriDataChunk.getCharChunk();
         char[] c = uriCharChunk.getChars();
         int start = uriCharChunk.getStart();

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -699,7 +699,7 @@ public class CoyoteAdapter extends HttpHandler {
                 throw new IOException("Request traversed outside of allowed context");
             }
             int index2 = -1;
-            for (pos = start + index - 1; (pos >= 0) && (index2 < 0); pos --) {
+            for (pos = start + index - 1; (pos >= 0) && (index2 < 0); pos--) {
                 if (c[pos] == '/') {
                     index2 = pos;
                 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -506,7 +506,7 @@ public class CoyoteAdapter extends HttpHandler {
         DataChunk.Type type = uriDataChunk.getType();
         if (type == DataChunk.Type.Chars) {
             normalizeChars(uriDataChunk);
-	        return;
+            return;
         }
 
         normalizeBytes(uriDataChunk);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/CoyoteAdapter.java
@@ -332,7 +332,7 @@ public class CoyoteAdapter extends HttpHandler {
 
         // Normalize Decoded URI
         if (!normalize(decodedURI, catalinaResponse)) {
-            catalinaResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid URI");
+            catalinaResponse.sendError(SC_BAD_REQUEST, catalinaResponse.getDetailMessage());
             return false;
         }
 
@@ -517,7 +517,7 @@ public class CoyoteAdapter extends HttpHandler {
 
         // An empty URL is not acceptable
         if (start == end) {
-            response.setDetailMessage("Empty URL");
+            response.setDetailMessage("Invalid URI: Empty URL");
             return false;
         }
 
@@ -536,19 +536,19 @@ public class CoyoteAdapter extends HttpHandler {
                 if (ALLOW_BACKSLASH) {
                     b[pos] = (byte) '/';
                 } else {
-                    response.setDetailMessage("Backslashes not allowed");
+                    response.setDetailMessage("Invalid URI: Backslashes not allowed");
                     return false;
                 }
             }
             if (b[pos] == (byte) 0) {
-                response.setDetailMessage("Null byte found during request normalization");
+                response.setDetailMessage("Invalid URI: Null byte found during request normalization");
                 return false;
             }
         }
 
         // The URL must start with '/'
         if (b[start] != (byte) '/') {
-            response.setDetailMessage("Request must start with /");
+            response.setDetailMessage("Invalid URI: Request must start with /");
             return false;
         }
 
@@ -599,7 +599,7 @@ public class CoyoteAdapter extends HttpHandler {
             }
             // Prevent from going outside our context
             if (index == 0) {
-                response.setDetailMessage("Request traversed outside of allowed context");
+                response.setDetailMessage("Invalid URI: Request traversed outside of allowed context");
                 return false;
             }
             int index2 = -1;
@@ -639,19 +639,19 @@ public class CoyoteAdapter extends HttpHandler {
                 if (ALLOW_BACKSLASH) {
                     c[pos] = '/';
                 } else {
-                    response.setDetailMessage("Backslashes not allowed");
+                    response.setDetailMessage("Invalid URI: Backslashes not allowed");
                     return false;
                 }
             }
             if (c[pos] == (char) 0) {
-                response.setDetailMessage("Null byte found during request normalization");
+                response.setDetailMessage("Invalid URI: Null byte found during request normalization");
                 return false;
             }
         }
 
         // The URL must start with '/'
         if (c[start] != '/') {
-            response.setDetailMessage("Request must start with /");
+            response.setDetailMessage("Invalid URI: Request must start with /");
             return false;
         }
 
@@ -702,7 +702,7 @@ public class CoyoteAdapter extends HttpHandler {
             }
             // Prevent from going outside our context
             if (index == 0) {
-                response.setDetailMessage("Request traversed outside of allowed context");
+                response.setDetailMessage("Invalid URI: Request traversed outside of allowed context");
                 return false;
             }
             int index2 = -1;


### PR DESCRIPTION
Security fix, from [Payara](https://github.com/payara/Payara/pull/6079)

The original investigation was done in Payara code so some things may not line up _perfectly_, but should be _near enough_

It was possible to circumvent JACC authentication using a ./ traversal, since the request normalisation which normally stops these attacks actually happens after the JACC check has occurred. So while the path is normalised as expected ([here](https://github.com/eclipse-ee4j/glassfish/blob/7.0.0-M10/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContextValve.java#L244)), the actual JACC check has already occurred and passed when it would fail against the normalised path ([here](https://github.com/eclipse-ee4j/glassfish/blob/7.0.0-M10/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/AuthenticatorBase.java#L514) - this kicks off a call to `AuthorizationService.isPermitted`).

This PR reactivates the old normalisation in the CoyoteAdapater which was commented out many many moons ago without explanation when integrating a Grizzly update with the forked Tomcat in the days of GlassFish 2 & 3.

What happens now is that if a request which would fail its normalisation checks occur, a HTTP 400 request is returned. This is, from a quick scan of their code, in line with how Tomcat / Catalina functions today.

The criteria for failing normalisation are:
* Request not starting with a "/"
* Request with backslashes in (if a property is not enabled: `org.glassfish.grizzly.tcp.tomcat5.CoyoteAdapter.ALLOW_BACKSLASH`)
* Request with null bytes in
* Requests which try to escape the context

Reproduction steps:
* Build attached application: [Helloworld.zip](https://github.com/eclipse-ee4j/glassfish/files/10114708/Helloworld.zip)
* Deploy application: `asadmin  --name Helloworld /path/to/Helloworld/target/Helloworld-1.0.war`
* Set as default module: `asadmin set configs.config.server-config.http-service.virtual-server.server.default-web-module=Helloworld`
* Poke endpoint with valid path, should receive 403: `echo -e "GET /test/index.html HTTP/1.1\nHost: localhost\r\n\r\n" | nc localhost 8080`
* Poke endpoint with naughty path, unpatched you're allowed in, patched you should get a "shoo": `echo -e "GET /test/index.html HTTP/1.1\nHost: localhost\r\n\r\n" | nc localhost 8080`

I don't seem to be able to build GlassFish locally atm, there seems to be some issue with the ant task which generates the Full Profile domain (seems `microprofile-jwt-auth-api.jar` is missing?), but I tested using the tried-and-true "build the jar and drop it in the modules dir" of GlassFish 7.0.0-M10 and it seems to fix the issue as it does in Payara.
