### PR TITLE
Add test cases for accessing EJB in multiple ways

### DIFF
--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessLocalEJBByCDIServlet.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessLocalEJBByCDIServlet.java
@@ -1,0 +1,26 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet(name = "AccessLocalEJBByCDIServlet", urlPatterns = {"/local_ejb_cdi"})
+public class AccessLocalEJBByCDIServlet extends HttpServlet {
+
+    @EJB(beanInterface = EchoServiceLocal.class)
+    private EchoService service;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        String message = request.getParameter("message");
+        try (PrintWriter out = response.getWriter()) {
+            out.println(service.echo(message));
+        }
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessLocalEJBByJNDIServlet.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessLocalEJBByJNDIServlet.java
@@ -1,0 +1,32 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Hashtable;
+
+@WebServlet(name = "AccessLocalEJBByJNDIServlet", urlPatterns = {"/local_ejb_jndi"})
+public class AccessLocalEJBByJNDIServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        String message = request.getParameter("message");
+        try (PrintWriter out = response.getWriter()) {
+            try {
+                Hashtable<String, String> env = new Hashtable<String, String>();
+                Context context = new InitialContext(env);
+                EchoService service = (EchoService) context
+                        .lookup("java:app/echoservice/EchoServiceEJB!org.glassfish.main.test.app.ejb.EchoServiceLocal");
+                out.println(service.echo(message));
+            } catch (Exception e) {
+                e.printStackTrace(out);
+            }
+        }
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessRemoteEJBByCDIServlet.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessRemoteEJBByCDIServlet.java
@@ -1,0 +1,26 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet(name = "AccessRemoteEJBByCDIServlet", urlPatterns = {"/remote_ejb_cdi"})
+public class AccessRemoteEJBByCDIServlet extends HttpServlet {
+
+    @EJB(lookup = "java:global/echoservice/EchoServiceEJB!org.glassfish.main.test.app.ejb.EchoServiceRemote")
+    private EchoService service;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        String message = request.getParameter("message");
+        try (PrintWriter out = response.getWriter()) {
+            out.println(service.echo(message));
+        }
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessRemoteEJBByJNDIServlet.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/AccessRemoteEJBByJNDIServlet.java
@@ -1,0 +1,35 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Hashtable;
+
+@WebServlet(name = "AccessRemoteEJBServlet", urlPatterns = {"/remote_ejb_jndi"})
+public class AccessRemoteEJBByJNDIServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        String message = request.getParameter("message");
+        try (PrintWriter out = response.getWriter()) {
+            try {
+                Hashtable<String, String> env = new Hashtable<String, String>();
+                env.put("org.omg.CORBA.ORBInitialHost", "localhost");
+                env.put("org.omg.CORBA.ORBInitialPort", "3700");
+                Context context = new InitialContext(env);
+                EchoService service = (EchoService) context
+                        .lookup("java:global/echoservice/EchoServiceEJB!org.glassfish.main.test.app.ejb.EchoServiceRemote");
+                out.println(service.echo(message));
+            } catch (Exception e) {
+                e.printStackTrace(out);
+            }
+        }
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoService.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoService.java
@@ -1,0 +1,6 @@
+package org.glassfish.main.test.app.ejb;
+
+
+public interface EchoService {
+    public String echo(String message);
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoServiceEJB.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoServiceEJB.java
@@ -1,0 +1,13 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.ejb.Stateless;
+
+import java.io.Serializable;
+
+@Stateless
+public class EchoServiceEJB implements EchoServiceLocal, EchoServiceRemote, Serializable {
+    @Override
+    public String echo(String message) {
+        return message;
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoServiceLocal.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoServiceLocal.java
@@ -1,0 +1,7 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.ejb.Local;
+
+@Local
+public interface EchoServiceLocal extends EchoService {
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoServiceRemote.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/ejb/EchoServiceRemote.java
@@ -1,0 +1,7 @@
+package org.glassfish.main.test.app.ejb;
+
+import jakarta.ejb.Remote;
+
+@Remote
+public interface EchoServiceRemote extends EchoService {
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/ejb/AccessEJBWebTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/ejb/AccessEJBWebTest.java
@@ -1,0 +1,122 @@
+package org.glassfish.main.test.app.ejb;
+
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.RandomGenerator;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AccessEJBWebTest {
+    private static final System.Logger LOG = System.getLogger(AccessEJBWebTest.class.getName());
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+    private static final String APP_NAME = "echoservice";
+
+    @BeforeAll
+    static void deploy() {
+        File war = createDeployment();
+        try {
+            AsadminResult result = ASADMIN.exec("deploy", "--contextroot", "/", "--name", APP_NAME,
+                    war.getAbsolutePath());
+            assertThat(result, AsadminResultMatcher.asadminOK());
+        } finally {
+            war.delete();
+        }
+    }
+
+    @AfterAll
+    static void undeploy() {
+        AsadminResult result = ASADMIN.exec("undeploy", APP_NAME);
+        assertThat(result, AsadminResultMatcher.asadminOK());
+    }
+
+    @Test
+    void testAccessLocalEJBByCDI() throws Exception {
+        String message = RandomGenerator.generateRandomString();
+        HttpURLConnection connection = GlassFishTestEnvironment
+                .openConnection(8080, "/local_ejb_cdi?message=" + message);
+        connection.setRequestMethod("GET");
+        assertAll(
+                () -> assertEquals(200, connection.getResponseCode()),
+                () -> assertEquals(message, readResponseContent(connection))
+        );
+    }
+
+    @Test
+    void testAccessLocalEJBByJNDI() throws Exception {
+        String message = RandomGenerator.generateRandomString();
+        HttpURLConnection connection = GlassFishTestEnvironment
+                .openConnection(8080, "/local_ejb_jndi?message=" + message);
+        connection.setRequestMethod("GET");
+        assertAll(
+                () -> assertEquals(200, connection.getResponseCode()),
+                () -> assertEquals(message, readResponseContent(connection))
+        );
+    }
+
+    @Test
+    void testAccessRemoteEJBByCDI() throws Exception {
+        String message = RandomGenerator.generateRandomString();
+        HttpURLConnection connection = GlassFishTestEnvironment
+                .openConnection(8080, "/remote_ejb_cdi?message=" + message);
+        connection.setRequestMethod("GET");
+        assertAll(
+                () -> assertEquals(200, connection.getResponseCode()),
+                () -> assertEquals(message, readResponseContent(connection))
+        );
+    }
+
+    @Test
+    void testAccessRemoteEJBByJNDI() throws Exception {
+        String message = RandomGenerator.generateRandomString();
+        HttpURLConnection connection = GlassFishTestEnvironment
+                .openConnection(8080, "/remote_ejb_jndi?message=" + message);
+        connection.setRequestMethod("GET");
+        assertAll(
+                () -> assertEquals(200, connection.getResponseCode()),
+                () -> assertEquals(message, readResponseContent(connection))
+        );
+    }
+
+    private String readResponseContent(HttpURLConnection connection) throws Exception {
+        StringBuilder response = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.append(line);
+            }
+        }
+        return response.toString();
+    }
+
+    private static File createDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                .addClasses(EchoService.class, EchoServiceLocal.class, EchoServiceRemote.class, EchoServiceEJB.class)
+                .addClasses(AccessLocalEJBByCDIServlet.class, AccessLocalEJBByJNDIServlet.class)
+                .addClasses(AccessRemoteEJBByCDIServlet.class, AccessRemoteEJBByJNDIServlet.class);
+        LOG.log(INFO, war.toString(true));
+        try {
+            File tempFile = File.createTempFile(APP_NAME, ".war");
+            war.as(ZipExporter.class).exportTo(tempFile, true);
+            return tempFile;
+        } catch (IOException e) {
+            throw new IllegalStateException("Deployment failed - cannot load the input archive!", e);
+        }
+    }
+}


### PR DESCRIPTION
The test case uses four ways to access the EJB in a Servlet:

1. using the CDI to access the EJB local interface
2. using JNDI lookup to access the EJB local interface
3. using CDI to access the EJB remote interface
4. using JNDI lookup to access the EJB remote interface

The first three test cases pass, but the fourth test case fails for the same reason I analyzed in [PR24497](https://github.com/eclipse-ee4j/glassfish/pull/24497).