### PR TITLE
Update Jakarta Mail to 2.1.1

### DIFF
--- a/nucleus/featuresets/atomic/pom.xml
+++ b/nucleus/featuresets/atomic/pom.xml
@@ -149,6 +149,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- nucleus-hk2 -->
         <dependency>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -106,12 +106,12 @@
         <jersey.version>3.1.0</jersey.version>
 
         <!-- Jakarta Mail -->
-        <jakarta.mail-api.version>2.1.0</jakarta.mail-api.version>
+        <jakarta.mail-api.version>2.1.1</jakarta.mail-api.version>
         <angus.mail.version>1.0.0</angus.mail.version>
 
         <!-- Jakarta Activation -->
-        <activation.version>2.1.0</activation.version>
-        <angus.activation.version>1.0.0</angus.activation.version>
+        <activation.version>2.1.1</activation.version>
+        <angus.activation.version>1.1.0</angus.activation.version>
 
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -558,6 +558,11 @@
                         <artifactId>org.osgi.core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.aries.spifly</groupId>
+                <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+                <version>1.3.6</version>
             </dependency>
             <!-- This is currently used by osgi-shell cmd -->
             <dependency>


### PR DESCRIPTION
Also needs org.apache.aries.spifly since activation now uses the following in its manifest:

`osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))"`

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>