### PR TITLE
Some Jenkins nodes are really slow - higher timeout values

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -66,9 +66,9 @@ public class AsadminLoggingITest {
     private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
 
     @BeforeAll
-    public static void fillUpLog() {
+    public static void fillUpServerLog() {
         // Fill up the server log.
-        AsadminResult result = ASADMIN.exec("restart-domain");
+        AsadminResult result = ASADMIN.exec(60_000, "restart-domain");
         assertThat(result, asadminOK());
     }
 

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/ClusterITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/ClusterITest.java
@@ -111,8 +111,8 @@ public class ClusterITest {
     @Test
     @Order(3)
     public void startInstancesTest() {
-        assertThat(ASADMIN.exec(30_000, "start-local-instance", INSTANCE_NAME_1), asadminOK());
-        assertThat(ASADMIN.exec(30_000, "start-local-instance", INSTANCE_NAME_2), asadminOK());
+        assertThat(ASADMIN.exec(60_000, "start-local-instance", INSTANCE_NAME_1), asadminOK());
+        assertThat(ASADMIN.exec(60_000, "start-local-instance", INSTANCE_NAME_2), asadminOK());
     }
 
     @Test


### PR DESCRIPTION
These tests are timing out sometimes. 

For maybe a month builds often use some slow nodes which have issues with restart-domain/start-instance, perhaps because of some throttling of the docker container. Until now resolved by several restarts which always take time. Now  the cup of patience overflowed!