### PR TITLE
Fix resetting security context if principal is the same

### DIFF
--- a/appserver/web/web-glue/src/main/java/com/sun/web/server/J2EEInstanceListener.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/web/server/J2EEInstanceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -203,7 +203,7 @@ public final class J2EEInstanceListener implements InstanceListener {
 
                 if (principal != null && principal == basePrincipal && principal.getClass().getName().equals(WEB_PRINCIPAL_CLASS)) {
                     securityContext.setSecurityContextWithPrincipal(principal);
-                } else if (principal != basePrincipal) {
+                } else if (principal != basePrincipal && principal != getCurrentCallerPrincipal()) {
 
                     // The wrapper has overridden getUserPrincipal
                     // reject the request if the wrapper does not have
@@ -212,7 +212,6 @@ public final class J2EEInstanceListener implements InstanceListener {
                     checkObjectForDoAsPermission(httpServletRequest);
                     securityContext.setSecurityContextWithPrincipal(principal);
                 }
-
             }
         }
 
@@ -246,7 +245,14 @@ public final class J2EEInstanceListener implements InstanceListener {
         }
     }
 
+    private Principal getCurrentCallerPrincipal() {
+        AppServSecurityContext currentSecurityContext = securityContext.getCurrentSecurityContext();
+        if (currentSecurityContext == null) {
+            return null;
+        }
 
+        return currentSecurityContext.getCallerPrincipal();
+    }
 
     private static void checkObjectForDoAsPermission(final Object o) throws AccessControlException {
         if (System.getSecurityManager() != null) {


### PR DESCRIPTION
If the principal in the request is equal to the principal in the current security context, there is no need to reset that context. Doing this can even lead to losing the roles.

Has also fixed #24196
