### PR TITLE
Refactor ProcessManager to Use ProcessBuilder

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -160,7 +160,7 @@ public class Asadmin {
         processManager.setTimeoutMsec(timeout);
         processManager.setEcho(false);
         if (LOG.isLoggable(Level.FINEST)) {
-            processManager.setEnvironment(new String[] {"AS_TRACE=true"});
+            processManager.setEnvironment("AS_TRACE","true");
         }
 
         int exitCode;

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
@@ -21,12 +21,15 @@ import com.sun.enterprise.util.OS;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
@@ -73,4 +76,76 @@ public class ProcessManagerTest {
 
         return l;
     }
+
+    @Test
+    void testCommandExecution() {
+        ProcessManager pm = new ProcessManager("sh", "-c", "echo hello; sleep 1");
+        try {
+            int exitCode = pm.execute();
+            assertEquals(0, exitCode);
+            assertEquals("hello\n", pm.getStdout());
+        } catch (ProcessManagerException e) {
+            fail("Process execution failed");
+        }
+    }
+
+    @Test
+    void testSetEnvironment() {
+        String value = String.valueOf(System.currentTimeMillis());
+        ProcessManager pm = new ProcessManager("sh", "-c", "echo ${PM_TEST_ENV_VAR}; sleep 1");
+        pm.setEnvironment("PM_TEST_ENV_VAR", value);
+        try {
+            int exitCode = pm.execute();
+            assertEquals(0, exitCode);
+            assertEquals(value + "\n", pm.getStdout());
+        } catch (ProcessManagerException e) {
+            fail("Process execution failed");
+        }
+    }
+
+    @Test
+    void testSetStdinLines() {
+        List<String> inputLines = Arrays.asList("line1", "line2", "line3");
+        ProcessManager pm = new ProcessManager("cat");
+        pm.setStdinLines(inputLines);
+        try {
+            int exitCode = pm.execute();
+            assertEquals(0, exitCode);
+            String expectedOutput = String.join("\n", inputLines) + "\n";
+            assertEquals(expectedOutput, pm.getStdout());
+        } catch (ProcessManagerException e) {
+            fail("Process execution failed");
+        }
+    }
+
+    @Test
+    void testSetTimeoutMsec_LessThanExecutionTime() {
+        int sleepTimeSeconds = 2;
+        int timeoutMsec = (sleepTimeSeconds - 1) * 1000; // timeout is shorter than sleep time
+        ProcessManager pm = new ProcessManager("sleep", String.valueOf(sleepTimeSeconds));
+        pm.setTimeoutMsec(timeoutMsec);
+        try {
+            pm.execute();
+            fail("Expected ProcessManagerTimeoutException was not thrown");
+        } catch (ProcessManagerTimeoutException e) {
+            // Expected exception, test passes
+        } catch (ProcessManagerException e) {
+            fail("Unexpected exception thrown", e);
+        }
+    }
+
+    @Test
+    void testSetTimeoutMsec_GreaterThanExecutionTime() {
+        int sleepTimeSeconds = 1;
+        int timeoutMsec = sleepTimeSeconds * 2 * 1000; // timeout is 2 times longer than sleep time
+        ProcessManager pm = new ProcessManager("sleep", String.valueOf(sleepTimeSeconds));
+        pm.setTimeoutMsec(timeoutMsec);
+        try {
+            int exitCode = pm.execute();
+            assertEquals(0, exitCode);  // Assert that the process completes successfully
+        } catch (ProcessManagerException e) {
+            fail("Process execution failed", e);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR aims to refactor the `ProcessManager`, transitioning from the usage of `Runtime.exec()` to `ProcessBuilder`. The main objective is to provide better control and configurability over the process execution. 

I have also added some tests for `ProcessManager`.

Based on the suggestions in [issue 23565](https://github.com/eclipse-ee4j/glassfish/issues/23565), I had planned to use the refactored `ProcessManager` instead of `ProcessExecutor`, but I found that I could not simply replace it. The `ProcessExecutor` redirects the standard output to a file, which is different from the mechanism of `ProcessManager` and requires more careful consideration and testing, so I still finished the refactoring of `ProcessManager` first.

