### PR TITLE
Fix OSGiShellCommand Test Error

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/OSGiCommandsITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/OSGiCommandsITest.java
@@ -31,6 +31,7 @@ import org.glassfish.main.itest.tools.asadmin.Asadmin;
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
 import org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher;
 import org.hamcrest.collection.IsEmptyCollection;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
@@ -47,6 +48,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OSGiCommandsITest {
 
     private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @BeforeAll
+    public static void waitOsgiReady() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            AsadminResult result = ASADMIN.exec("osgi", "lb");
+            if (!result.isError()) {
+                return;
+            }
+            Thread.sleep(1000);
+        }
+    }
 
     @Test
     public void basicOsgiCmd() {


### PR DESCRIPTION
This PR aims to fix an error with `OSGiShellCommand` that occurs when running full unit tests. The `OSGiCommandsITest.basicOsgiCmd` test consistently fails in non-debug mode with the following error message:

```
[ERROR] org.glassfish.main.admin.test.OSGiCommandsITest.basicOsgiCmd Time elapsed: 0.288 s <<< FAILURE!
java.lang.AssertionError:
Expected: asadmin succeeded
but: was <Command osgi failed.
remote failure: Command not found: lb
```

However, the test runs fine in debug mode. I suspect this is because the OSGI environment is not fully ready, so I've added a `@BeforeAll`.

## Changes

- Added a `@BeforeAll` method in the `OSGiCommandsITest` test class to ensure the OSGI environment is ready before running the tests.
