### PR TITLE
Updated dependency on old TCK

### DIFF
--- a/appserver/tests/tck/tck-download/jakarta-ant-based-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-ant-based-tck/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Be patient, it is over 500 MB -->
-        <tck.test.jee.file>jakarta-jakartaeetck-10.0.0.zip</tck.test.jee.file>
+        <tck.test.jee.file>jakarta-jakartaeetck-10.0.2.zip</tck.test.jee.file>
         <tck.test.jee.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/${tck.test.jee.file}</tck.test.jee.url>
     </properties>
 


### PR DESCRIPTION
In the 10.0.1 was fixed the start of the GlassFish, now there is a 10.0.2 available.
