### PR TITLE
Integrate Eclipselink 4.0.1-RC2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -106,7 +106,7 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
-        <eclipselink.version>4.0.1-RC1</eclipselink.version>
+        <eclipselink.version>4.0.1-RC2</eclipselink.version>
         <eclipselink.asm.version>9.4.0</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->


### PR DESCRIPTION
Changes: https://github.com/eclipse-ee4j/eclipselink/releases/tag/4.0.1-RC2

Integrate Eclipselink 4.0.1-RC2
