### PR TITLE
Bump OpenMQ version to 6.4.0-RC1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -102,7 +102,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.3.0</openmq.version>
+        <openmq.version>6.4.0-RC1</openmq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>


### PR DESCRIPTION
This is just to test integration of new OpenMQ RC.
RC1 is not planned for push to central.
The final OpenMQ version will be released and proposed here soon.
