### PR TITLE
Make ASM API version and bytecode level consistent with used ASM library and minimal requred Java version

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
@@ -219,7 +219,7 @@ public class EjbOptionalIntfGenerator {
                 // num params + one for 'this' pointer
                 maxValue = paramTypes.length + 1;
             }
-            cv.visitMethodInsn(INVOKESPECIAL,  Type.getType(superClass).getInternalName(), "<init>", paramTypeString);
+            cv.visitMethodInsn(INVOKESPECIAL,  Type.getType(superClass).getInternalName(), "<init>", paramTypeString, false);
             cv.visitInsn(RETURN);
             cv.visitMaxs(maxValue, 1);
         }
@@ -331,14 +331,14 @@ public class EjbOptionalIntfGenerator {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitTypeInsn(NEW, stringBuilder);
         mv.visitInsn(DUP);
-        mv.visitMethodInsn(INVOKESPECIAL, stringBuilder, "<init>", "()V");
+        mv.visitMethodInsn(INVOKESPECIAL, stringBuilder, "<init>", "()V", false);
         mv.visitLdcInsn(superClass.getName() + "@");
-        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;");
+        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;", false);
         mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Object", "hashCode", "()I");
-        mv.visitMethodInsn(INVOKESTATIC, "java/lang/Integer", "toHexString", "(I)Ljava/lang/String;");
-        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;");
-        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, toStringMethodName, toStringMethodDescriptor);
+        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Object", "hashCode", "()I", false);
+        mv.visitMethodInsn(INVOKESTATIC, "java/lang/Integer", "toHexString", "(I)Ljava/lang/String;", false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;", false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, toStringMethodName, toStringMethodDescriptor, false);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(2, 1);
 
@@ -379,7 +379,7 @@ public class EjbOptionalIntfGenerator {
         cv.visitTypeInsn(CHECKCAST, IndirectlySerializable.class.getName().replace('.', '/'));
         cv.visitMethodInsn(INVOKEINTERFACE,
                 IndirectlySerializable.class.getName().replace('.', '/'), "getSerializableObjectFactory",
-                "()L" + SerializableObjectFactory.class.getName().replace('.', '/') + ";");
+                "()L" + SerializableObjectFactory.class.getName().replace('.', '/') + ";", true);
         cv.visitInsn(ARETURN);
         cv.visitMaxs(1, 1);
     }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/AttributeMethodVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/AttributeMethodVisitor.java
@@ -20,7 +20,8 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.glassfish.api.admin.config.PropertiesDesc;
 import org.glassfish.api.admin.config.PropertyDesc;
 import org.jvnet.hk2.config.Attribute;
