### PR TITLE
Update documentation pages on the website 

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -110,6 +110,10 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -40,9 +40,14 @@
         <!-- the directory where the current snapshot is published -->
         <dir.snap>${site.output.dir}/docs/SNAPSHOT</dir.snap>
         <!-- add a new property for each new release -->
-        <dir.510>${site.output.dir}/docs/5.1.0</dir.510>
+        <docs.5x.version>5.1.0</docs.5x.version>
+        <docs.5x.dir>${site.output.dir}/docs/${docs.5x.version}</docs.5x.dir>
+        <docs.6x.version>6.2.5</docs.6x.version>
+        <docs.6x.dir>${site.output.dir}/docs/${docs.6x.version}</docs.6x.dir>
+        <docs.7x.version>7.0.0</docs.7x.version>
+        <docs.7x.dir>${site.output.dir}/docs/${docs.7x.version}</docs.7x.dir>
         <!-- the "latest" version; update when a new release is done -->
-        <docs.version>7.0.0</docs.version>
+        <docs.version>${docs.7x.version}</docs.version>
     </properties>
 
     <!--
@@ -112,10 +117,10 @@
                             </execution>
                             <!--
                                 Get the collection of documentation for the
-                                5.1.0 release.
+                                6.x release.
                             -->
                             <execution>
-                                <id>get-510</id>
+                                <id>get-7x</id>
                                 <phase>generate-sources</phase>
                                 <goals>
                                     <goal>unpack</goal>
@@ -129,9 +134,63 @@
                                         <artifactItem>
                                             <groupId>org.glassfish.docs</groupId>
                                             <artifactId>distribution</artifactId>
-                                            <version>5.1.0</version>
+                                            <version>${docs.7x.version}</version>
                                             <outputDirectory>
