### PR TITLE
Fix redirections in Admin Console

### DIFF
--- a/appserver/admingui/common/src/main/resources/appServer/jvmReport.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/jvmReport.jsf
@@ -36,7 +36,7 @@
     <sun:html id="html2"> 
         <sun:head id="propertyhead" title="JVM Report" javaScript="true" debug="false" parseOnLoad="false">
             <h:outputScript name="faces.js" library="jakarta.faces" target="head" />
-            <sun:script url="/resource/common/js/adminjsf.js" />
+            <sun:script url="$resource{i18nc.adminjsf.url}" />
             
         </sun:head>
         <sun:body id="body3">

--- a/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
+++ b/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
@@ -35,7 +35,7 @@
                 getUIComponent(clientId="$pageSession{tableRowGroupId}", component=>$attribute{tableRowGroup});
                 getSelectedSingleMapRows(TableRowGroup="$attribute{tableRowGroup}" selectedRows=>$attribute{selectedRows});
                 gf.undeploy(selectedRows="${selectedRows}" );
-                gf.navigate(page="#{listPageLink}");
+                gf.redirect(page="#{listPageLink}");
             />
          </sun:button>
         <sun:button id="button2" text="$resource{i18n.button.Enable}" rendered="#{pageSession.onlyDASExist}" disabled="#{true}" primary="#{false}"

--- a/appserver/admingui/common/src/main/resources/applications/fileChooser.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/fileChooser.jsf
@@ -21,6 +21,7 @@
 <sun:page id="page1">
     <!beforeCreate
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     getRequestValue(key="dirPathId" value=>$page{dirPathId});
     getRequestValue(key="appNameId" value=>$page{appNameId});
     getRequestValue(key="folderOnly" value=>$page{folderOnly});
@@ -40,7 +41,7 @@
     />
 <sun:html id="html2">
     <sun:head id="propertyhead">
-        <sun:script url="/resource/common/js/adminjsf.js" />
+        <sun:script url="$resource{i18nc.adminjsf.url}" />
     </sun:head>
     <sun:body id="body3">
         <sun:form id="propertyForm">

--- a/appserver/admingui/common/src/main/resources/help/help.jsf
+++ b/appserver/admingui/common/src/main/resources/help/help.jsf
@@ -25,14 +25,15 @@
 	gf.navigate("#{requestScope.newVR}");
     }
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     getRequestValue(key="contextRef" value="#{pageSession.tempContextRef}" );
     urlencode(value="#{pageSession.tempContextRef}" encoding="UTF-8" result="#{pageSession.contextRef}");
 </ui:event>
 <sun:page>
 <sun:html>
     <sun:head title="$resource{i18n.helpWindowTitle}" debug="false" parseOnLoad="false">
-	<sun:link url="/resource/common/help/help.css" />
-	<sun:script url="/resource/common/js/adminjsf.js" />
+	<sun:link url="$resource{i18nc.help.css.url}" />
+	<sun:script url="$resource{i18nc.adminjsf.url}" />
 	<h:outputScript name="faces.js" library="jakarta.faces" target="head" />
     </sun:head>
     <sun:body id="bodyTag" style="display:none;" onLoad="admingui.help.fixTreeOnclick(document.getElementById('tocTree')); admingui.help.fixTreeOnclick(document.getElementById('indexTree')); admingui.help.loadHelpPageFromContextRef('#{pageSession.contextRef}', 'helpContent'); document.getElementById('bodyTag').style.display='block';">

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -19,7 +19,9 @@
  * Common utility
  */
 
