### PR TITLE
Admin Console: Update instance status asynchronously

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterInstances.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterInstances.jsf
@@ -49,6 +49,7 @@
         createMap(result="#{requestScope.listInstanceAttrMap}");
         setPageSessionAttribute(key="clusterInstancesPage" value="#{true}" )
         mapPut(map="#{requestScope.listInstanceAttrMap}" key="whichtarget" value="#{pageSession.encodedClusterName}")
+        mapPut(map="#{requestScope.listInstanceAttrMap}" key="nostatus" value="true")
         gfr.getInstancesStatus();
         gf.getMapKeys(Map="#{pageSession.instanceStatusMap}" Keys="#{pageSession.instancesName}");
         gf.getChildList(parentEndpoint="#{pageSession.parentUrl}", childType="#{pageSession.childType}", includeList="#{pageSession.instancesName}", result="#{requestScope.listOfRows}");
@@ -72,6 +73,12 @@
 <sun:hidden id="helpKey" value="$resource{help_cluster.clusterInstances}" />
     </sun:form>
 #include "/common/shared/changeButtonsJS.inc"
+
+    <sun:script>
+	<f:verbatim>
+            fetchStatusesOfInstances("propertyForm:");
+        </f:verbatim>
+    </sun:script>
 
 </define>
 </composition>

--- a/appserver/admingui/cluster/src/main/resources/cluster/clusters.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusters.jsf
@@ -146,17 +146,24 @@
         <foreach key="instance" list="#{requestScope.listOfInstances}">
             <event>
             <!beforeEncode
-                setAttribute(key="tmp" value="#{instance}");
-                gf.listInstances(optionKeys={"id"} optionValues={"$attribute{tmp}"}, statusMap="#{requestScope.statusMap}");
-                setAttribute(key="status" value="#{requestScope.statusMap['$attribute{tmp}']}");
+                setAttribute(key="instanceName" value="#{instance}");
+                gf.listInstances(optionKeys={"id", "nostatus"} optionValues={"$attribute{instanceName}", "true"}, statusMap="#{requestScope.statusMap}");
+                setAttribute(key="status" value="UNKNOWN");
                 setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp;  $resource{i18nc.status.$attribute{status}}");
+                if (#{not empty requestScope.statusMap['$attribute{instanceName}']}) {
+                    setAttribute(key="status" value="#{requestScope.statusMap['$attribute{instanceName}']}");
+                    setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp;  $resource{i18nc.status.$attribute{status}}");
+                }
             />
             </event>
             "<tr>
             "<td>
             <sun:hyperlink id="iLink" url="#{request.contextPath}/cluster/cluster/clusterInstanceEdit.jsf?clusterName=#{pageSession.clusterName}&instanceName=#{instance}" text="#{instance}" />
-            "</td> <td>
+            "</td> <td class="status">
              <staticText id="colStopped" value="#{requestScope.statusString}" />
+            <f:verbatim>
+                <span class="instance-name" data-instancename="#{instance}"/>
+            </f:verbatim>
             "</td>
             "</tr>
         </foreach>
@@ -171,6 +178,23 @@
     </sun:form>
 #include "/common/shared/changeButtonsJS.inc"
 
+<sun:script>
+    <f:verbatim>
+        function fetchStatusesOfInstances(tableIdPrefix) {
+            const statusCells = document.querySelectorAll("[id='" + tableIdPrefix + "clustersTable'] tr td.status");
+            statusCells.forEach(e => {
+                const instName = e.querySelector("span.instance-name").attributes["data-instancename"].value;
+                admingui.ajax.get("#{request.contextPath}/shared/instanceStatus.jsf?instanceName=" + instName, "", (req) => {
+                e.innerHTML = req.responseText;
+                });
+            });
+        }
+
+        fetchStatusesOfInstances("propertyForm:");
+    </f:verbatim>
+
+</sun:script>
+        
 </define>
 </composition>
 

--- a/appserver/admingui/cluster/src/main/resources/cluster/clusters.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusters.jsf
@@ -148,7 +148,7 @@
             <!beforeEncode
                 setAttribute(key="instanceName" value="#{instance}");
                 gf.listInstances(optionKeys={"id", "nostatus"} optionValues={"$attribute{instanceName}", "true"}, statusMap="#{requestScope.statusMap}");
