### PR TITLE
Tasks submitted to executor during deployment executed after deployment.

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/AppLifecycleListener.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/AppLifecycleListener.java
@@ -1,0 +1,59 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package org.glassfish.concurrent.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.glassfish.enterprise.concurrent.internal.ManagedFutureTask;
+import org.glassfish.internal.deployment.ApplicationLifecycleInterceptor;
+import org.glassfish.internal.deployment.ExtendedDeploymentContext;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author ondro
+ */
+@Service
+public class AppLifecycleListener implements ApplicationLifecycleInterceptor {
+
+    public static class TasksDelayedAfterDeployment {
+        private List<DelayedTask> tasks = new ArrayList<>();
+
+        public boolean add(DeploymentAwareManagedExecutorService executor, ManagedFutureTask<?> task) {
+            return tasks.add(new DelayedTask(executor, task));
+        }
+    }
+
+    public static class DelayedTask {
+
+        public DelayedTask(DeploymentAwareManagedExecutorService executor, ManagedFutureTask<?> task) {
+            this.executor = executor;
+            this.task = task;
+        }
+
+        private DeploymentAwareManagedExecutorService executor;
+        private ManagedFutureTask<?> task;
+
+        public void executeNow() {
+            executor.executeManagedFutureTaskImmediately(task);
+        }
+    }
+
+    @Override
+    public void before(ExtendedDeploymentContext.Phase phase, ExtendedDeploymentContext context) {
+        context.addTransientAppMetaData(
+                TasksDelayedAfterDeployment.class.getName(), new TasksDelayedAfterDeployment());
+    }
+
+    @Override
+    public void after(ExtendedDeploymentContext.Phase phase, ExtendedDeploymentContext context) {
+        TasksDelayedAfterDeployment delayedTasks = context.getTransientAppMetaData(
+                TasksDelayedAfterDeployment.class.getName(), TasksDelayedAfterDeployment.class);
+        context.getTransientAppMetadata().remove(
+                TasksDelayedAfterDeployment.class.getName());
+        delayedTasks.tasks.forEach(DelayedTask::executeNow);
+    }
+
+}

--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/DeploymentAwareManagedExecutorService.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/DeploymentAwareManagedExecutorService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Payara Foundation and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.concurrent.runtime;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.glassfish.enterprise.concurrent.ManagedExecutorServiceImpl;
+import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.glassfish.enterprise.concurrent.internal.ManagedFutureTask;
+
+/**
+ * A ManagedExecutorService that delays tasks submitted during deployment until the app is deployed.
+ */
+public class DeploymentAwareManagedExecutorService extends ManagedExecutorServiceImpl {
+
+    Supplier<DeploymentContext> deploymentContextSupplier = null;
+
+    public DeploymentAwareManagedExecutorService(String name, ManagedThreadFactoryImpl managedThreadFactory, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, int maxPoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, ContextServiceImpl contextService, RejectPolicy rejectPolicy, BlockingQueue<Runnable> queue) {
+        super(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, maxPoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, contextService, rejectPolicy, queue);
+    }
+
+    public DeploymentAwareManagedExecutorService(String name, ManagedThreadFactoryImpl managedThreadFactory, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, int maxPoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, int queueCapacity, ContextServiceImpl contextService, RejectPolicy rejectPolicy) {
+        super(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, maxPoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueCapacity, contextService, rejectPolicy);
+    }
+
+    public void setDeploymentContextSupplier(Supplier<DeploymentContext> deploymentContextSupplier) {
+        this.deploymentContextSupplier = deploymentContextSupplier;
+    }
+
+    @Override
+    protected void executeManagedFutureTask(ManagedFutureTask<?> task) {
+        DeploymentContext deploymentContext = null;
+        if (deploymentContextSupplier != null) {
+            deploymentContext = deploymentContextSupplier.get();
+        }
+        if (deploymentContext != null) {
+            AppLifecycleListener.TasksDelayedAfterDeployment delayedTasks = deploymentContext.getTransientAppMetaData(
+                    AppLifecycleListener.TasksDelayedAfterDeployment.class.getName(),
+                    AppLifecycleListener.TasksDelayedAfterDeployment.class);
+            if (delayedTasks != null) {
+                delayedTasks.add(this, task);
+                // task is delayed to execute after deployment finishes, don't execute now
+                return;
+            }
+        }
+        super.executeManagedFutureTask(task); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody
+    }
+
+    public void executeManagedFutureTaskImmediately(ManagedFutureTask<?> task) {
+        super.executeManagedFutureTask(task);
+    }
+
+
+}

