### PR TITLE
Switch to a fork of jsch (com.github.mwiede) and upgrade to 0.2.9

### DIFF
--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -175,7 +175,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <optional>true</optional>
         </dependency>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -400,7 +400,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <optional>true</optional>
         </dependency>

--- a/nucleus/admin/template/src/main/resources/config/logging.properties
+++ b/nucleus/admin/template/src/main/resources/config/logging.properties
@@ -139,6 +139,7 @@ jakarta.enterprise.system.core.naming.level=INFO
 jakarta.enterprise.system.core.security.level=INFO
 jakarta.enterprise.system.core.security.web.level=INFO
 jakarta.enterprise.system.core.selfmanagement.level=INFO
+jakarta.enterprise.system.core.ssh.level=INFO
 jakarta.enterprise.system.core.transaction.level=INFO
 jakarta.enterprise.system.jmx.level=INFO
 jakarta.enterprise.system.security.ssl.level=INFO

--- a/nucleus/cluster/ssh/pom.xml
+++ b/nucleus/cluster/ssh/pom.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
         </dependency>
         <dependency>

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/JavaSystemJschLogger.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/JavaSystemJschLogger.java
@@ -19,6 +19,19 @@ import com.jcraft.jsch.JSch;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 
+/* JSCH triggers a lot of unimportant messages, which have a lower level than issued by JSCH
+  For example, for a single SSH connection, it triggers 1 WARNING about adding a host to the list of known hosts,
+  47 INFO messages, and 6 DEBUG messages. Therefore we decrease their level to match their real severity.
+
+  The log levels from JSCH are mapped to these levels in GlassFish:
+
+  JSCH DEBUG level -> TRACE level in GlassFish
+  JSCH INFO level -> DEBUG level in GlassFish
+  JSCH WARN level -> INFO level in GlassFish
+  JSCH ERROR level -> WARNING level in GlassFish
+  JSCH FATAL level -> ERROR/SEVERE level in GlassFish
+
+ */
 public class JavaSystemJschLogger implements com.jcraft.jsch.Logger {
 
     private final Logger logger;

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/JavaSystemJschLogger.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/JavaSystemJschLogger.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.cluster.ssh.launcher;
+
+import com.jcraft.jsch.JSch;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+
+public class JavaSystemJschLogger implements com.jcraft.jsch.Logger {
+
+    private final Logger logger;
+
+    public JavaSystemJschLogger() {
+        this.logger = System.getLogger(JSch.class.getName());
+    }
+
+    public JavaSystemJschLogger(String loggerName) {
+        this.logger = System.getLogger(loggerName);
+    }
+
+    @Override
+    public boolean isEnabled(int jschLevel) {
+        return logger.isLoggable(getSystemLoggerLevel(jschLevel));
+    }
+
+    @Override
+    public void log(int jschLevel, String message) {
+        logger.log(getSystemLoggerLevel(jschLevel), message);
+    }
+
+    @Override
+    public void log(int jschLevel, String message, Throwable cause) {
+        if (cause != null) {
+            logger.log(getSystemLoggerLevel(jschLevel), message, cause);
+        } else {
+            logger.log(getSystemLoggerLevel(jschLevel), message);
+        }
+    }
+
+    static Level getSystemLoggerLevel(int jschLevel) {
+        switch (jschLevel) {
+            case DEBUG:
+                return Level.TRACE;
+            case INFO:
+                return Level.DEBUG;
+            case WARN:
+                return Level.INFO;
+            case ERROR:
+                return Level.WARNING;
+            case FATAL:
+                return Level.ERROR;
+            default:
+                return Level.TRACE;
+        }
+    }
+
+}

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHLauncher.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -191,8 +192,7 @@ public class SSHLauncher {
     private void openConnection() throws JSchException {
         assert session == null;
         JSch jsch = new JSch();
-        // TODO: Logger?
-        // jsch.setLogger(logger);
+        jsch.setLogger(new JavaSystemJschLogger(logger != null ? logger.getName() + ".ssh" : JSch.class.getName()));
 
         // Client Auth
         String message = "";

--- a/nucleus/featuresets/nucleus/pom.xml
+++ b/nucleus/featuresets/nucleus/pom.xml
@@ -172,7 +172,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.external</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
             <exclusions>
                 <exclusion>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -141,7 +141,7 @@
         <jboss.logging.version>3.5.1.Final</jboss.logging.version>
         <javassist.version>3.29.2-GA</javassist.version>
         <asm.version>9.5</asm.version>
-        <jsch.version>0.1.56</jsch.version>
+        <jsch.version>0.2.9</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.12</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
@@ -739,7 +739,7 @@
                 <version>1.10.13</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.external</groupId>
+                <groupId>com.github.mwiede</groupId>
                 <artifactId>jsch</artifactId>
                 <version>${jsch.version}</version>
             </dependency>


### PR DESCRIPTION
The 0.2.9 version of jsch fixes a defect when creating an SSH node with a private key instead of password.

The repackaged artifact is no longer needed, the upstream artifact includes a correct OSGi manifest. 

I closed the previous PR for the repackaged repository: https://github.com/eclipse-ee4j/glassfish-repackaged/pull/21

I also added a logger for Jsch. The logger shifts log level of Jsch, which logs a lot of INFO messages that look more like DEBUG messages to me, and WARNING messages that look like INFO to me. The default level in logging .properties is INFO, which now logs only a message about adding a host to the list of known hosts on every SSH login, which is not very relevant but reasonable.