### PR TITLE
Integrate CDI TCK 4.0.10 in TCK test

### DIFF
--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.7</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.10</cdi.tck-4-0.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>
@@ -268,7 +268,7 @@
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
         </dependency>
 
         <dependency>
@@ -424,9 +424,7 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.0.0-M7</version>
                 <executions>
                     <execution>
                         <id>generate-test-report</id>

--- a/appserver/tests/tck/cdi/cdi-full/src/test/java/org/jboss/weld/tck/glassfish/GlassFishDeploymentExceptionTransformer.java
+++ b/appserver/tests/tck/cdi/cdi-full/src/test/java/org/jboss/weld/tck/glassfish/GlassFishDeploymentExceptionTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -35,6 +35,7 @@ import jakarta.enterprise.inject.spi.DeploymentException;
 public class GlassFishDeploymentExceptionTransformer implements DeploymentExceptionTransformer {
 
     private static final String[] DEPLOYMENT_EXCEPTION_FRAGMENTS = new String[] {
+            "Only normal scopes can be passivating",
             "org.jboss.weld.exceptions.DeploymentException",
             "org.jboss.weld.exceptions.UnserializableDependencyException",
             "org.jboss.weld.exceptions.InconsistentSpecializationException",
@@ -67,10 +68,10 @@ public class GlassFishDeploymentExceptionTransformer implements DeploymentExcept
             return root;
         }
         if (isFragmentFound(DEPLOYMENT_EXCEPTION_FRAGMENTS, root)) {
-            return new DeploymentException(root);
+            return new DeploymentException(root.getMessage());
         }
         if (isFragmentFound(DEFINITION_EXCEPTION_FRAGMENTS, root)) {
-            return new DefinitionException(root);
+            return new DefinitionException(root.getMessage());
         }
         return throwable;
     }

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.7</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.10</cdi.tck-4-0.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.7.0.Alpha13</version>
+            <version>1.7.0.Final</version>
             <scope>test</scope>
         </dependency>
 
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.2</version>
+            <version>1.4</version>
         </dependency>
 
     </dependencies>
@@ -151,7 +151,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
                 <configuration>
                     <!-- Disable annotation processor for test sources -->
                     <testCompilerArgument>-proc:none</testCompilerArgument>
@@ -159,7 +158,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -178,9 +176,7 @@
             </plugin>
             
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>unpack-glassfish</id>
@@ -220,9 +216,7 @@
             
             
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.0.0-M7</version>
                 <executions>
                     <execution>
                         <id>generate-test-report</id>


### PR DESCRIPTION
Added "Only normal scopes can be passivating" to detect a deployment error (exception transformers for the TCK are allowed to use such specific scanning), and seed a new exception from the transformer with `root.getMessage()` instead of `root` to prevent a stackoverflow (the code calling the transformer will use `getCause()` and then transform again, leading to an infinite loop.
