### PR TITLE
Update latest docs to 7.0.5 on the website

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,7 +42,10 @@ In this example we assume 7.0.3.
     - click [Build] button 
 23. Create the release on Github: https://github.com/eclipse-ee4j/glassfish/releases click "draft a new release"
 24. Create the release on Eclipse: https://projects.eclipse.org/projects/ee4j.glassfish click "create a new release"
-25. Create the release on Glassfish.org: do a PR for updating the website in [`docs/website/src/main/resources` in the **master** branch](https://github.com/eclipse-ee4j/glassfish/tree/master/docs/website/src/main/resources):
-    - in `download_gf7.md`, create a section for the new version at the top, based on the previous version. Update the info based on the release notes in github, e.g. https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.3
-    - in `download.md`, replace information in the "Eclipse GlassFish 7.x" section at the top with info for the new version in `download_gf7.md`
-    - in `README.md`, add a new piece into "Latest News", with the date of the release in Github, based on the info in `download.md`
+25. Create the release on Glassfish.org. Do a PR for the **master** branch with: 
+    -  an update for the website in [`docs/website/src/main/resources`](https://github.com/eclipse-ee4j/glassfish/tree/master/docs/website/src/main/resources):
+        - in `download_gf7.md`, create a section for the new version at the top, based on the previous version. Update the info based on the release notes in github, e.g. https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.3
+        - in `download.md`, replace information in the "Eclipse GlassFish 7.x" section at the top with info for the new version in `download_gf7.md`
+        - in `README.md`, add a new piece into "Latest News", with the date of the release in Github, based on the info in `download.md`
+    - with an update for the docs:
+        - Update the property `glassfish.version.7x` with the released version in [docs/pom.xml](https://github.com/eclipse-ee4j/glassfish/blob/master/docs/pom.xml)

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -36,8 +36,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <glassfish.version.5x>5.1.0</glassfish.version.5x>
         <glassfish.version.6x>6.2.5</glassfish.version.6x>
-        <glassfish.version.7x>7.0.0</glassfish.version.7x>
+        <glassfish.version.7x>7.0.5</glassfish.version.7x>
         <glassfish.version.latest>${glassfish.version.7x}</glassfish.version.latest>
+        <!-- Until we start releasing the docs artifact during a releaes, we'll use the SNAPSHOT version, which is released regularly -->
+        <glassfish.version.7x.artifact>${glassfish.version.7x}-SNAPSHOT</glassfish.version.7x.artifact>
     </properties>
 
     <modules>

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -130,7 +130,7 @@
                                         <artifactItem>
                                             <groupId>org.glassfish.docs</groupId>
                                             <artifactId>distribution</artifactId>
-                                            <version>${glassfish.version.7x}</version>
+                                            <version>${glassfish.version.7x.artifact}</version>
                                             <outputDirectory>
                                                 ${docs.7x.dir}
                                             </outputDirectory>


### PR DESCRIPTION
Until we release the 7.0.5 artifact of docs, we're using the 7.0.5-SNAPSHOT artifact.
Also updated RELEASE.md to include the step to update the docs version 