### PR TITLE
GlassfishUrlClassloader and toString

### DIFF
--- a/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/ACCAgentClassLoader.java
+++ b/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/ACCAgentClassLoader.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,6 +28,7 @@ import java.security.PrivilegedAction;
 import java.util.Enumeration;
 
 import org.glassfish.appclient.common.ClassPathUtils;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 
 /**
  * Used as the system class loader during app client launch.
@@ -52,7 +53,7 @@ public class ACCAgentClassLoader extends URLClassLoader {
 
 
     private static URLClassLoader prepareLoader(ClassLoader parent) {
-        PrivilegedAction<URLClassLoader> action = () -> new URLClassLoader(
+        PrivilegedAction<URLClassLoader> action = () -> new GlassfishUrlClassLoader(
             new URL[] {ClassPathUtils.getGFClientJarURL()}, new ClassLoaderWrapper(parent));
         return doPrivileged(action);
     }

--- a/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/ACCAgentClassLoader.java
+++ b/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/ACCAgentClassLoader.java
@@ -17,7 +17,6 @@
 
 package org.glassfish.appclient.client.acc.agent;
 
-import static java.security.AccessController.doPrivileged;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -30,6 +29,8 @@ import java.util.Enumeration;
 import org.glassfish.appclient.common.ClassPathUtils;
 import org.glassfish.common.util.GlassfishUrlClassLoader;
 
+import static java.security.AccessController.doPrivileged;
+
 /**
  * Used as the system class loader during app client launch.
  * <p>
@@ -39,7 +40,7 @@ import org.glassfish.common.util.GlassfishUrlClassLoader;
  *
  * @author tjquinn
  */
