### PR TITLE
Classloader security - the fixed package.policy parameter

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/loader/WebappLoader.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/loader/WebappLoader.java
@@ -64,6 +64,7 @@ import org.apache.catalina.LifecycleListener;
 import org.apache.catalina.Loader;
 import org.apache.catalina.LogFacade;
 import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.security.SecurityUtil;
 import org.apache.catalina.util.LifecycleSupport;
 import org.apache.catalina.util.StringManager;
 import org.apache.naming.resources.DirContextURLStreamHandler;
@@ -806,22 +807,19 @@ public class WebappLoader
         }
 
         try {
-            AccessController.doPrivileged(
-                  new PrivilegedExceptionAction<Object>() {
-                    @Override
-                    public Object run() throws SecurityException {
-                        setPermissions_priv();
-                        return null;
-                    }
-                });
-            } catch (PrivilegedActionException e) {
-                throw (SecurityException ) e.getException();
-            }
+            PrivilegedExceptionAction<Object> action = () -> {
+                setPermissions_priv();
+                return null;
+            };
+            AccessController.doPrivileged(action);
+        } catch (PrivilegedActionException e) {
+            throw (SecurityException) e.getException();
+        }
     }
 
 
     private void setPermissions_priv() {
-
+        classLoader.setPackageDefinitionSecurityEnabled(SecurityUtil.isPackageProtectionEnabled());
 
         // Tell the class loader the root of the context
         ServletContext servletContext =

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/security/SecurityUtil.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/security/SecurityUtil.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,28 +18,29 @@
 
 package org.apache.catalina.security;
 
-
-import org.apache.catalina.Globals;
-import org.apache.catalina.LogFacade;
-import org.apache.catalina.util.StringManager;
-
-import javax.security.auth.Subject;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.security.Security;
 import java.util.HashMap;
-import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.security.auth.Subject;
+
+import org.apache.catalina.Globals;
+import org.apache.catalina.LogFacade;
+
 /**
  * This utility class associates a <code>Subject</code> to the current
  * <code>AccessControlContext</code>. When a <code>SecurityManager</code> is
@@ -50,7 +52,6 @@ import java.util.logging.Logger;
  *
  * @author Jean-Francois Arcand
  */
-
 public final class SecurityUtil{
 
     private final static int INIT= 0;
@@ -66,22 +67,14 @@ public final class SecurityUtil{
     /**
      * Cache every object for which we are creating method on it.
      */
-    private static HashMap<Object, Method[]> objectCache =
-        new HashMap<Object, Method[]>();
+    private static HashMap<Object, Method[]> objectCache = new HashMap<>();
 
     private static final Logger log = LogFacade.getLogger();
-    private static final ResourceBundle rb = log.getResourceBundle();
 
-    private static boolean packageDefinitionEnabled = (
-         System.getProperty("package.definition") == null ||
-         System.getProperty("package.definition").equals("")) ? false : true;
-
-    // START SJS WS 7.0 6236329
     /**
      * Do we need to execute all invokation under a Subject.doAs call.
      */
     public static final boolean executeUnderSubjectDoAs = true;
-    // END SJS WS 7.0 6236329
 
 
     /**
@@ -270,7 +263,8 @@ public final class SecurityUtil{
         try{
             Subject subject = null;
             PrivilegedExceptionAction<Void> pea =
-                new PrivilegedExceptionAction<Void>(){
+                new PrivilegedExceptionAction<>(){
+                    @Override
                     public Void run() throws Exception{
                        method.invoke(targetObject, targetArguments);
                        return null;
@@ -319,16 +313,17 @@ public final class SecurityUtil{
                 log.log(Level.FINE, LogFacade.PRIVILEGE_ACTION_EXCEPTION, e);
             }
 
-            if (e instanceof UnavailableException)
+            if (e instanceof UnavailableException) {
                 throw (UnavailableException) e;
-            else if (e instanceof ServletException)
+            } else if (e instanceof ServletException) {
                 throw (ServletException) e;
-            else if (e instanceof IOException)
+            } else if (e instanceof IOException) {
                 throw (IOException) e;
-            else if (e instanceof RuntimeException)
+            } else if (e instanceof RuntimeException) {
                 throw (RuntimeException) e;
-            else
+            } else {
                 throw new ServletException(e.getMessage(), e);
+            }
         }
     }
 
@@ -410,10 +405,11 @@ public final class SecurityUtil{
      * package protection mechanism is enabled.
      */
     public static boolean isPackageProtectionEnabled(){
-        if (packageDefinitionEnabled && Globals.IS_SECURITY_ENABLED) {
-            return true;
+        if (!Globals.IS_SECURITY_ENABLED) {
+            return false;
         }
-        return false;
+        String value = Security.getProperty("package.definition");
+        return value != null && !value.isEmpty();
     }
 
 

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/security/SecurityUtil.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/security/SecurityUtil.java
@@ -28,7 +28,9 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.AccessController;
 import java.security.Principal;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.security.Security;
@@ -408,7 +410,8 @@ public final class SecurityUtil{
         if (!Globals.IS_SECURITY_ENABLED) {
             return false;
         }
-        String value = Security.getProperty("package.definition");
+        PrivilegedAction<String> action = () -> Security.getProperty("package.definition");
+        String value = AccessController.doPrivileged(action);
         return value != null && !value.isEmpty();
     }
 

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -178,6 +178,8 @@ jakarta.mail.level=INFO
 
 jakarta.ws.rs.client.level=INFO
 
+jdk.event.security.level=INFO
+
 MBeans.level=INFO
 
 org.apache.catalina.level=INFO


### PR DESCRIPTION
* The setter - Catalina parses and sets the property to the Security.setProperty, then originally WebappCl parsed this property (from wrong class, System). I have connected them together this way; I expect that Catalina configures the property (via it's constructor) before any creation of the WebappCL.
* Fixes #24245 
* Depends on #24243 
* I tried to compare files in history and it seems to me that it was always broken ... but I may be wrong. 
* Despite the first commit fixed the setting in WebappClassLoader, the feature still did not work.
* The second commit added some logs and then I was able to follow what is happening and fix the behavior.
* Then failed six QuickLook tests, because the server chose a secured path which was broken (see reflections in the `ApplicationContextFacade`)