### PR TITLE
Integrate Hibernate Validator 8.0.1

### DIFF
--- a/appserver/tests/tck/validation/pom.xml
+++ b/appserver/tests/tck/validation/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.7.0</version>
+            <version>7.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -79,7 +79,7 @@
 
         <!-- Jakarta Validation -->
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
 
         <!-- Jakarta Web Services -->
         <!--


### PR DESCRIPTION
Also fixed Validation TCK by downgrading TestNg to last working version.

Changes: https://github.com/hibernate/hibernate-validator/commit/b8a727f0eae3abd69f07af9a1c425301aa357e49