-public class ACCAgentClassLoader extends URLClassLoader {
+public class ACCAgentClassLoader extends GlassfishUrlClassLoader {
 
     private boolean isActive = true;
 

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientFacade.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientFacade.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,7 +17,18 @@
 
 package org.glassfish.appclient.client;
 
-import static org.glassfish.appclient.client.acc.CommandLaunchInfo.ClientLaunchType.UNKNOWN;
+import com.sun.enterprise.container.common.spi.util.InjectionException;
+import com.sun.enterprise.deployment.node.SaxParserHandlerBundled;
+import com.sun.enterprise.universal.glassfish.TokenResolver;
+import com.sun.enterprise.util.JDK;
+import com.sun.enterprise.util.LocalStringManager;
+import com.sun.enterprise.util.LocalStringManagerImpl;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.ValidationEvent;
+import jakarta.xml.bind.util.ValidationEventCollector;
 
 import java.io.BufferedReader;
 import java.io.CharArrayWriter;
@@ -34,7 +46,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -63,32 +74,21 @@ import org.glassfish.appclient.client.acc.config.ClientCredential;
 import org.glassfish.appclient.client.acc.config.MessageSecurityConfig;
 import org.glassfish.appclient.client.acc.config.Property;
 import org.glassfish.appclient.client.acc.config.TargetServer;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
-import com.sun.enterprise.container.common.spi.util.InjectionException;
-import com.sun.enterprise.deployment.node.SaxParserHandlerBundled;
-import com.sun.enterprise.universal.glassfish.TokenResolver;
-import com.sun.enterprise.util.JDK;
-import com.sun.enterprise.util.LocalStringManager;
-import com.sun.enterprise.util.LocalStringManagerImpl;
-
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
-import jakarta.xml.bind.ValidationEvent;
-import jakarta.xml.bind.util.ValidationEventCollector;
+import static org.glassfish.appclient.client.acc.CommandLaunchInfo.ClientLaunchType.UNKNOWN;
 
 /**
- *
  * @author tjquinn
  */
 public class AppClientFacade {
 
     private static final String ACC_CONFIG_CONTENT_PROPERTY_NAME = "glassfish-acc.xml.content";
     private static final String MAN_PAGE_PATH = "/org/glassfish/appclient/client/acc/appclient.1m";
-    private static final String LINE_SEP = System.getProperty("line.separator");
+    private static final String LINE_SEP = System.lineSeparator();
 
     private static final Class<?> stringsAnchor = ACCClassLoader.class;
     private static LocalStringManager localStrings = new LocalStringManagerImpl(stringsAnchor);
@@ -249,9 +249,9 @@ public class AppClientFacade {
 
     private static String getUsage() {
         return localStrings.getLocalString(stringsAnchor, "main.usage",
-                "appclient [ <classfile> | -client <appjar> ] [-mainclass <appClass-name>|-name <display-name>] [-xml <xml>] [-textauth] [-user <username>] [-password <password>|-passwordfile <password-file>] [-targetserver host[:port][,host[:port]...] [app-args]")
-                + System.getProperty("line.separator") + localStrings.getLocalString(stringsAnchor, "main.usage.1",
-                        "  or  :\n\tappclient [ <valid JVM options and valid ACC options> ] [ <appClass-name> | -jar <appjar> ] [app args]");
+        "appclient [ <classfile> | -client <appjar> ] [-mainclass <appClass-name>|-name <display-name>] [-xml <xml>] [-textauth] [-user <username>] [-password <password>|-passwordfile <password-file>] [-targetserver host[:port][,host[:port]...] [app-args]")
+        + System.lineSeparator() + localStrings.getLocalString(stringsAnchor, "main.usage.1",
+        "  or  :\n\tappclient [ <valid JVM options and valid ACC options> ] [ <appClass-name> | -jar <appjar> ] [app args]");
     }
 
     private static ACCClassLoader initClassLoader(final boolean loaderShouldTransform) throws MalformedURLException {
@@ -383,7 +383,7 @@ public class AppClientFacade {
 
     private static ClassLoader prepareLoaderToFindClassFile(final ClassLoader currentLoader) throws MalformedURLException {
         File currentDirPath = new File(System.getProperty("user.dir"));
-        ClassLoader newLoader = new URLClassLoader(new URL[] { currentDirPath.toURI().toURL() }, currentLoader);
+        ClassLoader newLoader = new GlassfishUrlClassLoader(new URL[] { currentDirPath.toURI().toURL() }, currentLoader);
         return newLoader;
     }
 
@@ -503,7 +503,7 @@ public class AppClientFacade {
         writer.close();
         reader.close();
 
-        Map<String, String> mapping = new HashMap<String, String>();
+        Map<String, String> mapping = new HashMap<>();
         Properties props = System.getProperties();
         for (Enumeration e = props.propertyNames(); e.hasMoreElements();) {
             String propName = (String) e.nextElement();

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCClassLoader.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.PrivilegedAction;
@@ -39,6 +38,7 @@ import java.util.function.Consumer;
 
 import org.glassfish.appclient.common.ClassPathUtils;
 import org.glassfish.appclient.common.ClientClassLoaderDelegate;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 
 import static java.security.AccessController.doPrivileged;
 
@@ -47,7 +47,7 @@ import static java.security.AccessController.doPrivileged;
  *
  * @author tjquinn
  */
-public class ACCClassLoader extends URLClassLoader {
+public class ACCClassLoader extends GlassfishUrlClassLoader {
 
     private static final String AGENT_LOADER_CLASS_NAME = "org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader";
     private static ACCClassLoader instance;

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/AppClientContainer.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/AppClientContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -229,24 +229,20 @@ public class AppClientContainer {
 
     private Builder builder;
 
-    private Cleanup cleanup = null;
+    private Cleanup cleanup;
 
     private State state = State.INSTANTIATED; // HK2 will create the instance
 
-    private ClientMainClassSetting clientMainClassSetting = null;
+    private ClientMainClassSetting clientMainClassSetting;
 
     private URLClassLoader classLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
 
-    private final Collection<EntityManagerFactory> emfs = null;
+    private Launchable client;
 
-//    private boolean isJWS = false;
-
-    private Launchable client = null;
-
-    private CallbackHandler callerSuppliedCallbackHandler = null;
+    private CallbackHandler callerSuppliedCallbackHandler;
 
     /** returned from binding the app client to naming; used in preparing component invocation */
-    private String componentId = null;
+    private String componentId;
 
 
     /*
@@ -474,7 +470,7 @@ public class AppClientContainer {
     }
 
     private void dumpLoaderURLs() {
-        final String sep = System.getProperty("line.separator");
+        final String sep = System.lineSeparator();
         final ClassLoader ldr = Thread.currentThread().getContextClassLoader();
         if (ldr instanceof ACCClassLoader) {
             final ACCClassLoader loader = (ACCClassLoader) ldr;

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/JWSACCClassLoader.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/JWSACCClassLoader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,15 +18,15 @@
 package org.glassfish.appclient.client.acc;
 
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 
 import org.glassfish.appclient.common.ClientClassLoaderDelegate;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 
-public class JWSACCClassLoader extends URLClassLoader {
+public class JWSACCClassLoader extends GlassfishUrlClassLoader {
 
-    private ClientClassLoaderDelegate clientCLDelegate;
+    private final ClientClassLoaderDelegate clientCLDelegate;
 
     public JWSACCClassLoader(URL[] urls, ClassLoader parent) {
         super(urls, parent);
@@ -36,16 +37,16 @@ public class JWSACCClassLoader extends URLClassLoader {
 
     @Override
     protected PermissionCollection getPermissions(CodeSource codesource) {
-
-        if (System.getSecurityManager() == null)
+        if (System.getSecurityManager() == null) {
             return super.getPermissions(codesource);
+        }
 
-        //when security manager is enabled, find the declared permissions
-        if (clientCLDelegate.getCachedPerms(codesource) != null)
+        // when security manager is enabled, find the declared permissions
+        if (clientCLDelegate.getCachedPerms(codesource) != null) {
             return clientCLDelegate.getCachedPerms(codesource);
+        }
 
-        return clientCLDelegate.getPermissions(codesource,
-                super.getPermissions(codesource));
+        return clientCLDelegate.getPermissions(codesource, super.getPermissions(codesource));
     }
 
 }

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ProviderContainerContractInfoImpl.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ProviderContainerContractInfoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@ import java.util.HashSet;
 
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.naming.SimpleJndiName;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.deployment.common.RootDeploymentDescriptor;
 import org.glassfish.persistence.jpa.ProviderContainerContractInfoBase;
 
@@ -79,14 +80,8 @@ public class ProviderContainerContractInfoImpl extends ProviderContainerContract
 
     @Override
     public ClassLoader getTempClassloader() {
-        return AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
-
-                @Override
-                public URLClassLoader run() {
-                    return new URLClassLoader(classLoader.getURLs());
-                }
-
-            });
+        PrivilegedAction<URLClassLoader> action = () -> new GlassfishUrlClassLoader(classLoader.getURLs());
+        return AccessController.doPrivileged(action);
     }
 
     @Override

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/jws/boot/ClassPathManager.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/jws/boot/ClassPathManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,8 +43,9 @@ public abstract class ClassPathManager {
             ;
 
     /** instance of appropriate type of class path manager, depending on the Java runtime version */
-    private static volatile ClassPathManager mgr = null;
-
+    private static volatile ClassPathManager mgr;
+    /** the JNLP class loader active during the instantiation of this mgr */
+    private final ClassLoader jnlpClassLoader;
     private final boolean keepJWSClassLoader;
 
     /**
@@ -67,8 +69,6 @@ public abstract class ClassPathManager {
         return mgr;
     }
 
-    /** the JNLP class loader active during the instantiation of this mgr */
-    private ClassLoader jnlpClassLoader = null;
 
     /**
      *Returns a new instance of the manager.

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientServerApplication.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientServerApplication.java
@@ -30,7 +30,7 @@ import org.glassfish.api.deployment.ApplicationContainer;
 import org.glassfish.api.deployment.ApplicationContext;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.appclient.server.core.jws.JavaWebStartInfo;
-
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -169,14 +169,8 @@ public class AppClientServerApplication implements
          * This cannot be null or it prevents the framework from invoking unload
          * on the deployer for this app.
          */
-        return AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
-
-            @Override
-            public URLClassLoader run() {
-                return new URLClassLoader(new URL[0]);
-            }
-
-        });
+        PrivilegedAction<URLClassLoader> action = () -> new GlassfishUrlClassLoader(new URL[0]);
+        return AccessController.doPrivileged(action);
     }
 
     public DeploymentContext dc() {

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientServerApplication.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/AppClientServerApplication.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,24 +18,25 @@
 package org.glassfish.appclient.server.core;
 
 import com.sun.enterprise.deployment.Application;
+import com.sun.enterprise.deployment.ApplicationClientDescriptor;
+
+import jakarta.inject.Inject;
+
 import java.net.URL;
 import java.net.URLClassLoader;
-import org.glassfish.api.deployment.DeployCommandParameters;
-import com.sun.enterprise.deployment.ApplicationClientDescriptor;
-import com.sun.logging.LogDomains;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.logging.Logger;
-import jakarta.inject.Inject;
+
+import org.glassfish.api.admin.ProcessEnvironment;
 import org.glassfish.api.deployment.ApplicationContainer;
 import org.glassfish.api.deployment.ApplicationContext;
+import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.appclient.server.core.jws.JavaWebStartInfo;
 import org.glassfish.common.util.GlassfishUrlClassLoader;
-import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.api.admin.ProcessEnvironment;
+import org.jvnet.hk2.annotations.Service;
 
 /**
  * Represents an app client module, either stand-alone or nested inside
@@ -52,8 +54,7 @@ import org.glassfish.api.admin.ProcessEnvironment;
  */
 @Service
 @PerLookup
-public class AppClientServerApplication implements
-        ApplicationContainer<ApplicationClientDescriptor> {
+public class AppClientServerApplication implements ApplicationContainer<ApplicationClientDescriptor> {
 
     @Inject
     private ServiceLocator habitat;
@@ -64,8 +65,6 @@ public class AppClientServerApplication implements
 
     private DeploymentContext dc;
 
-    private Logger logger;
-
     private AppClientDeployerHelper helper;
 
     private ApplicationClientDescriptor acDesc;
@@ -73,21 +72,14 @@ public class AppClientServerApplication implements
 
     private String deployedAppName;
 
-    private JavaWebStartInfo jwsInfo = null;
+    private JavaWebStartInfo jwsInfo;
 
-    public void init (final DeploymentContext dc,
-            final AppClientDeployerHelper helper) {
+    public void init(final DeploymentContext dc, final AppClientDeployerHelper helper) {
         this.dc = dc;
         this.helper = helper;
-        this.logger = Logger.getLogger(JavaWebStartInfo.APPCLIENT_SERVER_MAIN_LOGGER,
-                JavaWebStartInfo.APPCLIENT_SERVER_LOGMESSAGE_RESOURCE);
-
         acDesc = helper.appClientDesc();
-
         appDesc = acDesc.getApplication();
-
         deployedAppName = dc.getCommandParameters(DeployCommandParameters.class).name();
-
     }
 
     public String deployedAppName() {

--- a/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/CarHandler.java
+++ b/appserver/appclient/server/core/src/main/java/org/glassfish/appclient/server/core/CarHandler.java
@@ -89,12 +89,8 @@ public class CarHandler extends AbstractArchiveHandler {
 
     @Override
     public ClassLoader getClassLoader(final ClassLoader parent, DeploymentContext context) {
-        ASURLClassLoader cloader = AccessController.doPrivileged(new PrivilegedAction<ASURLClassLoader>() {
-            @Override
-            public ASURLClassLoader run() {
-                return new ASURLClassLoader(parent);
-            }
-        });
+        PrivilegedAction<ASURLClassLoader> action = () -> new ASURLClassLoader(parent);
+        ASURLClassLoader cloader = AccessController.doPrivileged(action);
         try {
             cloader.addURL(context.getSource().getURI().toURL());
             // add libraries referenced from manifest

--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorClassFinder.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorClassFinder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,6 +18,7 @@
 package com.sun.appserv.connectors.internal.api;
 
 import com.sun.enterprise.loader.ASURLClassLoader;
+
 import org.glassfish.internal.api.DelegatingClassLoader;
 
 /**
@@ -26,56 +28,61 @@ import org.glassfish.internal.api.DelegatingClassLoader;
  */
 public class ConnectorClassFinder extends ASURLClassLoader implements DelegatingClassLoader.ClassFinder {
 
-        private final DelegatingClassLoader.ClassFinder librariesClassFinder;
-        private volatile String raName;
+    private final DelegatingClassLoader.ClassFinder librariesClassFinder;
+    private volatile String raName;
 
-    public ConnectorClassFinder(ClassLoader parent, String raName,
-                                              DelegatingClassLoader.ClassFinder finder){
-            super(parent);
-            this.raName = raName;
+    public ConnectorClassFinder(ClassLoader parent, String raName, DelegatingClassLoader.ClassFinder finder) {
+        super(parent);
+        this.raName = raName;
 
-            // There should be better approach to skip libraries Classloader when none specified.
-            // casting to DelegatingClassLoader is not a clean approach
-            DelegatingClassLoader.ClassFinder libcf = null;
-            if(finder!= null && (finder instanceof DelegatingClassLoader)){
-                if(((DelegatingClassLoader)finder).getDelegates().size() > 0){
-                    libcf = finder;
-                }
+        // There should be better approach to skip libraries Classloader when none specified.
+        // casting to DelegatingClassLoader is not a clean approach
+        DelegatingClassLoader.ClassFinder libcf = null;
+        if (finder != null && (finder instanceof DelegatingClassLoader)) {
+            if (((DelegatingClassLoader) finder).getDelegates().size() > 0) {
+                libcf = finder;
             }
-            this.librariesClassFinder = libcf;
         }
-
-    public Class<?> findClass(String name) throws ClassNotFoundException {
-            Class c = null;
-
-            if(librariesClassFinder != null){
-                try{
-                    c = librariesClassFinder.findClass(name);
-                }catch(ClassNotFoundException cnfe){
-                    //ignore
-                }
-                if(c != null){
-                    return c;
-                }
-            }
-            return super.findClass(name);
-        }
-
-        public Class<?> findExistingClass(String name) {
-            if(librariesClassFinder != null){
-                Class claz = librariesClassFinder.findExistingClass(name);
-                if(claz != null){
-                    return claz;
-                }
-            }
-            return super.findLoadedClass(name);
-        }
-
-        public String getResourceAdapterName(){
-            return raName;
-        }
-
-        public void setResourceAdapterName(String raName){
-            this.raName = raName;
-        }
+        this.librariesClassFinder = libcf;
     }
+
+
+    @Override
+    public Class<?> findClass(String name) throws ClassNotFoundException {
+        Class<?> c = null;
+
+        if (librariesClassFinder != null) {
+            try {
+                c = librariesClassFinder.findClass(name);
+            } catch (ClassNotFoundException cnfe) {
+                // ignore
+            }
+            if (c != null) {
+                return c;
+            }
+        }
+        return super.findClass(name);
+    }
+
+
+    @Override
+    public Class<?> findExistingClass(String name) {
+        if (librariesClassFinder != null) {
+            Class<?> claz = librariesClassFinder.findExistingClass(name);
+            if (claz != null) {
+                return claz;
+            }
+        }
+        return super.findLoadedClass(name);
+    }
+
+
+    public String getResourceAdapterName() {
+        return raName;
+    }
+
+
+    public void setResourceAdapterName(String raName) {
+        this.raName = raName;
+    }
+}

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectorClassLoader.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectorClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -66,13 +66,8 @@ public class ConnectorClassLoader extends ASURLClassLoader {
 
     public static synchronized ConnectorClassLoader getInstance() {
         if (classLoader == null) {
-            classLoader = AccessController.doPrivileged(new PrivilegedAction<ConnectorClassLoader>() {
-
-                @Override
-                public ConnectorClassLoader run() {
-                    return new ConnectorClassLoader();
-                }
-            });
+            PrivilegedAction<ConnectorClassLoader> action = ConnectorClassLoader::new;
+            classLoader = AccessController.doPrivileged(action);
         }
         return classLoader;
     }
@@ -96,12 +91,8 @@ public class ConnectorClassLoader extends ASURLClassLoader {
         if (classLoader == null) {
             synchronized (ConnectorClassLoader.class) {
                 if (classLoader == null) {
-                    classLoader = AccessController.doPrivileged(new PrivilegedAction<ConnectorClassLoader>() {
-                        @Override
-                        public ConnectorClassLoader run() {
-                            return new ConnectorClassLoader(parent);
-                        }
-                    });
+                    PrivilegedAction<ConnectorClassLoader> action = () -> new ConnectorClassLoader(parent);
+                    classLoader = AccessController.doPrivileged(action);
                 }
             }
         }
@@ -120,13 +111,8 @@ public class ConnectorClassLoader extends ASURLClassLoader {
 
         try {
             File file = new File(moduleDir);
-            ASURLClassLoader cl = AccessController.doPrivileged(new PrivilegedAction<ASURLClassLoader>() {
-
-                @Override
-                public ASURLClassLoader run() {
-                    return new ASURLClassLoader(parent);
-                }
-            });
+            PrivilegedAction<ASURLClassLoader> action = () -> new ASURLClassLoader(parent);
+            ASURLClassLoader cl = AccessController.doPrivileged(action);
 
             cl.appendURL(file.toURI().toURL());
             appendJars(file, cl);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -441,43 +441,6 @@ public class DriverLoader implements ConnectorConstants {
         return isResType;
     }
 
-
-    /**
-     * This method should be executed before driverLoaders are queries for
-     * classloader to load the classname.
-     * @param classname
-     * @return
-     */
-    //TODO remove later
-    /*private boolean loadClass(File f, String classname, String resType) {
-        List<URL> urls = new ArrayList<URL>();
-        Class urlCls = null;
-        boolean isLoaded = false;
-        try {
-            urls.add(f.toURI().toURL());
-        } catch (MalformedURLException ex) {
-        }
-        ClassLoader loader = ConnectorRuntime.getRuntime().getConnectorClassLoader();
-        if (!urls.isEmpty()) {
-            ClassLoader urlClassLoader =
-                    new URLClassLoader(urls.toArray(new URL[urls.size()]), loader);
-            try {
-                urlCls = urlClassLoader.loadClass(classname);
-            } catch (ClassNotFoundException ex) {
-            }
-            isLoaded = isResType(urlCls, resType);
-            if(isLoaded) {
-                //Loaded the class and verified it to be a jdbc driver implementing
-                //java.sql.Driver or implementing javax.sql.DataSource
-                //Register the url classloader for later use.
-                //For ojdbc14 n ojdbc5 (same class names different url class loaders
-                //will be added.
-                classLoaders.put(classname, urlClassLoader);
-            }
-        } else {
-        }
-        return isLoaded;
-    }*/
 
     private String getClassName(String classname) {
         classname = classname.replaceAll("/", ".");

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/EjbJarHandler.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/deployment/EjbJarHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -101,13 +101,8 @@ public class EjbJarHandler extends AbstractArchiveHandler {
 
     @Override
     public ClassLoader getClassLoader(final ClassLoader parent, DeploymentContext context) {
-        ASURLClassLoader cloader = AccessController.doPrivileged(new PrivilegedAction<ASURLClassLoader>() {
-
-            @Override
-            public ASURLClassLoader run() {
-                return new ASURLClassLoader(parent);
-            }
-        });
+        PrivilegedAction<ASURLClassLoader> action = () -> new ASURLClassLoader(parent);
+        ASURLClassLoader cloader = AccessController.doPrivileged(action);
 
         try {
             String compatProp = context.getAppProps().getProperty(DeploymentProperties.COMPATIBILITY);

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
@@ -16,6 +16,7 @@
 
 package org.glassfish.web.loader;
 
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.deployment.common.ClassDependencyBuilder;
 import org.glassfish.hk2.classmodel.reflect.*;
 
@@ -112,18 +113,10 @@ public class ServletContainerInitializerUtil {
             }
 
             // Create temporary classloader for ServiceLoader#load
-            // TODO: Have temporary classloader honor delegate flag from
-            // sun-web.xml
-            URL[] urlsForNewClassLoader =
-                new URL[newClassLoaderUrlList.size()];
-            final URL[] urlArray = newClassLoaderUrlList.toArray(urlsForNewClassLoader);
-
-            cl = AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
-                @Override
-                public URLClassLoader run() {
-                    return new URLClassLoader(urlArray, webAppCl.getParent());
-                }
-            });
+            // TODO: Have temporary classloader honor delegate flag from sun-web.xml
+            final URL[] urlArray = newClassLoaderUrlList.toArray(URL[]::new);
+            PrivilegedAction<URLClassLoader> action = () -> new GlassfishUrlClassLoader(urlArray, webAppCl.getParent());
+            cl = AccessController.doPrivileged(action);
         }
 
         return ServiceLoader.load(ServletContainerInitializer.class, cl);

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ServletContainerInitializerUtil.java
@@ -50,9 +50,9 @@ public class ServletContainerInitializerUtil {
 
     private static final ResourceBundle rb = log.getResourceBundle();
 
-    public static interface LogContext {
+    public interface LogContext {
 
-        public default Level getNonCriticalClassloadingErrorLogLevel() {
+        default Level getNonCriticalClassloadingErrorLogLevel() {
             return Level.WARNING;
         }
     }
@@ -65,7 +65,7 @@ public class ServletContainerInitializerUtil {
      *
      * @return Iterable over all ServletContainerInitializers that were found
      */
-    public static Iterable<ServletContainerInitializer> getServletContainerInitializers(
+    public static ServiceLoader<ServletContainerInitializer> getServletContainerInitializers(
             Map<String, String> webFragmentMap, List<Object> absoluteOrderingList,
             boolean hasOthers, ClassLoader cl) {
         /*
@@ -86,7 +86,7 @@ public class ServletContainerInitializerUtil {
 
             // Create a new List of URLs with missing fragments removed from
             // the currentUrls
-            List<URL> newClassLoaderUrlList = new ArrayList<URL>();
+            List<URL> newClassLoaderUrlList = new ArrayList<>();
             for (URL classLoaderUrl : webAppCl.getURLs()) {
                 // Check that the URL is using file protocol, else ignore it
                 if (!"file".equals(classLoaderUrl.getProtocol())) {
@@ -152,10 +152,10 @@ public class ServletContainerInitializerUtil {
         // initializers are interested
         for (ServletContainerInitializer sc : initializers) {
             if(interestList == null) {
-                interestList = new HashMap<Class<?>, List<Class<? extends ServletContainerInitializer>>>();
+                interestList = new HashMap<>();
             }
             Class<? extends ServletContainerInitializer> sciClass = sc.getClass();
-            HandlesTypes ann = (HandlesTypes) sciClass.getAnnotation(HandlesTypes.class);
+            HandlesTypes ann = sciClass.getAnnotation(HandlesTypes.class);
             if(ann == null) {
                 // This initializer does not contain @HandlesTypes
                 // This means it should always be called for all web apps
@@ -164,7 +164,7 @@ public class ServletContainerInitializerUtil {
                         interestList.get(ServletContainerInitializerUtil.class);
                 if(currentInitializerList == null) {
                     List<Class<? extends ServletContainerInitializer>> arr =
-                            new ArrayList<Class<? extends ServletContainerInitializer>>();
+                            new ArrayList<>();
                     arr.add(sciClass);
                     interestList.put(ServletContainerInitializerUtil.class, arr);
                 } else {
@@ -178,7 +178,7 @@ public class ServletContainerInitializerUtil {
                                 interestList.get(c);
                         if(currentInitializerList == null) {
                             List<Class<? extends ServletContainerInitializer>> arr =
-                                    new ArrayList<Class<? extends ServletContainerInitializer>>();
+                                    new ArrayList<>();
                             arr.add(sciClass);
                             interestList.put(c, arr);
                         } else {
@@ -221,7 +221,7 @@ public class ServletContainerInitializerUtil {
         // If an initializer was present without any @HandleTypes, it
         // must be called with a null set of classes
         if(interestList.containsKey(ServletContainerInitializerUtil.class)) {
-            initializerList = new HashMap<Class<? extends ServletContainerInitializer>, Set<Class<?>>>();
+            initializerList = new HashMap<>();
             List<Class<? extends ServletContainerInitializer>> initializersWithoutHandleTypes =
                     interestList.get(ServletContainerInitializerUtil.class);
             for(Class<? extends ServletContainerInitializer> c : initializersWithoutHandleTypes) {
@@ -257,10 +257,12 @@ public class ServletContainerInitializerUtil {
                                     Enumeration<JarEntry> entries = jf.entries();
                                     while(entries.hasMoreElements()) {
                                         JarEntry anEntry = entries.nextElement();
-                                        if(anEntry.isDirectory())
+                                        if(anEntry.isDirectory()) {
                                             continue;
-                                        if(!anEntry.getName().endsWith(".class"))
+                                        }
+                                        if(!anEntry.getName().endsWith(".class")) {
                                             continue;
+                                        }
                                         InputStream jarInputStream = null;
                                         try {
                                             jarInputStream = jf.getInputStream(anEntry);
@@ -413,10 +415,11 @@ public class ServletContainerInitializerUtil {
 
             Class<?> c = e.getKey();
             Type type = classInfo.getBy(c.getName());
-            if (type==null)
+            if (type==null) {
                 continue;
+            }
 
-            Set<Class<?>> resultSet = new HashSet<Class<?>>();
+            Set<Class<?>> resultSet = new HashSet<>();
             if (type instanceof AnnotationType) {
                 for (AnnotatedElement ae : ((AnnotationType) type).allAnnotatedTypes()) {
                     if (ae instanceof Member) {
@@ -456,13 +459,13 @@ public class ServletContainerInitializerUtil {
                 }
             }
             if(initializerList == null) {
-                initializerList = new HashMap<Class<? extends ServletContainerInitializer>, Set<Class<?>>>();
+                initializerList = new HashMap<>();
             }
             List<Class<? extends ServletContainerInitializer>> containerInitializers = e.getValue();
             for(Class<? extends ServletContainerInitializer> initializer : containerInitializers) {
                 Set<Class<?>> classSet = initializerList.get(initializer);
                 if(classSet == null) {
-                    classSet = new HashSet<Class<?>>();
+                    classSet = new HashSet<>();
                 }
                 classSet.addAll(resultSet);
                 initializerList.put(initializer, classSet);
@@ -495,9 +498,9 @@ public class ServletContainerInitializerUtil {
             if(resultFromClassInfo.isEmpty()) {
                 continue;
             }
-            Set<Class<?>> resultSet = new HashSet<Class<?>>();
-            for(Iterator<String> iter = resultFromClassInfo.iterator(); iter.hasNext();) {
-                String className = iter.next().replace('/', '.');
+            Set<Class<?>> resultSet = new HashSet<>();
+            for (String string : resultFromClassInfo) {
+                String className = string.replace('/', '.');
                 try {
                     Class aClass = cl.loadClass(className);
                     resultSet.add(aClass);
@@ -510,13 +513,13 @@ public class ServletContainerInitializerUtil {
                 }
             }
             if(initializerList == null) {
-                initializerList = new HashMap<Class<? extends ServletContainerInitializer>, Set<Class<?>>>();
+                initializerList = new HashMap<>();
             }
             List<Class<? extends ServletContainerInitializer>> containerInitializers = e.getValue();
             for(Class<? extends ServletContainerInitializer> initializer : containerInitializers) {
                 Set<Class<?>> classSet = initializerList.get(initializer);
                 if(classSet == null) {
-                    classSet = new HashSet<Class<?>>();
+                    classSet = new HashSet<>();
                 }
                 classSet.addAll(resultSet);
                 initializerList.put(initializer, classSet);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -5272,22 +5272,18 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
         // Allow programmatic registration of ServletContextListeners, but
         // only within the scope of ServletContainerInitializer#onStartup
         isProgrammaticServletContextListenerRegistrationAllowed = true;
-
-        // We have the list of initializers and the classes that satisfy
-        // the condition. Time to call the initializers
-        ServletContext ctxt = this.getServletContext();
         try {
+            // We have the list of initializers and the classes that satisfy
+            // the condition. Time to call the initializers
+            ServletContext ctxt = this.getServletContext();
             for (var e : initializerList.entrySet()) {
                 Class<? extends ServletContainerInitializer> initializer = e.getKey();
-                // See IT 11333
                 if (isUseMyFaces() && FACES_INITIALIZER.equals(initializer.getName())) {
                     continue;
                 }
                 try {
-                    if (log.isLoggable(FINE)) {
-                        log.log(FINE, "Calling ServletContainerInitializer [" + initializer
-                            + "] onStartup with classes " + e.getValue());
-                    }
+                    log.log(FINE, "Calling ServletContainerInitializer [{0}] onStartup with classes {1} ",
+                        new Object[] {initializer, e.getValue()});
 
                     ServletContainerInitializer iniInstance = initializer.getDeclaredConstructor().newInstance();
                     fireContainerEvent(BEFORE_CONTEXT_INITIALIZER_ON_STARTUP, iniInstance);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/util/StringManager.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/util/StringManager.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,11 @@
 package org.apache.catalina.util;
 
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
 /**
  * An internationalization / localization helper class which reduces
@@ -44,12 +49,9 @@ import java.util.*;
  */
 
 public class StringManager {
-    // START SJSAS 6412710
-    private final HashMap<Locale, ResourceBundle> bundles =
-        new HashMap<Locale, ResourceBundle>(5);
-    private String bundleName = null;
-    // END SJSAS 6412710
 
+    private final HashMap<Locale, ResourceBundle> bundles = new HashMap<>(5);
+    private final String bundleName;
 
     /**
      * Creates a new StringManager for a given package. This is a
@@ -61,38 +63,7 @@ public class StringManager {
      */
 
     private StringManager(String packageName) {
-        /* 6412710
-        String bundleName = packageName + ".LocalStrings";
-        */
-        // START SJSAS 6412710
         this.bundleName = packageName + ".LocalStrings";
-        // END SJSAS 6412710
-        /* SJSAS 6412710
-        try {
-        */
-        /* SJSAS 6412710
-        } catch( MissingResourceException ex ) {
-            // Try from the current loader ( that's the case for trusted apps )
-            ClassLoader cl=Thread.currentThread().getContextClassLoader();
-            if( cl != null ) {
-                try {
-                    bundle=ResourceBundle.getBundle(bundleName, Locale.getDefault(), cl);
-                    return;
-                } catch(MissingResourceException ex2) {
-                }
-            }
-            if( cl==null )
-                cl=this.getClass().getClassLoader();
-
-            if (log.isDebugEnabled())
-                log.debug("Can't find resource " + bundleName +
-                    " " + cl);
-            if( cl instanceof URLClassLoader ) {
-                if (log.isDebugEnabled())
-                    log.debug( ((URLClassLoader)cl).getURLs());
-            }
-        }
-        */
     }
 
 
@@ -144,8 +115,9 @@ public class StringManager {
         }
         // END SJSAS 6412710
 
-        if( bundle==null )
+        if( bundle==null ) {
             return key;
+        }
 
         try {
             return bundle.getString(key);
@@ -186,7 +158,9 @@ public class StringManager {
             Object nonNullArgs[] = args;
             for (int i=0; i<args.length; i++) {
                 if (args[i] == null) {
-                    if (nonNullArgs==args) nonNullArgs=(Object[])args.clone();
+                    if (nonNullArgs==args) {
+                        nonNullArgs=args.clone();
+                    }
                     nonNullArgs[i] = "null";
                 }
             }
@@ -343,7 +317,7 @@ public class StringManager {
     // --------------------------------------------------------------
 
     private static Hashtable<String, StringManager> managers =
-            new Hashtable<String, StringManager>();
+            new Hashtable<>();
 
     /**
      * Get the StringManager for a particular package. If a manager for

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -57,7 +57,6 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -68,6 +67,7 @@ import java.util.logging.Logger;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.cdi.CDILoggerInfo;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.weld.connector.WeldUtils;
 import org.glassfish.weld.connector.WeldUtils.BDAType;
 import org.glassfish.weld.ejb.EjbDescriptorImpl;
@@ -319,9 +319,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         StringBuffer valBuff = new StringBuffer(initVal);
 
         Collection<BeanDeploymentArchive> bdas = getBeanDeploymentArchives();
-        Iterator<BeanDeploymentArchive> iter = bdas.iterator();
-        while (iter.hasNext()) {
-            BeanDeploymentArchive bda = iter.next();
+        for (BeanDeploymentArchive bda : bdas) {
             BDAType embedBDAType = BDAType.UNKNOWN;
             if (bda instanceof BeanDeploymentArchiveImpl) {
                 embedBDAType = ((BeanDeploymentArchiveImpl) bda).getBDAType();
@@ -619,16 +617,15 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
             try {
                 // use a throwaway classloader to load the application's beans.xml
                 final URL beansXmlUrl;
-                try (URLClassLoader throwAwayClassLoader = new URLClassLoader(new URL[] { archive.getURI().toURL() }, null)) {
+                try (URLClassLoader throwAwayClassLoader = new GlassfishUrlClassLoader(
+                    new URL[] {archive.getURI().toURL()}, null)) {
                     beansXmlUrl = throwAwayClassLoader.getResource(entry);
                 }
                 if (beansXmlUrl != null && !beansXmlURLs.contains(beansXmlUrl)) {
                     beansXmlURLs.add(beansXmlUrl);
                 }
             } catch (IOException e) {
-                if (LOG.isLoggable(Level.SEVERE)) {
-                    LOG.log(Level.SEVERE, CDILoggerInfo.SEVERE_ERROR_READING_ARCHIVE, new Object[] { e.getMessage() });
-                }
+                LOG.log(Level.SEVERE, CDILoggerInfo.SEVERE_ERROR_READING_ARCHIVE, e.getMessage());
             }
         }
     }
@@ -638,9 +635,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
     }
 
     private void collectRarInfo(ReadableArchive archive) throws IOException, ClassNotFoundException {
-        if (LOG.isLoggable(FINE)) {
-            LOG.log(FINE, CDILoggerInfo.COLLECTING_RAR_INFO, new Object[] { archive.getURI() });
-        }
+        LOG.log(FINE, CDILoggerInfo.COLLECTING_RAR_INFO, archive.getURI());
         Enumeration<String> entries = archive.entries();
         while (entries.hasMoreElements()) {
             String entry = entries.nextElement();

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +16,40 @@
  */
 
 package org.glassfish.weld;
+
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.api.deployment.archive.ReadableArchive;
+import org.glassfish.cdi.CDILoggerInfo;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
+import org.glassfish.weld.connector.WeldUtils;
+import org.glassfish.weld.connector.WeldUtils.BDAType;
+import org.glassfish.weld.ejb.EjbDescriptorImpl;
+import org.jboss.weld.bootstrap.WeldBootstrap;
+import org.jboss.weld.bootstrap.api.ServiceRegistry;
+import org.jboss.weld.bootstrap.api.helpers.SimpleServiceRegistry;
+import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.bootstrap.spi.BeansXml;
+import org.jboss.weld.ejb.spi.EjbDescriptor;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
@@ -46,41 +80,6 @@ import static org.glassfish.weld.connector.WeldUtils.WEB_INF_LIB;
 import static org.glassfish.weld.connector.WeldUtils.getCDIAnnotatedClassNames;
 import static org.glassfish.weld.connector.WeldUtils.hasExtension;
 import static org.glassfish.weld.connector.WeldUtils.isImplicitBeanArchive;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.glassfish.api.deployment.DeploymentContext;
-import org.glassfish.api.deployment.archive.ReadableArchive;
-import org.glassfish.cdi.CDILoggerInfo;
-import org.glassfish.common.util.GlassfishUrlClassLoader;
-import org.glassfish.weld.connector.WeldUtils;
-import org.glassfish.weld.connector.WeldUtils.BDAType;
-import org.glassfish.weld.ejb.EjbDescriptorImpl;
-import org.jboss.weld.bootstrap.WeldBootstrap;
-import org.jboss.weld.bootstrap.api.ServiceRegistry;
-import org.jboss.weld.bootstrap.api.helpers.SimpleServiceRegistry;
-import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
-import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
-import org.jboss.weld.bootstrap.spi.BeansXml;
-import org.jboss.weld.ejb.spi.EjbDescriptor;
-
-import jakarta.enterprise.inject.spi.AnnotatedType;
-import jakarta.enterprise.inject.spi.InjectionTarget;
 
 /**
  * The means by which Weld Beans are discovered on the classpath.
@@ -617,7 +616,7 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
             try {
                 // use a throwaway classloader to load the application's beans.xml
                 final URL beansXmlUrl;
-                try (URLClassLoader throwAwayClassLoader = new GlassfishUrlClassLoader(
+                try (GlassfishUrlClassLoader throwAwayClassLoader = new GlassfishUrlClassLoader(
                     new URL[] {archive.getURI().toURL()}, null)) {
                     beansXmlUrl = throwAwayClassLoader.getResource(entry);
                 }

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesDeployer.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -68,6 +68,7 @@ import org.glassfish.api.deployment.UndeployCommandParameters;
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.api.deployment.archive.WritableArchive;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.deployment.common.DeploymentException;
 import org.glassfish.javaee.core.deployment.JavaEEDeployer;
 import org.glassfish.loader.util.ASClassLoaderUtil;
@@ -149,12 +150,9 @@ public class WebServicesDeployer extends JavaEEDeployer<WebServicesContainer, We
             String moduleCP = getModuleClassPath(dc);
             final List<URL> moduleCPUrls = ASClassLoaderUtil.getURLsFromClasspath(moduleCP, File.pathSeparator, null);
             final ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
-            URLClassLoader newCl = AccessController.doPrivileged(new PrivilegedAction<URLClassLoader>() {
-                @Override
-                public URLClassLoader run() {
-                    return new URLClassLoader(ASClassLoaderUtil.convertURLListToArray(moduleCPUrls), oldCl);
-                }
-            });
+            PrivilegedAction<URLClassLoader> action = () -> new GlassfishUrlClassLoader(
+                ASClassLoaderUtil.convertURLListToArray(moduleCPUrls), oldCl);
+            URLClassLoader newCl = AccessController.doPrivileged(action);
 
             Thread.currentThread().setContextClassLoader(newCl);
             WebServicesDescriptor wsDesc = bundle.getWebServices();

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/DirectoryClassLoader.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/DirectoryClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,7 +22,6 @@ import com.sun.enterprise.universal.i18n.LocalStringsImpl;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -32,10 +31,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.glassfish.common.util.GlassfishUrlClassLoader;
+
 /**
  * A class loader that loads classes from all jar files in a specified directory.
  */
-public class DirectoryClassLoader extends URLClassLoader {
+public class DirectoryClassLoader extends GlassfishUrlClassLoader {
 
     private static final LocalStringsImpl STRINGS = new LocalStringsImpl(DirectoryClassLoader.class);
     private static final int MAX_DEPTH = 5;
@@ -90,15 +91,5 @@ public class DirectoryClassLoader extends URLClassLoader {
         } catch (final IOException e) {
             throw new IllegalStateException(STRINGS.get("DirError", dir), e);
         }
-    }
-
-
-    @Override
-    public String toString() {
-        final StringBuilder b = new StringBuilder();
-        b.append(getClass().getName()).append('@').append(hashCode()).append("(\n");
-        Arrays.stream(getURLs()).forEach(u -> b.append(u).append('\n'));
-        b.append(')');
-        return b.toString();
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/VerifyDomainXmlCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/VerifyDomainXmlCommand.java
@@ -24,7 +24,6 @@ import com.sun.enterprise.util.SystemPropertyConstants;
 
 import java.io.File;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/GlassfishUrlClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/GlassfishUrlClassLoader.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLStreamHandlerFactory;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 
 
 /**
@@ -73,7 +72,10 @@ public class GlassfishUrlClassLoader extends URLClassLoader {
      */
     @Override
     public String toString() {
-        return getClass().getName() + "@" + Integer.toHexString(hashCode()) + ": "
-            + Arrays.stream(getURLs()).collect(Collectors.toList());
+        final StringBuilder text = new StringBuilder(1024);
+        text.append(getClass().getName()).append('@').append(Integer.toHexString(hashCode())).append("[\n");
+        Arrays.stream(getURLs()).forEach(u -> text.append(u).append('\n'));
+        text.append(']');
+        return text.toString();
     }
 }

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/GlassfishUrlClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/GlassfishUrlClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,17 +14,22 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package com.sun.enterprise.glassfish.bootstrap;
+package org.glassfish.common.util;
 
+import java.io.Closeable;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLStreamHandlerFactory;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
 
 /**
- * {@link URLClassLoader} with overriden {@link #toString()} method, so it prints list of managed
- * URLs
+ * {@link URLClassLoader} with logs and overriden {@link #toString()} method so it prints list
+ * of managed URLs.
+ * <p>
+ * This classloader is {@link Closeable}! As of JDK11+ {@link #close()} just closes any
+ * unclosed resource streams which could survive the class loader.
  *
  * @author David Matejcek
  */
@@ -34,10 +39,32 @@ public class GlassfishUrlClassLoader extends URLClassLoader {
      * Initializes the internal classpath.
      *
      * @param urls
+     */
+    public GlassfishUrlClassLoader(URL[] urls) {
+        super(urls);
+    }
+
+
+    /**
+     * Initializes the internal classpath.
+     *
+     * @param urls
      * @param parent
      */
     public GlassfishUrlClassLoader(URL[] urls, ClassLoader parent) {
         super(urls, parent);
+    }
+
+
+    /**
+     * Initializes the internal classpath.
+     *
+     * @param urls
+     * @param parent
+     * @param factory
+     */
+    public GlassfishUrlClassLoader(URL[] urls, ClassLoader parent, URLStreamHandlerFactory factory) {
+        super(urls, parent, factory);
     }
 
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/ClassPathBuilder.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/ClassPathBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,6 +26,8 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 
 /**
  * Builds up a {@link ClassLoader}.

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassfishBootstrapClassLoader.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassfishBootstrapClassLoader.java
@@ -20,16 +20,19 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
  * This classloader is located between OSGI classloader and system JDK extensions classloader,
  * so it can provide early initialized libraries (before OSGI startup, so even OSGI can use them).
  * <p>
- * Examples
+ * List:
  * <ul>
  * <li>GlassFish Java Util Logging Extension
  * <li>Grizzly NPN API
@@ -37,7 +40,7 @@ import java.util.List;
  *
  * @author David Matejcek
  */
-public class GlassfishBootstrapClassLoader extends GlassfishUrlClassLoader {
+public class GlassfishBootstrapClassLoader extends URLClassLoader {
 
     /**
      * Initializes the classloader.
@@ -50,9 +53,14 @@ public class GlassfishBootstrapClassLoader extends GlassfishUrlClassLoader {
         super(createUrls(glassfishDir), parent);
     }
 
+
+    /**
+     * Returns class name, hash code and list of managed urls.
+     */
     @Override
-    public Class<?> loadClass(final String className) throws ClassNotFoundException {
-        return super.loadClass(className);
+    public String toString() {
+        return getClass().getName() + "@" + Integer.toHexString(hashCode()) + ": "
+            + Arrays.stream(getURLs()).collect(Collectors.toList());
     }
 
 

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/MainHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -38,6 +38,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 // WARNING: There must not be any references to java.util.logging.* instances in static initialization except levels.
+//          They would cause initialization of the JVM logging which we do AFTER this.
 import static com.sun.enterprise.glassfish.bootstrap.LogFacade.BOOTSTRAP_LOGGER;
 import static com.sun.enterprise.module.bootstrap.ArgumentManager.argsToMap;
 import static java.util.logging.Level.FINE;
@@ -62,12 +63,12 @@ public class MainHelper {
     }
 
     private static int getMajorJdkVersion() {
-      String jv = System.getProperty("java.version");
-      String[] split = jv.split("[\\._\\-]+");
-      if (split.length > 0) {
-        return Integer.parseInt(split[0]);
-      }
-      return -1;
+        String jv = System.getProperty("java.version");
+        String[] split = jv.split("[\\._\\-]+");
+        if (split.length > 0) {
+            return Integer.parseInt(split[0]);
+        }
+        return -1;
     }
 
     static String whichPlatform() {
@@ -308,14 +309,12 @@ public class MainHelper {
         return null;
     }
 
-    /* package */
-
     static File findInstallRoot() {
-        File bootstrapFile = findBootstrapFile(); // glassfish/modules/glassfish.jar
-        return bootstrapFile.getParentFile().getParentFile(); // glassfish/
+        // glassfish/modules/glassfish.jar
+        File bootstrapFile = findBootstrapFile();
+        // glassfish/
+        return bootstrapFile.getParentFile().getParentFile();
     }
-
-    /* package */
 
     static File findInstanceRoot(File installRoot, Properties args) {
         Properties asEnv = parseAsEnv(installRoot);
@@ -468,11 +467,9 @@ public class MainHelper {
 
     private static boolean wasStartedByCLI(final Properties props) {
         // if we were started by CLI there will be some special args set...
-
-        return
-                props.getProperty("-asadmin-classpath") != null &&
-                        props.getProperty("-asadmin-classname") != null &&
-                        props.getProperty("-asadmin-args") != null;
+        return props.getProperty("-asadmin-classpath") != null
+            && props.getProperty("-asadmin-classname") != null
+            && props.getProperty("-asadmin-args") != null;
     }
 
     /**
@@ -574,8 +571,10 @@ public class MainHelper {
             case Knopflerfish:
             case Equinox:
                 return true;
+            case Static:
+            default:
+                return false;
         }
-        return false;
     }
 
     static class ClassLoaderBuilder {
@@ -749,11 +748,11 @@ public class MainHelper {
 
     static class EquinoxHelper extends PlatformHelper {
 
-        /* if equinox is installed under glassfish/eclipse this would be the
-         *  glassfish/eclipse/plugins dir that contains the equinox jars
-         *  can be null
-         * */
-        private static File pluginsDir = null;
+        /**
+         * If equinox is installed under glassfish/eclipse this would be the
+         * glassfish/eclipse/plugins dir that contains the equinox jars can be null
+         */
+        private static File pluginsDir;
 
         @Override
         protected void setFwDir() {
@@ -841,7 +840,8 @@ public class MainHelper {
 
         @Override
         protected File getFrameworkConfigFile() {
-            return null;  // no config file for this platform.
+            // no config file for this platform.
+            return null;
         }
     }
 }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntime.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntime.java
@@ -17,13 +17,15 @@
 
 package com.sun.enterprise.glassfish.bootstrap.osgi;
 
-import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTALL_ROOT_PROP_NAME;
-import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTALL_ROOT_URI_PROP_NAME;
-import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTANCE_ROOT_PROP_NAME;
-import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTANCE_ROOT_URI_PROP_NAME;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.logging.Level.FINEST;
-import static org.glassfish.embeddable.GlassFish.Status.DISPOSED;
+import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
+import com.sun.enterprise.glassfish.bootstrap.GlassfishBootstrapClassLoader;
+import com.sun.enterprise.glassfish.bootstrap.MainHelper;
+import com.sun.enterprise.module.ModulesRegistry;
+import com.sun.enterprise.module.bootstrap.BootException;
+import com.sun.enterprise.module.bootstrap.Main;
+import com.sun.enterprise.module.bootstrap.ModuleStartup;
+import com.sun.enterprise.module.bootstrap.StartupContext;
+import com.sun.enterprise.util.FelixPrettyPrinter;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -39,6 +41,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
@@ -51,15 +54,13 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
 
-import com.sun.enterprise.glassfish.bootstrap.GlassFishImpl;
-import com.sun.enterprise.glassfish.bootstrap.GlassfishUrlClassLoader;
-import com.sun.enterprise.glassfish.bootstrap.MainHelper;
-import com.sun.enterprise.module.ModulesRegistry;
-import com.sun.enterprise.module.bootstrap.BootException;
-import com.sun.enterprise.module.bootstrap.Main;
-import com.sun.enterprise.module.bootstrap.ModuleStartup;
-import com.sun.enterprise.module.bootstrap.StartupContext;
-import com.sun.enterprise.util.FelixPrettyPrinter;
+import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTALL_ROOT_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTALL_ROOT_URI_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTANCE_ROOT_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.Constants.INSTANCE_ROOT_URI_PROP_NAME;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.logging.Level.FINEST;
+import static org.glassfish.embeddable.GlassFish.Status.DISPOSED;
 
 /**
  * Implementation of GlassFishRuntime in an OSGi environment.
@@ -272,7 +273,7 @@ public class EmbeddedOSGiGlassFishRuntime extends GlassFishRuntime {
 
 
     private String toString(final ClassLoader classLoader) {
-        if (classLoader instanceof GlassfishUrlClassLoader) {
+        if (classLoader instanceof GlassfishBootstrapClassLoader || classLoader instanceof GlassfishUrlClassLoader) {
             return classLoader.toString();
         }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -27,7 +27,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.glassfish.api.admin.ServerEnvironment;
+import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.kernel.KernelLoggerInfo;
 import org.jvnet.hk2.annotations.Service;
@@ -141,16 +141,13 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
             }
         }
         commonClassPath = cp.toString();
-        if (!urls.isEmpty()) {
+        if (urls.isEmpty()) {
+            logger.logp(Level.FINE, "CommonClassLoaderManager",
+                "Skipping creation of CommonClassLoader as there are no libraries available", "urls = {0}", urls);
+        } else {
             // Skip creation of an unnecessary classloader in the hierarchy,
             // when all it would have done was to delegate up.
-            commonClassLoader = new URLClassLoader(
-                urls.toArray(new URL[urls.size()]), APIClassLoader);
-        } else {
-            logger.logp(Level.FINE, "CommonClassLoaderManager",
-                "Skipping creation of CommonClassLoader " +
-                    "as there are no libraries available",
-                    "urls = {0}", new Object[]{urls});
+            commonClassLoader = new GlassfishUrlClassLoader(urls.toArray(URL[]::new), APIClassLoader);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.8</version>
+        <relativePath />
     </parent>
 
     <groupId>org.glassfish.main</groupId>


### PR DESCRIPTION
Extracted classloader changes from https://github.com/eclipse-ee4j/glassfish/pull/24225

* ClassLoader changes - all GF classloaders now have toString; it helped me when I had issues with OSGI; URLClassLoader printed just a classname and hashcode, now it prints managed URLs.
* WebappClassLoader, StandardManager small revision - fixed some stacktraces in logs I have seen along the path, produced by ugly workarounds in the code.