### PR TITLE
Fixed race condition in ProcessManager

### DIFF
--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/NodeUtils.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/NodeUtils.java
@@ -428,8 +428,7 @@ public class NodeUtils {
      */
     void runAdminCommandOnNode(Node node, List<String> command,
             AdminCommandContext context, String firstErrorMessage,
-            String humanCommand, StringBuilder output,
-            boolean waitForReaderThreads) {
+            String humanCommand, StringBuilder output) {
 
         ActionReport report = context.getActionReport();
         boolean failure = true;
@@ -502,13 +501,6 @@ public class NodeUtils {
 
 
         return;
-    }
-
-    void runAdminCommandOnNode(Node node, List<String> command,
-            AdminCommandContext context, String firstErrorMessage,
-            String humanCommand, StringBuilder output) {
-
-        runAdminCommandOnNode(node, command, context, firstErrorMessage, humanCommand, output);
     }
 
     private RemoteType parseType(ParameterMap map) throws CommandValidationException {

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/NodeUtils.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/NodeUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,15 +26,6 @@ import com.sun.enterprise.util.ExceptionUtil;
 import com.sun.enterprise.util.StringUtils;
 import com.sun.enterprise.util.cluster.RemoteType;
 import com.sun.enterprise.util.net.NetUtils;
-import org.glassfish.api.ActionReport;
-import org.glassfish.api.admin.AdminCommandContext;
-import org.glassfish.api.admin.CommandValidationException;
-import org.glassfish.api.admin.ParameterMap;
-import org.glassfish.api.admin.SSHCommandExecutionException;
-import org.glassfish.cluster.ssh.connect.NodeRunner;
-import org.glassfish.cluster.ssh.launcher.SSHLauncher;
-import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.internal.api.RelativePathResolver;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -45,6 +37,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.CommandValidationException;
+import org.glassfish.api.admin.ParameterMap;
+import org.glassfish.api.admin.SSHCommandExecutionException;
+import org.glassfish.cluster.ssh.connect.NodeRunner;
+import org.glassfish.cluster.ssh.launcher.SSHLauncher;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.internal.api.RelativePathResolver;
 
 /**
  * Utility methods for operating on Nodes
@@ -71,7 +73,7 @@ public class NodeUtils {
     static final String PARAM_INSTALL = "install";
     public static final String PARAM_WINDOWS_DOMAIN = "windowsdomain";
     static final String LANDMARK_FILE = "glassfish/modules/admin-cli.jar";
-    private static final String NL = System.getProperty("line.separator");
+    private static final String NL = System.lineSeparator();
     private TokenResolver resolver = null;
     private Logger logger = null;
     private ServiceLocator habitat = null;
@@ -89,8 +91,9 @@ public class NodeUtils {
     }
 
     static boolean isSSHNode(Node node) {
-        if (node == null)
+        if (node == null) {
             return false;
+        }
         return node.getType().equals("SSH");
     }
 
@@ -100,10 +103,11 @@ public class NodeUtils {
      * @return version string
      */
     String getGlassFishVersionOnNode(Node node, AdminCommandContext context) throws CommandValidationException {
-        if (node == null)
+        if (node == null) {
             return "";
+        }
 
-        List<String> command = new ArrayList<String>();
+        List<String> command = new ArrayList<>();
         command.add("version");
         command.add("--local");
         command.add("--terse");
@@ -170,8 +174,9 @@ public class NodeUtils {
         // guaranteed to either get a valid type -- or a CommandValidationException
         RemoteType type = parseType(map);
 
-        if (type == RemoteType.SSH)
+        if (type == RemoteType.SSH) {
             validateSsh(map, nodehost);
+        }
 
         // bn: shouldn't this be something more sophisticated than just the standard string?!?
         // i.e. check to see if the hostname is this machine?
@@ -181,8 +186,9 @@ public class NodeUtils {
         }
 
         // BN says: Shouldn't this be a fatal error?!?  TODO
-        if (sshL == null)
+        if (sshL == null) {
             return;
+        }
 
         validateRemoteConnection(map);
     }
@@ -314,8 +320,9 @@ public class NodeUtils {
         RemoteType type = parseType(map);
 
         // just too difficult to refactor now...
-        if (type == RemoteType.SSH)
+        if (type == RemoteType.SSH) {
             validateSSHConnection(map);
+        }
     }
 
     private void validateSSHConnection(ParameterMap map) throws
@@ -444,8 +451,7 @@ public class NodeUtils {
 
         NodeRunner nr = new NodeRunner(habitat, logger);
         try {
-            int status = nr.runAdminCommandOnNode(node, output, waitForReaderThreads,
-                    command, context);
+            int status = nr.runAdminCommandOnNode(node, output, command, context);
             if (status != 0) {
                 // Command ran, but didn't succeed. Log full information
                 msg2 = Strings.get("node.command.failed", nodeName,
@@ -502,8 +508,7 @@ public class NodeUtils {
             AdminCommandContext context, String firstErrorMessage,
             String humanCommand, StringBuilder output) {
 
-        runAdminCommandOnNode(node, command, context, firstErrorMessage,
-                humanCommand, output, true);
+        runAdminCommandOnNode(node, command, context, firstErrorMessage, humanCommand, output);
     }
 
     private RemoteType parseType(ParameterMap map) throws CommandValidationException {

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,32 +17,36 @@
 
 package com.sun.enterprise.v3.admin.cluster;
 
-import com.sun.enterprise.config.serverbeans.*;
+import com.sun.enterprise.config.serverbeans.Node;
+import com.sun.enterprise.config.serverbeans.Nodes;
+import com.sun.enterprise.config.serverbeans.Server;
+import com.sun.enterprise.config.serverbeans.Servers;
 import com.sun.enterprise.util.StringUtils;
-import java.util.logging.Logger;
 
-import com.sun.enterprise.util.SystemPropertyConstants;
-import com.sun.enterprise.util.OS;
-import org.glassfish.api.ActionReport;
-import org.glassfish.api.I18n;
-import org.glassfish.api.Param;
-import org.glassfish.api.admin.*;
 import jakarta.inject.Inject;
-
-import org.jvnet.hk2.annotations.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.I18n;
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.CommandLock;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RestParam;
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
-
-import com.sun.enterprise.config.serverbeans.Node;
+import org.jvnet.hk2.annotations.Service;
 
 
 /**
- * AdminCommand to start the instance
- * server.
+ * AdminCommand to start the instance server.
+ * <p>
  * If this is DAS -- we call the instance
  * If this is an instance we start it
  *
@@ -77,7 +82,7 @@ public class StartInstanceCommand implements AdminCommand {
     private String instanceName;
 
     @Param(optional = true, defaultValue = "normal", acceptableValues="none, normal, full")
-    private String sync="normal";
+    private final String sync="normal";
 
     @Param(optional = true, defaultValue = "false")
     private boolean debug;
@@ -96,7 +101,7 @@ public class StartInstanceCommand implements AdminCommand {
     private String nodeHost;
     private Server instance;
 
-    private static final String NL = System.getProperty("line.separator");
+    private static final String NL = System.lineSeparator();
 
     /**
      * restart-instance needs to try to start the instance from scratch if it is not
@@ -196,7 +201,7 @@ public class StartInstanceCommand implements AdminCommand {
 
     private void startInstance(AdminCommandContext ctx) {
         NodeUtils nodeUtils = new NodeUtils(habitat, logger);
-        ArrayList<String> command = new ArrayList<String>();
+        ArrayList<String> command = new ArrayList<>();
         String humanCommand = null;
 
         command.add("start-local-instance");
@@ -228,16 +233,8 @@ public class StartInstanceCommand implements AdminCommand {
 
         StringBuilder output = new StringBuilder();
 
-        // There is a problem on Windows waiting for IO to complete on a
-        // child process which runs a long running grandchild. See IT 12777.
-        boolean waitForReaderThreads = true;
-        if (OS.isWindows()) {
-            waitForReaderThreads = false;
-        }
-
         // Run the command on the node and handle errors.
-        nodeUtils.runAdminCommandOnNode(node, command, ctx, firstErrorMessage,
-                humanCommand, output, waitForReaderThreads);
+        nodeUtils.runAdminCommandOnNode(node, command, ctx, firstErrorMessage, humanCommand, output);
 
         ActionReport report = ctx.getActionReport();
         if (report.getActionExitCode() == ActionReport.ExitCode.SUCCESS) {
@@ -257,8 +254,9 @@ public class StartInstanceCommand implements AdminCommand {
         int counter = 0;  // 120 seconds
 
         while (++counter < 240) {
-            if (instance.isRunning())
+            if (instance.isRunning()) {
                 return null;
+            }
 
             try {
                 Thread.sleep(500);

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
@@ -82,7 +82,7 @@ public class StartInstanceCommand implements AdminCommand {
     private String instanceName;
 
     @Param(optional = true, defaultValue = "normal", acceptableValues="none, normal, full")
-    private final String sync="normal";
+    private String sync="normal";
 
     @Param(optional = true, defaultValue = "false")
     private boolean debug;

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/connect/NodeRunner.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/connect/NodeRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -100,18 +100,6 @@ public class NodeRunner {
             UnsupportedOperationException,
             IllegalArgumentException {
 
-        return runAdminCommandOnNode(node, output, false, args, context);
-    }
-
-    public int runAdminCommandOnNode(Node node, StringBuilder output,
-            boolean waitForReaderThreads,
-            List<String> args,
-            AdminCommandContext context) throws
-            SSHCommandExecutionException,
-            ProcessManagerException,
-            UnsupportedOperationException,
-            IllegalArgumentException {
-
 
         if (node == null) {
             throw new IllegalArgumentException("Node is null");
@@ -123,16 +111,13 @@ public class NodeRunner {
         args.add(0, "--interactive=false");            // No prompting!
 
         if (node.isLocal()) {
-            return runAdminCommandOnLocalNode(node, output, waitForReaderThreads,
-                    args, stdinLines);
-        }
-        else {
+            return runAdminCommandOnLocalNode(node, output, args, stdinLines);
+        } else {
             return runAdminCommandOnRemoteNode(node, output, args, stdinLines);
         }
     }
 
     private int runAdminCommandOnLocalNode(Node node, StringBuilder output,
-            boolean waitForReaderThreads,
             List<String> args,
             List<String> stdinLines) throws
             ProcessManagerException {
@@ -159,8 +144,6 @@ public class NodeRunner {
         ProcessManager pm = new ProcessManager(fullcommand);
         pm.setStdinLines(stdinLines);
 
-        // XXX should not need this after fix for 12777, but we seem to
-        pm.waitForReaderThreads(waitForReaderThreads);
         int exitValue = pm.execute();  // blocks until command is complete
 
         String stdout = pm.getStdout();
@@ -213,23 +196,5 @@ public class NodeRunner {
         }
 
         return fullCommand.toString();
-    }
-
-    /* hack TODO do not know how to get int status back from Windows
-     */
-    private int determineStatus(List<String> args, StringBuilder output) {
-        if (isDeleteFS(args) && output.toString().indexOf("UTIL6046") >= 0) {
-            return 1;
-        }
-        return 0;
-    }
-
-    private boolean isDeleteFS(List<String> args) {
-        for (String arg : args) {
-            if ("_delete-instance-filesystem".equals(arg)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
@@ -33,8 +33,8 @@ import java.util.concurrent.TimeUnit;
 
 
 /**
- * ProcessManager.java
  * Use this class for painless process spawning.
+ * <p>
  * This class was originally written to be compatible with JDK 1.4, using Runtime.exec(),
  * but has been refactored to use ProcessBuilder for better control and configurability.
  *
@@ -50,7 +50,6 @@ public class ProcessManager {
     private int timeout;
     private boolean echo = true;
     private String[] stdinLines;
-    private boolean waitForReaderThreads = true;
 
     public ProcessManager(String... cmds) {
         builder = new ProcessBuilder(cmds);
@@ -84,12 +83,9 @@ public class ProcessManager {
         }
     }
 
-    public void waitForReaderThreads(boolean b) {
-        waitForReaderThreads = b;
-    }
 
-
-    /** Should the output of the process be echoed to stdout?
+    /**
+     * Should the output of the process be echoed to stdout?
      *
      * @param newEcho
      */

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
@@ -30,6 +30,7 @@ import java.lang.System.Logger.Level;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 
 /**
@@ -211,7 +212,7 @@ public class ProcessManager {
         private final BufferedReader reader;
         private final StringBuilder sb;
         private final boolean echo;
-        private boolean stop;
+        private final AtomicBoolean stop = new AtomicBoolean();
 
         ReaderThread(InputStream stream, boolean echo, String threadName) {
             setName(threadName);
@@ -228,7 +229,7 @@ public class ProcessManager {
                     String line;
                     if (reader.ready()) {
                         line = reader.readLine();
-                    } else if (stop) {
+                    } else if (stop.getAcquire()) {
                         break;
                     } else {
                         Thread.yield();
@@ -260,7 +261,7 @@ public class ProcessManager {
          * @return the final output of the process.
          */
         public String finish() {
-            stop = true;
+            stop.setRelease(true);
             try {
                 join(10000L);
             } catch (InterruptedException ex) {

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
@@ -79,8 +79,7 @@ public class ProcessManager {
 
     public void setStdinLines(List<String> list) {
         if (list != null && !list.isEmpty()) {
-            stdinLines = new String[list.size()];
-            stdinLines = list.toArray(stdinLines);
+            stdinLines = list.toArray(String[]::new);
         }
     }
 
@@ -120,7 +119,9 @@ public class ProcessManager {
         } catch (Exception e) {
             throw new ProcessManagerException(e);
         } finally {
-            destroy(process);
+            if (process.isAlive()) {
+                destroy(process);
+            }
         }
     }
 
@@ -164,7 +165,7 @@ public class ProcessManager {
         }
         try (PrintWriter pipe = new PrintWriter(new BufferedWriter(new OutputStreamWriter(process.getOutputStream())))) {
             for (String stdinLine : stdinLines) {
-                LOG.log(Level.DEBUG, "InputLine -->" + stdinLine + "<--");
+                LOG.log(Level.DEBUG, "InputLine --> {0} <--", stdinLine);
                 pipe.println(stdinLine);
                 pipe.flush();
             }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManagerTimeoutException.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManagerTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,7 +21,7 @@ public class ProcessManagerTimeoutException extends ProcessManagerException {
 
     private static final long serialVersionUID = -634378999869311994L;
 
-    public ProcessManagerTimeoutException(String message, Throwable cause) {
-        super(message, cause);
+    public ProcessManagerTimeoutException(String message) {
+        super(message);
     }
 }

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -109,7 +110,7 @@ public class ProcessManagerTest {
         );
     }
 
-    @Test
+    @RepeatedTest(value = 2000)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testSetStdinLines() {

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,12 +23,18 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 /**
@@ -50,6 +56,7 @@ public class ProcessManagerTest {
      * This stuff is platform dependent.
      */
     @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void test1() throws ProcessManagerException {
         ProcessManager pm;
 
@@ -78,6 +85,7 @@ public class ProcessManagerTest {
     }
 
     @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testCommandExecution() {
         ProcessManager pm = new ProcessManager("sh", "-c", "echo hello; sleep 1");
@@ -89,6 +97,7 @@ public class ProcessManagerTest {
     }
 
     @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testSetEnvironment() {
         String value = String.valueOf(System.currentTimeMillis());
@@ -102,6 +111,7 @@ public class ProcessManagerTest {
     }
 
     @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testSetStdinLines() {
         List<String> inputLines = Arrays.asList("line1", "line2", "line3");
@@ -116,6 +126,7 @@ public class ProcessManagerTest {
     }
 
     @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testSetTimeoutLessThanExecutionTime() {
         int sleepTimeSeconds = 2;
@@ -126,6 +137,7 @@ public class ProcessManagerTest {
     }
 
     @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testSetTimeoutGreaterThanExecutionTime() {
         int sleepTimeSeconds = 1;

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 /**
- *
  * @author bnevins
  */
 public class ProcessManagerTest {


### PR DESCRIPTION
- reader.readLine can return null when there was nothing to read.
- escallate errors to logs, don't hide them.
- fixes issue discovered in https://github.com/eclipse-ee4j/glassfish/pull/24446#issuecomment-1585533239