### PR TITLE
Refactor Enterprise Beans no-interface view bytecode generation

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/AsmSerializableBeanGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/AsmSerializableBeanGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,31 +17,27 @@
 
 package com.sun.ejb.codegen;
 
-import java.io.Serializable;
-import java.lang.reflect.Constructor;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
+import static com.sun.ejb.codegen.ClassGenerator.defineClass;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V11;
 
-public class AsmSerializableBeanGenerator {
-
-    private static final int INTF_FLAGS = ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES;
+public class AsmSerializableBeanGenerator extends BeanGeneratorBase {
 
     private final ClassLoader loader;
-    private final Class<?> baseClass;
-    private final String subclassName;
-
+    private final Class<?> superClass;
+    private final String subClassName;
 
     /**
      * Adds _Serializable to the original name.
@@ -55,89 +51,73 @@ public class AsmSerializableBeanGenerator {
         return packageName == null ? generatedSimpleName : packageName + "." + generatedSimpleName;
     }
 
-
-    public AsmSerializableBeanGenerator(ClassLoader loader, Class baseClass, String serializableSubclassName) {
+    public AsmSerializableBeanGenerator(ClassLoader loader, Class<?> superClass, String serializableSubclassName) {
         this.loader = loader;
-        this.baseClass = baseClass;
-        this.subclassName = serializableSubclassName;
+        this.superClass = superClass;
+        this.subClassName = serializableSubclassName;
     }
 
+    @SuppressWarnings("unused")
     public String getSerializableSubclassName() {
-        return subclassName;
+        return subClassName;
     }
 
+    public Class<?> generateSerializableSubclass() {
+        String subClassInternalName = subClassName.replace('.', '/');
 
-    public Class generateSerializableSubclass() throws Exception {
-        ClassWriter cw = new ClassWriter(INTF_FLAGS);
+        ClassWriter cw = new ClassWriter(0);
 
-        //ClassVisitor tv = //(_debug)
-        //new TraceClassVisitor(cw, new PrintWriter(System.out));
-        ClassVisitor tv = cw;
-        String subclassInternalName = subclassName.replace('.', '/');
+        cw.visit(V11, ACC_PUBLIC, subClassInternalName, null, Type.getInternalName(superClass), new String[] {"java/io/Serializable"});
 
-        String[] interfaces = new String[] {
-            Type.getType(Serializable.class).getInternalName()
-        };
+        generateConstructor(cw, superClass, false);
 
-        tv.visit(V11, ACC_PUBLIC,
-            subclassInternalName, null,
-            Type.getType(baseClass).getInternalName(), interfaces);
+        generateWriteObjectMethod(cw);
 
+        generateReadObjectMethod(cw);
 
-        // Generate constructor. The EJB spec only allows no-arg constructors, but
-        // CDI added requirements that allow a single constructor to define
-        // parameters injected by CDI.
+        cw.visitEnd();
 
-        Constructor<?>[] ctors = baseClass.getConstructors();
-        Constructor<?> ctorWithParams = null;
-        for(Constructor<?> ctor : ctors) {
-            if(ctor.getParameterTypes().length == 0) {
-                ctorWithParams = null;    //exists the no-arg ctor, use it
-                break;
-            } else if(ctorWithParams == null) {
-                ctorWithParams = ctor;
-            }
-        }
+        PrivilegedAction<Class<?>> action =
+                () -> defineClass(loader, subClassName, cw.toByteArray(), superClass.getProtectionDomain());
 
-        int numArgsToPass = 1; // default is 1 to just handle 'this'
-        String paramTypeString = "()V";
-
-        if (ctorWithParams != null) {
-            Class<?>[] paramTypes = ctorWithParams.getParameterTypes();
-            numArgsToPass = paramTypes.length + 1;
-            paramTypeString = Type.getConstructorDescriptor(ctorWithParams);
-        }
-
-        MethodVisitor ctorv = tv.visitMethod(ACC_PUBLIC, "<init>", paramTypeString, null, null);
-
-        for (int i = 0; i < numArgsToPass; i++) {
-            ctorv.visitVarInsn(ALOAD, i);
-        }
-        ctorv.visitMethodInsn(INVOKESPECIAL,  Type.getType(baseClass).getInternalName(), "<init>", paramTypeString, false);
-        ctorv.visitInsn(RETURN);
-        ctorv.visitMaxs(numArgsToPass, numArgsToPass);
-
-        MethodVisitor cv = cw.visitMethod(ACC_PRIVATE, "writeObject", "(Ljava/io/ObjectOutputStream;)V", null, new String[] { "java/io/IOException" });
-        cv.visitVarInsn(ALOAD, 0);
-        cv.visitVarInsn(ALOAD, 1);
-        cv.visitMethodInsn(INVOKESTATIC, "com/sun/ejb/EJBUtils", "serializeObjectFields", "(Ljava/lang/Object;Ljava/io/ObjectOutputStream;)V", false);
-        cv.visitInsn(RETURN);
-        cv.visitMaxs(2, 2);
-
-
-        cv = cw.visitMethod(ACC_PRIVATE, "readObject", "(Ljava/io/ObjectInputStream;)V", null, new String[] { "java/io/IOException", "java/lang/ClassNotFoundException" });
-        cv.visitVarInsn(ALOAD, 0);
-        cv.visitVarInsn(ALOAD, 1);
-        cv.visitMethodInsn(INVOKESTATIC, "com/sun/ejb/EJBUtils", "deserializeObjectFields", "(Ljava/lang/Object;Ljava/io/ObjectInputStream;)V", false);
-        cv.visitInsn(RETURN);
-        cv.visitMaxs(2, 2);
-
-        tv.visitEnd();
-
-        byte[] classData = cw.toByteArray();
-
-        PrivilegedAction<Class<?>> action = () -> ClassGenerator.defineClass(loader, subclassName, classData,
-            baseClass.getProtectionDomain());
         return AccessController.doPrivileged(action);
+    }
+
+    private static void generateWriteObjectMethod(ClassVisitor cv) {
+        MethodVisitor mv = cv.visitMethod(ACC_PRIVATE,
+                "writeObject",
+                "(Ljava/io/ObjectOutputStream;)V",
+                null,
+                new String[] {"java/io/IOException"});
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitVarInsn(ALOAD, 1);
+        mv.visitMethodInsn(INVOKESTATIC,
+                "com/sun/ejb/EJBUtils",
+                "serializeObjectFields",
+                "(Ljava/lang/Object;Ljava/io/ObjectOutputStream;)V",
+                false);
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(2, 2);
+        mv.visitEnd();
+    }
+
+    private static void generateReadObjectMethod(ClassVisitor cv) {
+        MethodVisitor mv = cv.visitMethod(ACC_PRIVATE,
+                "readObject",
+                "(Ljava/io/ObjectInputStream;)V",
+                null,
+                new String[] {"java/io/IOException", "java/lang/ClassNotFoundException"});
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitVarInsn(ALOAD, 1);
+        mv.visitMethodInsn(INVOKESTATIC,
+                "com/sun/ejb/EJBUtils",
+                "deserializeObjectFields",
+                "(Ljava/lang/Object;Ljava/io/ObjectInputStream;)V",
+                false);
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(2, 2);
+        mv.visitEnd();
     }
 }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/BeanGeneratorBase.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/BeanGeneratorBase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ejb.codegen;
+
+import jakarta.inject.Inject;
+
+import java.lang.reflect.Constructor;
+
+import org.glassfish.deployment.common.DeploymentException;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.RETURN;
+
+/**
+ * Common methods related to ASM bytecode generation.
+ *
+ * @author Alexander Pinčuk
+ */
+class BeanGeneratorBase {
+
+    /**
+     * Generate constructor.
+     *
+     * <p>The EJB spec only allows no-arg constructors, but CDI added requirements
+     * that allow a single constructor to define parameters injected by CDI.
+     *
+     * @param cv the ASM {@code ClassVisitor}.
+     * @param superClass a superclass.
+     * @param withNoArguments indicates if generated constructor takes no arguments.
+     */
+    protected static void generateConstructor(ClassVisitor cv, Class<?> superClass, boolean withNoArguments) {
+        Constructor<?> parentCtor = findParentConstructor(superClass);
+        String parentCtorDesc = Type.getConstructorDescriptor(parentCtor);
+        String ctorDesc = withNoArguments ? "()V" : parentCtorDesc;
+        String superClassInternalName = Type.getInternalName(superClass);
+
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "<init>", ctorDesc, null, null);
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);  // load 'this'
+
+        int argCount = parentCtor.getParameterCount();
+        for (int i = 0; i < argCount; i++) {
+            if (withNoArguments) {
+                mv.visitInsn(ACONST_NULL);
+            } else {
+                mv.visitVarInsn(ALOAD, i + 1);
+            }
+        }
+
+        mv.visitMethodInsn(INVOKESPECIAL, superClassInternalName, "<init>", parentCtorDesc, false);
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(argCount + 1, withNoArguments ? 1 : argCount + 1);
+        mv.visitEnd();
+    }
+
+    private static Constructor<?> findParentConstructor(Class<?> superClass) {
+        Constructor<?>[] ctors = superClass.getConstructors();
+
+        Constructor<?> parentCtor = null;
+        for (Constructor<?> ctor : ctors) {
+            if (ctor.getParameterCount() == 0) {
+                // exists the no-arg constructor, use it
+                parentCtor = ctor;
+                break;
+            } else if (ctor.isAnnotationPresent(Inject.class)) {
+                // exists a CDI bean constructor, use it
+                parentCtor = ctor;
+            }
+        }
+
+        if (parentCtor == null) {
+            // Should never be thrown.
+            throw new DeploymentException("A class " + superClass.getName() + " doesn't have any appropriate constructor");
+        }
+
+        return parentCtor;
+    }
+}

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
 
