### PR TITLE
Fix a deployment-time recursive bytecode preprocessing in the WebappClassLoader

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -587,6 +587,8 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
                             // If bytecode preprocessing already started, we skip all classes,
                             // loaded by a preprocessors to prevent recursive transformation.
                             if (!BYTECODE_PREPROCESSING.get()) {
+                                LOG.log(TRACE, "Transforming {0}", name);
+
                                 BYTECODE_PREPROCESSING.set(true);
                                 try {
                                     String classFilePath = toClassFilePath(name);


### PR DESCRIPTION
Eliminates a recursive preprocessing of a classes loaded during the operation of the preprocessor itself.

This closes #24414.
