### PR TITLE
Ondromih profiles to speedup dev build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ The Zip distributions can be found on following paths:
 * `mvn clean install -Pfast` - Building all distribution artifacts, running just unit tests, QA and integration tests excluded. Typical time: 3 minutes.
 * `mvn clean install -Pfastest` - Building all distribution artifacts, excluded all QA and testing. Typical time: 1.5 minutes.
 
+You can also skip building specific distributions with the following profiles:
+
+* `noextras` profile - skips building extra artifacts, e.g. GlassFish Embedded artifacts
+* `noweb` profile - skips building GlassFish Server Web distribution
+
+For example, the following command will build only the GlassFish main distribution without QA and testing, with no Web and extra (GlassFish Embedded) artifacts: `mvn clean install -Pfastest,noweb,noextras`
+
 You can use also some maven optimizations, ie. using `-T4C` to allow parallel build.
 
 If you want to see more logs you can use the `-Dtest.logLevel=FINEST` option set to an appropriate log level.

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -32,108 +32,120 @@
 
     <name>Glassfish Web Profile Distribution</name>
 
-    <properties>
-        <glassfish.modules>${project.build.directory}/stage/glassfish7/glassfish/modules</glassfish.modules>
-        <patches>${basedir}/src/main/patches</patches>
-    </properties>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.glassfish.main.featuresets</groupId>
-            <artifactId>web</artifactId>
-            <version>${project.version}</version>
-            <type>pom</type>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.extras</groupId>
-            <artifactId>glassfish-embedded-shell</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.extras</groupId>
-            <artifactId>glassfish-embedded-static-shell</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.distributions</groupId>
-            <artifactId>glassfish-common</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-            <optional>true</optional>
-        </dependency>
+            <properties>
+                <glassfish.modules>${project.build.directory}/stage/glassfish7/glassfish/modules</glassfish.modules>
+                <patches>${basedir}/src/main/patches</patches>
+            </properties>
 
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-    </dependencies>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.featuresets</groupId>
+                    <artifactId>web</artifactId>
+                    <version>${project.version}</version>
+                    <type>pom</type>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-shell</artifactId>
+                    <version>${project.version}</version>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-static-shell</artifactId>
+                    <version>${project.version}</version>
+                    <optional>true</optional>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.main.distributions</groupId>
+                    <artifactId>glassfish-common</artifactId>
+                    <version>${project.version}</version>
+                    <type>zip</type>
+                    <optional>true</optional>
+                </dependency>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>glassfishbuild-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>create-domain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
+                <dependency>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                    <scope>test</scope>
+                    <optional>true</optional>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.glassfish.build</groupId>
+                        <artifactId>glassfishbuild-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-domain</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
             
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>do stuff</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <macrodef name="jarupdate">
-                                    <attribute name="basedir"/> 
-                                    <attribute name="includes"/>
-                                    <attribute name="destfile"/>
-                                    <sequential>
-                                        <zip destfile="@{destfile}.tmp">
-                                            <zipfileset src="@{destfile}" excludes="@{includes}"/>
-                                        </zip>
-                                        <move file="@{destfile}.tmp" tofile="@{destfile}" />
-                                        <zip update="true" basedir="@{basedir}" includes="@{includes}" destfile="@{destfile}" />
-                                    </sequential>
-                                </macrodef>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>do stuff</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <macrodef name="jarupdate">
+                                            <attribute name="basedir"/>
+                                            <attribute name="includes"/>
+                                            <attribute name="destfile"/>
+                                            <sequential>
+                                                <zip destfile="@{destfile}.tmp">
+                                                    <zipfileset src="@{destfile}" excludes="@{includes}"/>
+                                                </zip>
+                                                <move file="@{destfile}.tmp" tofile="@{destfile}" />
+                                                <zip update="true" basedir="@{basedir}" includes="@{includes}" destfile="@{destfile}" />
+                                            </sequential>
+                                        </macrodef>
                             
-                                <jarupdate 
-                                    basedir="${patches}/jersey-hk2" includes="META-INF/MANIFEST.MF"
-                                    destfile="${glassfish.modules}/jersey-hk2.jar"
-                                />
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+                                        <jarupdate
+                                            basedir="${patches}/jersey-hk2" includes="META-INF/MANIFEST.MF"
+                                            destfile="${glassfish.modules}/jersey-hk2.jar"
+                                        />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-            <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>spec-version-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-distribution</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                    <plugin>
+                        <groupId>org.glassfish.build</groupId>
+                        <artifactId>spec-version-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check-distribution</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>noweb</id>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -146,6 +146,36 @@
         </profile>
         <profile>
             <id>noweb</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-assembly-plugin</artifactId>
+                            <configuration>
+                                <skipAssembly>true</skipAssembly>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.glassfish.build</groupId>
+                            <artifactId>glassfishbuild-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-zip</id>
+                                    <configuration>
+                                        <filesets combine.self="override"></filesets>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <artifactId>maven-dependency-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/appserver/extras/pom.xml
+++ b/appserver/extras/pom.xml
@@ -31,9 +31,20 @@
 
     <name>GlassFish Extras modules</name>
 
-    <modules>
-        <module>jakartaee</module>
-        <module>appserv-rt</module>
-        <module>embedded</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>jakartaee</module>
+                <module>appserv-rt</module>
+                <module>embedded</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>noextras</id>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,15 @@
                 <module>appserver</module>
             </modules>
         </profile>
+
+        <profile>
+            <id>noextras</id>
+        </profile>
         
+        <profile>
+            <id>noweb</id>
+        </profile>
+
         <profile>
             <!--
                 RE profile for release purposes.


### PR DESCRIPTION
As described in the README:

* `noextras` profile - skips building extra artifacts, e.g. GlassFish Embedded artifacts
* `noweb` profile - skips building GlassFish Server Web distribution