### PR TITLE
JMX server should not accept an arbitrary object as credentials

### DIFF
--- a/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
+++ b/nucleus/common/mbeanserver/src/main/java/org/glassfish/admin/mbeanserver/RMIConnectorStarter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -254,6 +255,7 @@ final class RMIConnectorStarter extends ConnectorStarter {
         final Map<String, Object> env = new HashMap<String, Object>();
 
         env.put("jmx.remote.jndi.rebind", "true");
+        env.put(RMIConnectorServer.CREDENTIALS_FILTER_PATTERN, String.class.getName() + ";!*");
 
         // Provide SSL-based RMI socket factories.
         env.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, sslCsf);


### PR DESCRIPTION
Add a credential filter pattern to JMXConnector.

related to : [CVE-2016-3427](https://nvd.nist.gov/vuln/detail/cve-2016-3427)
also : https://github.com/openjdk/jdk/blob/195f31371f4612a2d9d12a83deb281698ff68bfb/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java#L524
