### PR TITLE
Fixes validation error when deploying an application to a cluster.

### DIFF
--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Cluster.java
@@ -395,7 +395,7 @@ public interface Cluster extends ConfigBeanProxy, PropertyBag, Named, SystemProp
     }
 
     default boolean isVirtual() {
-        return getExtensionsByType(VirtualMachineExtension.class).isEmpty();
+        return !getExtensionsByType(VirtualMachineExtension.class).isEmpty();
     }
 
     default ApplicationRef getApplicationRef(String appName) {


### PR DESCRIPTION
This is a regression introduced in 7.0.4 with https://github.com/eclipse-ee4j/glassfish/pull/24368

to reproduce in GlassFish 7.0.4:
* create a cluster with a local instance
* deploy a simple application, e.g. [clusterjsp.war](http://blogs.nologin.es/rickyepoderi/uploads/SimplebutFullGlassfishHAUsingDebian/clusterjsp.war) to the cluster (target is the cluster, not server)

Deployment fails with the error:
> Error during authorization
java.lang.RuntimeException: java.lang.IllegalArgumentException: Cannot 
specify target cluster for the operation. Target cluster is a managed 
target
![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/a97a9761-4adf-49b0-b25a-08298e7c553b)

The reason is that the method Cluster.isVirtual() wrongly returns `true` in the [ApplicationLifecycle.java](https://github.com/eclipse-ee4j/glassfish/blob/7.0.4/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java#L2114)