### PR TITLE
Bump OpenMQ version to 6.4.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -102,7 +102,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.3.0</openmq.version>
+        <openmq.version>6.4.0</openmq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>


### PR DESCRIPTION
- [TCK](https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build/45/artifact/messaging-tck/bin/summary.txt):
```
[javatest.batch] Number of Tests Passed      = 904
[javatest.batch] Number of Tests Failed      = 0
[javatest.batch] Number of Tests with Errors = 0
...
IMPL_download=https://jakarta.oss.sonatype.org/content/repositories/staging/org/glassfish/mq/mq-distribution/6.4.0/mq-distribution-6.4.0.zip
TCK_download=https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/promoted/eftl/jakarta-messaging-tck-3.1.0.zip
```

- https://projects.eclipse.org/projects/ee4j.openmq/releases/6.4.0
This might be of interest for GF, as RAR would be available as separate artifact, with no need to unpack it from mq-distribution archive.