-                                                ${dir.510}
+                                                ${docs.7x.dir}
+                                            </outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <!--
+                                Get the collection of documentation for the
+                                6.x release.
+                            -->
+                            <execution>
+                                <id>get-6x</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <includeGroupIds>
+                                        org.glassfish.docs
+                                    </includeGroupIds>
+                                    <excludes>META-INF/**</excludes>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.glassfish.docs</groupId>
+                                            <artifactId>distribution</artifactId>
+                                            <version>${docs.6x.version}</version>
+                                            <outputDirectory>
+                                                ${docs.6x.dir}
+                                            </outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <!--
+                                Get the collection of documentation for the
+                                5.1.0 release.
+                            -->
+                            <execution>
+                                <id>get-5x</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <includeGroupIds>
+                                        org.glassfish.docs
+                                    </includeGroupIds>
+                                    <excludes>META-INF/**</excludes>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.glassfish.docs</groupId>
+                                            <artifactId>distribution</artifactId>
+                                            <version>${docs.5x.version}</version>
+                                            <outputDirectory>
+                                                ${docs.5x.dir}
                                             </outputDirectory>
                                         </artifactItem>
                                     </artifactItems>
@@ -168,7 +227,7 @@
                                           />
                                         <symlink
                                           link="${site.output.dir}/docs/latest"
-                                          resource="${docs.version}"/>
+                                          resource="${docs.7x.dir}"/>
                                     </target>
                                 </configuration>
                             </execution>

--- a/docs/website/src/main/resources/README.md
+++ b/docs/website/src/main/resources/README.md
@@ -9,6 +9,18 @@ sponsored by the Eclipse Foundation.
 
 ## Latest News
 
+## December 14, 2022 - The final version of Eclipse GlassFish 7 released
+
+After huge effort by the Eclipse GlassFish team and a lot of fellow contributors, Eclipse GlassFish 7.0.0 is finally released.
+
+Download links are available from the [GlassFish Download page](download.md).
+
+The main new feature is [Jakarta EE 10](https://jakarta.ee/specifications/platform/10/) support, and everything that comes with that. Additionally GlassFish now provides support for the [MicroProfile Config](https://microprofile.io/microprofile-config/) and [MicroProfile JWT](https://microprofile.io/project/eclipse/microprofile-jwt-auth/) APIs, and the latest [Jakarta MVC](https://www.mvc-spec.org/) 2.0 release.
+
+This release also features a massive overhaul and cleanup of the DOL module (Deployment Object Library), a large cleanup of how JNDI names are handled internally, and many fixes in the logging functionality and in the way how GlassFish servers start and stop.
+
+Eclipse GlassFish 7.0.0 compiles and runs with JDK 11 to JDK 19 releases. MicroProfile support requires JDK 17 or higher.
+
 ## September 19, 2022 - Eclipse GlassFish 7.0.0-M8 certified as Jakarta EE 10 compatible
 
 We are pleased to announce that with the milestone release 7.0.0-M8, Eclipse GlassFish is officially certified as a Jakarta EE 10 compatible implementation.
@@ -21,7 +33,7 @@ You can download both milestone releases from the [Eclipse Foundation Download p
 ## February 13, 2022 -- Eclipse GlassFish 6.2.5 Available
 
 We are pleased to announce the release of Eclipse GlassFish 6.2.5. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.5 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.5 updates and reenables a lot of tests that were disabled in previous versions (most after the GF 5 to 6 transition), once again improves JDK 17 compatibility (cases found by the new tests), fixes several bugs, and contains new versions of Hibernate Validator, Jackson and others.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6.2.5 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.5 updates and reenables a lot of tests that were disabled in previous versions (most after the GF 5 to 6 transition), once again improves JDK 17 compatibility (cases found by the new tests), fixes several bugs, and contains new versions of Hibernate Validator, Jackson and others.
 
 GlassFish 6.2.5 compiles and run with JDK 11 to JDK 18-EA releases.
 
@@ -30,7 +42,7 @@ Note this release requires at least JDK 11.
 ## January 10, 2022 -- Eclipse GlassFish 6.2.4 Available
 
 We are pleased to announce the release of Eclipse GlassFish 6.2.4. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.4 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.4 brings initial support for JDK 18 (tested until ea29) and adds running several standalone Jakarta EE TCKs directly from the project. An import internal fix is removing a troublesome circular dependency between GlassFish and Jersey.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6.2.4 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.4 brings initial support for JDK 18 (tested until ea29) and adds running several standalone Jakarta EE TCKs directly from the project. An import internal fix is removing a troublesome circular dependency between GlassFish and Jersey.
 
 GlassFish 6.2.4 compiles and run with JDK 11 to JDK 18-EA releases.
 
@@ -39,7 +51,7 @@ Note this release requires at least JDK 11.
 ## November 18, 2021 -- Eclipse GlassFish 6.2.3 Available
 
 We are pleased to announce the release of Eclipse GlassFish 6.2.3. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.3 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.3 brings Admin console fixes, build times improvement, component updates, and bug fixes.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6.2.3 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.3 brings Admin console fixes, build times improvement, component updates, and bug fixes.
 
 GlassFish 6.2.3 compiles with JDK 11 to JDK 17 and runs on JDK 11 to JDK 17. GlassFish 6.2.3 also compiles and runs on JDK 18-EA releases.
 
@@ -48,7 +60,7 @@ Note this release requires at least JDK 11.
 ## October 1, 2021 -- Eclipse GlassFish 6.2.2 Available
 
 We are pleased to announce the release of Eclipse GlassFish 6.2.2. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.2 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.2 brings GlassFish embedded back to live, and contains an import fix for a memory leak. A major behind the scenes accomplishment is that all active tests now use JUnit 5.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6.2.2 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.2 brings GlassFish embedded back to live, and contains an import fix for a memory leak. A major behind the scenes accomplishment is that all active tests now use JUnit 5.
 
 GlassFish 6.2.2 compiles with JDK 11 to JDK 17 and runs on JDK 11 to JDK 17. GlassFish 6.2.2 has been briefly tested with JDK 18-EA releases.
 
@@ -57,7 +69,7 @@ Note this release requires at least JDK 11.
 ## August 28, 2021 -- Eclipse GlassFish 6.2.1 Available
 
 We are happy to announce the release of Eclipse GlassFish 6.2.1. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.2.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.1 now has much improved support for JDK 17, and includes new component Eclipse Exousia, the standalone Jakarta Authorization implementation. GlassFish 6.2.1 compiles with JDK 11 to JDK 17.
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6.2.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)). GlassFish 6.2.1 now has much improved support for JDK 17, and includes new component Eclipse Exousia, the standalone Jakarta Authorization implementation. GlassFish 6.2.1 compiles with JDK 11 to JDK 17.
 
 Note this release requires at least JDK 11.
 
@@ -65,7 +77,7 @@ Note this release requires at least JDK 11.
 ## May 25, 2021 -- Eclipse GlassFish 6.1 Available
 
 We are happy to announce the final release of Eclipse GlassFish 6.1. This release provides implementations
-of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)).
+of the Jakarta EE 9.1 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6.1 implements the Jakarta EE 9.1 specification ([Jakarta EE 9.1 Platform](https://jakarta.ee/specifications/platform/9.1/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9.1/)).
 
 Note this release requires JDK 11.
 
@@ -77,7 +89,7 @@ This is the first release candidate of Eclipse GlassFish 6.1 and is available fo
 ## December 31, 2020 -- Eclipse GlassFish 6 Stable Release
 
 We are pleased to announce the stable release of Eclipse GlassFish 6.0. This release provides implementations
-of the Jakarta EE 9 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](https://eclipse-ee4j.github.io/glassfish/download). Eclipse GlassFish 6 implements the Jakarta EE 9 specification ([Jakarta EE 9 Platform](https://jakarta.ee/specifications/platform/9/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9/)).
+of the Jakarta EE 9 Platform and Web Profile specifications. Download links are available from the [GlassFish Download page](download.md). Eclipse GlassFish 6 implements the Jakarta EE 9 specification ([Jakarta EE 9 Platform](https://jakarta.ee/specifications/platform/9/), [Jakarta EE 9 Web Profile](https://jakarta.ee/specifications/webprofile/9/)).
 
 ### October 24, 2020 -- Eclipse GlassFish 6.0 Release Candidate 1 is released
 

--- a/docs/website/src/main/resources/download.md
+++ b/docs/website/src/main/resources/download.md
@@ -1,25 +1,37 @@
 # Eclipse GlassFish Downloads
 
-## Eclipse GlassFish 7 milestone versions
+## Eclipse GlassFish 7.x
 
-GlassFish 7 version is going to provide Jakarta EE 10 and a lot of improvements and new features, including:
+Eclipse GlassFish 7.0.0 is a final release, containing final [Jakarta EE 10](https://jakarta.ee/specifications/platform/10) APIs and final Jakarta EE 10 implementation components. It compiles and runs on JDK 11 to JDK 19. MicroProfile support requires JDK 17 or higher.
 
-* Jakarta EE 10 Full Profile
-* Complete JDK 17 compatibility
-* Jakarta MVC 2.1
-* MicroProfile Config 3.0
-* Redesigned logging to improve logging performance
-* Embedded GlassFish Full Profile
-* A lot of performance improvements
-* A lot of security fixes and other fixes
+Download GlassFish Server:
 
-The final version of GlassFish 7 is not released yet but the latest milestone version already provides all the above features.
+* [Eclipse GlassFish 7.0.0, Jakarta EE Platform, 10](https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip)
+* [Eclipse GlassFish 7.0.0, Jakarta EE Web Profile, 10](https://download.eclipse.org/ee4j/glassfish/web-7.0.0.zip)
+
+Download GlassFish Embedded:
+
+* [Eclipse GlassFish Embedded 7.0.0, Jakarta EE Platform, 10](https://search.maven.org/artifact/org.glassfish.main.extras/glassfish-embedded-all/7.0.0/jar)
+* [Eclipse GlassFish Embedded 7.0.0, Jakarta EE Web Profile, 10](https://search.maven.org/artifact/org.glassfish.main.extras/glassfish-embedded-web/7.0.0/jar)
+
+More details:
+
+* [Eclipse GlassFish 7.0.0 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.0)
+* [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/) for more info about Jakarta EE 10
+
+### All Eclipse GlassFish 7.x Downloads
+
+Download all GlassFish 7.x releases at the [Eclipse GlassFish 7.x Downloads](download_gf7.md) page.
+
+----
+
+## Eclipse GlassFish Milestone & Nightly Downloads
 
 You can download the latest Eclipse GlassFish development milestone or nightly version in the [Eclipse Foundation Download portal](https://download.eclipse.org/ee4j/glassfish/).
 
-NOTE: The latest milestone version doesn't provide Admin Console (GUI for administering the server). This will be fixed in the final version of GlassFish 7.
+----
 
-## Eclipse GlassFish 6.2.5
+## Eclipse GlassFish 6.x
 
 GlassFish 6.2.5 updates and reenables a lot of tests that were disabled in previous versions (most after the GF 5 to 6 transition), once again improves JDK 17 compatibility (cases found by the new tests), fixes several bugs, and contains new versions of Hibernate Validator, Jackson and others.
 
@@ -28,92 +40,18 @@ For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specific
 * [Eclipse GlassFish 6.2.5, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.5.zip)
 * [Eclipse GlassFish 6.2.5, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.5.zip)
 
-## Eclipse GlassFish 6.2.4
+### All Eclipse GlassFish 6.x Downloads
 
-GlassFish 6.2.4 brings initial support for JDK 18 (tested until ea29) and adds running several standalone Jakarta EE TCKs directly from the project. An import internal fix is removing a troublesome circular dependency between GlassFish and Jersey.
+Download all GlassFish 6.x releases at the [Eclipse GlassFish 6.x Downloads](download_gf6.md) page.
 
-For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
+----
 
-* [Eclipse GlassFish 6.2.4, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.4.zip)
-* [Eclipse GlassFish 6.2.4, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.4.zip)
-
-## Eclipse GlassFish 6.2.3
-
-GlassFish 6.2.3 brings Admin console fixes, build times improvement, component updates, and bug fixes.
-
-For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
-
-* [Eclipse GlassFish 6.2.3, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.3.zip)
-* [Eclipse GlassFish 6.2.3, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.3.zip)
-
-## Eclipse GlassFish 6.2.2
-
-GlassFish 6.2.2 brings GlassFish embedded back to live, and contains an import fix for a memory leak. A major behind the scenes accomplishment is that all active tests now use JUnit 5.
-
-For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
-
-* [Eclipse GlassFish 6.2.2, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.2.zip)
-* [Eclipse GlassFish 6.2.2, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.2.zip)
-
-## Eclipse GlassFish 6.2.1
-
-GlassFish 6.2.1 brings integration of Eclipse Exousia, component updates, bug fixes.
-
-For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
-
-The major change is support for JDK 17.
-
-* [Eclipse GlassFish 6.2.1, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.1.zip)
-* [Eclipse GlassFish 6.2.1, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.1.zip)
-
-## Eclipse GlassFish 6.1
-
-Release Candidate build of Eclipse GlassFish is available for trial usage. This release will be certified compatible with
-Jakarta EE 9.1. This release supports JDK 11.
-
-The latest stable release for Eclipse GlassFish 6.1. It is functionally complete and meets the compatibility requirements of the approved final version of the Jakarta EE 9.1 Specification. Downloads are provided for both Jakarta EE Platform 9.1 and Jakarta EE Web Profile 9.1.
-For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/). 
-
-Other than bug-fixes, the major change is support for JDK 11.
-
-* [Eclipse GlassFish 6.1.0, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.1.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/glassfish-6.1.0.info)
-* [Eclipse GlassFish 6.1.0, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.1.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/web-6.1.0.info)
-
-## Eclipse GlassFish 6
-
-The latest stable release for Eclipse GlassFish 6.0. It is functionally complete and meets the compatibility requirements of the approved final version of the Jakarta EE 9 Specification. Downloads are provided for both Jakarta EE Platform 9 and Jakarta EE Web Profile 9.
-For more details on Jakarta EE 9, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/). 
-
-NOTE: Users upgrading from Jakarta EE 8 to Jakarta EE 9 may want to review the Spec. changes describing how to upgrade an EE 8 application to EE 9 (for example, you might start by watching [this video](https://youtu.be/3ClvncBrKJw?t=405)).
-
-* [Eclipse GlassFish 6.0.0, Jakarta EE Platform, 9](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0.info)
-* [Eclipse GlassFish 6.0.0, Jakarta EE Web Profile, 9](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.0.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/web-6.0.0.info)
-
-We welcome your feedback! Please include the details provided in the **info** link when reporting any [issues](https://github.com/eclipse-ee4j/glassfish/issues).
-
-
-## Eclipse GlassFish 5.1 Downloads
+## Eclipse GlassFish 5.x
 
 The latest stable releases of Eclipse GlassFish 5.1. This version is compatible with Jakarta EE 8 Specification.
 
 * [Eclipse GlassFish 5.1.0 - Jakarta EE Platform, 8](https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip)
 * [Eclipse GlassFish 5.1.0 - Jakarta EE Web Profile, 8](https://www.eclipse.org/downloads/download.php?file=/glassfish/web-5.1.0.zip)
-
-----
-
-# Legacy
-
-The downloads below are for legacy use only. Most users will want to use the stable releases listed above.
-
-### Eclipse GlassFish 6, Release Candidate 2
-
-This is the first release candidate for GlassFish 6.0 and is functionally complete and has passed an in-progress version of the Jakarta EE 9 TCK for both Web Profile and Full Profile.
-For more details on Jakarta EE 9, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/). We welcome your feedback! Please include the details provided in the **info** link when reporting any [issues](https://github.com/eclipse-ee4j/glassfish/issues).
-
-* [Eclipse GlassFish 6.0.0-RC2, Jakarta EE Platform 9](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-RC2.zip), - [info](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-RC2.info)
-* [Eclipse Glassfish Web Profile 6.0.0-RC2 Jakarta EE Web Profile 9](https://download.eclipse.org/ee4j/glassfish/web-6.0.0-RC2.zip), - [info](https://download.eclipse.org/ee4j/glassfish/web-6.0.0-RC2.info)
-
-
 
 
 ----

--- a/docs/website/src/main/resources/download_gf6.md
+++ b/docs/website/src/main/resources/download_gf6.md
@@ -1,0 +1,75 @@
+# Eclipse GlassFish 6.x Downloads
+
+## Eclipse GlassFish 6.2.5
+
+GlassFish 6.2.5 updates and reenables a lot of tests that were disabled in previous versions (most after the GF 5 to 6 transition), once again improves JDK 17 compatibility (cases found by the new tests), fixes several bugs, and contains new versions of Hibernate Validator, Jackson and others.
+
+For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
+
+* [Eclipse GlassFish 6.2.5, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.5.zip)
+* [Eclipse GlassFish 6.2.5, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.5.zip)
+
+## Eclipse GlassFish 6.2.4
+
+GlassFish 6.2.4 brings initial support for JDK 18 (tested until ea29) and adds running several standalone Jakarta EE TCKs directly from the project. An import internal fix is removing a troublesome circular dependency between GlassFish and Jersey.
+
+For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
+
+* [Eclipse GlassFish 6.2.4, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.4.zip)
+* [Eclipse GlassFish 6.2.4, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.4.zip)
+
+## Eclipse GlassFish 6.2.3
+
+GlassFish 6.2.3 brings Admin console fixes, build times improvement, component updates, and bug fixes.
+
+For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
+
+* [Eclipse GlassFish 6.2.3, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.3.zip)
+* [Eclipse GlassFish 6.2.3, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.3.zip)
+
+## Eclipse GlassFish 6.2.2
+
+GlassFish 6.2.2 brings GlassFish embedded back to live, and contains an import fix for a memory leak. A major behind the scenes accomplishment is that all active tests now use JUnit 5.
+
+For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
+
+* [Eclipse GlassFish 6.2.2, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.2.zip)
+* [Eclipse GlassFish 6.2.2, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.2.zip)
+
+## Eclipse GlassFish 6.2.1
+
+GlassFish 6.2.1 brings integration of Eclipse Exousia, component updates, bug fixes.
+
+For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/).
+
+The major change is support for JDK 17.
+
+* [Eclipse GlassFish 6.2.1, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.2.1.zip)
+* [Eclipse GlassFish 6.2.1, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.2.1.zip)
+
+## Eclipse GlassFish 6.1
+
+Release Candidate build of Eclipse GlassFish is available for trial usage. This release will be certified compatible with
+Jakarta EE 9.1. This release supports JDK 11.
+
+The latest stable release for Eclipse GlassFish 6.1. It is functionally complete and meets the compatibility requirements of the approved final version of the Jakarta EE 9.1 Specification. Downloads are provided for both Jakarta EE Platform 9.1 and Jakarta EE Web Profile 9.1.
+For more details on Jakarta EE 9.1, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/). 
+
+Other than bug-fixes, the major change is support for JDK 11.
+
+* [Eclipse GlassFish 6.1.0, Jakarta EE Platform, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.1.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/glassfish-6.1.0.info)
+* [Eclipse GlassFish 6.1.0, Jakarta EE Web Profile, 9.1](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.1.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/web-6.1.0.info)
+
+## Eclipse GlassFish 6
+
+The latest stable release for Eclipse GlassFish 6.0. It is functionally complete and meets the compatibility requirements of the approved final version of the Jakarta EE 9 Specification. Downloads are provided for both Jakarta EE Platform 9 and Jakarta EE Web Profile 9.
+For more details on Jakarta EE 9, please see the [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/). 
+
+NOTE: Users upgrading from Jakarta EE 8 to Jakarta EE 9 may want to review the Spec. changes describing how to upgrade an EE 8 application to EE 9 (for example, you might start by watching [this video](https://youtu.be/3ClvncBrKJw?t=405)).
+
+* [Eclipse GlassFish 6.0.0, Jakarta EE Platform, 9](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-6.0.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0.info)
+* [Eclipse GlassFish 6.0.0, Jakarta EE Web Profile, 9](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-6.0.0.zip), - [info](https://download.eclipse.org/ee4j/glassfish/web-6.0.0.info)
+
+We welcome your feedback! Please include the details provided in the **info** link when reporting any [issues](https://github.com/eclipse-ee4j/glassfish/issues).
+
+

--- a/docs/website/src/main/resources/download_gf7.md
+++ b/docs/website/src/main/resources/download_gf7.md
@@ -1,0 +1,17 @@
+# Eclipse GlassFish 7.x Downloads
+
+### GlassFish 7.0.0
+
+Eclipse GlassFish 7.0.0 is a final release, containing final [Jakarta EE 10](https://jakarta.ee/specifications/platform/10) APIs and final Jakarta EE 10 implementation components. It compiles and runs on JDK 11 to JDK 19. MicroProfile support requires JDK 17 or higher.
+
+Download:
+
+* [Eclipse GlassFish 7.0.0, Jakarta EE Platform, 10](https://download.eclipse.org/ee4j/glassfish/glassfish-7.0.0.zip)
+* [Eclipse GlassFish 7.0.0, Jakarta EE Web Profile, 10](https://download.eclipse.org/ee4j/glassfish/web-7.0.0.zip)
+* [Eclipse GlassFish Embedded 7.0.0, Jakarta EE Full Profile, 10](https://search.maven.org/artifact/org.glassfish.main.extras/glassfish-embedded-all/7.0.0/jar)
+* [Eclipse GlassFish Embedded 7.0.0, Jakarta EE Web Profile, 10](https://search.maven.org/artifact/org.glassfish.main.extras/glassfish-embedded-web/7.0.0/jar)
+
+More details:
+
+* [Eclipse GlassFish 7.0.0 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.0)
+* [Jakarte EE Platform Specification Project](https://eclipse-ee4j.github.io/jakartaee-platform/) for more info about Jakarta EE 10


### PR DESCRIPTION
Depends on https://github.com/eclipse-ee4j/glassfish/pull/24237

- use a newer Antrun plugin (works with target element)
- generate docs for GF 6 and 7, 7 is the latest

WARNING: Build fails until org.glassfish.docs:distribution version 6.2.5 and 7.0.0 are deployed to Maven repo