-import org.objectweb.asm.Opcodes;
+
+import static org.objectweb.asm.Opcodes.ASM9;
 
 public class AttributeMethodVisitor extends EmptyVisitor {
     private ClassDef def;
@@ -29,7 +30,7 @@ public class AttributeMethodVisitor extends EmptyVisitor {
     private boolean duckTyped;
 
     public AttributeMethodVisitor(ClassDef classDef, String method, String aggType) {
-        super(Opcodes.ASM7);
+        super(ASM9);
         def = classDef;
         name = method;
         type = aggType;

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/AttributeMethodVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/AttributeMethodVisitor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/DocClassVisitor.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.objectweb.asm.*;
 
+import static org.objectweb.asm.Opcodes.ASM9;
+
 public class DocClassVisitor extends ClassVisitor {
     private boolean hasConfiguredAnnotation = false;
     private String className;
@@ -28,7 +30,7 @@ public class DocClassVisitor extends ClassVisitor {
     private boolean showDeprecated;
 
     public DocClassVisitor(final boolean showDep) {
-        super(Opcodes.ASM7);
+        super(ASM9);
         showDeprecated = showDep;
     }
 

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/EmptyVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/EmptyVisitor.java
@@ -78,7 +78,7 @@ public class EmptyVisitor extends MethodVisitor {
     }
 
     @Override
-    public void visitMethodInsn(int i, String s, String s1, String s2) {
+    public void visitMethodInsn(int i, String s, String s1, String s2, boolean isInterface) {
     }
 
     @Override

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/EmptyVisitor.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/schemadoc/EmptyVisitor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
@@ -724,7 +724,7 @@ public class CompositeUtil {
             ifaceNames[i++] = iface.getName().replace(".", "/");
         }
         className = getInternalName(className);
-        classWriter.visit(V1_6, ACC_PUBLIC + ACC_SUPER, className, null, "org/glassfish/admin/rest/composite/RestModelImpl", ifaceNames);
+        classWriter.visit(V11, ACC_PUBLIC + ACC_SUPER, className, null, "org/glassfish/admin/rest/composite/RestModelImpl", ifaceNames);
 
         // Add @XmlRootElement
         classWriter.visitAnnotation("Ljakarta/xml/bind/annotation/XmlRootElement;", true).visitEnd();

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/composite/CompositeUtil.java
@@ -744,7 +744,7 @@ public class CompositeUtil {
         MethodVisitor method = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
         method.visitCode();
         method.visitVarInsn(ALOAD, 0);
-        method.visitMethodInsn(INVOKESPECIAL, "org/glassfish/admin/rest/composite/RestModelImpl", "<init>", "()V");
+        method.visitMethodInsn(INVOKESPECIAL, "org/glassfish/admin/rest/composite/RestModelImpl", "<init>", "()V", false);
 
         for (Map.Entry<String, Map<String, Object>> property : properties.entrySet()) {
             String fieldName = property.getKey();
@@ -808,7 +808,7 @@ public class CompositeUtil {
                 method.visitTypeInsn(NEW, internalName);
                 method.visitInsn(DUP);
                 method.visitLdcInsn(defaultValue);
-                method.visitMethodInsn(INVOKESPECIAL, internalName, "<init>", "(Ljava/lang/String;)V");
+                method.visitMethodInsn(INVOKESPECIAL, internalName, "<init>", "(Ljava/lang/String;)V", false);
                 method.visitFieldInsn(PUTFIELD, getInternalName(className), fieldName, type);
             } else {
                 method.visitVarInsn(ALOAD, 0);
@@ -873,7 +873,7 @@ public class CompositeUtil {
         setter.visitFieldInsn(PUTFIELD, className, getPropertyName(name), internalType);
         setter.visitVarInsn(ALOAD, 0);
         setter.visitLdcInsn(name);
-        setter.visitMethodInsn(INVOKEVIRTUAL, className, "fieldSet", "(Ljava/lang/String;)V");
+        setter.visitMethodInsn(INVOKEVIRTUAL, className, "fieldSet", "(Ljava/lang/String;)V", false);
         setter.visitInsn(RETURN);
         setter.visitMaxs(0, 0);
         setter.visitEnd();

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
@@ -70,7 +70,7 @@ public class ASMClassWriter implements ClassWriter {
         } else {
             baseClassName = "org/glassfish/admin/rest/resources/" + baseClassName;
         }
-        cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, generatedPath + className, null, baseClassName, null);
+        cw.visit(V11, ACC_PUBLIC + ACC_SUPER, generatedPath + className, null, baseClassName, null);
 
         if (resourcePath != null) {
             RestLogging.restLogger.log(Level.FINE, "Creating resource with path {0} (1)", resourcePath);
@@ -240,7 +240,7 @@ public class ASMClassWriter implements ClassWriter {
         }
         boolean isget = (httpMethod.equals("GET"));
 
-        cw.visit(V1_5, ACC_PUBLIC + ACC_SUPER, generatedPath + commandResourceClassName, null, baseClassName, null);
+        cw.visit(V11, ACC_PUBLIC + ACC_SUPER, generatedPath + commandResourceClassName, null, baseClassName, null);
         //     cw.visitInnerClass(generatedPath + commandResourceClassName +"$1", null, null, 0);
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
@@ -82,7 +82,7 @@ public class ASMClassWriter implements ClassWriter {
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
         mv.visitCode();
         mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKESPECIAL, baseClassName, "<init>", "()V");
+        mv.visitMethodInsn(INVOKESPECIAL, baseClassName, "<init>", "()V", false);
         mv.visitInsn(RETURN);
         mv.visitMaxs(1, 1);
         mv.visitEnd();
@@ -106,13 +106,13 @@ public class ASMClassWriter implements ClassWriter {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitFieldInsn(GETFIELD, baseClassName, INJECTOR_FIELD, FORNAME_INJECTOR_TYPE);
         mv.visitLdcInsn(Type.getType("L" + completeName + ";"));
-        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG);
+        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG, true);
         mv.visitTypeInsn(CHECKCAST, completeName);
         mv.visitVarInsn(ASTORE, 1);
         mv.visitVarInsn(ALOAD, 1);
         mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, baseClassName, "getEntity", "()Lorg/jvnet/hk2/config/Dom;");
-        mv.visitMethodInsn(INVOKEVIRTUAL, completeName, "setEntity", "(Lorg/jvnet/hk2/config/Dom;)V");
+        mv.visitMethodInsn(INVOKEVIRTUAL, baseClassName, "getEntity", "()Lorg/jvnet/hk2/config/Dom;", false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, completeName, "setEntity", "(Lorg/jvnet/hk2/config/Dom;)V", false);
         mv.visitVarInsn(ALOAD, 1);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(2, 2);
@@ -214,7 +214,7 @@ public class ASMClassWriter implements ClassWriter {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitFieldInsn(GETFIELD, generatedPath + className, INJECTOR_FIELD, FORNAME_INJECTOR_TYPE);
         mv.visitLdcInsn(Type.getType("L" + generatedPath + commandResourceClassName + ";"));
-        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG);
+        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG, true);
         mv.visitTypeInsn(CHECKCAST, generatedPath + commandResourceClassName);
         mv.visitVarInsn(ASTORE, 1);
         mv.visitVarInsn(ALOAD, 1);
@@ -262,9 +262,9 @@ public class ASMClassWriter implements ClassWriter {
         if (!isget) {
 
             mv.visitMethodInsn(INVOKESPECIAL, baseClassName, "<init>",
-                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V");
+                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V", false);
         } else {
-            mv.visitMethodInsn(INVOKESPECIAL, baseClassName, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V");
+            mv.visitMethodInsn(INVOKESPECIAL, baseClassName, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V", false);
 
         }
         mv.visitInsn(RETURN);
@@ -284,14 +284,14 @@ public class ASMClassWriter implements ClassWriter {
             mv.visitCode();
             mv.visitTypeInsn(NEW, "java/util/HashMap");
             mv.visitInsn(DUP);
-            mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V");
+            mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "()V", false);
             mv.visitVarInsn(ASTORE, 1);
 
             for (CommandResourceMetaData.ParameterMetaData commandParam : commandParams) {
                 mv.visitVarInsn(ALOAD, 1);
                 mv.visitLdcInsn(commandParam.name);
                 mv.visitLdcInsn(commandParam.value);
-                mv.visitMethodInsn(INVOKEVIRTUAL, "java/util/HashMap", "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+                mv.visitMethodInsn(INVOKEVIRTUAL, "java/util/HashMap", "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", false);
                 mv.visitInsn(POP);
             }
 
@@ -363,14 +363,14 @@ public class ASMClassWriter implements ClassWriter {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitFieldInsn(GETFIELD, generatedPath + className, INJECTOR_FIELD, FORNAME_INJECTOR_TYPE);
         mv.visitLdcInsn(Type.getType("L" + childClass + ";"));
-        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG);
+        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG, true);
         mv.visitTypeInsn(CHECKCAST, childClass);
         mv.visitVarInsn(ASTORE, 1);
         mv.visitVarInsn(ALOAD, 1);
         mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, generatedPath + className, "getEntity", "()Lorg/jvnet/hk2/config/Dom;");
+        mv.visitMethodInsn(INVOKEVIRTUAL, generatedPath + className, "getEntity", "()Lorg/jvnet/hk2/config/Dom;", false);
         mv.visitLdcInsn(path);
-        mv.visitMethodInsn(INVOKEVIRTUAL, childClass, "setParentAndTagName", "(Lorg/jvnet/hk2/config/Dom;Ljava/lang/String;)V");
+        mv.visitMethodInsn(INVOKEVIRTUAL, childClass, "setParentAndTagName", "(Lorg/jvnet/hk2/config/Dom;Ljava/lang/String;)V", false);
         mv.visitVarInsn(ALOAD, 1);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(3, 2);
@@ -395,7 +395,7 @@ public class ASMClassWriter implements ClassWriter {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitFieldInsn(GETFIELD, generatedPath + "List" + childResourceClassName, INJECTOR_FIELD, FORNAME_INJECTOR_TYPE);
         mv.visitLdcInsn(Type.getType("L" + generatedPath + childResourceClassName + ";"));
-        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG);
+        mv.visitMethodInsn(INVOKEINTERFACE, INTERFACE_INJECTOR_TYPE, CREATE_AND_INITIALIZE, CREATE_AND_INITIALIZE_SIG, true);
         mv.visitTypeInsn(CHECKCAST, generatedPath + childResourceClassName);
         mv.visitVarInsn(ASTORE, 2);
         mv.visitVarInsn(ALOAD, 2);
@@ -405,7 +405,7 @@ public class ASMClassWriter implements ClassWriter {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitFieldInsn(GETFIELD, generatedPath + "List" + childResourceClassName, "tagName", "Ljava/lang/String;");
         mv.visitMethodInsn(INVOKEVIRTUAL, generatedPath + childResourceClassName, "setBeanByKey",
-                "(Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V");
+                "(Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V", false);
         mv.visitVarInsn(ALOAD, 2);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(4, 3);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/generator/ASMClassWriter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/GenericAnnotationDetector.java
@@ -36,8 +36,9 @@ import org.glassfish.internal.api.Globals;
 import org.glassfish.logging.annotation.LogMessageInfo;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+
+import static org.objectweb.asm.Opcodes.ASM9;
 
 /**
  * This class will detect whether an archive contains specified annotations.
@@ -61,7 +62,7 @@ public class GenericAnnotationDetector extends AnnotationScanner {
     List<String> annotations = new ArrayList<>();
 
     public GenericAnnotationDetector(Class[] annotationClasses) {
-        super(Opcodes.ASM7);
+        super(ASM9);
         if (annotationClasses != null) {
             for (Class annClass : annotationClasses) {
                 annotations.add(Type.getDescriptor(annClass));

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/NodeInfo.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/NodeInfo.java
@@ -22,7 +22,8 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.HashSet;
-import java.io.InputStream;
+
+import static org.objectweb.asm.Opcodes.ASM9;
 
 
 /**
@@ -69,7 +70,7 @@ class NodeInfo
     }
 
     NodeInfo(byte[] classData) {
-        super(Opcodes.ASM7);
+        super(ASM9);
         ClassReader cr = new ClassReader(classData);
 
         cr.accept(this, ClassReader.SKIP_CODE);
@@ -117,7 +118,7 @@ class NodeInfo
     }
 
     NodeInfo(String className) {
-        super(Opcodes.ASM7);
+        super(ASM9);
         this.className = className;
     }
 

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/NodeInfo.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/NodeInfo.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/BtraceClientGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/BtraceClientGenerator.java
@@ -40,6 +40,8 @@ import java.security.PrivilegedActionException;
 import java.security.ProtectionDomain;
 import java.util.Collection;
 
+import static org.objectweb.asm.Opcodes.V11;
+
 public class BtraceClientGenerator {
     private BtraceClientGenerator() {
         // all static class -- no instances allowed
@@ -54,7 +56,7 @@ public class BtraceClientGenerator {
 
         //Define the access identifiers for the BTrace Client class
         int access = Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL;
-        cw.visit(Opcodes.V1_5, access, generatedClassName, null,
+        cw.visit(V11, access, generatedClassName, null,
                 "java/lang/Object", null);
         //Need a @OnMethod annotation, so prepare your Annotation Visitor for that
         cw.visitAnnotation("Lcom/sun/btrace/annotations/BTrace;", true);

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/BtraceClientGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/BtraceClientGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
@@ -18,6 +18,7 @@ package org.glassfish.flashlight.impl.client;
 
 import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.Utility;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.lang.instrument.ClassFileTransformer;
@@ -36,6 +37,8 @@ import java.util.WeakHashMap;
 
 import org.glassfish.flashlight.FlashlightLoggerInfo;
 import static org.glassfish.flashlight.FlashlightLoggerInfo.*;
+import static org.objectweb.asm.Opcodes.ASM9;
+
 import org.glassfish.flashlight.provider.FlashlightProbe;
 import org.glassfish.flashlight.provider.ProbeRegistry;
 
@@ -286,7 +289,7 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
             extends ClassVisitor {
 
         ProbeProviderClassVisitor(ClassVisitor cv) {
-            super(Opcodes.ASM7, cv);
+            super(ASM9, cv);
             if (Log.getLogger().isLoggable(Level.FINER)) {
                 for (String methodDesc : probes.keySet()) {
                     Log.finer("visit" + methodDesc);
@@ -315,7 +318,7 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
         private Label startFinally;
 
         ProbeProviderMethodVisitor(MethodVisitor mv, int access, String name, String desc, FlashlightProbe probe) {
-            super(Opcodes.ASM7, mv, access, name, desc);
+            super(ASM9, mv, access, name, desc);
             this.probe = probe;
         }
 

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderImplGenerator.java
@@ -40,6 +40,8 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.GeneratorAdapter;
 import org.objectweb.asm.commons.Method;
 
+import static org.objectweb.asm.Opcodes.V11;
+
 public class ProviderImplGenerator {
     private static final Logger logger = FlashlightLoggerInfo.getLogger();
 
@@ -74,7 +76,7 @@ public class ProviderImplGenerator {
 
         int access = Opcodes.ACC_PUBLIC + Opcodes.ACC_FINAL;
         String[] interfaces = new String[]{providerClazz.getName().replace('.', '/')};
-        cw.visit(Opcodes.V1_5, access, generatedClassName, null, "java/lang/Object", interfaces);
+        cw.visit(V11, access, generatedClassName, null, "java/lang/Object", interfaces);
 
 
         for (FlashlightProbe probe : provider.getProbes()) {

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderImplGenerator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
@@ -167,7 +167,7 @@ public class ProviderSubClassImplGenerator {
                 MethodVisitor mv = super.visitMethod(access, name, desc, signature, strings);
                 mv.visitCode();
                 mv.visitVarInsn(Opcodes.ALOAD, 0);
-                mv.visitMethodInsn(Opcodes.INVOKESPECIAL, superClassName, "<init>", desc);
+                mv.visitMethodInsn(Opcodes.INVOKESPECIAL, superClassName, "<init>", desc, false);
                 mv.visitInsn(Opcodes.RETURN);
                 mv.visitMaxs(1, 1);
                 mv.visitEnd();

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/core/ProviderSubClassImplGenerator.java
@@ -32,6 +32,8 @@ import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.objectweb.asm.Opcodes.ASM9;
+
 public class ProviderSubClassImplGenerator {
     private static final Logger logger = FlashlightLoggerInfo.getLogger();
     public final static LocalStringManagerImpl localStrings =
@@ -136,7 +138,7 @@ public class ProviderSubClassImplGenerator {
         String id;
 
         ProbeProviderSubClassGenerator(ClassVisitor cv, String token, String id) {
-            super(Opcodes.ASM7, cv);
+            super(ASM9, cv);
             this.id = id;
             this.token = token;
         }
@@ -184,7 +186,7 @@ public class ProviderSubClassImplGenerator {
         private String token;
 
         ProbeProviderAnnotationVisitor(AnnotationVisitor delegate, String token) {
-            super(Opcodes.ASM7);
+            super(ASM9);
             this.delegate = delegate;
             this.token = token;
         }

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2ClasssVisitor.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2ClasssVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2ClasssVisitor.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2ClasssVisitor.java
@@ -28,7 +28,8 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Opcodes;
+
+import static org.objectweb.asm.Opcodes.ASM9;
 
 
 /**
@@ -50,7 +51,7 @@ class HK2ClasssVisitor extends ClassVisitor {
      * @param excludedClasses
      */
     public HK2ClasssVisitor(final ServiceLocator locator, final Set<Class<?>> excludedClasses) {
-        super(Opcodes.ASM7);
+        super(ASM9);
         this.locator = locator;
         this.excludedClasses = excludedClasses.stream().map(Class::getName).collect(Collectors.toSet());
     }


### PR DESCRIPTION
In this PR

* Raise ASM API version to ASM9 in all places
* Raise bytecode level to Java 11 in all places
* Replace usage of deprecated ASM API

Signed-off-by: Alexander Pinchuk <alexander.v.pinchuk@gmail.com>