+import static com.sun.ejb.codegen.ClassGenerator.defineClass;
 import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
 import static org.objectweb.asm.Opcodes.ACC_INTERFACE;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
@@ -78,8 +79,7 @@ public class EjbOptionalIntfGenerator extends BeanGeneratorBase {
         } catch (ClassNotFoundException cnfe) {
             final byte[] classData = classMap.get(name);
             if (classData != null) {
-                PrivilegedAction<Class<?>> action =
-                        () -> ClassGenerator.defineClass(loader, name, classData, protectionDomain);
+                PrivilegedAction<Class<?>> action = () -> defineClass(loader, name, classData, protectionDomain);
                 clz = AccessController.doPrivileged(action);
             }
         }

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,13 +17,8 @@
 
 package com.sun.ejb.codegen;
 
-import com.sun.ejb.spi.container.OptionalLocalInterfaceProvider;
-import com.sun.enterprise.container.common.spi.util.IndirectlySerializable;
-import com.sun.enterprise.container.common.spi.util.SerializableObjectFactory;
-import com.sun.enterprise.deployment.util.TypeUtil;
-
 import java.io.Serializable;
-import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -33,59 +28,58 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.sun.ejb.spi.container.OptionalLocalInterfaceProvider;
+import com.sun.enterprise.container.common.spi.util.IndirectlySerializable;
+import com.sun.enterprise.container.common.spi.util.SerializableObjectFactory;
+import com.sun.enterprise.deployment.util.TypeUtil;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.commons.GeneratorAdapter;
-import org.objectweb.asm.commons.Method;
 
 import static org.objectweb.asm.Opcodes.ACC_ABSTRACT;
 import static org.objectweb.asm.Opcodes.ACC_INTERFACE;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Opcodes.ACONST_NULL;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.ATHROW;
 import static org.objectweb.asm.Opcodes.CHECKCAST;
 import static org.objectweb.asm.Opcodes.DUP;
 import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.ILOAD;
 import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.NEW;
 import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V11;
 
