### PR TITLE
Fixed error messages in logs

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ReferenceCleaner.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ReferenceCleaner.java
@@ -47,7 +47,7 @@ import static org.glassfish.web.loader.LogFacade.CHECK_THREAD_LOCALS_FOR_LEAKS_K
 import static org.glassfish.web.loader.LogFacade.getString;
 
 class ReferenceCleaner {
-    private static final Logger LOG = System.getLogger(ReferenceCleaner.class.getName());
+    private static final Logger LOG = LogFacade.getSysLogger(ReferenceCleaner.class);
 
     private final WebappClassLoader loader;
 


### PR DESCRIPTION
Noticed when manually testing the AdminUI (which has leaks).

```
[#|2023-01-26T10:18:04.048201Z|SEVERE|GlassFish 7.0|org.glassfish.web.loader.ReferenceCleaner|_ThreadID=235;_ThreadName=RunLevelControllerThread-1674728284015;_LevelValue=1000;|
AS-WEB-UTIL-00016|#]
```