### PR TITLE
Fixed StackOverflow in WebappClassLoader.getURLs + removed workaround

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ReferenceCleaner.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ReferenceCleaner.java
@@ -23,6 +23,7 @@ import java.lang.System.Logger;
 import java.lang.ref.Reference;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
@@ -270,7 +271,8 @@ class ReferenceCleaner {
             }
         } catch (ClassNotFoundException e) {
             LOG.log(INFO, getString(LogFacade.CLEAR_RMI_INFO, loader.getName()), e);
-        } catch (SecurityException | NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
+        } catch (SecurityException | NoSuchFieldException | IllegalArgumentException | IllegalAccessException
+            | InaccessibleObjectException e) {
             LOG.log(WARNING, getString(LogFacade.CLEAR_RMI_FAIL, loader.getName()), e);
         }
     }

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -998,7 +998,9 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
 
     @Override
     public synchronized URL[] getURLs() {
-        checkStatus(LifeCycleStatus.RUNNING);
+        if (this.status == LifeCycleStatus.CLOSED) {
+            return new URL[0];
+        }
         if (repositoryURLs != null) {
             return repositoryURLs.toArray(URL[]::new);
         }


### PR DESCRIPTION
Fixed SO
- seen in tests when logging used toString after the CL closed.
- Now when it is used after the closure, returns an empty array instead of exception

Removed clearReferencesRmiTargets
- Not required any more; fixes test failure mentioned in comments
- The memory leak was fixed in JDK9
- See https://bugs.openjdk.org/browse/JDK-8157570
