### PR TITLE
use zip goal with RB support

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -839,8 +839,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
-                    <!-- Don't use 3.2.28, FeatureSetsDependenciesMojo is broken. 3.3.0 is fixed, but not released yet. -->
-                    <version>3.2.27</version>
+                    <version>3.3.0-SNAPSHOT</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
requires https://github.com/eclipse-ee4j/glassfish-build-maven-plugin/pull/116

after this fix and #24372 , only 13 remaining files are not yet reproducible (730 are...)