### PR TITLE
Fix for JSR 109 WSDL generation when using JDK 21

### DIFF
--- a/nucleus/admin/template/src/main/resources/config/server.policy
+++ b/nucleus/admin/template/src/main/resources/config/server.policy
@@ -134,3 +134,8 @@ grant codeBase "jrt:/jdk.compiler" {
 grant {
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.misc";
 };
+
+// Following grant block is required for using WSToolsObjectFactory (jsr109 WSDL parsing) on JDK 21
+grant {
+    permission java.lang.RuntimePermission "getenv.JDK_JAVAC_OPTIONS";
+};


### PR DESCRIPTION
Should fix failures encountered here: https://ci.eclipse.org/glassfish/job/glassfish7_build-and-test_jdk21/