### PR TITLE
Fix for servlet tck - updated ApplicationContextFacade

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ApplicationContextFacade.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ApplicationContextFacade.java
@@ -30,90 +30,34 @@ import jakarta.servlet.SessionTrackingMode;
 import jakarta.servlet.descriptor.JspConfigDescriptor;
 
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.EventListener;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.catalina.Globals;
-import org.apache.catalina.LogFacade;
 import org.apache.catalina.security.SecurityUtil;
 
 /**
  * Facade object which masks the internal <code>ApplicationContext</code>
  * object from the web application.
  *
- * @author Remy Maucherat
- * @author Jean-Francois Arcand
- * @version $Revision: 1.7.6.1 $ $Date: 2008/04/17 18:37:06 $
+ * @author Remy Maucherat 2008
+ * @author Jean-Francois Arcand 2008
+ * @author David Matejcek 2023
  */
-
-public final class ApplicationContextFacade
-    implements ServletContext {
-
-    private static final Logger log = LogFacade.getLogger();
-
-    // ---------------------------------------------------------- Attributes
-    /**
-     * Cache Class object used for reflection.
-     */
-    private static HashMap<String, Class<?>[]> classCache = new HashMap<>();
-
-    static {
-        Class<?>[] clazz = new Class[]{String.class};
-        classCache.put("addFilter", new Class[]{String.class, String.class});
-        classCache.put("addListener", clazz);
-        classCache.put("addServlet", new Class[]{String.class, String.class});
-        classCache.put("addJspFile", new Class[]{String.class, String.class});
-        classCache.put("createFilter", new Class[]{Class.class});
-        classCache.put("createListener", new Class[]{Class.class});
-        classCache.put("createServlet", new Class[]{Class.class});
-        classCache.put("declareRoles", new Class<?>[] {(new String[0]).getClass()});
-        classCache.put("getAttribute", clazz);
-        classCache.put("getContext", clazz);
-        classCache.put("getFilterRegistration", clazz);
-        classCache.put("getInitParameter", clazz);
-        classCache.put("getMimeType", clazz);
-        classCache.put("getNamedDispatcher", clazz);
-        classCache.put("getRealPath", clazz);
-        classCache.put("getResourcePaths", clazz);
-        classCache.put("getResource", clazz);
-        classCache.put("getResourceAsStream", clazz);
-        classCache.put("getRequestDispatcher", clazz);
-        classCache.put("getServlet", clazz);
-        classCache.put("getServletRegistration", clazz);
-        classCache.put("log", clazz);
-        classCache.put("removeAttribute", clazz);
-        classCache.put("setAttribute", new Class[]{String.class, Object.class});
-        classCache.put("setInitParameter", new Class[]{String.class, String.class});
-        classCache.put("setSessionTrackingModes", new Class[]{Set.class});
-        classCache.put("getSessionTimeout", new Class[]{});
-        classCache.put("setSessionTimeout", new Class[]{Integer.class});
-        classCache.put("getRequestCharacterEncoding", new Class[]{});
-        classCache.put("setRequestCharacterEncoding", new Class[]{String.class});
-        classCache.put("getResponseCharacterEncoding", new Class[]{});
-        classCache.put("setResponseCharacterEncoding", new Class[]{String.class});
-    }
+public final class ApplicationContextFacade implements ServletContext {
 
     /**
-     * Cache method object.
+     * Wrapped application context.
      */
-    private final HashMap<String, Method> objectCache;
-
-
-    // ----------------------------------------------------------- Constructors
-
+    private final ApplicationContext context;
 
     /**
      * Construct a new instance of this class, associated with the specified
@@ -123,26 +67,14 @@ public final class ApplicationContextFacade
      */
     public ApplicationContextFacade(ApplicationContext context) {
         this.context = context;
-        objectCache = new HashMap<>();
     }
 
-
-    // ----------------------------------------------------- Instance Variables
-
-
-    /**
-     * Wrapped application context.
-     */
-    private final ApplicationContext context;
-
-
-
-    // ------------------------------------------------- ServletContext Methods
 
     @Override
     public String getContextPath() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getContextPath", null);
+            PrivilegedAction<String> action = context::getContextPath;
+            return AccessController.doPrivileged(action);
         }
         return context.getContextPath();
     }
@@ -150,16 +82,17 @@ public final class ApplicationContextFacade
 
     @Override
     public ServletContext getContext(String uripath) {
-        ServletContext theContext;
+        final ServletContext theContext;
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            theContext = doPrivileged("getContext", new Object[] {uripath});
+            PrivilegedAction<ServletContext> action = () -> context.getContext(uripath);
+            theContext = AccessController.doPrivileged(action);
         } else {
             theContext = context.getContext(uripath);
         }
