### PR TITLE
Refactor securing REST Admin interface integration test

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/DomainAdminRestClient.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/DomainAdminRestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,14 +19,12 @@ package org.glassfish.main.itest.tools;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation.Builder;
 import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import java.io.Closeable;
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -35,6 +33,10 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.createClient;
 
 /**
  * @author David Matejcek
@@ -46,12 +48,11 @@ public class DomainAdminRestClient implements Closeable {
     private final String responseType;
 
     public DomainAdminRestClient(final String baseUrl) {
-        this(baseUrl, MediaType.APPLICATION_JSON);
+        this(baseUrl, APPLICATION_JSON);
     }
 
-
     public DomainAdminRestClient(final String baseUrl, final String responseType) {
-        this(GlassFishTestEnvironment.createClient(), baseUrl, responseType);
+        this(createClient(), baseUrl, responseType);
     }
 
 
@@ -63,7 +64,7 @@ public class DomainAdminRestClient implements Closeable {
 
 
     /**
-     * @return http://localhost:4848/management or something else, see constructor.
+     * @return {@code http://localhost:4848/management} or something else, see constructor.
      */
     public final String getBaseUrl() {
         return baseUrl;
@@ -76,7 +77,7 @@ public class DomainAdminRestClient implements Closeable {
 
 
     public Response get(final String relativePath) {
-        return get(relativePath, new HashMap<String, String>());
+        return get(relativePath, null);
     }
 
 
@@ -115,15 +116,15 @@ public class DomainAdminRestClient implements Closeable {
             if (entry.getValue() instanceof File) {
                 form.getBodyParts().add((new FileDataBodyPart(entry.getKey(), (File) entry.getValue())));
             } else {
-                form.field(entry.getKey(), entry.getValue(), MediaType.TEXT_PLAIN_TYPE);
+                form.field(entry.getKey(), entry.getValue(), TEXT_PLAIN_TYPE);
             }
         }
-        return getRequestBuilder(relativePath).post(Entity.entity(form, MediaType.MULTIPART_FORM_DATA), Response.class);
+        return getRequestBuilder(relativePath).post(Entity.entity(form, MULTIPART_FORM_DATA), Response.class);
     }
 
 
     public Response delete(final String relativePath) {
-        return delete(relativePath, new HashMap<String, String>());
+        return delete(relativePath, null);
     }
 
     public Response delete(final String relativePath, final Map<String, String> queryParams) {
@@ -133,9 +134,12 @@ public class DomainAdminRestClient implements Closeable {
 
 
     public Builder getRequestBuilder(final String relativePath) {
-        return getTarget(relativePath, null).request(responseType);
+        return getRequestBuilder(relativePath, null);
     }
 
+    public Builder getRequestBuilder(final  String relativePath, Map<String, String> queryParams) {
+        return getTarget(relativePath, queryParams).request(responseType);
+    }
 
     public WebTarget getTarget(final String relativePath, final Map<String, String> queryParams) {
         WebTarget target = client.target(baseUrl + relativePath);

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/BasicAuthenticationITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/BasicAuthenticationITest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test.rest;
+
+import jakarta.ws.rs.core.Response;
+
+import org.glassfish.admin.rest.client.ClientWrapper;
+import org.glassfish.main.itest.tools.DomainAdminRestClient;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BasicAuthenticationITest extends SecuredRestTestBase {
+
+    private static final String INVALID_USER_NAME = "invaliduser";
+
+    private static final String INVALID_PASSWORD = "invalidpass";
+
+    @Test
+    public void testAuthRequired() {
+        // Invalid credentials
+        try (BasicClient basicClient = new BasicClient(INVALID_USER_NAME, INVALID_PASSWORD)) {
+            Response response = basicClient.get(URL_DOMAIN);
+            assertThat(response.getStatus(), equalTo(401));
+        }
+
+        // Anonymous access
+        try (AnonymousClient anonymousClient = new AnonymousClient()) {
+            Response response = anonymousClient.get(URL_DOMAIN);
+            assertThat(response.getStatus(), equalTo(401));
+        }
+
+        // Valid credentials
+        try (BasicClient basicClient = new BasicClient(AUTH_USER_NAME, AUTH_PASSWORD)) {
+            Response response = basicClient.get(URL_DOMAIN);
+            assertThat(response.getStatus(), equalTo(200));
+        }
+    }
+
+    private static final class AnonymousClient extends DomainAdminRestClient {
+
+        public AnonymousClient() {
+            super(new ClientWrapper(), managementClient.getBaseUrl(), APPLICATION_JSON);
+        }
+    }
+}

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/RestTestBase.java
@@ -59,6 +59,7 @@ public class RestTestBase {
 
     protected static final String CONTEXT_ROOT_MANAGEMENT = "/management";
 
+    protected static final String URL_DOMAIN = "/domain";
     protected static final String URL_CLUSTER = "/domain/clusters/cluster";
     protected static final String URL_APPLICATION_DEPLOY = "/domain/applications/application";
     protected static final String URL_CREATE_INSTANCE = "/domain/create-instance";

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/SecuredRestTestBase.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/SecuredRestTestBase.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test.rest;
+
+import jakarta.ws.rs.core.Response;
+
+import org.glassfish.admin.rest.client.ClientWrapper;
+import org.glassfish.main.itest.tools.DomainAdminRestClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.util.Map;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.glassfish.jersey.client.authentication.HttpAuthenticationFeature.basic;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class SecuredRestTestBase extends RestTestBase {
+
+    private static final String URL_CREATE_USER = "/domain/configs/config/server-config/security-service/auth-realm/admin-realm/create-user";
+
+    private static final String URL_DELETE_USER = "/domain/configs/config/server-config/security-service/auth-realm/admin-realm/delete-user";
+
+    protected static final String AUTH_USER_NAME = "dummyuser";
+
+    protected static final String AUTH_PASSWORD = "dummypass";
+
+    @BeforeAll
+    public static void createUser() {
+        // Create the new user
+        Map<String, String> newUser = Map.of(
+            "id", AUTH_USER_NAME,
+            "groups", "asadmin",
+            "authrealmname", "admin-realm",
+            "AS_ADMIN_USERPASSWORD", AUTH_PASSWORD
+        );
+        Response response = managementClient.post(URL_CREATE_USER, newUser);
+        assertThat(response.getStatus(), equalTo(200));
+    }
+
+    @AfterAll
+    public static void deleteUser() {
+        Response response = managementClient.delete(URL_DELETE_USER, Map.of("id", AUTH_USER_NAME));
+        assertThat(response.getStatus(), equalTo(200));
+    }
+
+    protected static final class BasicClient extends DomainAdminRestClient {
+
+        public BasicClient(String userName, String password) {
+            super(createClient(userName, password), managementClient.getBaseUrl(), APPLICATION_JSON);
+        }
+
+        private static ClientWrapper createClient(String userName, String password) {
+            ClientWrapper client = new ClientWrapper();
+            client.register(basic(userName, password));
+            return client;
+        }
+    }
+}

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/TokenAuthenticationITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/TokenAuthenticationITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,156 +17,87 @@
 
 package org.glassfish.main.admin.test.rest;
 
-import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Map;
 
 import org.glassfish.admin.rest.client.ClientWrapper;
-import org.glassfish.admin.rest.client.utils.MarshallingUtils;
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.glassfish.main.itest.tools.DomainAdminRestClient;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.glassfish.main.itest.tools.RandomGenerator.generateRandomString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Mitesh Meswani
  */
-public class TokenAuthenticationITest extends RestTestBase {
-    private static final String URL_DOMAIN_SESSIONS = "/sessions";
-    private static final String URL_CREATE_USER = "/domain/configs/config/server-config/security-service/auth-realm/admin-realm/create-user";
-    private static final String URL_DELETE_USER = "/domain/configs/config/server-config/security-service/auth-realm/admin-realm/delete-user";
-    private static final String GF_REST_TOKEN_COOKIE_NAME = "gfresttoken";
+public class TokenAuthenticationITest extends SecuredRestTestBase {
 
-    private static final String AUTH_USER_NAME = "dummyuser";
-    private static final String AUTH_PASSWORD = "dummypass";
-    private static final HttpAuthenticationFeature AUTH_DUMMY = HttpAuthenticationFeature.basic(AUTH_USER_NAME, AUTH_PASSWORD);
+    private static final String URL_SESSIONS = "/sessions";
 
-    @AfterAll
-    public static void cleanup() {
-        managementClient.delete(URL_DELETE_USER, Map.of("id", AUTH_USER_NAME));
-    }
-
-
-    @Test
-    public void testTokenCreateAndDelete() {
-        String token = getSessionToken(managementClient);
-        assertNotNull(token, "token");
-
-        // Verify we can use the session token.
-        Response response = managementClient.getRequestBuilder("/domain")
-            .cookie(new Cookie(GF_REST_TOKEN_COOKIE_NAME, token)).get(Response.class);
-        assertEquals(200, response.getStatus());
-
-        // Delete the token
-        response = managementClient.getRequestBuilder(URL_DOMAIN_SESSIONS + "/" + token)
-            .cookie(new Cookie(GF_REST_TOKEN_COOKIE_NAME, token)).delete(Response.class);
-        managementClient.delete(URL_DOMAIN_SESSIONS);
-        assertEquals(200, response.getStatus());
-    }
-
+    private static final String INVALID_TOKEN = generateRandomString();
 
     @Test
     public void testAuthRequired() {
-        Response delResponse = managementClient.delete(URL_DELETE_USER, Map.of("id", AUTH_USER_NAME));
-        // as of gf6 any error means 500. The user doesn't exist.
-        assertEquals(500, delResponse.getStatus());
+        // Invalid session token
+        try (TokenClient tokenClient = new TokenClient(INVALID_TOKEN)) {
+            Response response = tokenClient.get(URL_DOMAIN);
+            assertThat(response.getStatus(), equalTo(401));
+        }
 
-        try (DummyClient client = new DummyClient()) {
-            Response response = client.get("/domain");
-            assertEquals(401, response.getStatus());
-        }
-        {
-            // Create the new user
-            Map<String, String> newUser = Map.of(
-                "id", AUTH_USER_NAME,
-                "groups", "asadmin",
-                "authrealmname", "admin-realm",
-                "AS_ADMIN_USERPASSWORD", AUTH_PASSWORD
-                );
-            Response createUserResponse = managementClient.post(URL_CREATE_USER, newUser);
-            assertEquals(200, createUserResponse.getStatus());
-        }
-        try (AnonymousClient client = new AnonymousClient()) {
-            Response response = client.getRequestBuilder("/domain").get(Response.class);
-            assertEquals(401, response.getStatus());
-        }
         final String token;
-        try (DummyClient dummyClient = new DummyClient()) {
-            token = getSessionToken(dummyClient);
+        try (BasicClient basicClient = new BasicClient(AUTH_USER_NAME, AUTH_PASSWORD)) {
+            // Create session token
+            token = getSessionToken(basicClient);
         }
+        assertNotNull(token);
 
-        try (CookieClient cookieClient = new CookieClient(token)) {
-            Response response = cookieClient.get("/domain");
-            assertEquals(200, response.getStatus());
-        }
-        try (AnonymousClient client = new AnonymousClient()) {
-            Response response = client.getRequestBuilder("/domain").get(Response.class);
-            assertEquals(401, response.getStatus());
-        }
-        try (CookieClient cookieClient = new CookieClient(token)) {
-            Response response = cookieClient.delete(URL_DELETE_USER, Map.of("id", AUTH_USER_NAME));
-            assertEquals(200, response.getStatus());
+        // Valid session token
+        try (TokenClient tokenClient = new TokenClient(token)) {
+            Response response = tokenClient.get(URL_DOMAIN);
+            assertThat(response.getStatus(), equalTo(200));
+
+            // Delete session token
+            response = managementClient.delete(URL_SESSIONS + "/" + token);
+            assertThat(response.getStatus(), equalTo(200));
+
+            // And try again
+            response = tokenClient.get(URL_DOMAIN);
+            assertThat(response.getStatus(), equalTo(401));
         }
     }
 
 
     private String getSessionToken(DomainAdminRestClient client) {
-        Response response = client.post(URL_DOMAIN_SESSIONS);
-        assertEquals(200, response.getStatus());
-        Map<String, ?> responseMap = MarshallingUtils.buildMapFromDocument(response.readEntity(String.class));
-        Map<String, Object> extraProperties = (Map<String, Object>) responseMap.get("extraProperties");
+        Response response = client.post(URL_SESSIONS);
+        assertThat(response.getStatus(), equalTo(200));
+
+        Map<String, Object> extraProperties = getExtraProperties(response);
         return (String) extraProperties.get("token");
     }
 
+    private static final class TokenClient extends DomainAdminRestClient {
 
-    private static final class AnonymousClient extends DomainAdminRestClient {
+        private static final String GF_REST_TOKEN_NAME = "gfresttoken";
 
-        public AnonymousClient() {
+        private final String sessionToken;
+
+        public TokenClient(final String sessionToken) {
             super(new ClientWrapper(), managementClient.getBaseUrl(), APPLICATION_JSON);
-        }
-    }
-
-
-    private static final class DummyClient extends DomainAdminRestClient {
-
-        public DummyClient() {
-            super(createClient(), managementClient.getBaseUrl(), APPLICATION_JSON);
-        }
-
-        private static ClientWrapper createClient() {
-            ClientWrapper client = new ClientWrapper();
-            client.register(AUTH_DUMMY);
-            return client;
-        }
-    }
-
-
-    private static final class CookieClient extends DomainAdminRestClient {
-
-        private final String securityCookie;
-
-        public CookieClient(final String securityCookie) {
-            super(new ClientWrapper(), managementClient.getBaseUrl(), APPLICATION_JSON);
-            this.securityCookie = securityCookie;
+            this.sessionToken = sessionToken;
         }
 
         @Override
         public Response delete(final String relativePath, final Map<String, String> queryParams) {
-            return getTarget(relativePath, queryParams).request()
-                .cookie(new Cookie(GF_REST_TOKEN_COOKIE_NAME, securityCookie)).delete(Response.class);
+            return getRequestBuilder(relativePath, queryParams).cookie(GF_REST_TOKEN_NAME, sessionToken).delete();
         }
-
 
         @Override
         public Response get(final String relativePath, final Map<String, String> queryParams) {
-            return getTarget(relativePath, queryParams).request()
-                .cookie(new Cookie(GF_REST_TOKEN_COOKIE_NAME, securityCookie)).get(Response.class);
+            return getRequestBuilder(relativePath, queryParams).cookie(GF_REST_TOKEN_NAME, sessionToken).get();
         }
-
     }
 }

--- a/docs/administration-guide/src/main/asciidoc/general-administration.adoc
+++ b/docs/administration-guide/src/main/asciidoc/general-administration.adoc
@@ -1874,7 +1874,7 @@ credentials to enable the client to pass the credentials with each
 request. If you require a REST client not to cache credentials, your
 client must use session tokens for authentication.
 
-1. Request a session token by using the `GET` method on the resource at
+1. Request a session token by using the `POST` method on the resource at
 `http://`host`:`port`/management/sessions`.
 {productName} uses basic authentication to authenticate the client,
 generates a session token, and passes the token to the client.


### PR DESCRIPTION
Restructuring securing REST Admin interface integration test

* Separated tests for Basic Authentication and Token Authentication,
* Removed logically unrelated test cases and assertions (e.g. we should test access to resources rather than creation or deletion users),
* Small fix of AsciiDoc for request a session token.

Signed-off-by: Alexander Pinčuk <alexander.v.pinchuk@gmail.com>