-public class EjbOptionalIntfGenerator {
-
-    private static final int INTF_FLAGS = ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES;
+public class EjbOptionalIntfGenerator extends BeanGeneratorBase {
 
     private static final String DELEGATE_FIELD_NAME = "__ejb31_delegate";
 
     private final Map<String, byte[]> classMap = new HashMap<>();
-
     private final ClassLoader loader;
-
     private ProtectionDomain protectionDomain;
 
     public EjbOptionalIntfGenerator(ClassLoader loader) {
         this.loader = loader;
     }
 
-
-    public Class loadClass(final String name) throws ClassNotFoundException {
-        Class clz = null;
+    public Class<?> loadClass(final String name) throws ClassNotFoundException {
+        Class<?> clz = null;
         try {
             clz = loader.loadClass(name);
         } catch (ClassNotFoundException cnfe) {
             final byte[] classData = classMap.get(name);
             if (classData != null) {
-                PrivilegedAction<Class<?>> action = () -> ClassGenerator.defineClass(loader, name, classData,
-                    protectionDomain);
+                PrivilegedAction<Class<?>> action =
+                        () -> ClassGenerator.defineClass(loader, name, classData, protectionDomain);
                 clz = AccessController.doPrivileged(action);
             }
         }
@@ -95,62 +89,58 @@ public class EjbOptionalIntfGenerator {
         return clz;
     }
 
-    public void generateOptionalLocalInterface(Class ejbClass, String intfClassName)
-        throws Exception {
-
+    public void generateOptionalLocalInterface(Class<?> ejbClass, String intfClassName) {
         generateInterface(ejbClass, intfClassName, Serializable.class);
     }
 
-    public void generateInterface(Class ejbClass, String intfClassName, final Class... interfaces) throws Exception {
+    public void generateInterface(Class<?> ejbClass, String intfClassName, final Class<?>... interfaces) {
         String[] interfaceNames = new String[interfaces.length];
         for (int i = 0; i < interfaces.length; i++) {
-            interfaceNames[i] = Type.getType(interfaces[i]).getInternalName();
+            interfaceNames[i] = Type.getInternalName(interfaces[i]);
         }
 
         if (protectionDomain == null) {
             protectionDomain = ejbClass.getProtectionDomain();
         }
 
-        ClassWriter cw = new ClassWriter(INTF_FLAGS);
+        ClassWriter cw = new ClassWriter(0);
 
-        ClassVisitor tv = cw;
-        String intfInternalName = intfClassName.replace('.', '/');
-        tv.visit(V11, ACC_PUBLIC + ACC_ABSTRACT + ACC_INTERFACE,
-                intfInternalName, null,
-                Type.getType(Object.class).getInternalName(),
-                interfaceNames );
+        cw.visit(V11,
+                ACC_PUBLIC + ACC_ABSTRACT + ACC_INTERFACE,
+                intfClassName.replace('.', '/'),
+                null,
+                "java/lang/Object",
+                interfaceNames);
 
-        for (java.lang.reflect.Method m : ejbClass.getMethods()) {
-            if (qualifiedAsBeanMethod(m)) {
-                generateInterfaceMethod(tv, m);
+        for (Method method : ejbClass.getMethods()) {
+            if (qualifiedAsBeanMethod(method)) {
+                generateInterfaceMethod(cw, method);
             }
         }
 
-        tv.visitEnd();
+        cw.visitEnd();
 
-        byte[] classData = cw.toByteArray();
-        classMap.put(intfClassName, classData);
+        classMap.put(intfClassName, cw.toByteArray());
     }
 
     /**
      * Determines if a method from a bean class can be considered as a business
      * method for EJB of no-interface view.
-     * @param m a public method
+     * @param method a public method
      * @return true if m can be included as a bean business method.
      */
-    private boolean qualifiedAsBeanMethod(java.lang.reflect.Method m) {
-        if (m.getDeclaringClass() == Object.class) {
+    private boolean qualifiedAsBeanMethod(Method method) {
+        if (method.getDeclaringClass() == Object.class) {
             return false;
         }
-        int mod = m.getModifiers();
-        return !Modifier.isStatic(mod) && !Modifier.isFinal(mod);
+        int modifiers = method.getModifiers();
+        return !Modifier.isStatic(modifiers) && !Modifier.isFinal(modifiers);
     }
 
-    private boolean hasSameSignatureAsExisting(java.lang.reflect.Method toMatch,
-                                               Set<java.lang.reflect.Method> methods) {
+    private boolean hasSameSignatureAsExisting(Method methodToMatch, Set<Method> methods) {
         boolean sameSignature = false;
-        for(java.lang.reflect.Method m : methods) {
-            if( TypeUtil.sameMethodSignature(m, toMatch) ) {
+        for(Method method : methods) {
+            if( TypeUtil.sameMethodSignature(method, methodToMatch) ) {
                 sameSignature = true;
                 break;
             }
@@ -158,105 +148,63 @@ public class EjbOptionalIntfGenerator {
         return sameSignature;
     }
 
-
-    public void generateOptionalLocalInterfaceSubClass(Class superClass, String subClassName, Class delegateClass)
-        throws Exception {
+    public void generateOptionalLocalInterfaceSubClass(Class<?> superClass, String subClassName, Class<?> delegateClass) {
         generateSubclass(superClass, subClassName, delegateClass, IndirectlySerializable.class);
     }
 
+    public void generateSubclass(Class<?> superClass, String subClassName, Class<?> delegateClass, Class<?>... interfaces) {
+        String subClassInternalName = subClassName.replace('.', '/');
+        String fieldDesc = Type.getDescriptor(delegateClass);
 
-    public void generateSubclass(Class superClass, String subClassName, Class delegateClass, Class... interfaces)
-        throws Exception {
         if (protectionDomain == null) {
             protectionDomain = superClass.getProtectionDomain();
         }
 
-        ClassWriter cw = new ClassWriter(INTF_FLAGS);
-
-        ClassVisitor tv = cw;
+        ClassWriter cw = new ClassWriter(0);
 
         String[] interfaceNames = new String[interfaces.length + 1];
-        interfaceNames[0] = OptionalLocalInterfaceProvider.class.getName().replace('.', '/');
+        interfaceNames[0] = Type.getInternalName(OptionalLocalInterfaceProvider.class);
         for (int i = 0; i < interfaces.length; i++) {
-            interfaceNames[i+1] = interfaces[i].getName().replace('.', '/');
+            interfaceNames[i + 1] = Type.getInternalName(interfaces[i]);
         }
 
-        tv.visit(V11, ACC_PUBLIC, subClassName.replace('.', '/'), null,
-                Type.getType(superClass).getInternalName(), interfaceNames);
+        cw.visit(V11, ACC_PUBLIC, subClassInternalName, null, Type.getInternalName(superClass), interfaceNames);
 
-        String fldDesc = Type.getDescriptor(delegateClass);
-        FieldVisitor fv = tv.visitField(ACC_PRIVATE, DELEGATE_FIELD_NAME,
-                fldDesc, null, null);
-        fv.visitEnd();
+        generateDelegateField(cw, fieldDesc);
 
-        // Generate constructor. The EJB spec only allows no-arg constructors, but
-        // CDI added requirements that allow a single constructor to define
-        // parameters injected by CDI.
-        {
+        generateConstructor(cw, superClass, true);
 
-            Constructor[] ctors = superClass.getConstructors();
-            Constructor ctorWithParams = null;
-            for(Constructor ctor : ctors) {
-                if(ctor.getParameterTypes().length == 0) {
-                    ctorWithParams = null;    //exists the no-arg ctor, use it
-                    break;
-                } else if(ctorWithParams == null) {
-                    ctorWithParams = ctor;
-                }
-            }
+        generateSetDelegateMethod(cw, delegateClass, subClassInternalName);
 
-            MethodVisitor cv = tv.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
-            cv.visitVarInsn(ALOAD, 0);
-            String paramTypeString = "()V";
-            // if void, only one param (implicit 'this' param)
-            int maxValue = 1;
-            if (ctorWithParams != null) {
-                Class[] paramTypes = ctorWithParams.getParameterTypes();
-                for (Class paramType : paramTypes) {
-                    cv.visitInsn(ACONST_NULL);
-                }
-                paramTypeString = Type.getConstructorDescriptor(ctorWithParams);
-                // num params + one for 'this' pointer
-                maxValue = paramTypes.length + 1;
-            }
-            cv.visitMethodInsn(INVOKESPECIAL,  Type.getType(superClass).getInternalName(), "<init>", paramTypeString, false);
-            cv.visitInsn(RETURN);
-            cv.visitMaxs(maxValue, 1);
-        }
-
-        generateSetDelegateMethod(tv, delegateClass, subClassName);
-
-        for (Class anInterface : interfaces) {
-
+        for (Class<?> intf : interfaces) {
             // dblevins: Don't think we need this special case.
             // Should be covered by letting generateBeanMethod
             // handle the methods on IndirectlySerializable.
             //
             // Not sure where the related tests are to verify.
-            if (anInterface.equals(IndirectlySerializable.class)) {
-                generateGetSerializableObjectFactoryMethod(tv, fldDesc, subClassName.replace('.', '/'));
+            if (intf.equals(IndirectlySerializable.class)) {
+                generateGetSerializableObjectFactoryMethod(cw, fieldDesc, subClassInternalName);
                 continue;
             }
 
-            for (java.lang.reflect.Method method : anInterface.getMethods()) {
-                generateBeanMethod(tv, subClassName, method, delegateClass);
+            for (Method method : intf.getMethods()) {
+                generateBeanMethod(cw, subClassInternalName, method, delegateClass);
             }
         }
 
+        Set<Method> allMethods = new HashSet<>();
 
-        Set<java.lang.reflect.Method> allMethods = new HashSet<>();
-
-        for (java.lang.reflect.Method m : superClass.getMethods()) {
-            if (qualifiedAsBeanMethod(m)) {
-                generateBeanMethod(tv, subClassName, m, delegateClass);
+        for (Method method : superClass.getMethods()) {
+            if (qualifiedAsBeanMethod(method)) {
+                generateBeanMethod(cw, subClassInternalName, method, delegateClass);
             }
         }
 
-        for (Class clz = superClass; clz != Object.class; clz = clz.getSuperclass()) {
-            java.lang.reflect.Method[] beanMethods = clz.getDeclaredMethods();
-            for (java.lang.reflect.Method mth : beanMethods) {
-                if( !hasSameSignatureAsExisting(mth, allMethods)) {
-                    int modifiers = mth.getModifiers();
+        for (Class<?> clz = superClass; clz != Object.class; clz = clz.getSuperclass()) {
+            Method[] beanMethods = clz.getDeclaredMethods();
+            for (Method method : beanMethods) {
+                if(!hasSameSignatureAsExisting(method, allMethods)) {
+                    int modifiers = method.getModifiers();
                     boolean isPublic = Modifier.isPublic(modifiers);
                     boolean isPrivate = Modifier.isPrivate(modifiers);
                     boolean isProtected = Modifier.isProtected(modifiers);
@@ -265,157 +213,154 @@ public class EjbOptionalIntfGenerator {
                     boolean isStatic = Modifier.isStatic(modifiers);
 
                     if( (isPackage || isProtected) && !isStatic ) {
-                        generateNonAccessibleMethod(tv, mth);
+                        generateNonAccessibleMethod(cw, method);
                     }
-                    allMethods.add(mth);
+                    allMethods.add(method);
                 }
             }
         }
 
         // add toString() method if it was not overridden
-        java.lang.reflect.Method mth = Object.class.getDeclaredMethod("toString");
-        if (!hasSameSignatureAsExisting(mth, allMethods)) {
-            generateToStringBeanMethod(tv, superClass);
+        try {
+            Method method = Object.class.getDeclaredMethod("toString");
+            if (!hasSameSignatureAsExisting(method, allMethods)) {
+                generateToStringBeanMethod(cw, superClass);
+            }
+        } catch (NoSuchMethodException ignored) {
+            // Should never be reached
         }
 
-        tv.visitEnd();
+        cw.visitEnd();
 
-        byte[] classData = cw.toByteArray();
-        classMap.put(subClassName, classData);
+        classMap.put(subClassName, cw.toByteArray());
     }
 
-
-    private static void generateInterfaceMethod(ClassVisitor cv, java.lang.reflect.Method m)
-        throws Exception {
-
-        String methodName = m.getName();
-        Type returnType = Type.getReturnType(m);
-        Type[] argTypes = Type.getArgumentTypes(m);
-
-        Method asmMethod = new Method(methodName, returnType, argTypes);
-        GeneratorAdapter cg = new GeneratorAdapter(ACC_PUBLIC + ACC_ABSTRACT,
-                asmMethod, null, getExceptionTypes(m), cv);
-        cg.endMethod();
-
+    private static void generateDelegateField(ClassVisitor cv, String fieldDesc) {
+        FieldVisitor fv = cv.visitField(ACC_PRIVATE, DELEGATE_FIELD_NAME, fieldDesc, null, null);
+        fv.visitEnd();
     }
 
-    private static void generateBeanMethod(ClassVisitor cv, String subClassName,
-                                           java.lang.reflect.Method m, Class delegateClass)
-        throws Exception {
-
-        String methodName = m.getName();
-        Type returnType = Type.getReturnType(m);
-        Type[] argTypes = Type.getArgumentTypes(m);
-        Method asmMethod = new Method(methodName, returnType, argTypes);
-
-        GeneratorAdapter mg = new GeneratorAdapter(ACC_PUBLIC, asmMethod, null,
-                getExceptionTypes(m), cv);
-        mg.loadThis();
-        mg.visitFieldInsn(GETFIELD, subClassName.replace('.', '/'),
-                DELEGATE_FIELD_NAME, Type.getType(delegateClass).getDescriptor());
-        mg.loadArgs();
-        mg.invokeInterface(Type.getType(delegateClass), asmMethod);
-        mg.returnValue();
-        mg.endMethod();
-
+    private static void generateInterfaceMethod(ClassVisitor cv, Method method) {
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC + ACC_ABSTRACT,
+                method.getName(),
+                Type.getMethodDescriptor(method),
+                null,
+                getExceptions(method));
+        mv.visitEnd();
     }
 
-    private static void generateToStringBeanMethod(ClassVisitor cv, Class superClass)
-        throws Exception {
+    private static void generateBeanMethod(ClassVisitor cv, String subClassInternalName, Method method, Class<?> delegateClass) {
+        String methodName = method.getName();
+        String methodDesc = Type.getMethodDescriptor(method);
 
-        String toStringMethodName = "toString";
-        String toStringMethodDescriptor = "()Ljava/lang/String;";
-        String stringBuilder = "java/lang/StringBuilder";
-
-        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, toStringMethodName, toStringMethodDescriptor, null, null);
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, methodName, methodDesc, null, getExceptions(method));
+        mv.visitCode();
         mv.visitVarInsn(ALOAD, 0);
-        mv.visitTypeInsn(NEW, stringBuilder);
+        mv.visitFieldInsn(GETFIELD, subClassInternalName, DELEGATE_FIELD_NAME, Type.getDescriptor(delegateClass));
+
+        int varIndex = 1;
+        for (Type argumentType : Type.getArgumentTypes(methodDesc)) {
+            mv.visitVarInsn(argumentType.getOpcode(ILOAD), varIndex);
+            varIndex += argumentType.getSize();
+        }
+
+        mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(delegateClass), methodName, methodDesc, true);
+        mv.visitInsn(Type.getReturnType(methodDesc).getOpcode(IRETURN));
+        mv.visitMaxs(varIndex, varIndex);
+        mv.visitEnd();
+    }
+
+    private static void generateToStringBeanMethod(ClassVisitor cv, Class<?> superClass) {
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "toString", "()Ljava/lang/String;", null, null);
+        mv.visitCode();
+        mv.visitTypeInsn(NEW, "java/lang/StringBuilder");
         mv.visitInsn(DUP);
-        mv.visitMethodInsn(INVOKESPECIAL, stringBuilder, "<init>", "()V", false);
         mv.visitLdcInsn(superClass.getName() + "@");
-        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;", false);
+        mv.visitMethodInsn(INVOKESPECIAL,
+                "java/lang/StringBuilder",
+                "<init>",
+                "(Ljava/lang/String;)V",
+                false);
         mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/Object", "hashCode", "()I", false);
-        mv.visitMethodInsn(INVOKESTATIC, "java/lang/Integer", "toHexString", "(I)Ljava/lang/String;", false);
-        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;", false);
-        mv.visitMethodInsn(INVOKEVIRTUAL, stringBuilder, toStringMethodName, toStringMethodDescriptor, false);
+        mv.visitMethodInsn(INVOKEVIRTUAL,
+                "java/lang/Object",
+                "hashCode",
+                "()I",
+                false);
+        mv.visitMethodInsn(INVOKESTATIC,
+                "java/lang/Integer",
+                "toHexString",
+                "(I)Ljava/lang/String;",
+                false);
+        mv.visitMethodInsn(INVOKEVIRTUAL,
+                "java/lang/StringBuilder",
+                "append",
+                "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
+                false);
+        mv.visitMethodInsn(INVOKEVIRTUAL,
+                "java/lang/StringBuilder",
+                "toString",
+                "()Ljava/lang/String;",
+                false);
         mv.visitInsn(ARETURN);
-        mv.visitMaxs(2, 1);
-
+        mv.visitMaxs(3, 1);
+        mv.visitEnd();
     }
 
-    private static void generateNonAccessibleMethod(ClassVisitor cv,
-                                           java.lang.reflect.Method m)
-        throws Exception {
+    // Only called for non-static Protected or Package access
+    private static void generateNonAccessibleMethod(ClassVisitor cv, Method method) {
+        String methodDesc = Type.getMethodDescriptor(method);
 
-        String methodName = m.getName();
-        Type returnType = Type.getReturnType(m);
-        Type[] argTypes = Type.getArgumentTypes(m);
-        Method asmMethod = new Method(methodName, returnType, argTypes);
-
-        // Only called for non-static Protected or Package access
-        int access =  ACC_PUBLIC;
-
-        GeneratorAdapter mg = new GeneratorAdapter(access, asmMethod, null,
-                getExceptionTypes(m), cv);
-
-        mg.throwException(Type.getType(jakarta.ejb.EJBException.class),
-                "Illegal non-business method access on no-interface view");
-
-        mg.returnValue();
-
-        mg.endMethod();
-
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, method.getName(), methodDesc, null, getExceptions(method));
+        mv.visitCode();
+        mv.visitTypeInsn(NEW, "jakarta/ejb/EJBException");
+        mv.visitInsn(DUP);
+        mv.visitLdcInsn("Illegal non-business method access on no-interface view");
+        mv.visitMethodInsn(INVOKESPECIAL,
+                "jakarta/ejb/EJBException",
+                "<init>",
+                "(Ljava/lang/String;)V",
+                false);
+        mv.visitInsn(ATHROW);
+        mv.visitMaxs(3, Type.getArgumentsAndReturnSizes(methodDesc) >> 2);
+        mv.visitEnd();
     }
 
-    private static void generateGetSerializableObjectFactoryMethod(ClassVisitor classVisitor,
-                                                                   String fieldDesc,
-                                                                   String classDesc) {
+    private static void generateGetSerializableObjectFactoryMethod(ClassVisitor cv, String fieldDesc, String classDesc) {
+        String methodName = "getSerializableObjectFactory";
+        String methodDesc = "()" + Type.getDescriptor(SerializableObjectFactory.class);
+        String methodOwner = Type.getInternalName(IndirectlySerializable.class);
 
-        MethodVisitor cv = classVisitor.visitMethod(ACC_PUBLIC, "getSerializableObjectFactory",
-                "()L" + SerializableObjectFactory.class.getName().replace('.', '/') + ";", null, new String[] { "java/io/IOException" });
-        cv.visitVarInsn(ALOAD, 0);
-        cv.visitFieldInsn(GETFIELD, classDesc, DELEGATE_FIELD_NAME, fieldDesc);
-        cv.visitTypeInsn(CHECKCAST, IndirectlySerializable.class.getName().replace('.', '/'));
-        cv.visitMethodInsn(INVOKEINTERFACE,
-                IndirectlySerializable.class.getName().replace('.', '/'), "getSerializableObjectFactory",
-                "()L" + SerializableObjectFactory.class.getName().replace('.', '/') + ";", true);
-        cv.visitInsn(ARETURN);
-        cv.visitMaxs(1, 1);
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, methodName, methodDesc, null, new String[] {"java/io/IOException"});
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitFieldInsn(GETFIELD, classDesc, DELEGATE_FIELD_NAME, fieldDesc);
+        mv.visitTypeInsn(CHECKCAST, methodOwner);
+        mv.visitMethodInsn(INVOKEINTERFACE, methodOwner, methodName, methodDesc, true);
+        mv.visitInsn(ARETURN);
+        mv.visitMaxs(1, 1);
+        mv.visitEnd();
     }
 
-
-    private static Type[] getExceptionTypes(java.lang.reflect.Method m) {
-        Class[] exceptions = m.getExceptionTypes();
-        Type[] eTypes = new Type[exceptions.length];
-        for (int i=0; i<exceptions.length; i++) {
-            eTypes[i] = Type.getType(exceptions[i]);
+    private static String[] getExceptions(Method method) {
+        Class<?>[] exceptionTypes = method.getExceptionTypes();
+        String[] exceptions = new String[exceptionTypes.length];
+        for (int i = 0; i < exceptionTypes.length; i++) {
+            exceptions[i] = Type.getInternalName(exceptionTypes[i]);
         }
 
-        return eTypes;
+        return exceptions;
     }
 
-    private static void generateSetDelegateMethod(ClassVisitor cv, Class delegateClass,
-                                                  String subClassName)
-        throws Exception {
-
-        Class optProxyClass = OptionalLocalInterfaceProvider.class;
-        java.lang.reflect.Method proxyMethod = optProxyClass.getMethod(
-                "setOptionalLocalIntfProxy", java.lang.reflect.Proxy.class);
-
-        String methodName = proxyMethod.getName();
-        Type returnType = Type.getReturnType(proxyMethod);
-        Type[] argTypes = Type.getArgumentTypes(proxyMethod);
-        Type[] eTypes = getExceptionTypes(proxyMethod);
-
-        Method asmMethod = new Method(methodName, returnType, argTypes);
-        GeneratorAdapter mg2 = new GeneratorAdapter(ACC_PUBLIC, asmMethod, null, eTypes, cv);
-        mg2.visitVarInsn(ALOAD, 0);
-        mg2.visitVarInsn(ALOAD, 1);
-        mg2.visitTypeInsn(CHECKCAST, delegateClass.getName().replace('.', '/'));
-        String delIntClassDesc = Type.getType(delegateClass).getDescriptor();
-        mg2.visitFieldInsn(PUTFIELD, subClassName.replace('.', '/'), DELEGATE_FIELD_NAME, delIntClassDesc);
-        mg2.returnValue();
-        mg2.endMethod();
+    private static void generateSetDelegateMethod(ClassVisitor cv, Class<?> delegateClass, String subClassInternalName) {
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "setOptionalLocalIntfProxy", "(Ljava/lang/reflect/Proxy;)V", null, null);
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitVarInsn(ALOAD, 1);
+        mv.visitTypeInsn(CHECKCAST, Type.getInternalName(delegateClass));
+        mv.visitFieldInsn(PUTFIELD, subClassInternalName, DELEGATE_FIELD_NAME, Type.getDescriptor(delegateClass));
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(2, 2);
+        mv.visitEnd();
     }
 }

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanInterfaceGenerator.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanInterfaceGenerator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,9 +17,9 @@
 
 package org.glassfish.ejb.mdb;
 
-import com.sun.ejb.codegen.EjbOptionalIntfGenerator;
-
 import jakarta.resource.spi.endpoint.MessageEndpoint;
+
+import com.sun.ejb.codegen.EjbOptionalIntfGenerator;
 
 public class MessageBeanInterfaceGenerator extends EjbOptionalIntfGenerator {
 
@@ -26,17 +27,19 @@ public class MessageBeanInterfaceGenerator extends EjbOptionalIntfGenerator {
         super(loader);
     }
 
-    public Class generateMessageBeanSubClass(Class<?> beanClass, Class messageBeanInterface) throws Exception {
+    public Class<?> generateMessageBeanSubClass(Class<?> beanClass, Class<?> messageBeanInterface) throws Exception {
         final String generatedMessageBeanSubClassName = messageBeanInterface.getName() + "__Bean__";
 
         generateSubclass(beanClass, generatedMessageBeanSubClassName, messageBeanInterface, MessageEndpoint.class);
+
         return loadClass(generatedMessageBeanSubClassName);
     }
 
-    public Class generateMessageBeanInterface(Class<?> beanClass) throws Exception {
+    public Class<?> generateMessageBeanInterface(Class<?> beanClass) throws Exception {
         final String generatedMessageBeanInterfaceName = getGeneratedMessageBeanInterfaceName(beanClass);
 
         generateInterface(beanClass, generatedMessageBeanInterfaceName, MessageEndpoint.class);
+
         return loadClass(generatedMessageBeanInterfaceName);
     }
 
@@ -48,5 +51,4 @@ public class MessageBeanInterfaceGenerator extends EjbOptionalIntfGenerator {
 
         return packageName != null ? packageName + "." + name : name;
     }
-
 }


### PR DESCRIPTION
What's done:

* Make code more stylistically  consistent;
* Remove code duplicates;
* General code cleanup;
* Cleanup generated bytecode;
* Fix deployment bug. It could happen when session bean does not have the no-args constructor but has a CDI `@Inject`-annotated constructor and one one more "regular" constructors with primitive arguments (it's not prohibited by CDI spec explicitly).

Signed-off-by: Alexander Pinčuk <alexander.v.pinchuk@gmail.com>
