### PR TITLE
Make it easier to locate expired certificate

### DIFF
--- a/docs/error-messages-reference/src/main/asciidoc/error-messages.adoc
+++ b/docs/error-messages-reference/src/main/asciidoc/error-messages.adoc
@@ -9990,7 +9990,7 @@ Please provide a valid specification version for this optional package
 +
   Action: Resolve the situation described in the message, if necessary.
 
-[[sthref1941]]NCLS-SECURITY-05054 The SSL certificate has expired: \{0} ::
+[[sthref1941]]NCLS-SECURITY-05054 The SSL certificate with alias \{0} has expired: \{1} ::
   Cause: Certificate expired.
 +
   Action: Check the expiration date of the certificate.

--- a/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/impl/SecuritySupportImpl.java
+++ b/nucleus/security/ssl-impl/src/main/java/com/sun/enterprise/security/ssl/impl/SecuritySupportImpl.java
@@ -86,7 +86,7 @@ public class SecuritySupportImpl extends SecuritySupport {
 
     protected static final Logger _logger = Logger.getLogger(SEC_SSL_LOGGER, SHARED_LOGMESSAGE_RESOURCE);
 
-    @LogMessageInfo(message = "The SSL certificate has expired: {0}", level = "SEVERE", cause = "Certificate expired.", action = "Check the expiration date of the certicate.")
+    @LogMessageInfo(message = "The SSL certificate with alias {0} has expired: {1}", level = "SEVERE", cause = "Certificate expired.", action = "Check the expiration date of the certicate.")
     private static final String SSL_CERT_EXPIRED = "NCLS-SECURITY-05054";
 
     private static boolean initialized = false;
@@ -318,10 +318,11 @@ public class SecuritySupportImpl extends SecuritySupport {
 
         Enumeration<String> aliases = store.aliases();
         while (aliases.hasMoreElements()) {
-            Certificate cert = store.getCertificate(aliases.nextElement());
+            var alias = aliases.nextElement();
+            Certificate cert = store.getCertificate(alias);
             if (cert instanceof X509Certificate) {
                 if (((X509Certificate) cert).getNotAfter().before(initDate)) {
-                    _logger.log(Level.SEVERE, SSL_CERT_EXPIRED, cert);
+                    _logger.log(Level.SEVERE, SSL_CERT_EXPIRED, new Object[] { alias, cert });
                 }
             }
         }


### PR DESCRIPTION
With keystore having more than one, two certificates it's not very easy to locate the proper expired one based on current log entry.

This changes from
```
[2022-12-22T15:17:02.191330+01:00] [GlassFish 7.0] [SEVERE] [NCLS-SECURITY-05054] [jakarta.enterprise.system.security.ssl] [tid: _ThreadID=47 _ThreadName=admin-listener(5)] [levelValue: 1000] [[
  The SSL certificate has expired: [
[
  Version: V3
  Subject: CN=LuxTrust Global Root, O=LuxTrust s.a., C=LU
  Signature Algorithm: SHA256withRSA, OID = 1.2.840.113549.1.1.11

  Key:  Sun RSA public key, 2048 bits
  params: null
  modulus: 22533366489374119567108719411421711822003977524078554684402192342763273523447580565366563056896891103773075578638995250896803315162354174530413040641059880496302980350565156081539980669841504196327226100266894623165487161055344102518178080206442569863791113351483176216721385132731657415246198108437837039009700268435237294864939971821324276386670105501646726220648967977722700863269066815236986572751960611083231429244124782565928374461552289307300617417009825951614891308038436540254904904085138993362194863595147824950548398750901327855963362281065259268991365623819149358606372553081399490652952771726323316467711
  public exponent: 65537
  Validity: [From: Thu Mar 17 10:51:37 CET 2011,
               To: Wed Mar 17 10:51:37 CET 2021]
...
```
to
```
[2022-12-22T15:41:58.609529+01:00] [GlassFish 7.0] [SEVERE] [NCLS-SECURITY-05054] [jakarta.enterprise.system.security.ssl] [tid: _ThreadID=36 _ThreadName=http-listener-2(1)] [levelValue: 1000] [[
  The SSL certificate with alias lux has expired: [
[
  Version: V3
  Subject: CN=LuxTrust Global Root, O=LuxTrust s.a., C=LU
  Signature Algorithm: SHA256withRSA, OID = 1.2.840.113549.1.1.11

  Key:  Sun RSA public key, 2048 bits
  params: null
  modulus: 22533366489374119567108719411421711822003977524078554684402192342763273523447580565366563056896891103773075578638995250896803315162354174530413040641059880496302980350565156081539980669841504196327226100266894623165487161055344102518178080206442569863791113351483176216721385132731657415246198108437837039009700268435237294864939971821324276386670105501646726220648967977722700863269066815236986572751960611083231429244124782565928374461552289307300617417009825951614891308038436540254904904085138993362194863595147824950548398750901327855963362281065259268991365623819149358606372553081399490652952771726323316467711
  public exponent: 65537
  Validity: [From: Thu Mar 17 10:51:37 CET 2011,
               To: Wed Mar 17 10:51:37 CET 2021]
```


Tested with
```
-----BEGIN CERTIFICATE-----
MIIDZDCCAkygAwIBAgICC7gwDQYJKoZIhvcNAQELBQAwRDELMAkGA1UEBhMCTFUx
FjAUBgNVBAoTDUx1eFRydXN0IHMuYS4xHTAbBgNVBAMTFEx1eFRydXN0IEdsb2Jh
bCBSb290MB4XDTExMDMxNzA5NTEzN1oXDTIxMDMxNzA5NTEzN1owRDELMAkGA1UE
BhMCTFUxFjAUBgNVBAoTDUx1eFRydXN0IHMuYS4xHTAbBgNVBAMTFEx1eFRydXN0
IEdsb2JhbCBSb290MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsn+n
QPAiygz267Hxyw6VV0B1r6A/Ps7sqjJX5hmxZ0OYWmt8s7j6eJyqpoSyYBuAQc5j
zR8XCJmk9e8+EsdMsFeaXHhAePxFjdqRZ9w6Ubltc+a3OY52OrQfBfVpVfmTz3iI
Sr6qm9d7R1tGBEyCFqY19vx039a0r9jitScRdFmiwmYsaArhmIiIPIoFdRTjuK7z
CISbasE/MRivJ6VLm6T9eTHemD0OYcqHmMH4ijCc+j4z1aXEAwfh95Z0GAAnOCfR
K6qq4UFFi2/xJcLcopeVx0IUM115hCNq52XAV6DYXaljAeew5Ivo+MVjuOVsdJA9
x3f8K7p56aTGEnin/wIDAQABo2AwXjAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQE
AwIBBjAfBgNVHSMEGDAWgBQXFYWJCS8kh28/HRvk8pZ5g0gTzjAdBgNVHQ4EFgQU
FxWFiQkvJIdvPx0b5PKWeYNIE84wDQYJKoZIhvcNAQELBQADggEBAFrwHNDUUM9B
fua4nX3DcNBeNv9ujnov3kgR1TQuPLdFwlQlp+HBHjeDtpSutkVIA+qVvuucarQ3
XB8u02uCgUNbCj8RVWOs+nwIAjegPDkEM/6XMshS5dklTbDG7mgfcKpzzlcD3H0K
DTPy0lrfCmw7zBFRlxqkIaKFNQLXgCLShLL4wKpov9XrqsMLq6F8K/f1O4fhVFfs
BSTveUJO84ton+Ruy4KZycwq3FPCH3CDqyEPVrRI/98HIrOM+R2mBN8tAza53W/+
MYhm/2xtRDSvCHc+JtJy9LtHVpM8mGPhM7uZI5K1g3noHZ9nrWLWidb2/CfeMifL
hNp3hSGhEiE=
-----END CERTIFICATE-----
```