### PR TITLE
Fixed Concurrency TCK

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ContextServiceDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ContextServiceDefinitionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package com.sun.enterprise.deployment;
 
 import com.sun.enterprise.deployment.annotation.handlers.ContextServiceDefinitionData;
 
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
@@ -127,6 +128,21 @@ public class ContextServiceDefinitionDescriptor extends ResourceDescriptor {
         return data;
     }
 
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof ContextServiceDefinitionDescriptor) {
+            ContextServiceDefinitionDescriptor another = (ContextServiceDefinitionDescriptor) object;
+            return getJndiName().equals(another.getJndiName());
+        }
+        return false;
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
 
     @Override
     public String toString() {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedExecutorDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedExecutorDefinitionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package com.sun.enterprise.deployment;
 import com.sun.enterprise.deployment.annotation.factory.ManagedExecutorDefinitionData;
 import com.sun.enterprise.deployment.annotation.handlers.ContextualResourceDefinition;
 
+import java.util.Objects;
 import java.util.Properties;
 
 import org.glassfish.deployment.common.JavaEEResourceType;
@@ -116,6 +117,22 @@ public class ManagedExecutorDefinitionDescriptor extends ResourceDescriptor impl
 
     public ManagedExecutorDefinitionData getData() {
         return data;
+    }
+
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof ManagedExecutorDefinitionDescriptor) {
+            ManagedExecutorDefinitionDescriptor another = (ManagedExecutorDefinitionDescriptor) object;
+            return getJndiName().equals(another.getJndiName());
+        }
+        return false;
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedScheduledExecutorDefinitionDescriptor.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/ManagedScheduledExecutorDefinitionDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package com.sun.enterprise.deployment;
 import com.sun.enterprise.deployment.annotation.handlers.ContextualResourceDefinition;
 import com.sun.enterprise.deployment.annotation.handlers.ManagedScheduledExecutorDefinitionData;
 
+import java.util.Objects;
 import java.util.Properties;
 
 import org.glassfish.deployment.common.JavaEEResourceType;
@@ -111,6 +112,22 @@ public class ManagedScheduledExecutorDefinitionDescriptor extends ResourceDescri
 
     public ManagedScheduledExecutorDefinitionData getData() {
         return data;
+    }
+
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof ManagedScheduledExecutorDefinitionDescriptor) {
+            ManagedScheduledExecutorDefinitionDescriptor another = (ManagedScheduledExecutorDefinitionDescriptor) object;
+            return getName().equals(another.getName());
+        }
+        return false;
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/ContextServiceDefinitionData.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/handlers/ContextServiceDefinitionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package com.sun.enterprise.deployment.annotation.handlers;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
@@ -105,6 +106,22 @@ public class ContextServiceDefinitionData implements Serializable {
 
     public void addContextServiceExecutorDescriptor(String name, String value) {
         properties.put(name, value);
+    }
+
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof ContextServiceDefinitionData) {
+            ContextServiceDefinitionData another = (ContextServiceDefinitionData) object;
+            return getName().equals(another.getName());
+        }
+        return false;
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
     }
 
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ApplicationValidator.java
@@ -72,13 +72,22 @@ import static com.sun.enterprise.deployment.util.DOLUtils.INVALID_NAMESPACE;
 public class ApplicationValidator extends ComponentValidator implements ApplicationVisitor, ManagedBeanVisitor {
 
     @LogMessageInfo(
+        message = "Duplicate descriptor found for given jndi-name: {0}.\nDescriptor 1:\n{1}\nDescriptor 2:\n{2}",
+        level = "SEVERE",
+        cause = "Two or more resource definitions use the same jndi-name in the same or related contexts",
+        action = "Make sure that all JNDI names used to define resources in application's resource annotations"
+            + " or desciptors are unique in each context. For example java:app/myname conflicts"
+            + " with java:comp:myname because myname jndi-name is defined twice in the component context")
+    private static final String DUPLICATE_DESCRIPTOR = "dol.validation.application.jndiNameConflict";
+
+    @LogMessageInfo(
         message = "Application validation failed for application: {0}, jndi-name: {1}, resource adapter name: {2} is wrong.",
         level="SEVERE",
         cause = "For embedded resource adapter, its name should begin with '#' symbol",
         action = "Remove application name before the '#' symbol in the resource adapter name.",
         comment = "For the method validateResourceDescriptor of com.sun.enterprise.deployment.util.ApplicationValidator"
     )
-    private static final String RESOURCE_ADAPTER_NAME_INVALID = "AS-DEPLOYMENT-00020";
+    private static final String RESOURCE_ADAPTER_NAME_INVALID = "dol.validation.application.failed";
 
     private static final Logger LOG = DOLUtils.getLogger();
 
@@ -531,7 +540,8 @@ public class ApplicationValidator extends ComponentValidator implements Applicat
         }
 
         // Same JNDI names, but different descriptors
-        LOG.log(Level.ERROR, DOLUtils.DUPLICATE_DESCRIPTOR, name);
+        LOG.log(Level.ERROR, DUPLICATE_DESCRIPTOR, name, existingDescriptor, descriptor);
+        inValidJndiName = name;
         allUniqueResource = false;
         return true;
     }

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/DOLUtils.java
@@ -148,15 +148,6 @@ public class DOLUtils {
     public static final String INVALILD_DESCRIPTOR_SHORT = "AS-DEPLOYMENT-00120";
 
     @LogMessageInfo(
-        message = "DEP0002:Duplicate descriptor found for given jndi-name: {0}",
-        level = "SEVERE",
-        cause = "Two or more resource definitions use the same jndi-name in the same or related contexts",
-        action = "Make sure that all JNDI names used to define resources in application's resource annotations"
-            + " or desciptors are unique in each context. For example java:app/myname conflicts"
-            + " with java:comp:myname because myname jndi-name is defined twice in the component context")
-    public static final String DUPLICATE_DESCRIPTOR = "enterprise.deployment.util.descriptor.duplicate";
-
-    @LogMessageInfo(
         message = "DEP0003:The jndi-name is already used in the global tree failed for given jndi-name: {0}",
         level = "SEVERE",
         cause = "The JNDI name of the descriptor is already used in the global JNDI tree,"


### PR DESCRIPTION
- This should be refactored - using `equals` to validate just JNDI name conflicts is quite fragile.
