### PR TITLE
Jenkinsfile and StartStopITest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,7 +194,7 @@ spec:
             ls -la ${WORKSPACE}/bundles
           '''
         }
-        archiveArtifacts artifacts: 'bundles/*.zip'
+        archiveArtifacts artifacts: 'bundles/*.zip', onlyIfSuccessful: true
         stash includes: 'bundles/*', name: 'build-bundles'
       }
     }
@@ -209,8 +209,12 @@ spec:
             '''
           }
         }
-        archiveArtifacts artifacts: "**/server.log"
-        junit testResults: '**/*-reports/*.xml', allowEmptyResults: false
+      }
+      post {
+        always {
+          archiveArtifacts artifacts: "**/server.log", onlyIfSuccessful: false
+          junit testResults: '**/*-reports/*.xml', allowEmptyResults: false
+        }
       }
     }
     stage('ant-tests') {

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -204,7 +204,7 @@ public class Asadmin {
             result = new AsadminResult(args[0], exitCode, processManager.getStdout(), stdErr);
         }
         if (!result.getStdOut().isEmpty()) {
-            System.out.print(result.getStdOut());
+            System.out.println(result.getStdOut());
         }
         if (!result.getStdErr().isEmpty()) {
             System.err.println(result.getStdErr());

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,10 @@ import com.sun.enterprise.universal.process.ProcessManagerTimeoutException;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -55,6 +58,7 @@ public class Asadmin {
     private final File asadmin;
     private final String adminUser;
     private final File adminPasswordFile;
+    private final Map<String, String> environment = new HashMap<>();
 
 
     /**
@@ -68,6 +72,19 @@ public class Asadmin {
         this.asadmin = asadmin;
         this.adminUser = adminUser;
         this.adminPasswordFile = adminPasswordFile;
+    }
+
+
+    /**
+     * Adds environment property set for the asadmin execution.
+     *
+     * @param name
+     * @param value
+     * @return this
+     */
+    public Asadmin withEnv(final String name, final String value) {
+        this.environment.put(name, value);
+        return this;
     }
 
 
@@ -124,8 +141,8 @@ public class Asadmin {
     /**
      * Executes the command with arguments synchronously with given timeout in millis.
      *
-     * @param timeout
-     * @param args
+     * @param timeout timeout in millis
+     * @param args command and arguments.
      * @return {@link AsadminResult} never null.
      */
     public AsadminResult exec(final int timeout, final String... args) {
@@ -136,8 +153,8 @@ public class Asadmin {
      * Executes the command with arguments.
      *
      * @param timeout timeout in millis
-     * @param detachedAndTerse - detached command is executed asynchronously, can be attached later by the attach command.
-     * @param args - command and arguments.
+     * @param detachedAndTerse detached command is executed asynchronously, can be attached later by the attach command.
+     * @param args command and arguments.
      * @return {@link AsadminResult} never null.
      */
     private AsadminResult exec(final int timeout, final boolean detachedAndTerse, final String... args) {
@@ -159,8 +176,11 @@ public class Asadmin {
         final ProcessManager processManager = new ProcessManager(command);
         processManager.setTimeoutMsec(timeout);
         processManager.setEcho(false);
-        if (LOG.isLoggable(Level.FINEST)) {
-            processManager.setEnvironment("AS_TRACE","true");
+        for (Entry<String, String> env : this.environment.entrySet()) {
+            processManager.setEnvironment(env.getKey(), env.getValue());
+        }
+        if (System.getenv("AS_TRACE") == null && LOG.isLoggable(Level.FINEST)) {
+            processManager.setEnvironment("AS_TRACE", "true");
         }
 
         int exitCode;
@@ -168,7 +188,7 @@ public class Asadmin {
         try {
             exitCode = processManager.execute();
         } catch (final ProcessManagerTimeoutException e) {
-            asadminErrorMessage = "ProcessManagerTimeoutException: command timed out after " + timeout + " ms.\n";
+            asadminErrorMessage = e.getMessage();
             exitCode = 1;
         } catch (final ProcessManagerException e) {
             LOG.log(Level.SEVERE, "The execution failed.", e);
@@ -183,7 +203,12 @@ public class Asadmin {
         } else {
             result = new AsadminResult(args[0], exitCode, processManager.getStdout(), stdErr);
         }
-        System.out.print(result.getStdOut());
+        if (!result.getStdOut().isEmpty()) {
+            System.out.print(result.getStdOut());
+        }
+        if (!result.getStdErr().isEmpty()) {
+            System.err.println(result.getStdErr());
+        }
         return result;
     }
 }


### PR DESCRIPTION
- Following the discussion in #24457 this is a little progress"
   - Jenkins should collect server.log files after maven test failures now
   - StartStopITest should be able to set ENV options, but doesn't override those set by the developer.
