### PR TITLE
Add docs distribution artifact to mvn deploy plugin for Jenkins.

### DIFF
--- a/docs/distribution/pom.xml
+++ b/docs/distribution/pom.xml
@@ -36,6 +36,15 @@
         <maven.site.skip>true</maven.site.skip>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>release-phase2</id>
+            <properties>
+                <maven.deploy.skip>false</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -69,6 +69,12 @@
                 <module>publish</module>
             </modules>
         </profile>
+        <profile>
+            <id>release-phase2</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                 <module>qa</module>
                 <module>nucleus</module>
                 <module>appserver</module>
+                <module>docs</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
So that it's deployed by Jenkins during a GF release.

I tested locally by running `mvn -Prelease-phase2 deploy` and it looks like it works as it should - runs the deploy plugin on modules `qa`, `nucleus`, and `appserver` as before, and then it runs the deploy plugin on the docs/distribution module, and skips the deploy plugin for all other modules in the docs directory. All the dependencies of the docs `distribution` artifact are optional, therefore they don't have to be available in a maven repository.