-        if (theContext != null && (theContext instanceof ApplicationContext)) {
-            theContext = ((ApplicationContext) theContext).getFacade();
+        if (theContext instanceof ApplicationContext) {
+            return ((ApplicationContext) theContext).getFacade();
         }
-        return (theContext);
+        return theContext;
     }
 
 
@@ -198,7 +131,8 @@ public final class ApplicationContextFacade
     @Override
     public String getMimeType(String file) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getMimeType", new Object[]{file});
+            PrivilegedAction<String> action = () -> context.getMimeType(file);
+            return AccessController.doPrivileged(action);
         }
         return context.getMimeType(file);
     }
@@ -206,8 +140,9 @@ public final class ApplicationContextFacade
 
     @Override
     public Set<String> getResourcePaths(String path) {
-        if (SecurityUtil.isPackageProtectionEnabled()){
-            return doPrivileged("getResourcePaths", new Object[] {path});
+        if (SecurityUtil.isPackageProtectionEnabled()) {
+            PrivilegedAction<Set<String>> action = () -> context.getResourcePaths(path);
+            return AccessController.doPrivileged(action);
         }
         return context.getResourcePaths(path);
     }
@@ -216,13 +151,11 @@ public final class ApplicationContextFacade
     @Override
     public URL getResource(String path) throws MalformedURLException {
         if (Globals.IS_SECURITY_ENABLED) {
+            PrivilegedExceptionAction<URL> action = () -> context.getResource(path);
             try {
-                return invokeMethod(context, "getResource", new Object[] {path});
-            } catch (Throwable t) {
-                if (t instanceof MalformedURLException) {
-                    throw (MalformedURLException) t;
-                }
-                return null;
+                return AccessController.doPrivileged(action);
+            } catch (PrivilegedActionException e) {
+                throw (MalformedURLException) e.getCause();
             }
         }
         return context.getResource(path);
@@ -232,7 +165,8 @@ public final class ApplicationContextFacade
     @Override
     public InputStream getResourceAsStream(String path) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getResourceAsStream", new Object[] {path});
+            PrivilegedAction<InputStream> action = () -> context.getResourceAsStream(path);
+            return AccessController.doPrivileged(action);
         }
         return context.getResourceAsStream(path);
     }
@@ -241,7 +175,8 @@ public final class ApplicationContextFacade
     @Override
     public RequestDispatcher getRequestDispatcher(final String path) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getRequestDispatcher", new Object[] {path});
+            PrivilegedAction<RequestDispatcher> action = () -> context.getRequestDispatcher(path);
+            return AccessController.doPrivileged(action);
         }
         return context.getRequestDispatcher(path);
     }
@@ -250,7 +185,8 @@ public final class ApplicationContextFacade
     @Override
     public RequestDispatcher getNamedDispatcher(String name) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getNamedDispatcher", new Object[] {name});
+            PrivilegedAction<RequestDispatcher> action = () -> context.getNamedDispatcher(name);
+            return AccessController.doPrivileged(action);
         }
         return context.getNamedDispatcher(name);
     }
@@ -258,7 +194,11 @@ public final class ApplicationContextFacade
     @Override
     public void log(String msg) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("log", new Object[]{msg} );
+            PrivilegedAction<Void> action = () -> {
+                context.log(msg);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.log(msg);
         }
@@ -267,7 +207,11 @@ public final class ApplicationContextFacade
     @Override
     public void log(String message, Throwable throwable) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("log", new Class[] {String.class, Throwable.class}, new Object[] {message, throwable});
+            PrivilegedAction<Void> action = () -> {
+                context.log(message, throwable);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.log(message, throwable);
         }
@@ -277,7 +221,8 @@ public final class ApplicationContextFacade
     @Override
     public String getRealPath(String path) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getRealPath", new Object[]{path});
+            PrivilegedAction<String> action = () -> context.getRealPath(path);
+            return AccessController.doPrivileged(action);
         }
         return context.getRealPath(path);
     }
@@ -286,7 +231,8 @@ public final class ApplicationContextFacade
     @Override
     public String getServerInfo() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getServerInfo", null);
+            PrivilegedAction<String> action = context::getServerInfo;
+            return AccessController.doPrivileged(action);
         }
         return context.getServerInfo();
     }
@@ -295,7 +241,8 @@ public final class ApplicationContextFacade
     @Override
     public String getInitParameter(String name) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getInitParameter", new Object[] {name});
+            PrivilegedAction<String> action = () -> context.getInitParameter(name);
+            return AccessController.doPrivileged(action);
         }
         return context.getInitParameter(name);
     }
@@ -304,7 +251,8 @@ public final class ApplicationContextFacade
     @Override
     public Enumeration<String> getInitParameterNames() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getInitParameterNames", null);
+            PrivilegedAction<Enumeration<String>> action = context::getInitParameterNames;
+            return AccessController.doPrivileged(action);
         }
         return context.getInitParameterNames();
     }