-if (require) {
+/* Load dependencies eagerly to prevent issues with loading them asynchrnously later.
+ */    
+if (typeof(require) === typeof(Function)) {
     /* Don't load dependencies eagerly if require is not available. 
      * Allows using adminjsf without loading dojo for the require function,
      * in cases when only basic functionality is needed. For example in removeFrame.jsf.

--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -19,12 +19,19 @@
  * Common utility
  */
 
-require(['webui/suntheme/field']);
-require(['webui/suntheme/dropDown']);
-require(['webui/suntheme/upload']);
-require(['webui/suntheme/jumpDropDown']);
-require(['webui/suntheme/hyperlink']);
-require(['webui/suntheme/props']);
+if (require) {
+    /* Don't load dependencies eagerly if require is not available. 
+     * Allows using adminjsf without loading dojo for the require function,
+     * in cases when only basic functionality is needed. For example in removeFrame.jsf.
+     */
+
+    require(['webui/suntheme/field']);
+    require(['webui/suntheme/dropDown']);
+    require(['webui/suntheme/upload']);
+    require(['webui/suntheme/jumpDropDown']);
+    require(['webui/suntheme/hyperlink']);
+    require(['webui/suntheme/props']);
+}
 
 function checkPSWInCommon(secureAdminEnabled, id1, id2, alert1, alert2, confirmMessage) {
 	var ps1 = document.getElementById(id1); 

--- a/appserver/admingui/common/src/main/resources/logViewer/logEntryDetail.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logEntryDetail.jsf
@@ -19,7 +19,7 @@
 <!-- logViewer/logEntryDetail.jsf -->
 
 <!initPage
-    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings")
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     setResourceBundle(key="help_common" bundle="org.glassfish.common.admingui.Helplinks");
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
 />
@@ -56,7 +56,7 @@
     </event>
 <sun:html id="html2">
 <sun:head id="propertyhead" title="$resource{i18nc.logDetail.PageTitle}" debug="false" parseOnLoad="false">
-    <sun:script url="/resource/common/js/adminjsf.js" />
+    <sun:script url="$resource{i18nc.adminjsf.url}" />
 </sun:head>
 <sun:body id="body3">
 <sun:form id="propertyForm">

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewer.jsf
@@ -123,7 +123,7 @@
 <sun:html id="html2">
 <sun:head id="propertyhead" title="$resource{i18nc.logViewer.PageTitle}" debug="false" parseOnLoad="false">
 	<h:outputScript name="faces.js" library="jakarta.faces" target="head" />
-    <sun:script url="/resource/common/js/adminjsf.js" />
+    <sun:script url="$resource{i18nc.adminjsf.url}" />
 </sun:head>
 <sun:body onLoad="javascript: checkHiddenElements(); setFocusTableResults('#{hasResults}');" id="body3">
 <sun:form id="propertyForm">

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewerRaw.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewerRaw.jsf
@@ -21,7 +21,7 @@
 
 <ui:event type="initPage">
     initSessionAttributes();
-    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings")
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
 </ui:event>
 
@@ -38,7 +38,7 @@
 <sun:html id="html2">
 <sun:head id="propertyhead" title="$resource{i18nc.logViewerRaw.PageTitle}" debug="false" parseOnLoad="false">
 	<h:outputScript name="faces.js" library="jakarta.faces" target="head" />
-    <sun:script url="/resource/common/js/adminjsf.js" />
+    <sun:script url="$resource{i18nc.adminjsf.url}" />
 </sun:head>
 <sun:body onLoad="javascript: logViewerRaw('/download/log/?contentSourceId=LogViewer&start=0&instanceName=#{pageSession.encodedInstanceName}&restUrl=' + encodeURIComponent('#{sessionScope.REST_URL}'))" id="body3">
 <sun:form id="propertyForm">

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -15,6 +15,11 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
+## URLs to static resources. 
+# The query parameter 'v' should be increased 
+# every time the resource was updated to bypass browser caching
+adminjsf.url=/resource/common/js/adminjsf.js?v=2
+help.css.url=/resource/common/help/help.css?v=1
 
 ## 'server' is the name of the server instance. No Not Translate it.
 tree.adminServer=server (Admin Server)

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -15,8 +15,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-## URLs to static resources. 
-# The query parameter 'v' should be increased 
+## URLs to static resources.
+# The query parameter 'v' should be increased
 # every time the resource was updated to bypass browser caching
 adminjsf.url=/resource/common/js/adminjsf.js?v=2
 help.css.url=/resource/common/help/help.css?v=1

--- a/appserver/admingui/common/src/main/resources/removeFrame.jsf
+++ b/appserver/admingui/common/src/main/resources/removeFrame.jsf
@@ -15,11 +15,13 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-
+<!initPage
+    setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
+/>
 <f:verbatim>
 <html>
 <head>
-    <script type="text/javascript" src="#{request.contextPath}/resource/common/js/adminjsf.js" ></script>
+    <script type="text/javascript" src="#{request.contextPath}$resource{i18n.adminjsf.URL}" ></script>
     <script type="text/javascript">
 	function redirectToQS() {
 	    var loc = window.location.href;

--- a/appserver/admingui/common/src/main/resources/resourceNode/resXmlFileChooser.jsf
+++ b/appserver/admingui/common/src/main/resources/resourceNode/resXmlFileChooser.jsf
@@ -21,11 +21,12 @@
 <sun:page id="page1">
     <!beforeCreate
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     getRequestValue(key="dirPathId" value=>$page{dirPathId});
     />
 <sun:html id="html2">
     <sun:head id="propertyhead">
-        <sun:script url="/resource/common/js/adminjsf.js" />
+        <sun:script url="$resource{i18nc.adminjsf.url}" />
     </sun:head>
     <sun:body id="body3">
         <sun:form id="propertyForm">

--- a/appserver/admingui/core/src/main/resources/templates/baseLayout.xhtml
+++ b/appserver/admingui/core/src/main/resources/templates/baseLayout.xhtml
@@ -19,6 +19,7 @@
 
 <ui:event type="initPage">
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     getPluginIdFromViewId(viewId="#{facesContext.viewRoot.viewId}", pluginId="#{pluginId}");
 </ui:event>
 
@@ -56,7 +57,7 @@
             <script src="#{request.contextPath}/resources/yui/layout-min.js"></script>
         </f:verbatim>
 
-            <sun:script url="/resource/common/js/adminjsf.js" />
+            <sun:script url="$resource{i18nc.adminjsf.url}" />
             
             <!-- comment out for now since the file style.css doesn't exist.
              <link rel="stylesheet" type="text/css" href="#{request.contextPath}/style.css" />
@@ -238,51 +239,6 @@
 
     <!-- FIXME: this should be in adminjsf.js -->
 "    <script type="text/javascript">
-/*
-        function submitTagForm(el) {
-            YAHOO.util.Dom.get('tagForm:url').value = window.location;
-            DynaFaces.fireAjaxTransaction(el,
-            {
-                execute: 'tagForm:tag,tagForm:name,tagForm:url,'+el.id,
-                inputs: 'tagForm:tag,tagForm:name,tagForm:url,'+el.id,
-                render: 'tagForm:tag,tagForm:name,tagForm:url,'+el.id,
-                postReplace: function() {
-                    YAHOO.util.Dom.get('tagForm:tag').value = '';
-                    YAHOO.util.Dom.get('tagForm:name').value = '';
-                    hidePanel('addTagPanel');
-                }
-            } );
-        }
-        function submitTagSearchForm(el) {
-            DynaFaces.fireAjaxTransaction(el,
-            {
-                execute: 'hits,tagSearch:tag,'+el.id,
-                inputs: 'hits,tagSearch:tag,'+el.id,
-                render: 'hits',
-                postReplace: function(zone, html) {
-                    YAHOO.util.Dom.get('tagSearch:tag').value = '';
-                }
-            } );
-        }
-
-        <!--
-        FIXME: I think this would be better implemented using Y!'s KeyListener:
-        http://developer.yahoo.com/yui/examples/container/keylistener.html
-        function showSearchPanel(e) {
-            var result = true;
-            if ((e.charCode == 102) &amp;&amp; (e.ctrlKey == true)) {
-                showPanel('searchTagsPanel');
-                if (e.preventDefault) {
-                    e.preventDefault();
-                }
-                result = false;
-            }
-            return result;
-        }
-        YAHOO.util.Event.addListener(document, "keypress", showSearchPanel);
-        -->
-*/
-
 <f:verbatim>
         admingui.help.pluginId = '#{pluginId}';
 

--- a/appserver/admingui/core/src/main/resources/templates/iframe.layout
+++ b/appserver/admingui/core/src/main/resources/templates/iframe.layout
@@ -19,6 +19,7 @@
 
 <ui:event type="initPage">
     setResourceBundle(key="i18n" bundle="org.glassfish.admingui.core.Strings");
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings");
     getPluginIdFromViewId(viewId="#{facesContext.viewRoot.viewId}", pluginId="#{pluginId}");
 </ui:event>
 <sun:page>
@@ -28,7 +29,7 @@
 	</ui:event>
 	<sun:head title="#{guiTitle}" javaScript="true" debug="false" parseOnLoad="false">
 	    <h:outputScript name="faces.js" library="jakarta.faces" target="head" />
-	    <sun:script url="/resource/common/js/adminjsf.js" />
+	    <sun:script url="$resource{i18nc.adminjsf.url}" />
 	    <!insert name="guiTemplateExtraHead" />
 	    <!insert name="guiExtraHead" />
 	</sun:head>


### PR DESCRIPTION
Fix redirections when:
* application deployed, a blank page was displayed
* application undeployed, a blank page was displayed

Extract links to static resources to a string resource so that the links are defined in a single place. It's then easier to change the link, e.g. to increase the version number query param.

Added version number query param, so that the script adminjsf.js is loaded from the server and not from cache. An old version could be cached for about a month and it contains a bug. Without this users would have to wait to benefit from these bug fixes one month after they last used the previous version of Admin Console.