### PR TITLE
Refactor the Enterprise Beans no-interface view bytecode generation

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/BeanGeneratorBase.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/BeanGeneratorBase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ejb.codegen;
+
+import jakarta.inject.Inject;
+
+import java.lang.reflect.Constructor;
+
+import org.glassfish.deployment.common.DeploymentException;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.RETURN;
+
+/**
+ * Common methods related to ASM bytecode generation.
+ *
+ * @author Alexander Pinčuk
+ */
+class BeanGeneratorBase {
+
+    /**
+     * Generate constructor.
+     *
+     * <p>The EJB spec only allows no-arg constructors, but CDI added requirements
+     * that allow a single constructor to define parameters injected by CDI.
+     *
+     * @param cv the ASM {@code ClassVisitor}.
+     * @param superClass a superclass.
+     * @param withNoArguments indicates if generated constructor takes no arguments.
+     */
+    protected static void generateConstructor(ClassVisitor cv, Class<?> superClass, boolean withNoArguments) {
+        Constructor<?> parentCtor = findParentConstructor(superClass);
+        String parentCtorDesc = Type.getConstructorDescriptor(parentCtor);
+        String ctorDesc = withNoArguments ? "()V" : parentCtorDesc;
+        String superClassInternalName = Type.getInternalName(superClass);
+
+        MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "<init>", ctorDesc, null, null);
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);  // load 'this'
+
+        int argCount = parentCtor.getParameterCount();
+        for (int i = 0; i < argCount; i++) {
+            if (withNoArguments) {
+                mv.visitInsn(ACONST_NULL);
+            } else {
+                mv.visitVarInsn(ALOAD, i + 1);
+            }
+        }
+
+        mv.visitMethodInsn(INVOKESPECIAL, superClassInternalName, "<init>", parentCtorDesc, false);
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(argCount + 1, withNoArguments ? 1 : argCount + 1);
+        mv.visitEnd();
+    }
+
+    private static Constructor<?> findParentConstructor(Class<?> superClass) {
+        Constructor<?>[] ctors = superClass.getConstructors();
+
+        Constructor<?> parentCtor = null;
+        for (Constructor<?> ctor : ctors) {
+            if (ctor.getParameterCount() == 0) {
+                // exists the no-arg constructor, use it
+                parentCtor = ctor;
+                break;
+            } else if (ctor.isAnnotationPresent(Inject.class)) {
+                // exists a CDI bean constructor, use it
+                parentCtor = ctor;
+            }
+        }
+
+        if (parentCtor == null) {
+            // Should never be thrown.
+            throw new DeploymentException("A class " + superClass.getName() + " doesn't have any appropriate constructor");
+        }
+
+        return parentCtor;
+    }
+}

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanInterfaceGenerator.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanInterfaceGenerator.java
@@ -27,11 +27,12 @@ public class MessageBeanInterfaceGenerator extends EjbOptionalIntfGenerator {
         super(loader);
     }
 
-    public Class<?> generateMessageBeanSubClass(Class<?> beanClass, Class<?> messageBeanInterface) throws Exception {
+    @SuppressWarnings("unchecked")
+    public <T> Class<? extends T> generateMessageBeanSubClass(Class<?> beanClass, Class<T> messageBeanInterface) throws Exception {
         final String generatedMessageBeanSubClassName = messageBeanInterface.getName() + "__Bean__";
 
         generateSubclass(beanClass, generatedMessageBeanSubClassName, messageBeanInterface, MessageEndpoint.class);
-        return loadClass(generatedMessageBeanSubClassName);
+        return (Class<? extends T>) loadClass(generatedMessageBeanSubClassName);
     }
 
     public Class<?> generateMessageBeanInterface(Class<?> beanClass) throws Exception {

--- a/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanInterfaceGenerator.java
+++ b/appserver/ejb/ejb-full-container/src/main/java/org/glassfish/ejb/mdb/MessageBeanInterfaceGenerator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,17 +27,18 @@ public class MessageBeanInterfaceGenerator extends EjbOptionalIntfGenerator {
         super(loader);
     }
 
-    public Class generateMessageBeanSubClass(Class<?> beanClass, Class messageBeanInterface) throws Exception {
+    public Class<?> generateMessageBeanSubClass(Class<?> beanClass, Class<?> messageBeanInterface) throws Exception {
         final String generatedMessageBeanSubClassName = messageBeanInterface.getName() + "__Bean__";
 
         generateSubclass(beanClass, generatedMessageBeanSubClassName, messageBeanInterface, MessageEndpoint.class);
         return loadClass(generatedMessageBeanSubClassName);
     }
 
-    public Class generateMessageBeanInterface(Class<?> beanClass) throws Exception {
+    public Class<?> generateMessageBeanInterface(Class<?> beanClass) throws Exception {
         final String generatedMessageBeanInterfaceName = getGeneratedMessageBeanInterfaceName(beanClass);
 
         generateInterface(beanClass, generatedMessageBeanInterfaceName, MessageEndpoint.class);
+
         return loadClass(generatedMessageBeanInterfaceName);
     }
 
@@ -48,5 +50,4 @@ public class MessageBeanInterfaceGenerator extends EjbOptionalIntfGenerator {
 
         return packageName != null ? packageName + "." + name : name;
     }
-
 }


### PR DESCRIPTION
What's done:

* Code cleanup (replace use of raw types, remove unused variables etc.);
* Moved code duplicates to common base class;
* Removed ASM adapters, used ASM core API to bytecode generation;
* Fixed *maxStack* and *maxLocals* computation;
* Cleanup generated bytecode;
* Limit a type of generated MDB subclass (based on [advice](https://github.com/eclipse-ee4j/glassfish/pull/24353#discussion_r1148555091) from @dmatej).

Signed-off-by: Alexander Pinčuk <alexander.v.pinchuk@gmail.com>
