### PR TITLE
Fix remote EJB access issue in glassfish-naming by updating osgi.bundle

### DIFF
--- a/appserver/common/glassfish-naming/osgi.bundle
+++ b/appserver/common/glassfish-naming/osgi.bundle
@@ -20,3 +20,10 @@
                         com.sun.enterprise.naming.spi; \
                         com.sun.enterprise.naming.util; version=${project.osgi.version}
 
+Import-Package: \
+                        org.omg.CORBA;resolution:=optional, \
+                        org.omg.CORBA.portable;resolution:=optional, \
+                        org.omg.CORBA_2_3.portable;resolution:=optional, \
+                        javax.rmi.CORBA;resolution:=optional, \
+                        com.sun.corba.ee.impl.presentation.rmi.codegen;resolution:=optional, \
+                        *


### PR DESCRIPTION
I am calling an EJB deployed on another server in a servlet running in a glassfish instance:

```java
try {
	Hashtable<String, String> env = new Hashtable<String, String>();
	env.put("org.omg.CORBA.ORBInitialHost", "172.21.32.84");
	env.put("org.omg.CORBA.ORBInitialPort", "3700");
                
	Context context = new InitialContext(env);
	Order order = (Order) context.lookup("java:global/ejbtest/OrderBean");
	order.createOrder();
} catch (Exception e) {
	e.printStackTrace();
}
```

The call fails with a captured exception message of:
```java
...
Caused by: java.lang.NullPointerException: Cannot invoke "com.sun.enterprise.naming.impl.SerialContextProvider.lookup(String)" because "prvdr" is null
	at com.sun.enterprise.naming.impl.SerialContext.lookup(SerialContext.java:825)
	... 34 more
```

Getting SerialContextProvider in SerialContext via getRemoteProvider is null. Further debugging revealed that the actual exception occurs in [Utility.loadStub](https://github.com/eclipse-ee4j/orb/blob/e94c45b67f9f2e71b1b535d8bced62692955f08a/orbmain/src/main/java/com/sun/corba/ee/impl/util/Utility.java#L809):

```java
public static Remote loadStub (org.omg.CORBA.Object narrowFrom,
                                   Class narrowTo) 
{
	Remote result = null;
            
	try {
        ...
        result = (Remote)sf.makeStub() ;
        ...
	} catch (Exception err) {
		wrapper.exceptionInLoadStub( err ) ;
	}
	return result;
}
```
[Utility.loadStub](https://github.com/eclipse-ee4j/orb/blob/e94c45b67f9f2e71b1b535d8bced62692955f08a/orbmain/src/main/java/com/sun/corba/ee/impl/util/Utility.java#L809) will load the stub of the remote `SerialContextProvider`, where an exception will be thrown:

```java
java.lang.ClassNotFoundException: javax.rmi.CORBA.Stub not found by org.glassfish.main.common.glassfish-naming [254]
```

It should be that the class `javax.rmi.CORBA.Stub` could not be loaded in the glassfish-naming project.

So I added the relevant Import-Package information to glassfish-naming's `osgi.bundle`. This way the remote EJB can be accessed normally in the servlet by means of jndi lookup.