### PR TITLE
Startserv script starts GlassFish in foreground in a single JVM process

### DIFF
--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
+AS_INSTALL=`dirname "$0"`/../glassfish
 case "`uname`" in
   CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
 esac

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
@@ -1,0 +1,19 @@
+@echo off
+REM
+REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+
+java -jar "%~dp0..\glassfish\modules\admin-cli.jar" start-domain --verbose %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+AS_INSTALL=`dirname "$0"`/../glassfish
+AS_INSTALL_LIB="$AS_INSTALL/modules"
+
+exec java -jar "$AS_INSTALL_LIB/admin-cli.jar" stop-domain "$@"

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
@@ -1,0 +1,19 @@
+@echo off
+REM
+REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+REM
+REM  This program and the accompanying materials are made available under the
+REM  terms of the Eclipse Public License v. 2.0, which is available at
+REM  http://www.eclipse.org/legal/epl-2.0.
+REM
+REM  This Source Code may also be made available under the following Secondary
+REM  Licenses when the conditions for such availability set forth in the
+REM  Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM  version 2 with the GNU Classpath Exception, which is available at
+REM  https://www.gnu.org/software/classpath/license.html.
+REM
+REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+REM
+
+
+java -jar "%~dp0..\glassfish\modules\admin-cli.jar" stop-domain %*

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
@@ -143,7 +143,18 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
                 logger.fine(Strings.get("dry_run_msg"));
                 List<String> cmd = glassFishLauncher.getCommandLine();
                 StringBuilder sb = new StringBuilder();
+                boolean skipLine = false;
                 for (String s : cmd) {
+                    if (s.equals("-read-stdin")) {
+                        // Don't print this option as it's not needed to run the server
+                        // Also skip the next line with "true", which is related to this option
+                        skipLine = true;
+                        continue;
+                    }
+                    if (skipLine) {
+                        skipLine = false;
+                        continue;
+                    }
                     sb.append(s);
                     sb.append('\n');
                 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
@@ -51,6 +51,9 @@ import static com.sun.enterprise.admin.cli.CLIConstants.WALL_CLOCK_START_PROP;
 import static java.util.logging.Level.FINER;
 import static org.glassfish.api.admin.RuntimeType.DAS;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /**
  * The start-domain command.
  *
@@ -142,23 +145,15 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
             if (dry_run) {
                 logger.fine(Strings.get("dry_run_msg"));
                 List<String> cmd = glassFishLauncher.getCommandLine();
-                StringBuilder sb = new StringBuilder();
-                boolean skipLine = false;
-                for (String s : cmd) {
-                    if (s.equals("-read-stdin")) {
-                        // Don't print this option as it's not needed to run the server
+                int indexOfReadStdin = cmd.indexOf("-read-stdin");
+                String cmdToLog = IntStream.range(0, cmd.size())
+                        // Don't print -read-stdin option as it's not needed to run the server
                         // Also skip the next line with "true", which is related to this option
-                        skipLine = true;
-                        continue;
-                    }
-                    if (skipLine) {
-                        skipLine = false;
-                        continue;
-                    }
-                    sb.append(s);
-                    sb.append('\n');
-                }
-                logger.info(sb.toString());
+                        .filter(index -> index < indexOfReadStdin || index > indexOfReadStdin + 1)
+                        .mapToObj(cmd::get)
+                        .collect(Collectors.joining("\n"))
+                        + "\n";
+                logger.info(cmdToLog);
                 return SUCCESS;
             }
 

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
@@ -34,20 +34,16 @@ start_as_main_process () {
 
       else
         # Filter the command
-        #   - remove 1st line,
-        #   - remove line with -read-stdin to prevent waiting for master password in stdin
-        #   - remove last line
+        #   - remove 1st line (Dump of JVM Invocation line...)
+        #   - remove line with "-read-stdin" and the following line with "true"
+        #     to prevent waiting for master password in stdin
+        #   - remove last line (Command executed successfully)
 
         COMMAND=("${COMMAND[@]:1}")
         unset 'COMMAND[-1]'
-        for i in "${!COMMAND[@]}"; do
-            if [[ ${COMMAND[i]} = "-read-stdin" ]]; then
-                unset 'COMMAND[i]'
-            fi
-        done
 
         # Execute the command to start GlassFish
-        exec "${COMMAND[@]}"
+        echo "${COMMAND[@]}"
     fi
 
 }

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
@@ -16,6 +16,43 @@
 #
 
 AS_INSTALL=`dirname "$0"`/..
-AS_INSTALL_LIB="$AS_INSTALL/modules"
+AS_INSTALL_LIB="$AS_INSTALL/lib"
 
-exec java -jar "$AS_INSTALL_LIB/admin-cli.jar" start-domain --verbose "$@"
+start_as_main_process () {
+    local COMMAND
+
+    # Execute start-domain --dry-run and store the output line by line into an array.
+    # If it fails, the array will contain a single element FAILED
+    readarray -t COMMAND < <(java -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" start-domain --dry-run "$@" 2> /dev/null || echo -e 'FAILED' )
+
+    # If asadmin command failed, we execute it again to show the output to the user and exit
+    # If all OK, we filter and execute the command
+    if [ "${COMMAND[1]}" = FAILED ]
+      then
+
+        java -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" start-domain --dry-run "$@"
+
+      else
+        # Filter the command
+        #   - remove 1st line,
+        #   - remove line with -read-stdin to prevent waiting for master password in stdin
+        #   - remove last line
+
+        COMMAND=("${COMMAND[@]:1}")
+        unset 'COMMAND[-1]'
+        for i in "${!COMMAND[@]}"; do
+            if [[ ${COMMAND[i]} = "-read-stdin" ]]; then
+                unset 'COMMAND[i]'
+            fi
+        done
+
+        # Execute the command to start GlassFish
+        exec "${COMMAND[@]}"
+    fi
+
+}
+
+start_as_main_process "$@"
+
+# Alternatively, run the following:
+# exec java -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" start-domain --verbose "$@"


### PR DESCRIPTION
Instead of starting a launcher with `start-domain --verbose`, which starts GF and then waits for it to finish 
(2 JVM processes running), runs GF in `dry-run` mode and then executes GF in foreground directly, 
using the command line retrieved from dry-run mode.

We need to remove the `-read-stdin` option from the command in the `dry-run` output, otherwise the command waits for input and that's not needed.

This is a preparation for Docker images that will run GlassFish in foreground in a single JVM process to save memory consumed by Docker containers.

I also copied the startserv and stopserv scripts to the top-level bin directory, to make them easier to use and accessible to users.