@@ -318,7 +266,11 @@ public final class ApplicationContextFacade
     @Override
     public boolean setInitParameter(String name, String value) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("setInitParameter", new Object[] {name, value});
+            PrivilegedAction<Void> action = () -> {
+                context.setInitParameter(name, value);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         }
         return context.setInitParameter(name, value);
     }
@@ -327,7 +279,8 @@ public final class ApplicationContextFacade
     @Override
     public Object getAttribute(String name) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getAttribute", new Object[]{name});
+            PrivilegedAction<Object> action = () -> context.getAttribute(name);
+            return AccessController.doPrivileged(action);
         }
         return context.getAttribute(name);
     }
@@ -336,7 +289,8 @@ public final class ApplicationContextFacade
     @Override
     public Enumeration<String> getAttributeNames() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getAttributeNames", null);
+            PrivilegedAction<Enumeration<String>> action = context::getAttributeNames;
+            return AccessController.doPrivileged(action);
         }
         return context.getAttributeNames();
     }
@@ -345,7 +299,11 @@ public final class ApplicationContextFacade
     @Override
     public void setAttribute(String name, Object object) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("setAttribute", new Object[]{name,object});
+            PrivilegedAction<Void> action = () -> {
+                context.setAttribute(name, object);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.setAttribute(name, object);
         }
@@ -355,7 +313,11 @@ public final class ApplicationContextFacade
     @Override
     public void removeAttribute(String name) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("removeAttribute", new Object[]{name});
+            PrivilegedAction<Void> action = () -> {
+                context.removeAttribute(name);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.removeAttribute(name);
         }
@@ -365,7 +327,8 @@ public final class ApplicationContextFacade
     @Override
     public String getServletContextName() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getServletContextName", null);
+            PrivilegedAction<String> action = context::getServletContextName;
+            return AccessController.doPrivileged(action);
         }
         return context.getServletContextName();
     }
@@ -374,7 +337,8 @@ public final class ApplicationContextFacade
     @Override
     public ServletRegistration.Dynamic addServlet(String servletName, String className) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addServlet", new Object[] {servletName, className});
+            PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addServlet(servletName, className);
+            return AccessController.doPrivileged(action);
         }
         return context.addServlet(servletName, className);
     }
@@ -383,8 +347,8 @@ public final class ApplicationContextFacade
     @Override
     public ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addServlet", new Class[] {String.class, Servlet.class},
-                new Object[] {servletName, servlet});
+            PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addServlet(servletName, servlet);
+            return AccessController.doPrivileged(action);
         }
         return context.addServlet(servletName, servlet);
     }
@@ -393,16 +357,18 @@ public final class ApplicationContextFacade
     @Override
     public ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addServlet", new Class[] {String.class, Class.class},
-                new Object[] {servletName, servletClass});
+            PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addServlet(servletName, servletClass);
+            return AccessController.doPrivileged(action);
         }
         return context.addServlet(servletName, servletClass);
     }
 
+
     @Override
     public ServletRegistration.Dynamic addJspFile(String servletName, String jspFile) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addJspFile", new Object[] {servletName, jspFile});
+            PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addJspFile(servletName, jspFile);
+            return AccessController.doPrivileged(action);
         }
         return context.addJspFile(servletName, jspFile);
     }
@@ -416,7 +382,12 @@ public final class ApplicationContextFacade
     @Override
     public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("createServlet", new Object[] {clazz});
+            PrivilegedExceptionAction<T> action = () -> context.createServlet(clazz);
+            try {
+                return AccessController.doPrivileged(action);
+            } catch (PrivilegedActionException e) {
+                throw (ServletException) e.getCause();
+            }
         }
         return context.createServlet(clazz);
     }
@@ -429,7 +400,8 @@ public final class ApplicationContextFacade
     @Override
     public ServletRegistration getServletRegistration(String servletName) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getServletRegistration", new Object[] {servletName});
+            PrivilegedAction<ServletRegistration> action = () -> context.getServletRegistration(servletName);
+            return AccessController.doPrivileged(action);
         }
         return context.getServletRegistration(servletName);
     }
@@ -442,7 +414,8 @@ public final class ApplicationContextFacade
     @Override
     public Map<String, ? extends ServletRegistration> getServletRegistrations() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getServletRegistrations", null);
+            PrivilegedAction<Map<String, ? extends ServletRegistration>> action = context::getServletRegistrations;
+            return AccessController.doPrivileged(action);
         }
         return context.getServletRegistrations();
     }
@@ -454,7 +427,8 @@ public final class ApplicationContextFacade
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, String className) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addFilter", new Object[] {filterName, className});
+            PrivilegedAction<FilterRegistration.Dynamic> action = () -> context.addFilter(filterName, className);
+            return AccessController.doPrivileged(action);
         }
         return context.addFilter(filterName, className);
     }
