### PR TITLE
Refactor around REST resources related to server logs

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,44 +17,48 @@
 
 package org.glassfish.admin.rest.logviewer;
 
-import java.io.StringWriter;
+import java.io.Serializable;
 import java.time.OffsetDateTime;
-import java.util.Date;
+import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Result;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 /**
- * internal REST wrapper for a log record will be used to emit JSON easily with Jackson framework
+ * Internal REST wrapper for a log record will be used to emit JSON easily
+ * with Jackson framework.
  *
  * @author ludo
  */
+@SuppressWarnings("unused")
 public class LogRecord {
 
-    long recordNumber;
-    OffsetDateTime loggedDateTime;
-    String loggedLevel;
-    String productName;
-    String loggerName;
-    String nameValuePairs;
-    String messageID;
-    String message;
+    private long recordNumber;
+    private OffsetDateTime loggedDateTime;
+    private String loggedLevel;
+    private String productName;
+    private String loggerName;
+    private String nameValuePairs;
+    private String messageID;
+    private String message;
+
+    public LogRecord() { }
+
+    public LogRecord(List<? extends Serializable> logRecord) {
+        int fieldIndex = 0;
+
+        this.recordNumber = (Long) logRecord.get(fieldIndex++);
+        this.loggedDateTime = (OffsetDateTime) logRecord.get(fieldIndex++);
+        this.loggedLevel = (String) logRecord.get(fieldIndex++);
+        this.productName = (String) logRecord.get(fieldIndex++);
+        this.loggerName = (String) logRecord.get(fieldIndex++);
+        this.nameValuePairs = (String) logRecord.get(fieldIndex++);
+        this.messageID = (String) logRecord.get(fieldIndex++);
+        this.message = (String) logRecord.get(fieldIndex);
+    }
 
     public String getMessage() {
         return message;
@@ -120,65 +124,40 @@ public class LogRecord {
         this.recordNumber = recordNumber;
     }
 
-    public String toJSON() {
-        JSONObject obj = new JSONObject();
-        try {
-            obj.put("recordNumber", recordNumber);
-            obj.put("loggedDateTimeInMS", loggedDateTime == null ? null : loggedDateTime.toInstant().toEpochMilli());
-            obj.put("loggedLevel", loggedLevel);
-            obj.put("productName", productName);
-            obj.put("loggerName", loggerName);
-            obj.put("nameValuePairs", nameValuePairs);
-            obj.put("messageID", messageID);
-            obj.put("Message", message);
-        } catch (JSONException ex) {
-            throw new RuntimeException(ex);
-        }
-        return obj.toString();
+    public JSONObject toJSONObject() throws JSONException {
+        return new JSONObject()
+                .put("recordNumber", recordNumber)
+                .put("loggedDateTimeInMS",
+                        loggedDateTime == null ? null : loggedDateTime.toInstant().toEpochMilli())
+                .put("loggedLevel", loggedLevel)
+                .put("productName", productName)
+                .put("loggerName", loggerName)
+                .put("nameValuePairs", nameValuePairs)
+                .put("messageID", messageID)
+                .put("Message", message);
     }
 
-    public String toXML() {
+    public void writeXml(XMLStreamWriter writer) throws XMLStreamException {
+        boolean hasMessage = message != null && !message.isEmpty();
 
-        try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            DocumentBuilder db = dbf.newDocumentBuilder();
+        if (hasMessage) {
+            writer.writeStartElement("record");
+        } else {
+            writer.writeEmptyElement("record");
+        }
 
-            Document d = db.newDocument();
-
-            Element result = d.createElement("record");
-            result.setAttribute("recordNumber", Long.toString(recordNumber));
-            result.setAttribute("loggedDateTimeInMS",
+        writer.writeAttribute("recordNumber", Long.toString(recordNumber));
+        writer.writeAttribute("loggedDateTimeInMS",
                 loggedDateTime == null ? "" : Long.toString(loggedDateTime.toInstant().toEpochMilli()));
-            result.setAttribute("loggedLevel", loggedLevel);
-            result.setAttribute("productName", productName);
-            result.setAttribute("loggerName", loggerName);
-            result.setAttribute("nameValuePairs", nameValuePairs);
-            result.setAttribute("messageID", messageID);
-            result.setNodeValue(message);
-            d.appendChild(result);
-            return xmlToString(d);
+        writer.writeAttribute("loggedLevel", loggedLevel);
+        writer.writeAttribute("productName", productName);
+        writer.writeAttribute("loggerName", loggerName);
+        writer.writeAttribute("nameValuePairs", nameValuePairs);
+        writer.writeAttribute("messageID", messageID);
 
-        } catch (ParserConfigurationException pex) {
-            throw new RuntimeException(pex);
+        if (hasMessage) {
+            writer.writeCharacters(message);
+            writer.writeEndElement();
         }
-    }
-
-    private String xmlToString(Node node) {
-        try {
-            Source source = new DOMSource(node);
-            StringWriter stringWriter = new StringWriter();
-            Result result = new StreamResult(stringWriter);
-            TransformerFactory factory = TransformerFactory.newInstance();
-            Transformer transformer = factory.newTransformer();
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-
-            transformer.transform(source, result);
-            return stringWriter.getBuffer().toString();
-        } catch (TransformerConfigurationException e) {
-            //  e.printStackTrace();
-        } catch (TransformerException e) {
-            //  e.printStackTrace();
-        }
-        return null;
     }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
@@ -160,4 +160,15 @@ public class LogRecord {
             writer.writeEndElement();
         }
     }
+
+    public void writeCsv(StringBuilder sb) {
+        sb.append(recordNumber).append(",");
+        sb.append(loggedDateTime == null ?
+                  "" : Long.toString(loggedDateTime.toInstant().toEpochMilli())).append(",");
+        sb.append(loggedLevel).append(",");
+        sb.append(productName).append(",");
+        sb.append(loggerName).append(",");
+        sb.append(nameValuePairs).append(",");
+        sb.append("\"").append(message.replace("\"", "\"\"")).append("\"");
+    }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/logviewer/LogRecord.java
@@ -33,7 +33,6 @@ import org.codehaus.jettison.json.JSONObject;
  *
  * @author ludo
  */
-@SuppressWarnings("unused")
 public class LogRecord {
 
     private long recordNumber;

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/provider/JsonStringReaderWriter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/provider/JsonStringReaderWriter.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,43 +23,51 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.Provider;
 
-import jakarta.inject.Singleton;
-
 import org.glassfish.jersey.message.internal.AbstractMessageReaderWriterProvider;
+
+import static jakarta.ws.rs.Priorities.USER;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
  * Json String reader writer.
- * <p>
- * The whole purpose is to override (and effectively disable) JSON-B processing of {@link String} returned as
- * application/json.
+ *
+ * <p>The whole purpose is to override (and effectively disable) JSON-B processing of {@link String}
+ * returned as application/json.
  *
  * @author Pavel Bucek (pavel.bucek at oracle.com)
  */
 @Provider
 @Singleton
-@Produces("application/json")
-@Consumes("application/json")
+@Priority(USER - 500)
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
 public class JsonStringReaderWriter extends AbstractMessageReaderWriterProvider<String> {
 
     @Override
-    public boolean isReadable(Class<?> type, Type genericType, Annotation annotations[], MediaType mediaType) {
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return type == String.class;
     }
 
     @Override
-    public String readFrom(Class<String> type, Type genericType, Annotation annotations[], MediaType mediaType,
-            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+    public String readFrom(Class<String> type,
+            Type genericType,
+            Annotation[] annotations,
+            MediaType mediaType,
+            MultivaluedMap<String, String> httpHeaders,
+            InputStream entityStream) throws IOException {
         return readFromAsString(entityStream, mediaType);
     }
 
     @Override
-    public boolean isWriteable(Class<?> type, Type genericType, Annotation annotations[], MediaType mediaType) {
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return type == String.class;
     }
 
@@ -68,8 +77,13 @@ public class JsonStringReaderWriter extends AbstractMessageReaderWriterProvider<
     }
 
     @Override
-    public void writeTo(String t, Class<?> type, Type genericType, Annotation annotations[], MediaType mediaType,
-            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
-        writeToAsString(t, entityStream, mediaType);
+    public void writeTo(String entity,
+            Class<?> type,
+            Type genericType,
+            Annotation[] annotations,
+            MediaType mediaType,
+            MultivaluedMap<String, Object> httpHeaders,
+            OutputStream entityStream) throws IOException {
+        writeToAsString(entity, entityStream, mediaType);
     }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/LogNamesResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/LogNamesResource.java
@@ -108,14 +108,12 @@ public class LogNamesResource {
                 StringBuilder sb = new StringBuilder();
 
                 String separator = "";
-                sb.append("{\"InstanceLogFileNames\": [");
                 // extract every record
-                for (String name : files) {
+                for (String file : files) {
                     sb.append(separator);
-                    sb.append("\"").append(name).append("\"");
+                    sb.append(file);
                     separator = ",";
                 }
-                sb.append("]}\n");
 
                 entity = sb;
                 break;

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/LogNamesResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/LogNamesResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,14 +22,25 @@ import com.sun.enterprise.server.logging.logviewer.backend.LogFilter;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.List;
 
+import javax.xml.stream.XMLStreamWriter;
+
+import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.api.LogManager;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static javax.xml.stream.XMLOutputFactory.newDefaultFactory;
 
 /**
  * REST resource to get Log Names simple wrapper around internal LogFilter class
@@ -41,60 +52,78 @@ public class LogNamesResource {
     protected ServiceLocator habitat = Globals.getDefaultBaseServiceLocator();
 
     @GET
-    @Produces({ MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON })
-    public String getLogNamesJSON(@QueryParam("instanceName") String instanceName) throws IOException {
-        return getLogNames(instanceName, "json");
+    @Produces("text/plain; qs=0.5")
+    public Response getLogNamesText(@QueryParam("instanceName") String instanceName) throws Exception {
+        return getLogNames(instanceName, TEXT_PLAIN);
     }
 
     @GET
-    @Produces({ MediaType.APPLICATION_XML })
-    public String getLogNamesJXML(@QueryParam("instanceName") String instanceName) throws IOException {
-        return getLogNames(instanceName, "xml");
+    @Produces("application/json; qs=1")
+    public Response getLogNamesJson(@QueryParam("instanceName") String instanceName) throws Exception {
+        return getLogNames(instanceName, APPLICATION_JSON);
     }
 
-    private String getLogNames(String instanceName, String type) throws IOException {
+    @GET
+    @Produces("application/xml; qs=0.75")
+    public Response getLogNamesXml(@QueryParam("instanceName") String instanceName) throws Exception {
+        return getLogNames(instanceName, APPLICATION_XML);
+    }
 
+    private Response getLogNames(String instanceName, String type) throws Exception {
         if (habitat.getService(LogManager.class) == null) {
-            //the logger service is not install, so we cannot rely on it.
-            //return an error
+            // the logger service is not install, so we cannot rely on it.
+            // return an error
             throw new IOException("The GlassFish LogManager Service is not available. Not installed?");
         }
 
         LogFilter logFilter = habitat.getService(LogFilter.class);
 
         return convertQueryResult(logFilter.getInstanceLogFileNames(instanceName), type);
-
     }
 
-    private String convertQueryResult(List<String> files, String type) {
-        StringBuilder sb = new StringBuilder();
-        String sep = "";
-        if (type.equals("json")) {
-            sb.append("{\"InstanceLogFileNames\": [");
-        } else {
-            sb.append("<InstanceLogFileNames>\n");
+    private Response convertQueryResult(List<String> files, String type) throws Exception {
+        Object entity;
+
+        switch (type) {
+            case APPLICATION_JSON:
+                entity = new JSONObject().put("InstanceLogFileNames", files);
+                break;
+            case APPLICATION_XML:
+                Writer xml = new StringWriter();
+
+                XMLStreamWriter writer = newDefaultFactory().createXMLStreamWriter(xml);
+                try {
+                    writer.writeStartElement("InstanceLogFileNames");
+                    for (String file : files) {
+                        writer.writeEmptyElement(file);
+                    }
+                    writer.writeEndElement();
+                } finally {
+                    writer.close();
+                }
+
+                entity = xml;
+                break;
+            case TEXT_PLAIN:
+                StringBuilder sb = new StringBuilder();
+
+                String separator = "";
+                sb.append("{\"InstanceLogFileNames\": [");
+                // extract every record
+                for (String name : files) {
+                    sb.append(separator);
+                    sb.append("\"").append(name).append("\"");
+                    separator = ",";
+                }
+                sb.append("]}\n");
+
+                entity = sb;
+                break;
+            default:
+                // should not reach here
+                return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
         }
 
-        // extract every record
-        for (String name : files) {
-            if (type.equals("json")) {
-                sb.append(sep);
-                sb.append(quote(name));
-                sep = ",";
-            } else {
-                sb.append("<" + name + "/>");
-            }
-        }
-        if (type.equals("json")) {
-            sb.append("]}\n");
-        } else {
-            sb.append("\n</InstanceLogFileNames>\n");
-
-        }
-        return sb.toString();
-    }
-
-    private String quote(String s) {
-        return "\"" + s + "\"";
+        return Response.ok(entity.toString(), type).build();
     }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -41,7 +42,6 @@ import javax.management.Attribute;
 import javax.management.AttributeList;
 import javax.xml.stream.XMLStreamWriter;
 
-import jakarta.ws.rs.core.Response;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.admin.rest.logviewer.LogRecord;
@@ -162,14 +162,12 @@ public class StructuredLogViewerResource {
             case TEXT_PLAIN:
                 StringBuilder sb = new StringBuilder();
 
-                sb.append("{\"records\": [");
-                String separator = "";
+                String lineSeparator = "";
                 for (List<Serializable> logRecord : logRecords) {
-                    sb.append(separator);
-                    sb.append(new LogRecord(logRecord).toJSONObject().toString());
-                    separator = ",";
+                    sb.append(lineSeparator);
+                    new LogRecord(logRecord).writeCsv(sb);
+                    lineSeparator = "\r\n";
                 }
-                sb.append("]}\n");
 
                 entity = sb;
                 break;

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
@@ -179,7 +179,6 @@ public class StructuredLogViewerResource {
         return Response.ok(entity.toString(), type).build();
     }
 
-    @SuppressWarnings("unused")
     private static final class Params {
 
         @QueryParam("logFileName")

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/StructuredLogViewerResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,18 +19,19 @@ package org.glassfish.admin.rest.resources.custom;
 
 import com.sun.enterprise.server.logging.logviewer.backend.LogFilter;
 
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,11 +39,21 @@ import java.util.Properties;
 
 import javax.management.Attribute;
 import javax.management.AttributeList;
+import javax.xml.stream.XMLStreamWriter;
 
+import jakarta.ws.rs.core.Response;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONObject;
 import org.glassfish.admin.rest.logviewer.LogRecord;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.api.LogManager;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static javax.xml.stream.XMLOutputFactory.newDefaultFactory;
 
 /**
  * REST resource to get Log records simple wrapper around internal LogFilter query class
@@ -58,145 +69,206 @@ public class StructuredLogViewerResource {
 
     @Path("lognames/")
     public LogNamesResource getLogNamesResource() {
-        LogNamesResource resource = injector.createAndInitialize(LogNamesResource.class);
-        return resource;
+        return injector.createAndInitialize(LogNamesResource.class);
     }
 
     @GET
-    @Produces({MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON})
-    public String getJson(
-        @QueryParam("logFileName") @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log") String logFileName,
-        @QueryParam("startIndex") @DefaultValue("-1") long startIndex,
-        @QueryParam("searchForward") @DefaultValue("false") boolean searchForward,
-        @QueryParam("maximumNumberOfResults") @DefaultValue("40") int maximumNumberOfResults,
-        @QueryParam("onlyLevel") @DefaultValue("false") boolean onlyLevel,
-        @QueryParam("fromTime") @DefaultValue("-1") long fromTime,
-        @QueryParam("toTime") @DefaultValue("-1") long toTime,
-        @QueryParam("logLevel") @DefaultValue("INFO") String logLevel,
-        @QueryParam("anySearch") @DefaultValue("") String anySearch,
-        @QueryParam("listOfModules") String listOfModules, //default value is empty for List
-        @QueryParam("instanceName") @DefaultValue("") String instanceName)
-        throws IOException {
-
-        return getWithType(logFileName, startIndex, searchForward, maximumNumberOfResults, fromTime, toTime, logLevel,
-            onlyLevel, anySearch, listOfModules, instanceName, "json");
-
+    @Produces("text/plain; qs=0.5")
+    public Response getViewLogDetailsText(@BeanParam Params params) throws Exception {
+        return getViewLogDetails(params, TEXT_PLAIN);
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_XML})
-    public String getXML(
-        @QueryParam("logFileName") @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log") String logFileName,
-        @QueryParam("startIndex") @DefaultValue("-1") long startIndex,
-        @QueryParam("searchForward") @DefaultValue("false") boolean searchForward,
-        @QueryParam("maximumNumberOfResults") @DefaultValue("40") int maximumNumberOfResults,
-        @QueryParam("onlyLevel") @DefaultValue("true") boolean onlyLevel,
-        @QueryParam("fromTime") @DefaultValue("-1") long fromTime,
-        @QueryParam("toTime") @DefaultValue("-1") long toTime,
-        @QueryParam("logLevel") @DefaultValue("INFO") String logLevel,
-        @QueryParam("anySearch") @DefaultValue("") String anySearch,
-        @QueryParam("listOfModules") String listOfModules, //default value is empty for List,
-        @QueryParam("instanceName") @DefaultValue("") String instanceName)
-        throws IOException {
-
-        return getWithType(logFileName, startIndex, searchForward, maximumNumberOfResults, fromTime, toTime, logLevel,
-            onlyLevel, anySearch, listOfModules, instanceName, "xml");
-
+    @Produces("application/json; qs=1")
+    public Response getViewLogDetailsJson(@BeanParam Params params) throws Exception {
+        return getViewLogDetails(params, APPLICATION_JSON);
     }
 
-    private String getWithType(String logFileName, long startIndex, boolean searchForward, int maximumNumberOfResults, long fromTime,
-            long toTime, String logLevel, boolean onlyLevel, String anySearch, String listOfModules, String instanceName, String type)
-            throws IOException {
+    @GET
+    @Produces("application/xml; qs=0.75")
+    public Response getViewLogDetailsXml(@BeanParam Params params) throws Exception {
+        return getViewLogDetails(params, APPLICATION_XML);
+    }
+
+    private Response getViewLogDetails(Params params, String type) throws Exception {
         if (habitat.getService(LogManager.class) == null) {
             // the logger service is not install, so we cannot rely on it.
             throw new IOException("The GlassFish LogManager Service is not available. Not installed?");
         }
 
         List<String> modules = new ArrayList<>();
-        if (listOfModules != null && !listOfModules.isEmpty()) {
-            modules.addAll(Arrays.asList(listOfModules.split(",")));
+        if (params.getListOfModules() != null && !params.getListOfModules().isEmpty()) {
+            modules.addAll(Arrays.asList(params.getListOfModules().split(",")));
         }
 
         Properties nameValueMap = new Properties();
 
-        boolean sortAscending = true;
-        if (!searchForward) {
-            sortAscending = false;
-        }
         LogFilter logFilter = habitat.getService(LogFilter.class);
-        if (instanceName.isEmpty()) {
-            final AttributeList result = logFilter.getLogRecordsUsingQuery(logFileName, startIndex, searchForward,
-                sortAscending, maximumNumberOfResults, fromTime == -1 ? null : Instant.ofEpochMilli(fromTime),
-                toTime == -1 ? null : Instant.ofEpochMilli(toTime), logLevel, onlyLevel, modules, nameValueMap,
-                anySearch);
-            return convertQueryResult(result, type);
+
+        boolean sortAscending = params.isSearchForward();
+        AttributeList result;
+        if (params.getInstanceName().isEmpty()) {
+            result = logFilter.getLogRecordsUsingQuery(params.getLogFileName(), params.getStartIndex(),
+                    params.isSearchForward(), sortAscending, params.getMaximumNumberOfResults(),
+                    params.getFromTime() == -1 ? null : Instant.ofEpochMilli(params.getFromTime()),
+                    params.getToTime() == -1 ? null : Instant.ofEpochMilli(params.getToTime()),
+                    params.getLogLevel(), params.isOnlyLevel(), modules, nameValueMap, params.getAnySearch());
+        } else {
+            result = logFilter.getLogRecordsUsingQuery(params.getLogFileName(), params.getStartIndex(),
+                    params.isSearchForward(), sortAscending, params.getMaximumNumberOfResults(),
+                    params.getFromTime() == -1 ? null : Instant.ofEpochMilli(params.getFromTime()),
+                    params.getToTime() == -1 ? null : Instant.ofEpochMilli(params.getToTime()),
+                    params.getLogLevel(), params.isOnlyLevel(), modules, nameValueMap, params.getAnySearch(), params.getInstanceName());
         }
-        final AttributeList result = logFilter.getLogRecordsUsingQuery(logFileName, startIndex, searchForward,
-            sortAscending, maximumNumberOfResults, fromTime == -1 ? null : Instant.ofEpochMilli(fromTime),
-            toTime == -1 ? null : Instant.ofEpochMilli(toTime), logLevel, onlyLevel, modules, nameValueMap,
-            anySearch, instanceName);
         return convertQueryResult(result, type);
-
     }
 
+    @SuppressWarnings("unchecked")
     private <T> List<T> asList(final Object list) {
-        return List.class.cast(list);
+        return (List<T>) list;
     }
 
+    private Response convertQueryResult(final AttributeList queryResult, String type) throws Exception {
+        Object entity;
 
-    private String convertQueryResult(final AttributeList queryResult, String type) {
-        // extract field descriptions into a String[]
-        StringBuilder sb = new StringBuilder();
-        String sep = "";
-        if (type.equals("json")) {
-            sb.append("{\"records\": [");
-        } else {
-            sb.append("<records>\n");
-        }
+        List<List<Serializable>> logRecords = asList(((Attribute) queryResult.get(1)).getValue());
 
-        if (queryResult.size() > 0) {
-            final AttributeList fieldAttrs = (AttributeList) ((Attribute) queryResult.get(0)).getValue();
-            String[] fieldHeaders = new String[fieldAttrs.size()];
-            for (int i = 0; i < fieldHeaders.length; ++i) {
-                final Attribute attr = (Attribute) fieldAttrs.get(i);
-                fieldHeaders[i] = (String) attr.getValue();
-            }
+        switch (type) {
+            case APPLICATION_JSON:
+                JSONArray logDetails = new JSONArray();
 
-            List<List<Serializable>> srcRecords = asList(((Attribute) queryResult.get(1)).getValue());
-
-            // extract every record
-            for (List<Serializable> record : srcRecords) {
-                assert (record.size() == fieldHeaders.length);
-                //Serializable[] fieldValues = new Serializable[fieldHeaders.length];
-
-                LogRecord rec = new LogRecord();
-                int fieldIdx = 0;
-                rec.setRecordNumber(((Long) record.get(fieldIdx++)).longValue());
-                rec.setLoggedDateTime((OffsetDateTime) record.get(fieldIdx++));
-                rec.setLoggedLevel((String) record.get(fieldIdx++));
-                rec.setProductName((String) record.get(fieldIdx++));
-                rec.setLoggerName((String) record.get(fieldIdx++));
-                rec.setNameValuePairs((String) record.get(fieldIdx++));
-                rec.setMessageID((String) record.get(fieldIdx++));
-                rec.setMessage((String) record.get(fieldIdx++));
-                if (type.equals("json")) {
-                    sb.append(sep);
-                    sb.append(rec.toJSON());
-                    sep = ",";
-                } else {
-                    sb.append(rec.toXML());
-
+                for (List<Serializable> logRecord : logRecords) {
+                    logDetails.put(new LogRecord(logRecord).toJSONObject());
                 }
-            }
+
+                entity = new JSONObject().put("records", logDetails);
+                break;
+            case APPLICATION_XML:
+                Writer xml = new StringWriter();
+
+                XMLStreamWriter writer = newDefaultFactory().createXMLStreamWriter(xml);
+                try {
+                    writer.writeStartElement("records");
+                    for (List<Serializable> logRecord : logRecords) {
+                        new LogRecord(logRecord).writeXml(writer);
+                    }
+                    writer.writeEndElement();
+                } finally {
+                    writer.close();
+                }
+
+                entity = xml;
+                break;
+            case TEXT_PLAIN:
+                StringBuilder sb = new StringBuilder();
+
+                sb.append("{\"records\": [");
+                String separator = "";
+                for (List<Serializable> logRecord : logRecords) {
+                    sb.append(separator);
+                    sb.append(new LogRecord(logRecord).toJSONObject().toString());
+                    separator = ",";
+                }
+                sb.append("]}\n");
+
+                entity = sb;
+                break;
+            default:
+                // should not reach here
+                return Response.status(UNSUPPORTED_MEDIA_TYPE).build();
         }
 
-        if (type.equals("json")) {
-            sb.append("]}\n");
-        } else {
-            sb.append("\n</records>\n");
+        return Response.ok(entity.toString(), type).build();
+    }
 
+    @SuppressWarnings("unused")
+    private static final class Params {
+
+        @QueryParam("logFileName")
+        @DefaultValue("${com.sun.aas.instanceRoot}/logs/server.log")
+        private String logFileName;
+
+        @QueryParam("startIndex")
+        @DefaultValue("-1")
+        private long startIndex;
+
+        @QueryParam("searchForward")
+        @DefaultValue("false")
+        private boolean searchForward;
+
+        @QueryParam("maximumNumberOfResults")
+        @DefaultValue("40")
+        private int maximumNumberOfResults;
+
+        @QueryParam("onlyLevel")
+        @DefaultValue("false")
+        private boolean onlyLevel;
+
+        @QueryParam("fromTime")
+        @DefaultValue("-1")
+        private long fromTime;
+
+        @QueryParam("toTime")
+        @DefaultValue("-1")
+        private long toTime;
+
+        @QueryParam("logLevel")
+        @DefaultValue("INFO")
+        private String logLevel;
+
+        @QueryParam("anySearch")
+        @DefaultValue("")
+        private String anySearch;
+
+        @QueryParam("listOfModules")
+        private String listOfModules; //default value is empty for List
+
+        @QueryParam("instanceName")
+        @DefaultValue("")
+        private String instanceName;
+
+        public String getLogFileName() {
+            return logFileName;
         }
 
-        return sb.toString();
+        public long getStartIndex() {
+            return startIndex;
+        }
+
+        public boolean isSearchForward() {
+            return searchForward;
+        }
+
+        public int getMaximumNumberOfResults() {
+            return maximumNumberOfResults;
+        }
+
+        public boolean isOnlyLevel() {
+            return onlyLevel;
+        }
+
+        public long getFromTime() {
+            return fromTime;
+        }
+
+        public long getToTime() {
+            return toTime;
+        }
+
+        public String getLogLevel() {
+            return logLevel;
+        }
+
+        public String getAnySearch() {
+            return anySearch;
+        }
+
+        public String getListOfModules() {
+            return listOfModules;
+        }
+
+        public String getInstanceName() {
+            return instanceName;
+        }
     }
 }


### PR DESCRIPTION
This PR should resolve #24068.

What's done:

* Refactored Log Names REST endpoint.
* Refactored View Log Details endpoint.
* Used JSON as a default output format when client has not defined a media type.
* Changed output format for media type `text/plain` from JSON-like string to [CSV](https://www.ietf.org/rfc/rfc4180.txt) (based on advice from @dmatej).
* Raised priority of the JSON entity provider.

Signed-off-by: Alexander Pinčuk <alexander.v.pinchuk@gmail.com>