-                setAttribute(key="status" value="UNKNOWN");
+                setAttribute(key="status" value="PROGRESS");
                 setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp;  $resource{i18nc.status.$attribute{status}}");
                 if (#{not empty requestScope.statusMap['$attribute{instanceName}']}) {
                     setAttribute(key="status" value="#{requestScope.statusMap['$attribute{instanceName}']}");

--- a/appserver/admingui/cluster/src/main/resources/node/nodes.jsf
+++ b/appserver/admingui/cluster/src/main/resources/node/nodes.jsf
@@ -131,7 +131,7 @@
             <foreach key="instance" list="#{requestScope.instanceList}">
                 <event>
                 <!beforeEncode
-                    setAttribute(key="status" value="UNKNOWN");
+                    setAttribute(key="status" value="PROGRESS");
                     if (#{not empty requestScope.statusMap[ '${instance}']}) {
                         setAttribute(key="status" value="#{requestScope.statusMap[ '${instance}']}");
                     }

--- a/appserver/admingui/cluster/src/main/resources/node/nodes.jsf
+++ b/appserver/admingui/cluster/src/main/resources/node/nodes.jsf
@@ -70,7 +70,7 @@
         setPageSessionAttribute(key="editLink" value="#{request.contextPath}/cluster/node/nodeEdit.jsf");
         setPageSessionAttribute(key="tableTitle" value="$resource{i18ncs.nodes.TableTitle}");
         createMap(result="#{pageSession.nodeInstanceMap}");
-        gf.listInstances(optionKeys={"standaloneonly" } optionValues={"true"}, instances="#{pageSession.standaloneList}");
+        gf.listInstances(optionKeys={"standaloneonly", "nostatus" } optionValues={"true", "true"}, instances="#{pageSession.standaloneList}");
     />
     </event>
 "    <script type="text/javascript">admingui.nav.selectTreeNodeById(admingui.nav.TREE_ID + ":nodeTreeNode");</script>
@@ -123,7 +123,7 @@
     <sun:tableColumn headerText="$resource{i18ncs.clusters.instanceCol}" rowHeader="$boolean{false}" id="col3">
          <event>
             <!beforeEncode
-                gf.listInstances(optionKeys={"id"} optionValues={"$pageSession{nodeName}"}, instances="#{requestScope.instanceList}" statusMap="#{requestScope.statusMap}");
+                gf.listInstances(optionKeys={"id", "nostatus"} optionValues={"$pageSession{nodeName}", "true"}, instances="#{requestScope.instanceList}" statusMap="#{requestScope.statusMap}");
                 mapPut(map="#{pageSession.nodeInstanceMap}" key="#{pageSession.nodeName}" value="#{requestScope.instanceList}");
             />
          </event>
@@ -131,7 +131,10 @@
             <foreach key="instance" list="#{requestScope.instanceList}">
                 <event>
                 <!beforeEncode
-                    setAttribute(key="status" value="#{requestScope.statusMap[ '${instance}']}");
+                    setAttribute(key="status" value="UNKNOWN");
+                    if (#{not empty requestScope.statusMap[ '${instance}']}) {
+                        setAttribute(key="status" value="#{requestScope.statusMap[ '${instance}']}");
+                    }
                     gf.containedIn(list="#{pageSession.standaloneList}" testStr="#{requestScope.instance}" contain="#{requestScope.isStandalone}" );
                     urlencode(value="#{requestScope.instance}" encoding="UTF-8" result="#{pageSession.encodedInstanceName}");
                     if (#{requestScope.isStandalone}){
@@ -148,7 +151,10 @@
                 </event>
                 <sun:hyperlink url="#{requestScope.iurl}" text="#{requestScope.instance}" />
                 "&nbsp;&nbsp;&nbsp;
+                "<span class="status" data-instancename="#{instance}">
+
                 <staticText id="colStopped" value="#{requestScope.statusString}" />
+                "</span>
                 "<br />
             </foreach>
             </if>
@@ -178,6 +184,24 @@
 <sun:hidden id="helpKey" value="$resource{help_cluster.nodes}" />
     </sun:form>
 #include "/common/shared/changeButtonsJS.inc"
+
+<sun:script>
+    <f:verbatim>
+        function fetchStatusesOfInstances(tableIdPrefix) {
+            const statusCells = document.querySelectorAll("[id='" + tableIdPrefix + "nodesTable'] tr td span.status");
+            statusCells.forEach(e => {
+                const instName = e.attributes["data-instancename"].value;
+                admingui.ajax.get("#{request.contextPath}/shared/instanceStatus.jsf?instanceName=" + instName, "", (req) => {
+                e.innerHTML = req.responseText;
+                });
+            });
+        }
+
+        fetchStatusesOfInstances("propertyForm:");
+    </f:verbatim>
+
+</sun:script>
+
 
 </define>
 </composition>

--- a/appserver/admingui/cluster/src/main/resources/shared/instanceStatus.jsf
+++ b/appserver/admingui/cluster/src/main/resources/shared/instanceStatus.jsf
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (c) 2023 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!initPage
+    setResourceBundle(key="i18nc" bundle="org.glassfish.common.admingui.Strings")
+    getRequestValue(key="instanceName" value="#{pageSession.instanceName}");
+/>
+#include "/cluster/shared/handlers.inc"
+<!composition>
+    <staticText value="#{requestScope.statusString}">
+            <!beforeCreate
+                createMap(result="#{requestScope.listInstanceAttrMap}");
+                mapPut(map="#{requestScope.listInstanceAttrMap}" key="whichTarget" value="#{pageSession.instanceName}")
+                gfr.getInstancesStatus();
+            />
+            <!beforeEncode
+                mapGet(Map="#{pageSession.instanceStatusMap}" Key="#{pageSession.instanceName}" Value="#{requestScope.status}")
+                setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp; $resource{i18nc.status.$attribute{status}}");
+            />
+            </staticText>
+            <f:verbatim>
+                <span class="instance-name" data-instancename="#{pageSession.instanceName}"/>
+            </f:verbatim>
+</composition>

--- a/appserver/admingui/cluster/src/main/resources/shared/instancesTable.inc
+++ b/appserver/admingui/cluster/src/main/resources/shared/instancesTable.inc
@@ -58,7 +58,7 @@
         <staticText id="statusCol" value="#{requestScope.statusString}">
             <!beforeEncode
                 mapGet(Map="#{pageSession.instanceStatusMap}" Key="#{td.value.name}" Value="#{requestScope.status}")
-                setAttribute(key="statusString" value="$resource{i18nc.status.image.UNKNOWN}  &nbsp; $resource{i18nc.status.UNKNOWN}");
+                setAttribute(key="statusString" value="$resource{i18nc.status.image.PROGRESS}  &nbsp; $resource{i18nc.status.PROGRESS}");
                 if ( #{not empty requestScope.status} ) {
                     setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp; $resource{i18nc.status.$attribute{status}}");
                 }

--- a/appserver/admingui/cluster/src/main/resources/shared/instancesTable.inc
+++ b/appserver/admingui/cluster/src/main/resources/shared/instancesTable.inc
@@ -54,14 +54,35 @@
     <sun:tableColumn headerText="$resource{i18ncs.common.NodeCol}" sort="node" rowHeader="$boolean{false}" id="col5">
         <sun:hyperlink id="nodeAgentlink" text="#{td.value.nodeRef}"  url="#{request.contextPath}/cluster/node/nodeEdit.jsf?nodeName=#{td.value.nodeRef}" />
     </sun:tableColumn>
-    <sun:tableColumn headerText="$resource{i18n.common.Status}"  rowHeader="$boolean{false}" id="col6">
-        <staticText id="statusCol" value="#{requestScope.statusString}" >
+    <sun:tableColumn headerText="$resource{i18n.common.Status}"  rowHeader="$boolean{false}" id="col6" styleClass="status">
+        <staticText id="statusCol" value="#{requestScope.statusString}">
             <!beforeEncode
                 mapGet(Map="#{pageSession.instanceStatusMap}" Key="#{td.value.name}" Value="#{requestScope.status}")
-                setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp; $resource{i18nc.status.$attribute{status}}");
+                setAttribute(key="statusString" value="$resource{i18nc.status.image.UNKNOWN}  &nbsp; $resource{i18nc.status.UNKNOWN}");
+                if ( #{not empty requestScope.status} ) {
+                    setAttribute(key="statusString" value="$resource{i18nc.status.image.$attribute{status}}  &nbsp; $resource{i18nc.status.$attribute{status}}");
+                }
             />
         </staticText>
+        <f:verbatim>
+            <span class="instance-name" data-instancename="#{td.value.name}"/>
+        </f:verbatim>
     </sun:tableColumn>
 </sun:tableRowGroup>
 
 </sun:table>
+
+<sun:script>
+    <f:verbatim>
+        function fetchStatusesOfInstances(tableIdPrefix) {
+            const statusCells = document.querySelectorAll("[id='" + tableIdPrefix + "instancesTable'] tr td.status");
+            statusCells.forEach(e => {
+                const instName = e.querySelector("span.instance-name").attributes["data-instancename"].value;
+                admingui.ajax.get("#{request.contextPath}/shared/instanceStatus.jsf?instanceName=" + instName, "", (req) => {
+                e.innerHTML = req.responseText;
+                });
+            });
+        }
+    </f:verbatim>
+
+</sun:script>

--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstances.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneInstances.jsf
@@ -44,6 +44,7 @@
         setPageSessionAttribute(key="childType" value="server");
         createMap(result="#{requestScope.listInstanceAttrMap}");
         mapPut(map="#{requestScope.listInstanceAttrMap}" key="standaloneonly" value="true")
+        mapPut(map="#{requestScope.listInstanceAttrMap}" key="nostatus" value="true")
         gfr.getInstancesStatus();
         gf.getMapKeys(Map="#{pageSession.instanceStatusMap}" Keys="#{pageSession.standalone}");
         gf.getChildList(parentEndpoint="#{pageSession.parentUrl}", childType="#{pageSession.childType}",
@@ -67,6 +68,13 @@
 <sun:hidden id="helpKey" value="$resource{help_cluster.standaloneInstances}" />
     </sun:form>
 #include "/common/shared/changeButtonsJS.inc"
+
+
+    <sun:script>
+	<f:verbatim>
+            fetchStatusesOfInstances("propertyForm:");
+        </f:verbatim>
+    </sun:script>
 
 </define>
 </composition>

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -852,6 +852,7 @@ status.image.RUNNING=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/o
 status.image.NOT_RUNNING=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/failed_small.gif" alt="Stopped" title="Stopped"/>
 status.image.REQUIRES_RESTART=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/degraded_small.gif" alt="Restart Required" title="Restart Required"/>
 status.image.UNKNOWN=
+status.image.PROGRESS=<img src="/theme/com/sun/webui/jsf/suntheme/images/alerts/progress_small.gif" alt="Retrieving status" title="Retrieving status"/>
 
 status.RUNNING=Running
 status.REQUIRES_RESTART=Restart Required
@@ -859,7 +860,7 @@ status.UNKNOWN=Unknown
 status.NO_RESPONSE=No Response
 status.NOT_RUNNING=Stopped
 status.STARTING=Starting
-
+status.PROGRESS=Retrieving status...
 
 resourcesTarget.pageTitle=Resources
 resourcesTarget.pageTitleHelp=Enable, disable, or create a new resource type to associate with the instance.


### PR DESCRIPTION
Pages for list of standalone instance, clusters and nodes show information about instance status. In real life deployments, due to network issues, it can take a long while to retrieve the status of the instances.

This change defers checking the statuses to an ajax call, one ajax call per each instance. This could be optimized to retrieve statuses of all instances in a single ajax call to save admin threads but this solution is faster because it polls the instances in parallel. And it's also easier to write.

What it does:
* in all cases, the page is displayed almost immediately, with statuses of all instances displayed as UNKNOWN
* AJAX calls then update the statuses after the page is loaded

When everything is fast, all works as before - correct statuses are displayed. If retrieving statuses is slow, before this change it took a long time to display the whole page until statuses of all instances were retrieved. After this change, the page is displayed instantly with UKNOWN statuses, and statuses are updated with correct values after a while. Each status can be updated independently, so some instances can show Running or Stopped, while some other will keep showing UNKNOWN for a longer while.

Examples:

Standalone instance when statuses take longer time to retrieve, before they are retrieved:

![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/7c78a30e-3cef-49fa-b975-23b86854ea57)

After they are retrieved:

![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/30a5f8ee-01ba-4b1c-9c57-749be5f0f5c6)

Cluster instances (some are retrieved, some show UNKNOWN because they take a bit longer to retrieve the status):

![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/8bf3ba29-7b3c-4415-894c-b1ccf31da265)

And nodes, with all statuses retrieved:

![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/91e44fd3-4b4b-4d58-869d-e6d52b9ae526)


