### PR TITLE
Publish 7.0.6 docs on the webpage

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,7 +42,10 @@ In this example we assume 7.0.3.
     - click [Build] button 
 23. Create the release on Github: https://github.com/eclipse-ee4j/glassfish/releases click "draft a new release"
 24. Create the release on Eclipse: https://projects.eclipse.org/projects/ee4j.glassfish click "create a new release"
-25. Create the release on Glassfish.org: do a PR for updating the website in [`docs/website/src/main/resources` in the **master** branch](https://github.com/eclipse-ee4j/glassfish/tree/master/docs/website/src/main/resources):
-    - in `download_gf7.md`, create a section for the new version at the top, based on the previous version. Update the info based on the release notes in github, e.g. https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.3
-    - in `download.md`, replace information in the "Eclipse GlassFish 7.x" section at the top with info for the new version in `download_gf7.md`
-    - in `README.md`, add a new piece into "Latest News", with the date of the release in Github, based on the info in `download.md`
+25. Create the release on Glassfish.org. Do a PR for the **master** branch with: 
+    -  an update for the website in [`docs/website/src/main/resources`](https://github.com/eclipse-ee4j/glassfish/tree/master/docs/website/src/main/resources):
+        - in `download_gf7.md`, create a section for the new version at the top, based on the previous version. Update the info based on the release notes in github, e.g. https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.3
+        - in `download.md`, replace information in the "Eclipse GlassFish 7.x" section at the top with info for the new version in `download_gf7.md`
+        - in `README.md`, add a new piece into "Latest News", with the date of the release in Github, based on the info in `download.md`
+    - with an update for the docs:
+        - Update the property `glassfish.version.7x` with the released version in [docs/pom.xml](https://github.com/eclipse-ee4j/glassfish/blob/master/docs/pom.xml)

--- a/docs/administration-guide/src/main/asciidoc/title.adoc
+++ b/docs/administration-guide/src/main/asciidoc/title.adoc
@@ -11,7 +11,7 @@ next=preface.adoc
 
 Administration Guide
 
-Release 7, {status}
+Release 7
 
 Contributed 2018 - 2022
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -36,8 +36,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <glassfish.version.5x>5.1.0</glassfish.version.5x>
         <glassfish.version.6x>6.2.5</glassfish.version.6x>
-        <glassfish.version.7x>7.0.0</glassfish.version.7x>
+        <glassfish.version.7x>7.0.6</glassfish.version.7x>
         <glassfish.version.latest>${glassfish.version.7x}</glassfish.version.latest>
+        <glassfish.version.7x.artifact>${glassfish.version.7x}</glassfish.version.7x.artifact>
     </properties>
 
     <modules>

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -130,7 +130,7 @@
                                         <artifactItem>
                                             <groupId>org.glassfish.docs</groupId>
                                             <artifactId>distribution</artifactId>
-                                            <version>${glassfish.version.7x}</version>
+                                            <version>${glassfish.version.7x.artifact}</version>
                                             <outputDirectory>
                                                 ${docs.7x.dir}
                                             </outputDirectory>

--- a/docs/website/src/main/resources/documentation.md
+++ b/docs/website/src/main/resources/documentation.md
@@ -1,18 +1,4 @@
-# Jakarta EE and GlassFish Documentation
-
-## Jakarta EE Tutorials
-
-* [Jakarta EE 8 First Cup](https://eclipse-ee4j.github.io/jakartaee-firstcup)
-* [Jakarta EE 8 Tutorial](https://eclipse-ee4j.github.io/jakartaee-tutorial)
-
-## Jakarta EE API Documentation and Tag Reference
-(Coming soon!)
-
-* [Jakarta EE 8 Specification APIs]()
-* [JavaServer Faces 2.3 Facelets Tag Library Documentation]()
-* [JavaServer Faces 2.3 JSP Tag Library Documentation]()
-* [JavaServer Faces 2.3 Standard HTML RenderKit Documentation]()
-* [JavaServer Faces 2.3 JavaScript Documentation]()
+# GlassFish Documentation
 
 ## Eclipse GlassFish Documentation and User Guides
 
@@ -23,3 +9,9 @@
 ## Eclipse Open MQ Documentation
 
 * See the [Open MQ Project](https://eclipse-ee4j.github.io/openmq/guides)
+
+## Jakarta EE Documentation
+
+* [Jakarta EE Platform 10 Specification APIs](https://jakarta.ee/specifications/platform/10/)
+* [Jakarta EE Documentatoin](https://jakarta.ee/resources/#documentation)
+


### PR DESCRIPTION
Brings back changes reverted in https://github.com/eclipse-ee4j/glassfish/pull/24450.

Now the build of the webpage works because the docs artifact is already published in Maven Central.

Also updates Jakarta EE docs links and move them to the bottom.

Preview of this PR: https://ondromih-glassfish.github.io/documentation