### PR TITLE
Use archive suffix to determine the compression program

### DIFF
--- a/appserver/tests/common_test.sh
+++ b/appserver/tests/common_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
 #
+# Copyright (c) 2023 Contributors to the Eclipse Foundation. All rights reserved.
 # Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -82,7 +83,7 @@ copy_test_artifacts() {
   cp ${APS_HOME}/test_results*.* ${WORKSPACE}/results/ || true
   cp `pwd`/*/*logs.zip ${WORKSPACE}/results/ || true
   cp `pwd`/*/*/*logs.zip ${WORKSPACE}/results/ || true
-  tar -cf ${WORKSPACE}/${1}-results.tar.gz ${WORKSPACE}/results
+  tar -caf ${WORKSPACE}/${1}-results.tar.gz ${WORKSPACE}/results
 }
 
 generate_junit_report(){


### PR DESCRIPTION
Currently observed:
```
$ wget https://ci.eclipse.org/glassfish/view/GlassFish/job/glassfish_build-and-test-using-jenkinsfile/job/master/907/artifact/jdbc_all-results.tar.gz
$ gzip --decompress web_jsp-results.tar.gz 

gzip: web_jsp-results.tar.gz: not in gzip format
$ file web_jsp-results.tar.gz 
web_jsp-results.tar.gz: POSIX tar archive (GNU)
```
