### PR TITLE
Admin console: ignore standalone instance status for app details

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/standalone/standaloneTreeNode.jsf
+++ b/appserver/admingui/cluster/src/main/resources/standalone/standaloneTreeNode.jsf
@@ -28,7 +28,7 @@
 	url="/cluster/standalone/standaloneInstances.jsf">
     <ui:event type="beforeCreate">
 	setResourceBundle(key="i18ncs" bundle="org.glassfish.cluster.admingui.Strings");
-	gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances.json?standaloneonly=true" method="get" result="#{requestScope.resp}"); 
+	gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances.json?standaloneonly=true&nostatus=true" method="get" result="#{requestScope.resp}");
 	setAttribute(key="children" value="#{requestScope.resp.data.extraProperties.instanceList}");
     </ui:event>
 </dynamicTreeNode>

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
@@ -52,6 +52,7 @@ public class TargetUtil {
         String endpoint = GuiUtil.getSessionValue("REST_URL") + "/list-instances" ;
         Map attrsMap = new HashMap();
         attrsMap.put("standaloneonly", "true");
+        attrsMap.put("nostatus", "true");
         try{
             Map responseMap = RestUtil.restRequest( endpoint , attrsMap, "get" , null, false);
             Map  dataMap = (Map) responseMap.get("data");


### PR DESCRIPTION
This adds the nostatus option when querying the list of instances where status isn't needed:

* which instances applications are deployed to
* list of standalone instances in the sidebar

The status is never displayed, so it's not necessary to query it. Querying the status may take a very long time because it may call remote instances. If we don't need it, better avoid querying it. If we want to show the status of the instances later, it's better to do it asynchronously, as in https://github.com/eclipse-ee4j/glassfish/pull/24432.