--- a/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/runtime/ConcurrentRuntimeTest.java
+++ b/appserver/concurrent/concurrent-impl/src/test/java/org/glassfish/concurrent/runtime/ConcurrentRuntimeTest.java
@@ -136,7 +136,7 @@ public class ConcurrentRuntimeTest {
 
         assertEquals(100_000L, managedThreadFactory.getHungTaskThreshold());
 
-        ManagedThreadPoolExecutor executor = getField(mes, "threadPoolExecutor");
+        ManagedThreadPoolExecutor executor = getField(mes, "threadPoolExecutor", ManagedExecutorServiceImpl.class);
         assertEquals(1, executor.getCorePoolSize());
         assertEquals(88, executor.getKeepAliveTime(TimeUnit.SECONDS));
         assertEquals(5, executor.getMaximumPoolSize());

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModule.java
@@ -169,11 +169,12 @@ import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.annotation.ServletSecurity;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpUpgradeHandler;
+import org.glassfish.internal.api.WithDeploymentContext;
 
 /**
  * Class representing a web module for use by the Application Server.
  */
-public class WebModule extends PwcWebModule implements Context {
+public class WebModule extends PwcWebModule implements Context, WithDeploymentContext {
 
 
     private static final Logger logger = LogFacade.getLogger();
@@ -264,6 +265,11 @@ public class WebModule extends PwcWebModule implements Context {
         this.adHocPipeline.setBasic(new AdHocContextValve(this));
 
         notifyContainerListeners = false;
+    }
+
+    @Override
+    public DeploymentContext getDeploymentContext() {
+        return getWebModuleConfig().getDeploymentContext();
     }
 
     /**

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/WithDeploymentContext.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/WithDeploymentContext.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.internal.api;
+
+import org.glassfish.api.deployment.DeploymentContext;
+
+/**
+ *
+ * This should be implemented by deployment containers which can provide a deployment context
+ */
+public interface WithDeploymentContext {
+    DeploymentContext getDeploymentContext();
+}


### PR DESCRIPTION
An improvement of https://github.com/eclipse-ee4j/glassfish/pull/24539.

If tasks submitted during deployment, e.g. in @Initialized(ApplicationScoped.class) observer, they are added to a queue in the deployment context and triggered after deployment finished. This draft currently modifies the ManagedExecutorService to execute tasks after deployment complete. It doesn't modify ManagedScheduledExecutorService.

Description of the solution:
1. Application lifecycle listener creates storage for tasks when deployment starts
2. Executor detects that storage exists in deployment context (deployment is not complete) - it won't execute tasks immediately but will add tasks to the storage
3.  When deployment completes, application lifecycle listener executes the tasks from the storage and removes storage.
4. Executor no longer detects storage and executes the tasks immediately

To do:

* Implement also for scheduled executor service
* Add some logging
* An option to trigger tasks immediately during deployment, or trigger tasks immediately for plain executor and only delay with scheduled executor (the logic is that tasks are scheduled after deployment) - there are multiple options, see below
* tests (task submitted during deployment is triggered after startup method completes, task submitted after deployment triggers immediately)

There are multiple options to implement this whole feature:

* execute all tasks after deployment
* execute only tasks submitted by scheduled executor after deployment but tasks submitted by plain executor immediately (the logic is tasks should be scheduled to execute after deployment and thus should be submitted by a scheduled executor)
* support an option on the executor or deployment descriptor to switch the behavior - either execute immediately or execute after deployment completes.