### PR TITLE
Issue #24228 Fixed shutdown monitoring

### DIFF
--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopInstanceInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopInstanceInstanceCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,17 +17,24 @@
 
 package com.sun.enterprise.v3.admin.cluster;
 
-
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.v3.admin.StopServer;
-import org.glassfish.api.Async;
-import org.glassfish.api.Param;
-import org.glassfish.api.admin.*;
+
 import jakarta.inject.Inject;
 
-import org.jvnet.hk2.annotations.Service;
+import org.glassfish.api.Async;
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
 
 /**
  * AdminCommand to stop the instance
@@ -59,6 +67,7 @@ public class StopInstanceInstanceCommand extends StopServer implements AdminComm
     @Param(optional = true, defaultValue = "true")
     private Boolean force = true;
 
+    @Override
     public void execute(AdminCommandContext context) {
 
         if (!env.isInstance()) {

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -90,6 +90,10 @@ public final class ProcessUtils {
     }
 
 
+    /**
+     * @param pidFile
+     * @return true if the pid file exists and the process with the pid inside is alive.
+     */
     public static boolean isAlive(final File pidFile) {
         if (!pidFile.exists()) {
             return false;

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiGlassFishRuntimeBuilder.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiGlassFishRuntimeBuilder.java
@@ -194,13 +194,15 @@ public final class OSGiGlassFishRuntimeBuilder implements RuntimeBuilder {
     private void deleteHK2Cache(Properties properties) throws GlassFishException {
         // This is a HACK - thanks to some weired optimization trick
         // done for GlassFish. HK2 maintains a cache of inhabitants and
-        // that needs  to be recreated when there is a change in modules dir.
+        // that needs to be recreated when there is a change in modules dir.
         final String cacheDir = properties.getProperty(HK2_CACHE_DIR);
         if (cacheDir != null) {
             File inhabitantsCache = new File(cacheDir, INHABITANTS_CACHE);
             if (inhabitantsCache.exists()) {
+                logger.logp(Level.CONFIG, "OSGiGlassFishRuntimeBuilder", "deleteHK2Cache",
+                    "Deleting OSGI inhabitants cache {0} ...", inhabitantsCache);
                 if (!inhabitantsCache.delete()) {
-                    throw new GlassFishException("cannot delete cache:" + inhabitantsCache.getAbsolutePath());
+                    throw new GlassFishException("Cannot delete cache: " + inhabitantsCache.getAbsolutePath());
                 }
             }
         }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/StopDomainCommand.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/StopDomainCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,17 +17,23 @@
 
 package com.sun.enterprise.v3.admin;
 
-import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.util.LocalStringManagerImpl;
+
+import jakarta.inject.Inject;
+
 import org.glassfish.api.Async;
 import org.glassfish.api.I18n;
 import org.glassfish.api.Param;
-import org.glassfish.api.admin.*;
-import jakarta.inject.Inject;
-import org.jvnet.hk2.annotations.Service;
-
+import org.glassfish.api.admin.AccessRequired;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
 
 /**
  * AdminCommand to stop the domain execution which mean shuting down the application
@@ -57,6 +64,7 @@ public class StopDomainCommand extends StopServer implements AdminCommand {
      * All running services are stopped.
      * LookupManager is flushed.
      */
+    @Override
     public void execute(AdminCommandContext context) {
 
         if (!env.isDas()) {


### PR DESCRIPTION
- The pid file was removed twice while it is used to check if the instance is still running.
- faster check to increase probability of issues if there are some - and also to be really faster :-)
- Local testing: start: 2200-2500 ms, stop: 30-1200 ms (the slower value after undeploy in tests).
- Added log for failures.
- The javadoc was not right, it is not possible in current Java versions with the current GlassFish implementation, but it is possible to avoid hooks by using SIGKILL signal. But that isn't an issue any more, because since GF7 we use ProcessHandles to check if the process is running, while old versions used commands of the operating system.
- However, I am still not sure if this is enough to resolve the issue, because Felix really writes to the osgi cache until the real end. But JVM hooks are executed AFTER parallely executed application hooks and the DeleteOnExitHook should be the last one. That should remove the pid file. Then asadmin command checks if it exists or not, if it exists, it loads it's content and checks handles if the process is alive or not. On startup it checks the same, so there is no problem.
- Tested CTRL+C, SIGKILL, pid, stop, --force, --kill, restart-domain, everything works now.

Copy-pasted comment from the DeleteOnExitHook in the JDK17 (same at least from JDK8, I don't see older in Eclipse):
```
        // DeleteOnExitHook must be the last shutdown hook to be invoked.
        // Application shutdown hooks may add the first file to the
        // delete on exit list and cause the DeleteOnExitHook to be
        // registered during shutdown in progress. So set the
        // registerShutdownInProgress parameter to true.
```

The last commit fixed the issue (tested locally, let's see what Jenkins says).
- For local domains: domain stopped if (it is not listening on port AND (the pid file doesn't exist OR the process with the pid is not alive).
- For remote domains: domain stopped if it is not listening. Therefore when we stop remote domain, it stops listening, but then still does a cleanup for some time. But we cannot see it, for us it stopped.

This PR finishes what started here: https://github.com/eclipse-ee4j/glassfish/pull/24200 (I hope I did not miss any use case).