### PR TITLE
enable reproducible builds

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -172,7 +172,7 @@
         <schema2beans.version>6.7</schema2beans.version>
         <derby.version>10.15.2.0</derby.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
-        <maven-rar-plugin.version>2.4</maven-rar-plugin.version>
+        <maven-rar-plugin.version>3.0.0</maven-rar-plugin.version>
 
         <product.name>Eclipse GlassFish</product.name>
         <product.name.abbreviation>GF</product.name.abbreviation>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -174,7 +174,7 @@
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>
         <!-- Overrides the value from parent and enables the one we generate. -->
-        <project.build.outputTimestamp></project.build.outputTimestamp>
+        <project.build.outputTimestamp>2023-04-02T15:44:03Z</project.build.outputTimestamp>
 
         <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
         <maven.test.jvmoptions.memory.sizes>-Xss512k -Xms256m -Xmx1g -XX:MaxDirectMemorySize=512m</maven.test.jvmoptions.memory.sizes>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
       <url>https://github.com/eclipse-ee4j/glassfish</url>
     </scm>
 
+    <properties>
+        <project.build.outputTimestamp>2023-04-02T15:44:03Z</project.build.outputTimestamp>
+    </properties>
+
     <build>
         <defaultGoal>install</defaultGoal>
         <pluginManagement>


### PR DESCRIPTION
just applied fixes proposed by `mvn artifact:check-buildplan`, because release 7.0.3 is not reproducible at all (outputTimestamp fully dropped instead of setting an initial value)

see https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/glassfish/main/README.md