@@ -467,8 +441,8 @@ public final class ApplicationContextFacade
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addFilter", new Class[] {String.class, Filter.class},
-                new Object[] {filterName, filter});
+            PrivilegedAction<FilterRegistration.Dynamic> action = () -> context.addFilter(filterName, filter);
+            return AccessController.doPrivileged(action);
         }
         return context.addFilter(filterName, filter);
     }
@@ -481,8 +455,8 @@ public final class ApplicationContextFacade
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("addFilter", new Class[] {String.class, Class.class},
-                new Object[] {filterName, filterClass});
+            PrivilegedAction<FilterRegistration.Dynamic> action = () -> context.addFilter(filterName, filterClass);
+            return AccessController.doPrivileged(action);
         }
         return context.addFilter(filterName, filterClass);
     }
@@ -494,10 +468,14 @@ public final class ApplicationContextFacade
      * it.
      */
     @Override
-    public <T extends Filter> T createFilter(Class<T> clazz)
-            throws ServletException {
+    public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("createFilter", new Object[] {clazz});
+            PrivilegedExceptionAction<T> action = () -> context.createFilter(clazz);
+            try {
+                return AccessController.doPrivileged(action);
+            } catch (PrivilegedActionException e) {
+                throw (ServletException) e.getCause();
+            }
         }
         return context.createFilter(clazz);
     }
@@ -510,7 +488,8 @@ public final class ApplicationContextFacade
     @Override
     public FilterRegistration getFilterRegistration(String filterName) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getFilterRegistration", new Object[] {filterName});
+            PrivilegedAction<FilterRegistration> action = () -> context.getFilterRegistration(filterName);
+            return AccessController.doPrivileged(action);
         }
         return context.getFilterRegistration(filterName);
     }
@@ -523,7 +502,8 @@ public final class ApplicationContextFacade
     @Override
     public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getFilterRegistrations", null);
+            PrivilegedAction<Map<String, ? extends FilterRegistration>> action = context::getFilterRegistrations;
+            return AccessController.doPrivileged(action);
         }
         return context.getFilterRegistrations();
     }
@@ -537,7 +517,8 @@ public final class ApplicationContextFacade
     @Override
     public SessionCookieConfig getSessionCookieConfig() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getSessionCookieConfig", null);
+            PrivilegedAction<SessionCookieConfig> action = context::getSessionCookieConfig;
+            return AccessController.doPrivileged(action);
         }
         return context.getSessionCookieConfig();
     }
@@ -550,7 +531,11 @@ public final class ApplicationContextFacade
     @Override
     public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("setSessionTrackingModes", new Object[] {sessionTrackingModes});
+            PrivilegedAction<Void> action = () -> {
+                context.setSessionTrackingModes(sessionTrackingModes);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.setSessionTrackingModes(sessionTrackingModes);
         }
@@ -567,7 +552,8 @@ public final class ApplicationContextFacade
     @Override
     public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return doPrivileged("getDefaultSessionTrackingModes", null);
+            PrivilegedAction<Set<SessionTrackingMode>> action = context::getDefaultSessionTrackingModes;
+            return AccessController.doPrivileged(action);
         }
         return context.getDefaultSessionTrackingModes();
     }
@@ -581,10 +567,10 @@ public final class ApplicationContextFacade
      * <tt>ServletContext</tt>
      */
     @Override
-    @SuppressWarnings("unchecked") // doPrivileged() returns the correct type
     public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (Set<SessionTrackingMode>) doPrivileged("getEffectiveSessionTrackingModes", null);
+            PrivilegedAction<Set<SessionTrackingMode>> action = context::getEffectiveSessionTrackingModes;
+            return AccessController.doPrivileged(action);
         }
         return context.getEffectiveSessionTrackingModes();
     }
@@ -596,7 +582,11 @@ public final class ApplicationContextFacade
     @Override
     public void addListener(String className) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("addListener", new Object[] {className});
+            PrivilegedAction<Void> action = () -> {
+                context.addListener(className);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.addListener(className);
         }
@@ -607,11 +597,15 @@ public final class ApplicationContextFacade
      * Adds the given listener to this ServletContext.
      */
     @Override
-    public <T extends EventListener> void addListener(T t) {
+    public <T extends EventListener> void addListener(T listener) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("addListener", new Class[] {EventListener.class}, new Object[] {t});
+            PrivilegedAction<Void> action = () -> {
+                context.addListener(listener);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
-            context.addListener(t);
+            context.addListener(listener);
         }
     }
 
@@ -622,7 +616,11 @@ public final class ApplicationContextFacade
     @Override
     public void addListener(Class<? extends EventListener> listenerClass) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("addListener", new Class[] {Class.class}, new Object[] {listenerClass});
+            PrivilegedAction<Void> action = () -> {
+                context.addListener(listenerClass);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.addListener(listenerClass);
         }
@@ -635,10 +633,14 @@ public final class ApplicationContextFacade
      * before returning it.
      */
     @Override
