### PR TITLE
Removed hk2.version from bundle plugin config

### DIFF
--- a/appserver/web/jersey-ejb-component-provider/pom.xml
+++ b/appserver/web/jersey-ejb-component-provider/pom.xml
@@ -78,7 +78,7 @@
                     <instructions>
                         <Import-Package>
                             jakarta.annotation.*;version="${jakarta.annotation-api.version}",
-                            org.glassfish.hk2.*;version="${hk2.version}",
+                            org.glassfish.hk2.*,
                             *
                         </Import-Package>
                         <Export-Package>


### PR DESCRIPTION
- had issues with the snapshot hk2 versions.
- now produces: org.glassfish.hk2.api;version="[3.0,4)"
- based on [advice](https://github.com/eclipse-ee4j/glassfish/issues/24345#issuecomment-1483504410) from @avpinchuk 
- tested with hk2 3.0.4-SNAPSHOT