### PR TITLE
More timeouts in admin commands and Admin Console

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/shared/handlers.inc
+++ b/appserver/admingui/cluster/src/main/resources/shared/handlers.inc
@@ -58,6 +58,11 @@
  Output: #{pageSession.instanceStatusMap}
 -->
 <handler id="gfr.getInstancesStatus">
+    if ("#{requestScope.listInstanceAttrMap} = ${null}") {
+        createMap(result="#{requestScope.listInstanceAttrMap}");
+    }
+    getDefaultAdminTimeout(result="#{requestScope.adminTimeout}");
+    mapPut(map="#{requestScope.listInstanceAttrMap}" key="timeoutmsec" value="#{requestScope.adminTimeout}" );
     gf.restRequest( endpoint="#{sessionScope.REST_URL}/list-instances"
         attrs="#{requestScope.listInstanceAttrMap}"
         method="GET"

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/ClusterHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/ClusterHandler.java
@@ -30,6 +30,7 @@ package org.glassfish.admingui.common.handlers;
 
 import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Domain;
+import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.jsftemplating.annotation.Handler;
 import com.sun.jsftemplating.annotation.HandlerInput;
 import com.sun.jsftemplating.annotation.HandlerOutput;
@@ -481,6 +482,10 @@ public class ClusterHandler {
             for (int i = 0; i < keys.size(); i++) {
                 attrs.put(keys.get(i), values.get(i));
             }
+        }
+        final String TIMEOUT_ATTR = "timeoutmsec";
+        if (!attrs.containsKey(TIMEOUT_ATTR)) {
+            attrs.put(TIMEOUT_ATTR, SystemPropertyConstants.getDefaultAdminTimeout().toString());
         }
         String endpoint = GuiUtil.getSessionValue("REST_URL")+"/list-instances";
         try{

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/CommonHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/CommonHandlers.java
@@ -47,6 +47,7 @@ import org.glassfish.admingui.common.util.RestUtil;
 import org.glassfish.admingui.common.util.TargetUtil;
 
 import com.sun.enterprise.config.serverbeans.ServerTags;
+import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.jsftemplating.annotation.Handler;
 import com.sun.jsftemplating.annotation.HandlerInput;
 import com.sun.jsftemplating.annotation.HandlerOutput;
@@ -817,6 +818,14 @@ public class CommonHandlers {
         return result;
     }
 
+    @Handler(id = "getDefaultAdminTimeout",
+            output = {
+                @HandlerOutput(name = "result", type = String.class)
+            })
+    public static void getDefaultAdminTimeout(HandlerContext handlerCtx) {
+        String result = SystemPropertyConstants.getDefaultAdminTimeout().toString();
+        handlerCtx.setOutputValue("result", result);
+    }
 
     /**
      * If the bare attribute is found in the query string and the value is "true",

--- a/appserver/admingui/common/src/main/resources/shared/commonHandlers.inc
+++ b/appserver/admingui/common/src/main/resources/shared/commonHandlers.inc
@@ -49,7 +49,10 @@
    output = #{pageSession.runningInstances}
 -->
 <handler id="gfr.getListOfRunningInstances">
-    gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances",  method="get", result="#{requestScope.results}");
+    getDefaultAdminTimeout(result="#{requestScope.adminTimeout}");
+    createMap(result="#{requestScope.listInstanceAttrMap}");
+    mapPut(map="#{requestScope.listInstanceAttrMap}" key="timeoutmsec" value="#{requestScope.adminTimeout}" );
+    gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances",  attrs="#{requestScope.listInstanceAttrMap}", method="get", result="#{requestScope.results}");
     listAdd(value="server", result="#{pageSession.runningInstances}");
     foreach (var="instance", list="#{requestScope.results.data.extraProperties.instanceList}") {
         if ('!(#{instance.status} = NOT_RUNNING)') {
@@ -64,6 +67,10 @@
    output:  #{pageSession.instanceList}
  -->
 <handler id="gfr.getListOfInstances">
+    if ("#{requestScope.listInstanceAttrMap} = ${null}") {
+        createMap(result="#{requestScope.listInstanceAttrMap}");
+    }
+    mapPut(map="#{requestScope.listInstanceAttrMap}" key="nostatus" value="true" );
     gf.restRequest(endpoint="#{sessionScope.REST_URL}/list-instances",  attrs="#{requestScope.listInstanceAttrMap}" method="get", result="#{requestScope.result}");
     setPageSessionAttribute(key="instanceList" value={});
     foreach (var="instance", list="#{requestScope.result.data.extraProperties.instanceList}") {

--- a/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
+++ b/nucleus/cluster/common/src/main/java/com/sun/enterprise/util/cluster/InstanceInfo.java
@@ -246,7 +246,8 @@ public final class InstanceInfo {
             map.set("type", "terse");
             InstanceCommandExecutor ice =
                     new InstanceCommandExecutor(habitat, "__locations", FailurePolicy.Error, FailurePolicy.Error,
-                    svr, host, port, logger, map, aReport, aResult);
+                            svr, host, port, logger, map, aReport, aResult);
+            ice.setConnectTimeout(timeoutInMsec);
             return stateService.submitJob(svr, ice, aResult);
             /*
             String ret = rac.executeCommand(map).trim();

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
@@ -201,6 +201,9 @@ public class SystemPropertyConstants {
     public static final String DEFAULT_ADMIN_USER = "admin";
     public static final String DEFAULT_ADMIN_PASSWORD = "";
 
+    public static final String DEFAULT_ADMIN_TIMEOUT_PROPERTY = "org.glassfish.admin.timeout";
+    private static final int DEFAULT_ADMIN_TIMEOUT_VALUE = 5000;
+
     private static final StringManager sm = StringManager.getManager(SystemPropertyConstants.class);
 
     public static final String OPEN = "${";
@@ -318,5 +321,19 @@ public class SystemPropertyConstants {
      */
     public static final String getComponentName() {
         return new File(System.getProperty(INSTALL_ROOT_PROPERTY)).getName();
+    }
+
+    /**
+     * Returns the default timeout in milliseconds used in some Admin commands.
+     *
+     * @return The value of the system property {@link SystemPropertyConstants#DEFAULT_ADMIN_TIMEOUT_PROPERTY} or the
+     * value {@link SystemPropertyConstants#DEFAULT_ADMIN_TIMEOUT_VALUE} if the system property not set.
+     */
+    public static final Integer getDefaultAdminTimeout() {
+        final Integer result = Integer.getInteger(DEFAULT_ADMIN_TIMEOUT_PROPERTY);
+        if (result == null) {
+            return DEFAULT_ADMIN_TIMEOUT_VALUE;
+        }
+        return result;
     }
 }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/net/NetUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/net/NetUtils.java
@@ -28,8 +28,10 @@ import java.util.logging.Logger;
 public class NetUtils {
     public static final int MAX_PORT = 65535;
     private final static int IS_RUNNING_DEFAULT_TIMEOUT = 3000;
-    private final static boolean asDebug =
-            Boolean.parseBoolean(System.getenv("AS_DEBUG"));
+    private final static int IS_PORT_FREE_TIMEOUT = 1000;
+    private final static int IS_SECURE_PORT_TIMEOUT = 4000;
+    private final static boolean asDebug
+            =            Boolean.parseBoolean(System.getenv("AS_DEBUG"));
     private final static Logger logger = CULoggerInfo.getLogger();
     private static Boolean badHostErrorWasReportedAlready = Boolean.FALSE;
     private final static Object SYNC_OBJECT = new Object();
@@ -530,7 +532,8 @@ public class NetUtils {
             if (hostName == null) {
                 hostName = getHostName();
             }
-            Socket socket = new Socket(hostName, portNumber);
+            Socket socket = new Socket();
+            socket.connect(new InetSocketAddress(hostName, portNumber), IS_PORT_FREE_TIMEOUT);
             OutputStream os = socket.getOutputStream();
             InputStream is = socket.getInputStream();
             os.close();
@@ -695,7 +698,7 @@ public class NetUtils {
         if (false){
             // Open the socket w/ a 4 second timeout
             Socket socket = new Socket();
-            socket.connect(new InetSocketAddress(hostname, port), 4000);
+            socket.connect(new InetSocketAddress(hostname, port), IS_SECURE_PORT_TIMEOUT);
 
             // Send an https query (w/ trailing http query)
             java.io.OutputStream ostream = socket.getOutputStream();


### PR DESCRIPTION
Add connection timeouts to some admin commands and Admin Console, which are related to instance status. This avoids Admin Console being stuck when trying to find out instance status but the instance isn't responding.

Add a default timeout to the free port finder in NetUtils (used e.g. when creating a new instance) - it tried to check free ports with no timeout, and got eternally stuck if the remote instance wasn't responding on the port (firewall blocked all communication). 