### PR TITLE
Attempt to delete JDBC resource ref only if it exists

### DIFF
--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCResourceManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -236,13 +236,6 @@ public class JDBCResourceManager implements ResourceManager {
                     return new ResourceStatus(ResourceStatus.FAILURE, msg);
                 }
             } else {
-                if (!resourceUtil.isResourceRefInTarget(jndiName, target)) {
-                    String msg = localStrings.getLocalString("delete.jdbc.resource.no.resource-ref",
-                            "jdbc-resource [ {0} ] is not referenced in target [ {1} ]",
-                            jndiName, target);
-                    return new ResourceStatus(ResourceStatus.FAILURE, msg);
-                }
-
                 if (resourceUtil.getTargetsReferringResourceRef(jndiName).size() > 1) {
                     String msg = localStrings.getLocalString("delete.jdbc.resource.multiple.resource-refs",
                             "jdbc resource [ {0} ] is referenced in multiple " +
@@ -256,7 +249,7 @@ public class JDBCResourceManager implements ResourceManager {
         try {
 
             // delete resource-ref
-            if (!CommandTarget.TARGET_DOMAIN.equals(target)) {
+            if (!CommandTarget.TARGET_DOMAIN.equals(target) && resourceUtil.isResourceRefInTarget(jndiName, target)) {
                 resourceUtil.deleteResourceRef(jndiName, target);
             }
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/LocalStrings.properties
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/LocalStrings.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
 # Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -35,7 +36,6 @@ delete.jdbc.resource.fail=Command create-jdbc-resource failed.
 delete.jdbc.resource.notfound=A JDBC resource named {0} does not exist.
 delete.jdbc.resource.resource-ref.exist=jdbc-resource [ {0} ] is referenced in an instance/cluster target, Use delete-resource-ref on appropriate target.
 delete.jdbc.resource.multiple.resource-refs=jdbc-resource [ {0} ] is referenced in multiple instance/cluster targets, Use delete-resource-ref on appropriate target
-delete.jdbc.resource.no.resource-ref=jdbc-resource [ {0} ] is not referenced in target [ {1} ]
 delete.jdbc.resource.system-all-req.object-type=The jdbc resource [ {0} ] cannot be deleted as it is required to be configured in the system.
 list.jdbc.resources=List all JDBC resources.
 list.jdbc.resources.success=Command list-jdbc-resources executed successfully.


### PR DESCRIPTION
Doesn't fail resource deletion if ref doesn't exist (was deleted before).

Fixes #24459.

# Details

When the delete button to delete the JDBC resource is clicked, it calls the `gfr.deleteSelectedResources` handler, which first deletes all the resource references for all targets, and then deletes the resource. 

The `JDBCResourceManager`, which is called from `DeleteJDBCResource` admin resource, expects that the resource references the target server, otherwise gives an error. Because the reference was removed earlier (in the `gfr.deleteSelectedResources` handler), it shouldn't expect the reference exist and silently skip deleting it if it doesn't exist, and only delete the resource itself.

# Note about non-JDBC resources

I tested many other non-JDBC resources (connection pools, concurrency resources, JMS resources) and they all can be deleted. It looks like only the `JDBCResourceManager` is checking that the reference exists to the target server and attempted to delete the reference. Other resource types don't fail deleting the resource even if the reference was deleted earlier.