### PR TITLE
Integrate WaSP 3.2.0

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
     Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -1532,18 +1532,13 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.wasp</groupId>
-            <artifactId>wasp</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <groupId>org.glassfish.wasp</groupId>
+            <artifactId>wasp</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
     Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -1023,14 +1023,11 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+        
+        <!-- Jakarta Pages and Jakarta Pages Standard Tags -->
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.wasp</groupId>
-            <artifactId>wasp</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -1039,8 +1036,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <groupId>org.glassfish.wasp</groupId>
+            <artifactId>wasp</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -979,14 +979,11 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+        
+        <!-- Jakarta Pages and Jakarta Pages Standard Tags -->
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.wasp</groupId>
-            <artifactId>wasp</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -995,8 +992,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <groupId>org.glassfish.wasp</groupId>
+            <artifactId>wasp</artifactId>
             <optional>true</optional>
         </dependency>
         

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
     Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -1166,19 +1166,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        
+        <!-- Jakarta Pages and Jakarta Pages Standard Tags -->
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.wasp</groupId>
-            <artifactId>wasp</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -1197,8 +1189,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <groupId>org.glassfish.wasp</groupId>
+            <artifactId>wasp</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -129,18 +129,16 @@
         <jakarta.json.bind-api.version>3.0.0</jakarta.json.bind-api.version>
         <yasson.version>3.0.2</yasson.version>
 
-        <!-- Jakarta Pages -->
-        <jakarta.pages-api.version>3.1.0</jakarta.pages-api.version>
-        <wasp.version>3.1.0</wasp.version>
+        <!-- Jakarta Pages and Jakarta Standard Tag Library -->
+        <jakarta.pages-api.version>3.1.1</jakarta.pages-api.version>
+        <jstl-api.version>3.0.0</jstl-api.version>
+        <wasp.version>3.2.0</wasp.version>
 
         <!-- Used for Jakarta SOAP (XML Web Services) -->
         <xmlsec.version>3.0.1</xmlsec.version>
         <woodstox.version>6.5.0</woodstox.version>
         <stax2-api.version>4.2.1</stax2-api.version>
 
-        <!-- Jakarta Standard Tag Library -->
-        <jstl-api.version>3.0.0</jstl-api.version>
-        <jstl-impl.version>3.0.1</jstl-impl.version>
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.0.1</jakarta.cdi-api.version>
@@ -440,6 +438,12 @@
                 <artifactId>jakarta.servlet.jsp-api</artifactId>
                 <version>${jakarta.pages-api.version}</version>
             </dependency>
