### PR TITLE
Fix login again after logout

### DIFF
--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -714,11 +714,14 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
     // utility method to get web security anager.
     // will log warning if the manager is not found in the factory, and
     // logNull is true.
+    // Note: webSecurityManagerFactory can be null the very questionable SOAP code just
+    // instantiates a RealmAdapter
     public WebSecurityManager getWebSecurityManager(boolean logNull) {
-        if (webSecurityManager == null) {
+        if (webSecurityManager == null && webSecurityManagerFactory != null) {
             synchronized (this) {
                 webSecurityManager = webSecurityManagerFactory.getManager(contextId);
             }
+
             if (webSecurityManager == null && logNull) {
                 _logger.log(WARNING, "realmAdapter.noWebSecMgr", contextId);
             }

--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -1781,7 +1781,7 @@ public class RealmAdapter extends RealmBase implements RealmInitializer, PostCon
         }
     }
 
-    private Key findDigestKey(com.sun.enterprise.security.auth.digest.api.DigestAlgorithmParameter[] digestParameters) {
+    private Key findDigestKey(DigestAlgorithmParameter[] digestParameters) {
         for (DigestAlgorithmParameter digestParameter : digestParameters) {
             if (A1.equals(digestParameter.getName()) && digestParameter instanceof Key) {
                 return (Key) digestParameter;

--- a/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/webservices/SecurityServiceImpl.java
+++ b/appserver/security/webservices.security/src/main/java/com/sun/enterprise/security/webservices/SecurityServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -140,7 +140,7 @@ public class SecurityServiceImpl implements SecurityService {
             }
 
             RealmAdapter ra = new RealmAdapter(realmName, endpoint.getBundleDescriptor().getModuleID());
-            authenticated = ra.authenticate(webPrincipal);
+            authenticated = ra.authenticate(hreq, webPrincipal);
             if (authenticated) {
                 sendAuthenticationEvents(true, hreq.getRequestURI(), webPrincipal);
             } else {

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Realm.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Realm.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,18 +18,17 @@
 
 package org.apache.catalina;
 
-import org.apache.catalina.deploy.SecurityConstraint;
-import org.jvnet.hk2.annotations.Contract;
-
-import org.glassfish.hk2.api.PerLookup;
-
-import jakarta.servlet.http.HttpServletRequest;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
+
+import org.apache.catalina.deploy.SecurityConstraint;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Contract;
+
 import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 /**
  * A <b>Realm</b> is a read-only facade for an underlying security realm
  * used to authenticate individual users, and identify the security roles
@@ -111,7 +111,7 @@ public interface Realm {
      * @param credentials Password or other credentials to use in
      *  authenticating this username
      */
-    public Principal authenticate(String username, char[] credentials);
+    public Principal authenticate(HttpRequest request, String username, char[] credentials);
 
 
     /**
@@ -140,7 +140,7 @@ public interface Realm {
      * @param certs Array of client certificates, with the first one in
      *  the array being the certificate of the client itself.
      */
-    public Principal authenticate(X509Certificate certs[]);
+    public Principal authenticate(HttpRequest request, X509Certificate certs[]);
 
     /**
      * Return the SecurityConstraints configured to guard the request URI for

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/AuthenticatorBase.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/AuthenticatorBase.java
@@ -731,7 +731,7 @@ public abstract class AuthenticatorBase extends ValveBase implements Authenticat
      * @throws ServletException
      */
     protected Principal doLogin(HttpRequest request, String username, char[] password) throws ServletException {
-        Principal callerPrincipal = context.getRealm().authenticate(username, password);
+        Principal callerPrincipal = context.getRealm().authenticate(request, username, password);
         if (callerPrincipal == null) {
             throw new ServletException(rb.getString(LOGIN_FAIL));
         }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/BasicAuthenticator.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/BasicAuthenticator.java
@@ -106,7 +106,7 @@ public class BasicAuthenticator extends AuthenticatorBase {
             String username = parseUsername(authorization);
             char[] password = parsePassword(authorization);
 
-            Principal authenticatedPrincipal = context.getRealm().authenticate(username, password);
+            Principal authenticatedPrincipal = context.getRealm().authenticate(request, username, password);
 
             if (authenticatedPrincipal != null) {
                 register(request, response, authenticatedPrincipal, BASIC_METHOD, username, password);

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/FormAuthenticator.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/FormAuthenticator.java
@@ -145,7 +145,7 @@ public class FormAuthenticator extends AuthenticatorBase {
                 if (log.isLoggable(FINE)) {
                     log.log(FINE, neutralizeForLog("Reauthenticating username '" + username + "'"));
                 }
-                principal = context.getRealm().authenticate(username, password);
+                principal = context.getRealm().authenticate(request, username, password);
                 if (principal != null) {
                     session.setNote(FORM_PRINCIPAL_NOTE, principal);
                     if (!matchRequest(request)) {
@@ -210,7 +210,7 @@ public class FormAuthenticator extends AuthenticatorBase {
             log.log(FINE, neutralizeForLog("Authenticating username '" + username + "'"));
         }
 
-        principal = realm.authenticate(username, password);
+        principal = realm.authenticate(request, username, password);
         if (principal == null) {
             forwardToErrorPage(request, response, config);
             return false;

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/SSLAuthenticator.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/SSLAuthenticator.java
@@ -119,7 +119,7 @@ public class SSLAuthenticator extends AuthenticatorBase {
         }
 
         // Authenticate the specified certificate chain
-        callerPrincipal = context.getRealm().authenticate(certificates);
+        callerPrincipal = context.getRealm().authenticate(request, certificates);
         if (callerPrincipal == null) {
             if (debug >= 1) {
                 log("Realm.authenticate() returned false");


### PR DESCRIPTION
Fixes #23757 

After a logout the Jakarta Authorization security context was cleared (the data it depends on; the current HTTPServletRequest and the context ID), but after a login not set again. Previously login depended on this being set at the start of a request.

The fix is to set that context upon calling login, in the same wat that some of the constraints checking methods are called on the realm adapter. For consistency the set and reset methods for this context are both in the WebSecurityManager, which encapsulates the (Exousia) authorization manager.

I locally executed the Security, Authentication, Authorization and Servlet TCKs.
