### PR TITLE
fix: update update_version per 7.0.1 release

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -191,7 +191,7 @@
         <version_suffix />
         <major_version>7</major_version>
         <minor_version>0</minor_version>
-        <update_version>0</update_version>
+        <update_version>1</update_version>
         <install.dir.name>glassfish7</install.dir.name>
 
         <test.logManager>org.glassfish.main.jul.GlassFishLogManager</test.logManager>


### PR DESCRIPTION
Looks like the glassfish 7.0.1 release artifact contains the 7.0.0 version info, raise this PR to patch that version mismatch

relates to https://github.com/Homebrew/homebrew-core/pull/121872