-    @SuppressWarnings("unchecked") // doPrivileged() returns the correct type
     public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (T) doPrivileged("createListener", new Object[] {clazz});
+            PrivilegedExceptionAction<T> action = () -> context.createListener(clazz);
+            try {
+                return AccessController.doPrivileged(action);
+            } catch (PrivilegedActionException e) {
+                throw (ServletException) e.getCause();
+            }
         }
         return context.createListener(clazz);
     }
@@ -653,7 +655,8 @@ public final class ApplicationContextFacade
     @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (JspConfigDescriptor) doPrivileged("getJspConfigDescriptor", null);
+            PrivilegedAction<JspConfigDescriptor> action = context::getJspConfigDescriptor;
+            return AccessController.doPrivileged(action);
         }
         return context.getJspConfigDescriptor();
     }
@@ -662,7 +665,8 @@ public final class ApplicationContextFacade
     @Override
     public ClassLoader getClassLoader() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (ClassLoader) doPrivileged("getClassLoader", null);
+            PrivilegedAction<ClassLoader> action = context::getClassLoader;
+            return AccessController.doPrivileged(action);
         }
         return context.getClassLoader();
     }
@@ -671,7 +675,11 @@ public final class ApplicationContextFacade
     @Override
     public void declareRoles(String... roleNames) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("declareRoles", roleNames);
+            PrivilegedAction<Void> action = () -> {
+                context.declareRoles(roleNames);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.declareRoles(roleNames);
         }
@@ -680,7 +688,8 @@ public final class ApplicationContextFacade
     @Override
     public String getVirtualServerName() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (String)doPrivileged("getVirtualServerName", null);
+            PrivilegedAction<String> action = context::getVirtualServerName;
+            return AccessController.doPrivileged(action);
         }
         return context.getVirtualServerName();
     }
@@ -688,7 +697,8 @@ public final class ApplicationContextFacade
     @Override
     public int getSessionTimeout() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (Integer)doPrivileged("getSessionTimeout", null);
+            PrivilegedAction<Integer> action = context::getSessionTimeout;
+            return AccessController.doPrivileged(action);
         }
         return context.getSessionTimeout();
     }
@@ -696,7 +706,11 @@ public final class ApplicationContextFacade
     @Override
     public void setSessionTimeout(int sessionTimeout) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("getSessionTimeout", null);
+            PrivilegedAction<Void> action = () -> {
+                context.setSessionTimeout(sessionTimeout);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.setSessionTimeout(sessionTimeout);
         }
@@ -705,7 +719,8 @@ public final class ApplicationContextFacade
     @Override
     public String getRequestCharacterEncoding() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (String)doPrivileged("getRequestCharacterEncoding", null);
+            PrivilegedAction<String> action = context::getRequestCharacterEncoding;
+            return AccessController.doPrivileged(action);
         }
         return context.getRequestCharacterEncoding();
     }
@@ -713,7 +728,11 @@ public final class ApplicationContextFacade
     @Override
     public void setRequestCharacterEncoding(String encoding) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("setRequestCharacterEncoding", null);
+            PrivilegedAction<Void> action = () -> {
+                context.setRequestCharacterEncoding(encoding);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.setRequestCharacterEncoding(encoding);
         }
@@ -722,7 +741,8 @@ public final class ApplicationContextFacade
     @Override
     public String getResponseCharacterEncoding() {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            return (String)doPrivileged("getResponseCharacterEncoding", null);
+            PrivilegedAction<String> action = context::getResponseCharacterEncoding;
+            return AccessController.doPrivileged(action);
         }
         return context.getResponseCharacterEncoding();
     }
