### PR TITLE
Uberjar compilable again

### DIFF
--- a/appserver/extras/embedded/common/bootstrap/src/main/java/org/glassfish/uberjar/UberJarMain.java
+++ b/appserver/extras/embedded/common/bootstrap/src/main/java/org/glassfish/uberjar/UberJarMain.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,16 +17,18 @@
 
 package org.glassfish.uberjar;
 
-import org.glassfish.embeddable.BootstrapProperties;
-import org.glassfish.embeddable.GlassFish;
-import org.glassfish.embeddable.GlassFishRuntime;
+import com.sun.enterprise.glassfish.bootstrap.Constants;
+import com.sun.enterprise.glassfish.bootstrap.Constants.Platform;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Properties;
 import java.util.logging.Logger;
 
+import org.glassfish.embeddable.BootstrapProperties;
+import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
 
 /**
  *
@@ -33,7 +36,6 @@ import org.glassfish.embeddable.GlassFishProperties;
  *
  * @author bhavanishankar@dev.java.net
  */
-
 public class UberJarMain {
 
     private static Logger logger = Logger.getLogger("embedded-glassfish");
@@ -73,11 +75,12 @@ public class UberJarMain {
 
     private void privilegedStart() throws Exception {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
             public Void run() {
                 try {
                     Properties props = new Properties();
-                    props.setProperty(BootstrapProperties.PLATFORM_PROPERTY_KEY,
-                            System.getProperty(BootstrapProperties.PLATFORM_PROPERTY_KEY, BootstrapProperties.Platform.Felix.toString()));
+                    props.setProperty(Constants.PLATFORM_PROPERTY_KEY,
+                            System.getProperty(Constants.PLATFORM_PROPERTY_KEY, Platform.Felix.name()));
 
                     long startTime = System.currentTimeMillis();
 

--- a/appserver/extras/embedded/common/bootstrap/src/main/java/org/glassfish/uberjar/activator/UberJarGlassFishActivator.java
+++ b/appserver/extras/embedded/common/bootstrap/src/main/java/org/glassfish/uberjar/activator/UberJarGlassFishActivator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +17,14 @@
 
 package org.glassfish.uberjar.activator;
 
+import com.sun.enterprise.glassfish.bootstrap.Constants;
+import com.sun.enterprise.glassfish.bootstrap.Constants.Platform;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Properties;
+import java.util.logging.Logger;
+
 import org.glassfish.embeddable.BootstrapProperties;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishProperties;
@@ -23,11 +32,6 @@ import org.glassfish.embeddable.GlassFishRuntime;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.launch.Framework;
-
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Properties;
-import java.util.logging.Logger;
 
 /**
  * This is an activator to allow just dropping the uber jar
@@ -46,6 +50,7 @@ public class UberJarGlassFishActivator implements BundleActivator {
             "org.glassfish.embedded.osgimain.autostartBundles";
 
 
+    @Override
     public void start(BundleContext bundleContext) throws Exception {
         privilegedStart(bundleContext);
 
@@ -86,10 +91,11 @@ public class UberJarGlassFishActivator implements BundleActivator {
 
     private void privilegedStart(final BundleContext bundleContext) throws Exception {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
             public Void run() {
                 try {
                     Properties props = new Properties();
-                    props.setProperty(BootstrapProperties.PLATFORM_PROPERTY_KEY, BootstrapProperties.Platform.Felix.toString());
+                    props.setProperty(Constants.PLATFORM_PROPERTY_KEY, Platform.Felix.name());
 
                     logger.info("ThreadContextClassLoader = " + Thread.currentThread().getContextClassLoader() +
                             ", classloader = " + getClass().getClassLoader());
@@ -128,6 +134,7 @@ public class UberJarGlassFishActivator implements BundleActivator {
         });
     }
 
+    @Override
     public void stop(BundleContext bundleContext) throws Exception {
         logger.info("EmbeddedGlassFishActivator is stopped");
     }

--- a/appserver/extras/embedded/common/installroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/installroot-builder/pom.xml
@@ -66,6 +66,12 @@
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <type>zip</type>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
-
 </project>

--- a/appserver/extras/embedded/common/instanceroot-builder/pom.xml
+++ b/appserver/extras/embedded/common/instanceroot-builder/pom.xml
@@ -66,6 +66,13 @@
             <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <type>zip</type>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/appserver/extras/embedded/pom.xml
+++ b/appserver/extras/embedded/pom.xml
@@ -32,6 +32,7 @@
     <name>GlassFish Embedded modules</name>
 
     <modules>
+        <module>common</module>
         <module>all</module>
         <module>nucleus</module>
         <module>web</module>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -14,7 +14,6 @@
     https://www.gnu.org/software/classpath/license.html.
 
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,21 +34,6 @@
     <modules>
         <module>jakartaee</module>
         <module>appserv-rt</module>
+        <module>embedded</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>embedded</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <modules>
-                <module>embedded</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/BootstrapProperties.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/BootstrapProperties.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,15 +21,23 @@ import java.util.Properties;
 
 /**
  * Encapsulates the set of properties required to bootstrap GlassFishRuntime.
- * <p/>
- * <p/>Eg.., GlassFishRuntime.bootstrap(new BootstrapProperties());
+ *
+ * <pre>
+ * ...
+ * GlassFishRuntime runtime = GlassFishRuntime.bootstrap(new BootstrapProperties());
+ * GlassFish glassfish = runtime.newGlassFish(glassFishProperties);
+ * ...
+ * </pre>
  *
  * @author bhavanishankar@dev.java.net
  * @author Prasad.Subramanian@Sun.COM
  */
 public class BootstrapProperties {
 
-    private Properties properties;
+    /** Key for specifying which installation root the GlassFish should run with. */
+    private static final String INSTALL_ROOT_PROP_NAME = "com.sun.aas.installRoot";
+
+    private final Properties properties;
 
     /**
      * Create BootstrapProperties with default properties.
@@ -67,6 +76,24 @@ public class BootstrapProperties {
     }
 
     /**
+     * Optionally set the installation root using which the GlassFish should run.
+     *
+     * @param installRoot Location of installation root.
+     */
+    public void setInstallRoot(String installRoot) {
+        properties.setProperty(INSTALL_ROOT_PROP_NAME, installRoot);
+    }
+
+    /**
+     * Get the location installation root set using {@link #setInstallRoot}
+     *
+     * @return Location of installation root set using {@link #setInstallRoot}
+     */
+    public String getInstallRoot() {
+        return properties.getProperty(INSTALL_ROOT_PROP_NAME);
+    }
+
+    /**
      * Set any custom bootstrap property. May be required for the plugged in
      * {@link org.glassfish.embeddable.spi.RuntimeBuilder} (if any)
      *
@@ -87,25 +114,8 @@ public class BootstrapProperties {
         return properties.getProperty(key);
     }
 
-    /**
-     * Optionally set the installation root using which the GlassFish should run.
-     *
-     * @param installRoot Location of installation root.
-     * @return This object after setting the installation root.
-     */
-    public void setInstallRoot(String installRoot) {
-        properties.setProperty(INSTALL_ROOT_PROP_NAME, installRoot);
+    @Override
+    public String toString() {
+        return super.toString() + "[" + properties + "]";
     }
-
-    /**
-     * Get the location installation root set using {@link #setInstallRoot}
-     *
-     * @return Location of installation root set using {@link #setInstallRoot}
-     */
-    public String getInstallRoot() {
-        return properties.getProperty(INSTALL_ROOT_PROP_NAME);
-    }
-
-    // Key for specifying which installation root the GlassFish should run with.
-    private static final String INSTALL_ROOT_PROP_NAME = "com.sun.aas.installRoot";
 }

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishProperties.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishProperties.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,15 +21,31 @@ import java.util.Properties;
 
 /**
  * Encapsulates the set of properties required to create a new GlassFish instance.
- * <p/>
- * <p/>Eg.., GlassFishRuntime.bootstrap(new BootstrapProperties()).newGlassFish(<b>new GlassFishProperties()</b>);
+ *
+ * <pre>
+ * ...
+ * GlassFishRuntime runtime = GlassFishRuntime.bootstrap(new BootstrapProperties());
+ * GlassFish glassfish = runtime.newGlassFish(glassFishProperties);
+ * ...
+ * </pre>
  *
  * @author bhavanishankar@dev.java.net
  * @author Prasad.Subramanian@Sun.COM
  */
 public class GlassFishProperties {
 
-    private Properties gfProperties;
+    /** Key for specifying which instance root (aka domain dir) GlassFish should run with. */
+    public static final String INSTANCE_ROOT_PROP_NAME = "com.sun.aas.instanceRoot";
+    /** Key for specifying which configuration file (domain.xml) GlassFish should run with. */
+    public static final String CONFIG_FILE_URI_PROP_NAME = "org.glassfish.embeddable.configFileURI";
+    /**
+     * Key for specifying whether the specified configuration file (domain.xml) or config/domain.xml
+     * at the user specified instanceRoot should be operated by GlassFish in read only mode or not.
+     */
+    public static final String CONFIG_FILE_READ_ONLY = "org.glassfish.embeddable.configFileReadOnly";
+    private static final String NETWORK_LISTENER_KEY = "embedded-glassfish-config.server.network-config.network-listeners.network-listener.%s";
+
+    private final Properties gfProperties;
 
     /**
      * Create GlassFishProperties with default properties.
@@ -37,16 +54,17 @@ public class GlassFishProperties {
         gfProperties = new Properties();
     }
 
+
     /**
      * Create GlassFishProperties with custom properties.
-     * This method does not take a copy of the passed in properties object; instead it just maintains a reference to
-     * it, so all semantics of "pass-by-reference" applies.
+     * This method does not take a copy of the passed in properties object; instead it just
+     * maintains a reference to it, so all semantics of "pass-by-reference" applies.
      * <p/>
-     * <p/>Custom properties can include values for all or some of the keys
+     * Custom properties can include values for all or some of the keys
      * defined as constants in this class. Eg., a value for com.sun.aas.instanceRoot
      * can be included in the custom properties.
      * <p/>
-     * <p/>Custom properties can also include additional properties which are required
+     * Custom properties can also include additional properties which are required
      * for the plugged in {@link GlassFishRuntime} (if any)
      *
      * @param props Properties object which will back this GlassFishProperties object.
@@ -55,10 +73,11 @@ public class GlassFishProperties {
         gfProperties = props;
     }
 
+
     /**
      * Get the underlying Properties object which backs this GlassFishProperties.
      * <p/>
-     * <p/> If getProperties().setProperty(key,value) is called, then it will
+     * If getProperties().setProperty(key,value) is called, then it will
      * add a property to this GlassFishProperties.
      *
      * @return The Properties object that is backing this GlassFishProperties.
@@ -78,23 +97,23 @@ public class GlassFishProperties {
         gfProperties.setProperty(key, value);
     }
 
+
     /**
      * Optionally set the instance root (aka domain dir) using which the
      * GlassFish should run.
      * <p/>
-     * <p/> Make sure to specify a valid GlassFish instance directory
+     * Make sure to specify a valid GlassFish instance directory
      * (eg., GF_INSTALL_DIR/domains/domain1).
      * <p/>
-     * <p/> By default, the config/domain.xml at the specified instance root is operated in
+     * By default, the config/domain.xml at the specified instance root is operated in
      * read only mode. To writeback changes to it, call
      * {@link #setConfigFileReadOnly(boolean)} by passing 'false'
      * <p/>
-     * <p/>If the instance root is not specified, then a small sized temporary
+     * If the instance root is not specified, then a small sized temporary
      * instance directory is created in the current directory. The temporary
      * instance directory will get deleted when the glassfish.dispose() is called.
      *
      * @param instanceRoot Location of the instance root.
-     * @return This object after setting the instance root.
      */
     public void setInstanceRoot(String instanceRoot) {
         gfProperties.setProperty(INSTANCE_ROOT_PROP_NAME, instanceRoot);
@@ -122,7 +141,6 @@ public class GlassFishProperties {
         gfProperties.setProperty(CONFIG_FILE_URI_PROP_NAME, configFileURI);
     }
 
-
     /**
      * Get the configurationFileURI set using {@link #setConfigFileURI(String)}
      *
@@ -140,8 +158,7 @@ public class GlassFishProperties {
      *         specified instance root remains unchanged when the glassfish runs, false otherwise.
      */
     public boolean isConfigFileReadOnly() {
-        return Boolean.valueOf(gfProperties.getProperty(
-                CONFIG_FILE_READ_ONLY, "true"));
+        return Boolean.parseBoolean(gfProperties.getProperty(CONFIG_FILE_READ_ONLY, "true"));
     }
 
     /**
@@ -153,8 +170,7 @@ public class GlassFishProperties {
      * @param readOnly false to writeback any changes.
      */
     public void setConfigFileReadOnly(boolean readOnly) {
-        gfProperties.setProperty(CONFIG_FILE_READ_ONLY,
-                Boolean.toString(readOnly));
+        gfProperties.setProperty(CONFIG_FILE_READ_ONLY, Boolean.toString(readOnly));
     }
 
     /**
@@ -180,14 +196,12 @@ public class GlassFishProperties {
      * <p/>
      * will point to server.network-config.network-listeners.network-listener.joe. Hence the
      * GlassFish server will use "joe" network listener with its port set to 8080.
-     *
      * <p/>
      * If there is no such network-listener by name "joe" in the supplied domain.xml,
      * then the server will throw an exception and fail to start.
      *
      * @param networkListener Name of the network listener.
      * @param port            Port number
-     * @return This object after setting the port.
      */
     public void setPort(String networkListener, int port) {
         if (networkListener != null) {
@@ -221,19 +235,4 @@ public class GlassFishProperties {
         }
         return port;
     }
-
-    // PRIVATE constants.
-    // Key for specifying which instance root (aka domain dir) GlassFish should run with.
-    private final static String INSTANCE_ROOT_PROP_NAME =
-            "com.sun.aas.instanceRoot";
-    // Key for specifying which configuration file (domain.xml) GlassFish should run with.
-    private static final String CONFIG_FILE_URI_PROP_NAME =
-            "org.glassfish.embeddable.configFileURI";
-    // Key for specifying whether the specified configuration file (domain.xml) or config/domain.xml
-    // at the user specified instanceRoot should be operated by GlassFish in read only mode or not.
-    private static final String CONFIG_FILE_READ_ONLY =
-            "org.glassfish.embeddable.configFileReadOnly";
-    private static final String NETWORK_LISTENER_KEY =
-            "embedded-glassfish-config.server.network-config.network-listeners.network-listener.%s";
-
 }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiGlassFishRuntimeBuilder.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/OSGiGlassFishRuntimeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -50,9 +50,9 @@ import static org.osgi.framework.Constants.FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT;
 /**
  * This RuntimeBuilder can only handle GlassFish_Platform of following types:
  * <p/>
- * {@link Constants.Platform#Felix},
- * {@link Constants.Platform#Equinox},
- * and {@link Constants.Platform#Knopflerfish}.
+ * {@link com.sun.enterprise.glassfish.bootstrap.Constants.Platform#Felix},
+ * {@link com.sun.enterprise.glassfish.bootstrap.Constants.Platform#Equinox},
+ * and {@link com.sun.enterprise.glassfish.bootstrap.Constants.Platform#Knopflerfish}.
  * <p/>
  * <p/>It can't handle GenericOSGi platform,
  * because it reads framework configuration from a framework specific file when it calls

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/embedded/EmbeddedDomainXml.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/embedded/EmbeddedDomainXml.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +19,8 @@ package org.glassfish.kernel.embedded;
 
 import com.sun.enterprise.module.bootstrap.StartupContext;
 import com.sun.enterprise.v3.server.GFDomainXml;
+
+import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.server.ServerEnvironmentImpl;
 import jakarta.inject.Inject;
 
@@ -43,8 +46,7 @@ public class EmbeddedDomainXml extends GFDomainXml {
     }
 
     static URL getDomainXml(StartupContext startupContext) throws IOException {
-        String configFileURI = startupContext.getArguments().getProperty(
-                "org.glassfish.embeddable.configFileURI");
+        String configFileURI = startupContext.getArguments().getProperty(GlassFishProperties.CONFIG_FILE_URI_PROP_NAME);
         if (configFileURI != null) { // user specified domain.xml
             return URI.create(configFileURI).toURL();
         }


### PR DESCRIPTION
- Updated to use the current api
- Some constants have to be public
  - If we agree to kill Uberjar, they can be marked as private again, or even better, they should be moved outside - note that some are used as System.properties, some don't. So it may need more work.
