### PR TITLE
Fix Enterprise Beans business method generation

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/codegen/EjbOptionalIntfGenerator.java
@@ -267,8 +267,11 @@ public class EjbOptionalIntfGenerator extends BeanGeneratorBase {
         }
 
         mv.visitMethodInsn(INVOKEINTERFACE, Type.getInternalName(delegateClass), methodName, methodDesc, true);
-        mv.visitInsn(Type.getReturnType(methodDesc).getOpcode(IRETURN));
-        mv.visitMaxs(varIndex, varIndex);
+
+        Type returnType = Type.getReturnType(methodDesc);
+
+        mv.visitInsn(returnType.getOpcode(IRETURN));
+        mv.visitMaxs(Math.max(varIndex, returnType.getSize()), varIndex);
         mv.visitEnd();
     }
 


### PR DESCRIPTION
Generates wrong bytecode for a proxy method when a no-interface view bean business method have no arguments and return type is `long` or `double`.

This fixes #24488.