@@ -730,7 +750,11 @@ public final class ApplicationContextFacade
     @Override
     public void setResponseCharacterEncoding(String encoding) {
         if (SecurityUtil.isPackageProtectionEnabled()) {
-            doPrivileged("setResponseCharacterEncoding", null);
+            PrivilegedAction<Void> action = () -> {
+                context.setResponseCharacterEncoding(encoding);
+                return null;
+            };
+            AccessController.doPrivileged(action);
         } else {
             context.setResponseCharacterEncoding(encoding);
         }
@@ -739,121 +763,5 @@ public final class ApplicationContextFacade
     @Override
     public String toString() {
         return super.toString() + "[context=" + context + ']';
-    }
-
-
-    /**
-     * Use reflection to invoke the requested method. Cache the method object
-     * to speed up the process
-     *                   will be invoked
-     * @param methodName The method to call.
-     * @param params The arguments passed to the called method.
-     */
-    private <T> T doPrivileged(final String methodName, Object[] params){
-        try {
-            return invokeMethod(context, methodName, params);
-        } catch (Throwable t) {
-            throw new RuntimeException(t.getMessage());
-        }
-    }
-
-
-    /**
-     * Use reflection to invoke the requested method. Cache the method object
-     * to speed up the process
-     * @param appContext The AppliationContext object on which the method
-     *                   will be invoked
-     * @param methodName The method to call.
-     * @param params The arguments passed to the called method.
-     */
-    private <T> T invokeMethod(ApplicationContext appContext,
-                                final String methodName,
-                                Object[] params)
-        throws Throwable{
-
-        try{
-            Method method = objectCache.get(methodName);
-            if (method == null){
-                method = appContext.getClass()
-                    .getMethod(methodName, classCache.get(methodName));
-                objectCache.put(methodName, method);
-            }
-
-            return executeMethod(method,appContext,params);
-        } catch (Exception ex){
-            handleException(ex, methodName);
-            return null;
-        }
-    }
-
-    /**
-     * Use reflection to invoke the requested method. Cache the method object
-     * to speed up the process
-     * @param methodName The method to call.
-     * @param parameterTypes The list of argument classes for the given method
-     * @param params The arguments passed to the called method.
-     */
-    private <T> T doPrivileged(final String methodName,
-                                final Class<?>[] parameterTypes,
-                                Object[] params){
-
-        try{
-            Method method = context.getClass().getMethod(methodName, parameterTypes);
-            return executeMethod(method,context,params);
-        } catch (Exception ex){
-            try{
-                handleException(ex, methodName);
-            }catch (Throwable t){
-                throw new RuntimeException(t.getMessage(), t);
-            }
-            return null;
-        }
-    }
-
-
-    /**
-     * Executes the method of the specified <code>ApplicationContext</code>
-     * @param method The method object to be invoked.
-     * @param context The AppliationContext object on which the method
-     *                   will be invoked
-     * @param params The arguments passed to the called method.
-     */
-    @SuppressWarnings("unchecked")
-    private static <T> T executeMethod(final Method method, final ApplicationContext context, final Object[] params)
-        throws PrivilegedActionException, IllegalAccessException, InvocationTargetException {
-        log.log(Level.FINEST, "executeMethod(method={0}, context, params={1})",
-            new Object[] {method, Arrays.toString(params)});
-        if (Globals.IS_SECURITY_ENABLED) {
-            PrivilegedExceptionAction<T> action = () -> {
-                return (T) method.invoke(context, params);
-            };
-            return AccessController.doPrivileged(action);
-        }
-        return (T) method.invoke(context, params);
-    }
-
-
-    /**
-     * Throw the real exception.
-     * @param ex The current exception
-     */
-    private static void handleException(Exception ex, String methodName) throws Throwable {
-        Throwable realException;
-
-        if (log.isLoggable(Level.FINE)) {
-            log.log(Level.FINE, "ApplicationContextFacade." + methodName, ex);
-        }
-
-        if (ex instanceof PrivilegedActionException) {
-            ex = ((PrivilegedActionException) ex).getException();
-        }
-
-        if (ex instanceof InvocationTargetException) {
-            realException = ((InvocationTargetException) ex).getTargetException();
-        } else {
-            realException = ex;
-        }
-
-        throw realException;
     }
 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/ApplicationContextFacade.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/ApplicationContextFacade.java
@@ -41,8 +41,7 @@ import java.util.EventListener;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.catalina.Globals;
-import org.apache.catalina.security.SecurityUtil;
+import static org.apache.catalina.Globals.IS_SECURITY_ENABLED;
 
 /**
  * Facade object which masks the internal <code>ApplicationContext</code>
@@ -72,7 +71,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getContextPath() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = context::getContextPath;
             return AccessController.doPrivileged(action);
         }
@@ -83,7 +82,7 @@ public final class ApplicationContextFacade implements ServletContext {
     @Override
     public ServletContext getContext(String uripath) {
         final ServletContext theContext;
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ServletContext> action = () -> context.getContext(uripath);
             theContext = AccessController.doPrivileged(action);
         } else {
@@ -130,7 +129,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getMimeType(String file) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = () -> context.getMimeType(file);
             return AccessController.doPrivileged(action);
         }
@@ -140,7 +139,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public Set<String> getResourcePaths(String path) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Set<String>> action = () -> context.getResourcePaths(path);
             return AccessController.doPrivileged(action);
         }
@@ -150,7 +149,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public URL getResource(String path) throws MalformedURLException {
-        if (Globals.IS_SECURITY_ENABLED) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedExceptionAction<URL> action = () -> context.getResource(path);
             try {
                 return AccessController.doPrivileged(action);
@@ -164,7 +163,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public InputStream getResourceAsStream(String path) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<InputStream> action = () -> context.getResourceAsStream(path);
             return AccessController.doPrivileged(action);
         }
@@ -174,7 +173,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public RequestDispatcher getRequestDispatcher(final String path) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<RequestDispatcher> action = () -> context.getRequestDispatcher(path);
             return AccessController.doPrivileged(action);
         }
@@ -184,7 +183,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public RequestDispatcher getNamedDispatcher(String name) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<RequestDispatcher> action = () -> context.getNamedDispatcher(name);
             return AccessController.doPrivileged(action);
         }
@@ -193,7 +192,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void log(String msg) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.log(msg);
                 return null;
@@ -206,7 +205,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void log(String message, Throwable throwable) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.log(message, throwable);
                 return null;
@@ -220,7 +219,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getRealPath(String path) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = () -> context.getRealPath(path);
             return AccessController.doPrivileged(action);
         }
@@ -230,7 +229,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getServerInfo() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = context::getServerInfo;
             return AccessController.doPrivileged(action);
         }
@@ -240,7 +239,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getInitParameter(String name) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = () -> context.getInitParameter(name);
             return AccessController.doPrivileged(action);
         }
@@ -250,7 +249,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public Enumeration<String> getInitParameterNames() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Enumeration<String>> action = context::getInitParameterNames;
             return AccessController.doPrivileged(action);
         }
@@ -265,7 +264,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public boolean setInitParameter(String name, String value) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.setInitParameter(name, value);
                 return null;
@@ -278,7 +277,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public Object getAttribute(String name) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Object> action = () -> context.getAttribute(name);
             return AccessController.doPrivileged(action);
         }
@@ -288,7 +287,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public Enumeration<String> getAttributeNames() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Enumeration<String>> action = context::getAttributeNames;
             return AccessController.doPrivileged(action);
         }
@@ -298,7 +297,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void setAttribute(String name, Object object) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.setAttribute(name, object);
                 return null;
@@ -312,7 +311,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void removeAttribute(String name) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.removeAttribute(name);
                 return null;
@@ -326,7 +325,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getServletContextName() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = context::getServletContextName;
             return AccessController.doPrivileged(action);
         }
@@ -336,7 +335,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public ServletRegistration.Dynamic addServlet(String servletName, String className) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addServlet(servletName, className);
             return AccessController.doPrivileged(action);
         }
@@ -346,7 +345,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addServlet(servletName, servlet);
             return AccessController.doPrivileged(action);
         }
@@ -356,7 +355,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addServlet(servletName, servletClass);
             return AccessController.doPrivileged(action);
         }
@@ -366,7 +365,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public ServletRegistration.Dynamic addJspFile(String servletName, String jspFile) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ServletRegistration.Dynamic> action = () -> context.addJspFile(servletName, jspFile);
             return AccessController.doPrivileged(action);
         }
@@ -381,7 +380,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedExceptionAction<T> action = () -> context.createServlet(clazz);
             try {
                 return AccessController.doPrivileged(action);
@@ -399,7 +398,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public ServletRegistration getServletRegistration(String servletName) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ServletRegistration> action = () -> context.getServletRegistration(servletName);
             return AccessController.doPrivileged(action);
         }
@@ -413,7 +412,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public Map<String, ? extends ServletRegistration> getServletRegistrations() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Map<String, ? extends ServletRegistration>> action = context::getServletRegistrations;
             return AccessController.doPrivileged(action);
         }
@@ -426,7 +425,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, String className) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<FilterRegistration.Dynamic> action = () -> context.addFilter(filterName, className);
             return AccessController.doPrivileged(action);
         }
@@ -440,7 +439,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<FilterRegistration.Dynamic> action = () -> context.addFilter(filterName, filter);
             return AccessController.doPrivileged(action);
         }
@@ -454,7 +453,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<FilterRegistration.Dynamic> action = () -> context.addFilter(filterName, filterClass);
             return AccessController.doPrivileged(action);
         }
@@ -469,7 +468,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedExceptionAction<T> action = () -> context.createFilter(clazz);
             try {
                 return AccessController.doPrivileged(action);
@@ -487,7 +486,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public FilterRegistration getFilterRegistration(String filterName) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<FilterRegistration> action = () -> context.getFilterRegistration(filterName);
             return AccessController.doPrivileged(action);
         }
@@ -501,7 +500,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Map<String, ? extends FilterRegistration>> action = context::getFilterRegistrations;
             return AccessController.doPrivileged(action);
         }
@@ -516,7 +515,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public SessionCookieConfig getSessionCookieConfig() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<SessionCookieConfig> action = context::getSessionCookieConfig;
             return AccessController.doPrivileged(action);
         }
@@ -530,7 +529,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.setSessionTrackingModes(sessionTrackingModes);
                 return null;
@@ -551,7 +550,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Set<SessionTrackingMode>> action = context::getDefaultSessionTrackingModes;
             return AccessController.doPrivileged(action);
         }
@@ -568,7 +567,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Set<SessionTrackingMode>> action = context::getEffectiveSessionTrackingModes;
             return AccessController.doPrivileged(action);
         }
@@ -581,7 +580,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public void addListener(String className) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.addListener(className);
                 return null;
@@ -598,7 +597,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public <T extends EventListener> void addListener(T listener) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.addListener(listener);
                 return null;
@@ -615,7 +614,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public void addListener(Class<? extends EventListener> listenerClass) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.addListener(listenerClass);
                 return null;
@@ -634,7 +633,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedExceptionAction<T> action = () -> context.createListener(clazz);
             try {
                 return AccessController.doPrivileged(action);
@@ -654,7 +653,7 @@ public final class ApplicationContextFacade implements ServletContext {
      */
     @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<JspConfigDescriptor> action = context::getJspConfigDescriptor;
             return AccessController.doPrivileged(action);
         }
