### PR TITLE
Methods to build classpath of ScatteredArchive from the current classpath

### DIFF
--- a/nucleus/common/scattered-archive-api/pom.xml
+++ b/nucleus/common/scattered-archive-api/pom.xml
@@ -32,4 +32,58 @@
     <packaging>glassfish-jar</packaging>
 
     <name>Scattered Archive APIs of Glassfish</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>        
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- To display JUnit 5 test argument names-->
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    
+                    <!-- Enable JUNit 5 reporting features, like test display name -->
+                    <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <version>3.0</version>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                        <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                        <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                    </statelessTestsetReporter>
+                    <consoleOutputReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                        <disable>false</disable>
+                        <encoding>UTF-8</encoding>
+                        <usePhrasedFileName>true</usePhrasedFileName>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+                        <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                    </statelessTestsetInfoReporter>
+                    <!-- END of enable JUnit 5 reporting features -->
+                    
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/nucleus/common/scattered-archive-api/src/test/java/org/glassfish/embeddable/archive/ScatteredArchiveTest.java
+++ b/nucleus/common/scattered-archive-api/src/test/java/org/glassfish/embeddable/archive/ScatteredArchiveTest.java
@@ -1,0 +1,123 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/UnitTests/JUnit5TestClass.java to edit this template
+ */
+package org.glassfish.embeddable.archive;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ *
+ * @author ondro
+ */
+public class ScatteredArchiveTest {
+
+    private final String REGEX_COMMA_WITH_SPACE_AROUND = "[ ]*,[ ]*";
+
+    public ScatteredArchiveTest() {
+    }
+
+    public static class TestableScatteredArchive extends ScatteredArchive {
+
+        List<File> classpathElements = new ArrayList<>();
+
+        public TestableScatteredArchive(String name, Type type) {
+            super(name, type);
+        }
+
+        @Override
+        public void addClassPath(File classpath) throws IOException {
+            classpathElements.add(classpath);
+        }
+
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+                "path, '', 1",
+                "path:path2, '', 2",
+                "'jakarta.jakarta-api.jar:/folder/path2:/folder/glassfish-embedded-all.jar', '', 1",
+                "'jakarta.jakarta-api.jar:glassfish-embedded-all.jar', '', 0",
+                "path, 'path', 0",
+                "path111:/folder/path222, 'path.*', 0",
+                "path333:path111:/folder/path222, 'path1.* , path2.*', 1",
+                "'jakarta.jakarta-api.jar:path2:/some/folder/path3:somepath', 'path.', 1",
+                "'', '', 0"
+            })
+    public void addCurrentClasspathUsingExcludes(String classpath, String excludesList, int expectedElementsInClasspath) {
+
+        // GIVEN
+        setCurrentClasspath(classpath);
+        String[] excludesPatterns = excludesList.split(REGEX_COMMA_WITH_SPACE_AROUND);
+        TestableScatteredArchive archive = new TestableScatteredArchive("test", ScatteredArchive.Type.WAR);
+
+        // WHEN
+        archive.addCurrentClassPath(excludesPatterns);
+
+        // THEN
+        assertAll("classpath",
+                () -> assertThat("Number of classpath elements",
+                        archive.classpathElements, hasSize(expectedElementsInClasspath))
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "path, '', 1",
+        "path:path2, '', 2",
+        "'jakarta.jakarta-api.jar:/folder/path2:/folder/glassfish-embedded-all.jar', '0', 2",
+        "'jakarta.jakarta-api.jar:glassfish-embedded-all.jar', '0,1', 0",
+        "path, '0', 0",
+        "path111:/folder/path222, '0,1', 0",
+        "path111:/folder/path222, '0', 1",
+        "'jakarta.jakarta-api.jar:path2:/some/folder/path3:somepath', '1,2', 2",
+        "'', '', 0"
+    })
+    public void addCurrentClasspathUsingPredicate(String classpath, String excludesIndexes, int expectedElementsInClasspath) {
+
+        // GIVEN
+        var cpElements = setCurrentClasspath(classpath);
+        Predicate<String> exclude = value -> {
+            return Stream.of(excludesIndexes.split(REGEX_COMMA_WITH_SPACE_AROUND))
+                    .filter(s -> !s.isBlank())
+                    .map(Integer::valueOf)
+                    .anyMatch(i -> cpElements[i].equals(value));
+        };
+        TestableScatteredArchive archive = new TestableScatteredArchive("test", ScatteredArchive.Type.WAR);
+
+        // WHEN
+        archive.addCurrentClassPath(exclude);
+
+        // THEN
+        try {
+            assertAll("classpath",
+                    () -> assertThat("Number of classpath elements " + archive.classpathElements,
+                            archive.classpathElements, hasSize(expectedElementsInClasspath))
+            );
+        } catch (AssertionError e) {
+            throw e;
+        }
+    }
+
+    private static String[] setCurrentClasspath(String classpath) {
+        String osSpecificClasspath = classpath.replace('/', File.separatorChar).replace(':', File.pathSeparatorChar);
+        System.setProperty(ScatteredArchive.JAVA_CLASS_PATH_PROPERTY_KEY, osSpecificClasspath);
+        return osSpecificClasspath.split("\\" + File.pathSeparator);
+    }
+
+}


### PR DESCRIPTION
Allows to easily build and deploy app with GF Embedded from within the existing JVM classpath. 

Example what will be possible with this:

```
        final GlassFishProperties gfProperties = new GlassFishProperties();
        gfProperties.setPort("http-listener", 18080);

        GlassFish glassfish = GlassFishRuntime.bootstrap().newGlassFish(gfProperties);
        glassfish.start();

        ScatteredArchive archive = new ScatteredArchive("simpleapp", ScatteredArchive.Type.WAR);

        archive.addCurrentClassPath(); 
        /* HERE: without this method, each classpath element would have to be discovered 
        and added to the classpath manually using archive.addClasspath()
        */

        final Deployer deployer = glassfish.getDeployer();

```

