### PR TITLE
Allow ALL value for loggers in Admin Console.

### DIFF
--- a/appserver/admingui/common/src/main/resources/configuration/loggerLevels.jsf
+++ b/appserver/admingui/common/src/main/resources/configuration/loggerLevels.jsf
@@ -44,7 +44,8 @@
             loggerLevels="#{requestScope.loggerLevels.data.extraProperties.logLevels}"
             loggerList="#{requestScope.tableList}");
 
-        setPageSessionAttribute(key="levelList" value={"OFF" "FINEST" "FINER" "FINE" "CONFIG" "INFO" "WARNING" "SEVERE" "ALERT" "EMERGENCY"})
+        setPageSessionAttribute(key="levelList" value={"ALL" "FINEST" "FINER" "FINE" "CONFIG" "INFO" "WARNING" "SEVERE" "ALERT" "EMERGENCY" "OFF"});
+        setPageSessionAttribute(key="defaultNewLevel" value="OFF");
 		gf.isConfigName(configName="#{pageSession.configName}" );
     />
 </event>
@@ -75,7 +76,7 @@
         <sun:button id="addSharedTableButton" disabled="#{false}" text="$resource{i18nc.log.addLogger}" >
         <!command
             getUIComponent(clientId="$pageSession{tableRowGroupId}", component=>$attribute{tableRowGroup});
-            addRowToTable(TableRowGroup="$attribute{tableRowGroup}", NameList={"loggerName", "level"});
+            addRowToTable(TableRowGroup="$attribute{tableRowGroup}", NameList={"loggerName", "level"}, DefaultValueList={"","$pageSession{defaultNewLevel}"});
         />
         </sun:button>
 


### PR DESCRIPTION
A fix of a serious bug in Admin Console:
* When Module Log Levels modified (e.g. a new logger is added), `GlassFishLogHandler` is set to OFF, which means that logging to `server.log` stops.

Before this, Admin Console was showing OFF level instead of ALL level, and saved the OFF level even  if a user didn't change this intentionally.
ALL is used for GlassFishLogHandler by default, and, according to Javadoc, it's also a valid value for logger levels, meaning that all messages are logged.

Keep the OFF default level for new loggers as before. 

This is what Admin Console was showing when `org.glassfish.main.jul.handler.GlassFishLogHandler.level=ALL` in `logging.properties` (the default value):

![image](https://user-images.githubusercontent.com/2195988/234882610-08e066cf-aa0f-4038-8080-7ef6fa122098.png)

Now it's shows:
![image](https://user-images.githubusercontent.com/2195988/234883169-e57e8beb-1e99-46f5-b719-51eaca10b822.png)

When a new logger is added, the default level is OFF as before. I just made this configurable and not dependant on the order of the values in the drop down:
![image](https://user-images.githubusercontent.com/2195988/234883488-721dddee-5033-403b-9d90-8da415037c86.png)
