### PR TITLE
Refactor logging admin integration tests

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -21,7 +21,11 @@ import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
 import org.glassfish.main.itest.tools.asadmin.Asadmin;
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
 import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.File;
 import java.io.FileReader;
@@ -56,11 +60,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * @author David Matejcek
  */
+@TestMethodOrder(OrderAnnotation.class)
 public class AsadminLoggingITest {
 
     private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
 
+    @BeforeAll
+    public static void fillUpLog() {
+        // Fill up the server log.
+        AsadminResult result = ASADMIN.exec("restart-domain");
+        assertThat(result, asadminOK());
+    }
+
     @Test
+    @Order(1)
     public void collectLogFiles() {
         AsadminResult result = ASADMIN.exec("collect-log-files");
         assertThat(result, asadminOK());
@@ -75,6 +88,7 @@ public class AsadminLoggingITest {
 
 
     @Test
+    @Order(2)
     public void listLogLevels() {
         AsadminResult result = ASADMIN.exec("list-log-levels");
         assertThat(result, asadminOK());
@@ -95,6 +109,7 @@ public class AsadminLoggingITest {
      * META-INF/loggerinfo/LoggerInfoMetadata.properties files.
      */
     @Test
+    @Order(3)
     public void listLoggers() {
         AsadminResult result = ASADMIN.exec("list-loggers");
         assertThat(result, asadminOK());
@@ -116,6 +131,7 @@ public class AsadminLoggingITest {
 
 
     @Test
+    @Order(4)
     public void listLogAttributes() {
         AsadminResult result = ASADMIN.exec("list-log-attributes");
         assertThat(result, asadminOK());
@@ -135,6 +151,7 @@ public class AsadminLoggingITest {
 
 
     @Test
+    @Order(5)
     public void setLogAttributes() throws Exception {
         AsadminResult result = ASADMIN.exec("set-log-attributes", "--target", "server",
             "org.glassfish.main.jul.handler.GlassFishLogHandler.rotation.maxArchiveFiles=100"
@@ -171,6 +188,7 @@ public class AsadminLoggingITest {
 
 
     @Test
+    @Order(100)
     public void rotateLog() throws Exception {
         File serverLogDirectory = getDomain1Directory().resolve("logs").toFile();
         File serverLogFile = new File(serverLogDirectory, "server.log");

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,17 +16,6 @@
 
 package org.glassfish.main.admin.test;
 
-import org.apache.commons.lang3.StringUtils;
-import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
-import org.glassfish.main.itest.tools.asadmin.Asadmin;
-import org.glassfish.main.itest.tools.asadmin.AsadminResult;
-import org.hamcrest.io.FileMatchers;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-
 import java.io.File;
 import java.io.FileReader;
 import java.io.LineNumberReader;
@@ -38,6 +27,17 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.apache.commons.lang3.StringUtils.replaceChars;
 import static org.apache.commons.lang3.StringUtils.substringBefore;

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
@@ -25,8 +25,12 @@ import java.net.HttpURLConnection;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getAsadmin;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -38,6 +42,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author David Matejcek
  */
 public class LoggingRestITest {
+
+    @BeforeAll
+    public static void fillUpLog() {
+        // The server log may become empty due to log rotation.
+        // Restart domain to fill it up.
+        AsadminResult result = getAsadmin().exec("restart-domain");
+        assertThat(result, asadminOK());
+    }
 
     @Test
     public void logFileNames() throws Exception {

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
@@ -19,6 +19,7 @@ package org.glassfish.main.admin.test.rest;
 import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
+
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.main.itest.tools.DomainAdminRestClient;

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
@@ -76,7 +76,7 @@ public class RestTestBase {
         baseAdminUrl = "http://localhost:4848";
         baseInstanceUrl = "http://localhost:8080";
         managementClient = new DomainAdminRestClient(baseAdminUrl + CONTEXT_ROOT_MANAGEMENT);
-        Response response = managementClient.get("/domain/rotate-log");
+        Response response = managementClient.post("/domain/rotate-log");
         assertThat(response.getStatus(), equalTo(200));
     }
 


### PR DESCRIPTION
In admin integration tests log rotation actually didn't work. This patch

* Fix log rotation
* `LoggingRestITest` inherits from `RestTestBase` hence writes a log to `surefire-reports` dir
* Add test case to check `X-Text-Append-Next` header
* Reuse some GF utility methods instead of custom code

Signed-off-by: Alexander Pinĉuk <alexandr.v.pinchuk@gmail.com>


