### PR TITLE
Security fix: regexp catastrophic backtracking fix

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/parser/ODLLogParser.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/parser/ODLLogParser.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,7 +35,7 @@ final class ODLLogParser implements LogParser {
     private static final int FIXED_FIELD_COUNT = 5;
     private static final Pattern RECORD_START = Pattern.compile("^\\[" + P_TIMESTAMP + "\\].*");
     private static final Pattern FIELD = Pattern.compile("(\\[[^\\[\\]\n]*\\])+");
-    private static final Pattern THREAD_FIELD = Pattern.compile("[ ]*_ThreadID=(.+) _ThreadName=(.+)");
+    private static final Pattern THREAD_FIELD = Pattern.compile("[^_]*_ThreadID=(.+) _ThreadName=(.+)");
 
     @Override
     public void parseLog(BufferedReader reader, LogParserListener listener) throws LogParserException {

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogManager.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogManager.java
@@ -486,9 +486,7 @@ public class GlassFishLogManager extends LogManager {
             return super.addLogger(newLogger);
         }
         // CORBA and IMQ stand aside
-        PrivilegedAction<Boolean> action = () -> {
-            return super.addLogger(newLogger);
-        };
+        PrivilegedAction<Boolean> action = () -> super.addLogger(newLogger);
         return AccessController.doPrivileged(action);
     }
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/ConfigurationHelper.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/ConfigurationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
+import java.util.stream.Collectors;
 
 import org.glassfish.main.jul.tracing.GlassFishLoggingTracer;
 
@@ -85,7 +86,7 @@ public class ConfigurationHelper {
         if (v == null || v.isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.asList(v.split("[\\s]*,[\\s]*"));
+        return Arrays.stream(v.split(",")).map(String::trim).collect(Collectors.toList());
     };
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/LogFormatDetector.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/LogFormatDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -132,7 +132,7 @@ public class LogFormatDetector {
      * @return true if the given line is probably a beginning of a {@link OneLineFormatter}'s log record.
      */
     public boolean isOneLineLFormatLogHeader(final String firstLine) {
-        return firstLine.matches(P_TIME + "\\s+[A-Z]{4,13}\\s+[^\\s]+\\s+[^\\s]+\\s+[^\\s]+\\s+.+");
+        return firstLine.matches(P_TIME + "\\s+[A-Z]{4,13}\\s+.+\\s+.+\\s+.+");
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/cfg/ConfigurationHelperTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/cfg/ConfigurationHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,9 @@ package org.glassfish.main.jul.cfg;
 
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author David Matejcek
  */
-public class ConfigurationHelperTest {
+class ConfigurationHelperTest {
 
     @Test
     void getBoolean() {
@@ -40,5 +43,17 @@ public class ConfigurationHelperTest {
             () -> assertNull(helper.getBoolean(() -> "boolean.unset", null), "boolean.unset and null as default"),
             () -> assertTrue(helper.getBoolean(() -> "boolean.unset", true), "boolean.unset and true as default")
         );
+    }
+
+
+    @Test
+    void getList() {
+        final ConfigurationHelper helper = new ConfigurationHelper(ConfigurationHelperTest.class.getPackage().getName(),
+            ConfigurationHelper.ERROR_HANDLER_PRINT_TO_STDERR);
+        assertAll(
+            () -> assertThat(helper.getList(() -> "multilineList", null), hasSize(2)),
+            () -> assertThat(helper.getList(() -> "multilineList", null), contains("abc", "def"))
+        );
+
     }
 }

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/cfg/LoggingPropertiesTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/cfg/LoggingPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class LoggingPropertiesTest {
 
-    public static final int PROPERTY_COUNT = 11;
+    public static final int PROPERTY_COUNT = 12;
 
     @Test
     void conversions() throws Exception {

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/formatter/LogFormatDetectorTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/formatter/LogFormatDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -98,6 +98,16 @@ public class LogFormatDetectorTest {
         assertAll(
             () -> assertFalse(detector.isCompressedFile("xxx.log")),
             () -> assertTrue(detector.isCompressedFile("xxx.gz"))
+        );
+    }
+
+
+    @Test
+    public void isOneLineFormat() {
+        assertAll(
+            () -> assertFalse(detector.isOneLineLFormatLogHeader("22:22:15.796552    INFO thread")),
+            () -> assertTrue(detector.isOneLineLFormatLogHeader("22:22:15.796552    INFO t c m")),
+            () -> assertTrue(detector.isOneLineLFormatLogHeader("22:22:15.796552    INFO t c m xxx xxx x "))
         );
     }
 }

--- a/nucleus/glassfish-jul-extension/src/test/resources/logging.properties
+++ b/nucleus/glassfish-jul-extension/src/test/resources/logging.properties
@@ -12,6 +12,9 @@ org.glassfish.main.jul.GlassFishLogManagerLifeCycleTest.level=FINE
 org.glassfish.main.jul.cfg.boolean.false=false
 org.glassfish.main.jul.cfg.boolean.true=true
 org.glassfish.main.jul.cfg.boolean.incorrect=This value is not a boolean
+org.glassfish.main.jul.cfg.multilineList=\
+abc,\
+def
 
 # JUnit uses logging too and can cause deadlock, because tries to log between test phases
 # when we locked logging. Then it cannot run test which would unlock it.


### PR DESCRIPTION
- Based on SonarQube report: https://sonarcloud.io/project/security_hotspots?id=dmatej_glassfish&sinceLeakPeriod=true&tab=code
- Also fixed OneLine detection, there was one block more than required
- https://rules.sonarsource.com/java/RSPEC-5852
