### PR TITLE
Fix ConfigInjector metadata generation in config-generator maven plugin

### DIFF
--- a/nucleus/hk2/config-generator/src/main/java/org/jvnet/hk2/config/generator/ConfigInjectorGenerator.java
+++ b/nucleus/hk2/config-generator/src/main/java/org/jvnet/hk2/config/generator/ConfigInjectorGenerator.java
@@ -297,7 +297,7 @@ public class ConfigInjectorGenerator extends AbstractProcessor {
                     }
                 }
 
-                for (TypeMirror it : clz.getInterfaces())
+                for (TypeMirror it : t.getInterfaces())
                     q.add((TypeElement) ((DeclaredType)it).asElement());
 
                 if (ElementKind.CLASS.equals(t.getKind())) {


### PR DESCRIPTION
Generated `ConfigInjector`'s metadata does not include elements and attributes from an indirectly implemented interfaces.

This fixes it.

**Note**: we should build the GlassFish with this fixed plugin, not with old 2.5.0-b53.