+             <!-- Jakarta Standard Tag Library -->
+            <dependency>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                <version>${jstl-api.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.wasp</groupId>
                 <artifactId>wasp</artifactId>
@@ -488,18 +492,6 @@
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-osgi</artifactId>
                 <version>${jakarta.jaxb-impl.version}</version>
-            </dependency>
-
-            <!-- Jakarta Standard Tag Library -->
-            <dependency>
-                <groupId>jakarta.servlet.jsp.jstl</groupId>
-                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-                <version>${jstl-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.web</groupId>
-                <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-                <version>${jstl-impl.version}</version>
             </dependency>
 
             <!-- Jakarta CDI -->
@@ -832,7 +824,7 @@
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
                             <specVersion>2.0</specVersion>
-                            <specImplVersion>${jstl-impl.version}</specImplVersion>
+                            <specImplVersion>${wasp.version}</specImplVersion>
                             <apiPackage>jakarta.servlet.jsp.jstl</apiPackage>
                         </spec>
                         <spec>

--- a/appserver/tests/tck/pages/pom.xml
+++ b/appserver/tests/tck/pages/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -186,7 +186,7 @@
                                 <tck-setting key="impl.deploy.timeout.multiplier" value="30"/>
                                 
                                 <tck-setting key="jspservlet.classes" value="${webServerHome}/modules/jakarta.servlet-api.jar${pathsep}${webServerHome}/modules/wasp.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp-api.jar"/>
-                                <tck-setting key="jstl.classes" value="${webServerHome}/modules/jakarta.servlet.jsp.jstl.jar"/>
+                                <tck-setting key="jstl.classes" value="${webServerHome}/modules/wasp.jar"/>
                                 <tck-setting key="el.classes" value="${webServerHome}/modules/jakarta.el.jar${pathsep}${webServerHome}/modules/jakarta.el-api.jar"/>
 								
                           

--- a/appserver/tests/v2-tests/appserv-tests/sqetests/jsfcomponents/src/demo/taglib/EscapeHtmlTag.java
+++ b/appserver/tests/v2-tests/appserv-tests/sqetests/jsfcomponents/src/demo/taglib/EscapeHtmlTag.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023, 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2004, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 1999 The Apache Software Foundation.  All rights
  * Copyright (c) 1999 The Apache Software Foundation.  All rights
@@ -54,7 +55,7 @@
 
 package demo.taglib;
 
-import org.apache.taglibs.standard.lang.support.ExpressionEvaluatorManager;
+import org.glassfish.wasp.standard.lang.support.ExpressionEvaluatorManager;
 
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspTagException;

--- a/appserver/web/jstl-connector/pom.xml
+++ b/appserver/web/jstl-connector/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2023, 2023 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -30,7 +31,7 @@
     <artifactId>jstl-connector</artifactId>
     <packaging>glassfish-jar</packaging>
 
-    <name>JSTL implementation connector module</name>
+    <name>Jakarta Pages Standard Tags implementation connector module</name>
 
     <developers>
         <developer>
@@ -46,16 +47,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.hk2</groupId>
-            <artifactId>hk2-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.wasp</groupId>
+            <artifactId>wasp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -18,13 +18,14 @@
 
 package org.glassfish.web.loader;
 
-import com.sun.appserv.BytecodePreprocessor;
-import com.sun.enterprise.loader.ResourceLocator;
-import com.sun.enterprise.security.integration.DDPermissionsLoader;
-import com.sun.enterprise.security.integration.PermsHolder;
-import com.sun.enterprise.util.io.FileUtils;
-
-import jakarta.annotation.PreDestroy;
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
+import static org.glassfish.web.loader.LogFacade.UNABLE_TO_LOAD_CLASS;
+import static org.glassfish.web.loader.LogFacade.UNSUPPORTED_VERSION;
+import static org.glassfish.web.loader.LogFacade.getString;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -78,14 +79,13 @@ import org.glassfish.api.deployment.InstrumentableClassLoader;
 import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.web.loader.RepositoryManager.RepositoryResource;
 
-import static java.lang.System.Logger.Level.DEBUG;
-import static java.lang.System.Logger.Level.ERROR;
-import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.TRACE;
-import static java.lang.System.Logger.Level.WARNING;
-import static org.glassfish.web.loader.LogFacade.UNABLE_TO_LOAD_CLASS;
-import static org.glassfish.web.loader.LogFacade.UNSUPPORTED_VERSION;
-import static org.glassfish.web.loader.LogFacade.getString;
+import com.sun.appserv.BytecodePreprocessor;
+import com.sun.enterprise.loader.ResourceLocator;
+import com.sun.enterprise.security.integration.DDPermissionsLoader;
+import com.sun.enterprise.security.integration.PermsHolder;
+import com.sun.enterprise.util.io.FileUtils;
+
+import jakarta.annotation.PreDestroy;
 
 /**
  * Specialized web application class loader.
@@ -151,7 +151,7 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
         "sun",                                       // Sun classes (JRE internals)
         "org.xml.sax",                               // SAX 1 & 2 (JRE, jrt-fs.jar)
         "org.w3c.dom",                               // DOM 1 & 2 (JRE, jrt-fs.jar)
-        "org.apache.taglibs.standard",               // jakarta.servlet.jsp.jstl.jar
+        "org.glassfish.wasp.standard",               // wasp.jar
         "com.sun.faces"                              // jakarta.faces.jar
     );
     private static final Set<String> DELEGATED_RESOURCE_PATHS = DELEGATED_PACKAGES.stream()


### PR DESCRIPTION
WaSP now includes Pages Standard Tags, so the existing impl lib for that is replaced and some integration code updated.

Signed-off-by: Arjan Tijms <arjan.tijms@omnifish.ee>
