### PR TITLE
Fix website build after #24238 was merged

### DIFF
--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -227,7 +227,7 @@
                                           />
                                         <symlink
                                           link="${site.output.dir}/docs/latest"
-                                          resource="${docs.7x.dir}"/>
+                                          resource="${docs.version}"/>
                                     </target>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
In #24238, the way how the `latest` link to the docs for the latest version is generated was changed and generated an absolute link. This fails the build of the website: https://github.com/eclipse-ee4j/glassfish/actions/runs/3998736326

This PR reverts this change - the `latest` link should be relative, so that it works on any machine, in any directory.