### PR TITLE
Fixed dependency on LANG env property in QL tests

### DIFF
--- a/gftest.sh
+++ b/gftest.sh
@@ -20,6 +20,7 @@ export WORKSPACE=`pwd`
 export S1AS_HOME="${WORKSPACE}/glassfish7/glassfish"
 export APS_HOME="${WORKSPACE}/appserver/tests/appserv-tests"
 export TEST_RUN_LOG="${WORKSPACE}/tests-run.log"
+export LANG="en_US.UTF-8"
 
 echo WORKSPACE =  $WORKSPACE
 echo S1AS_HOME =  $S1AS_HOME


### PR DESCRIPTION
Caused failure of 2 QL tests which printed validation messages in czech language and failed the validation