### PR TITLE
Don't log a stacktrace if MANIFEST file not found in deployed JAR

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/FilteringClassLoader.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/FilteringClassLoader.java
@@ -124,7 +124,11 @@ class FilteringClassLoader extends ClassLoader {
         try (InputStream stream = manifestURL.openStream()) {
             return new Manifest(stream);
         } catch (final IOException e) {
-            LOG.log(Level.WARNING, "Could not read manifest at " + manifestURL, e);
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.WARNING, "Could not read manifest at " + manifestURL, e);
+            } else {
+                LOG.log(Level.WARNING, "Could not read manifest. " + e.getMessage());
+            }
             return null;
         }
     }


### PR DESCRIPTION
Avoids polluting log by an unnecessary stacktrace when GlassFish Embedded  used in an Arquillian connector.

Only with Java 11 or Java less than 17.

To reproduce the log message, run a test using Arquillian GlassFish Embedded connector. This can be reproduced with this PR: https://github.com/eclipse-ee4j/cargotracker/pull/273 - with Java 11, run `mvn clean package -Pglassfish`