### PR TITLE
Setup config for the versions plug-in to ignore OLDER versions.

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1074,6 +1074,32 @@
                         </includeOnlyProperties>
                     </configuration>
                 </plugin>
+                
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.14.2</version>
+                    <executions>
+                        <execution>
+                            <id>default-cli</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>display-dependency-updates</goal>
+                            </goals>
+                            <configuration>
+                                <!-- 
+                                    Exclude several versions that we never want to update to since they are OLDER than 
+                                    what we currently use.
+                                    
+                                    Note that we actually want to specify the version per artefact, but this is currently 
+                                    broken. 
+                                    See https://github.com/mojohaus/versions/issues/258#issuecomment-1438149133
+                                 -->
+                                <ignoredVersions>3.2-b..,2.5.0-b..,5.0-jdk8-rc.,20030911,10.0-b..</ignoredVersions>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Note these are versions that are OLDER than what we're currently using, but they are being presented as newer (according to the Maven rules they are, but they are not actually newer)

Signed-off-by: Arjan Tijms <arjan.tijms@omnifish.ee>