@@ -664,7 +663,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public ClassLoader getClassLoader() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<ClassLoader> action = context::getClassLoader;
             return AccessController.doPrivileged(action);
         }
@@ -674,7 +673,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void declareRoles(String... roleNames) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.declareRoles(roleNames);
                 return null;
@@ -687,7 +686,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getVirtualServerName() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = context::getVirtualServerName;
             return AccessController.doPrivileged(action);
         }
@@ -696,7 +695,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public int getSessionTimeout() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Integer> action = context::getSessionTimeout;
             return AccessController.doPrivileged(action);
         }
@@ -705,7 +704,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void setSessionTimeout(int sessionTimeout) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.setSessionTimeout(sessionTimeout);
                 return null;
@@ -718,7 +717,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getRequestCharacterEncoding() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = context::getRequestCharacterEncoding;
             return AccessController.doPrivileged(action);
         }
@@ -727,7 +726,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void setRequestCharacterEncoding(String encoding) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.setRequestCharacterEncoding(encoding);
                 return null;
@@ -740,7 +739,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public String getResponseCharacterEncoding() {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<String> action = context::getResponseCharacterEncoding;
             return AccessController.doPrivileged(action);
         }
@@ -749,7 +748,7 @@ public final class ApplicationContextFacade implements ServletContext {
 
     @Override
     public void setResponseCharacterEncoding(String encoding) {
-        if (SecurityUtil.isPackageProtectionEnabled()) {
+        if (IS_SECURITY_ENABLED) {
             PrivilegedAction<Void> action = () -> {
                 context.setResponseCharacterEncoding(encoding);
                 return null;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -5212,12 +5212,14 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
             loadOnStartup(findChildren());
         } catch (Throwable t) {
             log.log(SEVERE, STARTUP_CONTEXT_FAILED_EXCEPTION, getName());
+            LifecycleException exception = new LifecycleException(t);
             try {
                 stop();
             } catch (Throwable tt) {
+                exception.addSuppressed(tt);
                 log.log(SEVERE, LogFacade.CLEANUP_FAILED_EXCEPTION, tt);
             }
-            throw new LifecycleException(t);
+            throw exception;
         } finally {
             // Unbinding thread
             unbindThread(oldCCL);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/security/SecurityUtil.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/security/SecurityUtil.java
@@ -264,13 +264,9 @@ public final class SecurityUtil{
 
         try{
             Subject subject = null;
-            PrivilegedExceptionAction<Void> pea =
-                new PrivilegedExceptionAction<>(){
-                    @Override
-                    public Void run() throws Exception{
-                       method.invoke(targetObject, targetArguments);
-                       return null;
-                    }
+            PrivilegedExceptionAction<Void> pea = () -> {
+                method.invoke(targetObject, targetArguments);
+                return null;
             };
 
             // The first argument is always the request object
@@ -305,15 +301,12 @@ public final class SecurityUtil{
         } catch( PrivilegedActionException pe) {
             Throwable e;
             if (pe.getException() instanceof InvocationTargetException) {
-                e = ((InvocationTargetException)pe.getException())
-                                .getTargetException();
+                e = ((InvocationTargetException) pe.getException()).getTargetException();
             } else {
                 e = pe;
             }
 
-            if (log.isLoggable(Level.FINE)){
-                log.log(Level.FINE, LogFacade.PRIVILEGE_ACTION_EXCEPTION, e);
-            }
+            log.log(Level.FINE, LogFacade.PRIVILEGE_ACTION_EXCEPTION, e);
 
             if (e instanceof UnavailableException) {
                 throw (UnavailableException) e;
@@ -416,7 +409,6 @@ public final class SecurityUtil{
     }
 
 
-    // START OF SJS WS 7.0 6236329
     /**
      * Return true if a <code>SecurityManager</code> is used and is
      * <code>isDoAsRequired</code> is required.
@@ -427,6 +419,4 @@ public final class SecurityUtil{
         }
         return false;
     }
-    // END OF SJS WS 7.0 6236329
-
 }


### PR DESCRIPTION
Removed reflection from ApplicationContextFacade
    
- When we fixed #24245 , we enabled broken path
- This commit fixes that (reproducer: old TCK for servlet/api)
- Removed all that reflective workaround, which was masking and incorrectly unmasking checked exceptions