### PR TITLE
Drop mvn's `-T` option

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
           uname -a
 
           # Until we fix ANTLR in cmp-support-sqlstore, broken in parallel builds. Just -Pfast after the fix.
-          mvn clean install -Pfastest,staging -T4C
+          mvn clean install -Pfastest,staging
           ./gfbuild.sh archive_bundles
           mvn clean
           tar -c -C ${WORKSPACE}/appserver/tests common_test.sh gftest.sh appserv-tests quicklook | gzip --fast > ${WORKSPACE}/bundles/appserv_tests.tar.gz

--- a/gfbuild.sh
+++ b/gfbuild.sh
@@ -67,7 +67,7 @@ archive_bundles(){
 }
 
 dev_build(){
-  mvn -U clean install -Pstaging,fastest -T2C ${MVN_EXTRA}
+  mvn -U clean install -Pstaging,fastest ${MVN_EXTRA}
 }
 
 build_re_dev(){


### PR DESCRIPTION
Parallel build uses goals not marked as `@threadSafe` by plugins:
```
 [WARNING] org.glassfish.build:glassfishbuild-maven-plugin:3.2.27
 [WARNING] org.glassfish.build:spec-version-maven-plugin:2.1
 [WARNING] org.glassfish.hk2:config-generator:2.5.0-b53
 [WARNING] org.glassfish.hk2:consolidatedbundle-maven-plugin:3.0.3
 [WARNING] org.glassfish.hk2:hk2-inhabitant-generator:3.0.3
 [WARNING] org.omnifaces:antlr-maven-plugin:2.4
```

Thus I propose to consider **not using** `-T` option, until above are upgraded.

`-T`s seem to be introduced in
- https://github.com/eclipse-ee4j/glassfish/pull/23770

but in that PR the usage of non-threadSafe goals and warnings from maven are not discussed.