### PR TITLE
Optimize CDI extensions to reduce unnecessary PAT handler calls

### DIFF
--- a/appserver/jms/gf-jms-injection/src/main/java/org/glassfish/jms/injection/JMSCDIExtension.java
+++ b/appserver/jms/gf-jms-injection/src/main/java/org/glassfish/jms/injection/JMSCDIExtension.java
@@ -31,20 +31,14 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
-import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
-import jakarta.enterprise.inject.spi.BeforeShutdown;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.InjectionTarget;
 import jakarta.enterprise.inject.spi.InjectionTargetFactory;
 import jakarta.enterprise.inject.spi.PassivationCapable;
-import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
-import jakarta.enterprise.inject.spi.ProcessInjectionTarget;
-import jakarta.enterprise.inject.spi.ProcessProducer;
 import jakarta.transaction.TransactionScoped;
 
 /*
@@ -62,33 +56,6 @@ public class JMSCDIExtension implements Extension {
 
         Bean contextBean = createLocalBean(beanManager, InjectableJMSContext.class);
         afterBeanDiscoveryEvent.addBean(contextBean);
-    }
-
-    void addScope(@Observes final BeforeBeanDiscovery event) {
-    }
-
-    void afterBeanDiscovery(@Observes final AfterBeanDiscovery event) {
-    }
-
-    public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery event) {
-    }
-
-    public void beforeBeanDiscovery(@Observes BeforeBeanDiscovery event, BeanManager beanManager) {
-    }
-
-    public void afterDeploymentValidation(@Observes AfterDeploymentValidation event, BeanManager beanManager) {
-    }
-
-    public void beforeShutdown(@Observes BeforeShutdown event, BeanManager beanManager) {
-    }
-
-    public <T> void processInjectionTarget(@Observes ProcessInjectionTarget<T> pit) {
-    }
-
-    public <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> pat) {
-    }
-
-    public <T, X> void processProducer(@Observes ProcessProducer<T, X> event) {
     }
 
     public static class LocalPassivationCapableBean implements Bean, PassivationCapable {

--- a/appserver/web/web-sse/src/main/java/org/glassfish/sse/impl/ServerSentEventCdiExtension.java
+++ b/appserver/web/web-sse/src/main/java/org/glassfish/sse/impl/ServerSentEventCdiExtension.java
@@ -44,6 +44,7 @@ import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.WithAnnotations;
 import jakarta.enterprise.util.AnnotationLiteral;
 
 /**
@@ -174,7 +175,7 @@ public class ServerSentEventCdiExtension implements Extension {
         }
     }
 
-    <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> pat, BeanManager beanManager) {
+    <T> void processAnnotatedType(@Observes @WithAnnotations(ServerSentEvent.class) ProcessAnnotatedType<T> pat, BeanManager beanManager) {
         if (LOGGER.isLoggable(FINE)) {
             LOGGER.fine("scanning type: " + pat.getAnnotatedType().getJavaClass().getName());
         }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/rest/RestExtension.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/rest/RestExtension.java
@@ -67,7 +67,7 @@ public class RestExtension implements Extension {
     private static final LazyValue<Set<Class<?>>> REST_BOUND_INJECTABLES = Values.lazy((Value<Set<Class<?>>>)
             () -> sumNonJerseyBoundInjectables());
 
-    private void processAnnotatedType(@Observes ProcessAnnotatedType<?> processAnnotatedType, BeanManager beanManager) {
+    private void processAnnotatedType(@Observes ProcessAnnotatedType<? extends Application> processAnnotatedType, BeanManager beanManager) {
         final Class<?> baseClass = (Class<?>) processAnnotatedType.getAnnotatedType().getBaseType();
 
         if (Application.class.isAssignableFrom(baseClass) && Configuration.class.isAssignableFrom(baseClass)) {


### PR DESCRIPTION
Follows the advice from WELD in the log:
WELD-000411: Observer method [BackedAnnotatedMethod] public org.glassfish.jms.injection.JMSCDIExtension.processAnnotatedType(@Observes ProcessAnnotatedType<T>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.|#]

Tested manually that the RestExtension and ServerSentEventCdiExtension processesAnnotatedType mathods are executed many times on GF 7.0.7 even if there's only a single matching bean in the app. With this PR, I observed that those methods are triggered only once if there's an Application bean in the app or a bean with the ServerSentEvent annotation (the latter is an annotation from internal GF API, not from Jakarta API).

