### PR TITLE
Get the timeout for CMT from TransactionService

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
@@ -22,6 +22,7 @@ import com.sun.ejb.EjbInvocation;
 import com.sun.enterprise.deployment.MethodDescriptor;
 import com.sun.enterprise.transaction.api.JavaEETransaction;
 import com.sun.enterprise.transaction.api.JavaEETransactionManager;
+import com.sun.enterprise.transaction.config.TransactionService;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 
 import jakarta.ejb.EJBException;
@@ -39,6 +40,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.ejb.deployment.descriptor.ContainerTransaction;
 import org.glassfish.ejb.deployment.descriptor.EjbApplicationExceptionInfo;
 import org.glassfish.ejb.deployment.descriptor.EjbDescriptor;
@@ -74,6 +76,14 @@ public class EJBContainerTransactionManager {
         container = (BaseContainer)c;
         ejbDescriptor = ejbDesc;
         transactionManager = ejbContainerUtilImpl.getTransactionManager();
+
+        // get transactionTimeout from TransactionService
+        TransactionService txnService = ejbContainerUtilImpl.getServices().getService(TransactionService.class,
+                ServerEnvironment.DEFAULT_INSTANCE_NAME);
+        int transactionTimeout = Integer.parseInt(txnService.getTimeoutInSeconds());
+        if (transactionTimeout != 0) {
+            cmtTimeoutInSeconds = transactionTimeout;
+        }
 
         IASEjbExtraDescriptors iased = ejbDesc.getIASEjbExtraDescriptors();
 


### PR DESCRIPTION
fix the issue  https://github.com/eclipse-ee4j/glassfish/issues/22741

Regarding this issue, I did some exploration in the source code and finally figured out the cause of the problem.

Here is a brief description of the background of this issue.

## Related classes
[JavaEETransactionManagerSimplified](https://github.com/eclipse-ee4j/glassfish/blob/master/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java) is an implementation of `TransactionManager`, providing support for managing transactions internally in Glassfish.

[EJBContainerTransactionManager](https://github.com/eclipse-ee4j/glassfish/blob/master/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java)  provides transaction support for EJB containers, and it is responsible forContainer Managed Transaction (CMT). `EJBContainerTransactionManager` actually delegates transaction management to `JavaEETransactionManagerSimplified`.

[TransactionService](https://github.com/eclipse-ee4j/glassfish/blob/master/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/config/TransactionService.java)  represents the configuration information of the Transaction Service. Users can set the properties of the Transaction Service in the configuration file `domain.xml`, such as setting the transaction timeout through `<transaction-service timeout-in-seconds="180"></transaction-service>`.

## Problem analysis

`EJBContainerTransactionManager` has an instance variable `cmtTimeoutInSeconds`, which represents the timeout for Container Managed Transaction.

In [Glassfish 4.1](https://github.com/javaee/glassfish/blob/b8dfe38521eb79f2040437ec77ccb608bd958145/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java#L90), `cmtTimeoutInSeconds` is initialized to 0:

```java
private int cmtTimeoutInSeconds = 0;
```

If `cmt-timeout-in-seconds` is not configured in `glassfish-ejb-jar.xml`, `cmtTimeoutInSeconds` will remain its initial value of 0. When the EJB container starts a new transaction, `cmtTimeoutInSeconds` will not be passed to `JavaEETransactionManagerSimplified`


```java
private void startNewTx(Transaction prevTx, EjbInvocation inv) throws Exception {
    ...

    if (cmtTimeoutInSeconds > 0) {
        transactionManager.begin(cmtTimeoutInSeconds);
    } else {
        transactionManager.begin();
    }
    ...
}
```

At this point, `JavaEETransactionManagerSimplified` will use `TransactionService.getTimeoutInSeconds()` as the transaction timeout. That is, if `cmtTimeoutInSeconds` is 0, the `timeout-in-seconds` set by the user for the Transaction Service will be used. Note that the default value of `timeout-in-seconds` is 0, which means transactions will not time out.

However, starting from Glassfish 4.1.1, the initial value of `cmtTimeoutInSeconds` is changed to 120:

```java
private int cmtTimeoutInSeconds = 120;
```

Perhaps the developer at that time thought that using 0 as the default value was not a good idea, because if `cmtTimeoutInSeconds` is 0 and no `timeout-in-seconds` is set for the Transaction Service, Container Managed Transaction will not time out and may be suspended indefinitely.

However, initializing `cmtTimeoutInSeconds` to a non-zero value has an additional side effect: the `timeout-in-seconds` set by the user for the Transaction Service will no longer take effect for CMT. This is because `EJBContainerTransactionManager` always uses `transactionManager.begin(cmtTimeoutInSeconds)` to start a new transaction, instead of taking into account the `timeout-in-seconds` set by users for the Transaction Service.

This is the problem that users encountered: the application runs as expected on GlassFish 4.1, but on 5.1, no matter what `timeout-in-seconds` is set for Transaction Service, it no longer has any effect for CMT.

## Solution

One solution to this problem is to have users configure the `cmt-timeout-in-seconds` in `glassfish-ejb-jar.xml`. This way, the timeout time for container-managed transactions will meet the user's expectations, and this method does not require any modification to GlassFish itself.

Another approach that I believe is better is to make the `timeout-in-seconds` set by the user for the Transaction Service also effective for the container-managed transactions, which is exactly what my code modification achieves.