### PR TITLE
Add application tests for classloading-time bytecode preprocessing

### DIFF
--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -73,6 +90,11 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/ejb/ClassTransformerBean.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/ejb/ClassTransformerBean.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.ejb;
+
+import jakarta.ejb.Stateless;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+
+@Stateless
+public class ClassTransformerBean {
+
+    @PersistenceUnit(unitName = "transformPU")
+    private EntityManagerFactory persistenceUnit;
+
+    public String getResult() {
+        return null;
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/ClassTransformerImpl.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/ClassTransformerImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.provider;
+
+import jakarta.persistence.spi.ClassTransformer;
+
+import java.security.ProtectionDomain;
+
+public class ClassTransformerImpl implements ClassTransformer {
+
+    @Override
+    public byte[] transform(ClassLoader loader,
+                            String className,
+                            Class<?> classBeingRedefined,
+                            ProtectionDomain protectionDomain,
+                            byte[] classfileBuffer) {
+        // Produces circular attempts of transformation.
+        return Enhancer.enhance(classfileBuffer, new EnhancerContext());
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/Enhancer.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/Enhancer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.provider;
+
+public class Enhancer {
+
+    public static byte[] enhance(byte[] classfileBuffer, EnhancerContext context) {
+        return classfileBuffer;
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/EnhancerContext.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/EnhancerContext.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.provider;
+
+public class EnhancerContext {
+
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/EntityManagerFactoryImpl.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/EntityManagerFactoryImpl.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.provider;
+
+import jakarta.persistence.Cache;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnitUtil;
+import jakarta.persistence.Query;
+import jakarta.persistence.SynchronizationType;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.metamodel.Metamodel;
+import jakarta.persistence.spi.PersistenceUnitInfo;
+
+import java.util.Map;
+
+public class EntityManagerFactoryImpl implements EntityManagerFactory {
+
+    public EntityManagerFactoryImpl(PersistenceUnitInfo persistenceUnitInfo) {
+        persistenceUnitInfo.addTransformer(new ClassTransformerImpl());
+    }
+
+    @Override
+    public EntityManager createEntityManager() {
+        return new EntityManagerImpl();
+    }
+
+    @Override
+    public EntityManager createEntityManager(Map properties) {
+        return null;
+    }
+
+    @Override
+    public EntityManager createEntityManager(SynchronizationType synchronizationType) {
+        return null;
+    }
+
+    @Override
+    public EntityManager createEntityManager(SynchronizationType synchronizationType, Map properties) {
+        return null;
+    }
+
+    @Override
+    public CriteriaBuilder getCriteriaBuilder() {
+        return null;
+    }
+
+    @Override
+    public Metamodel getMetamodel() {
+        return null;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return null;
+    }
+
+    @Override
+    public Cache getCache() {
+        return null;
+    }
+
+    @Override
+    public PersistenceUnitUtil getPersistenceUnitUtil() {
+        return null;
+    }
+
+    @Override
+    public void addNamedQuery(String name, Query query) {
+
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) {
+        return null;
+    }
+
+    @Override
+    public <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph) {
+
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/EntityManagerImpl.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/EntityManagerImpl.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.provider;
+
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Query;
+import jakarta.persistence.StoredProcedureQuery;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.metamodel.Metamodel;
+
+import java.util.List;
+import java.util.Map;
+
+public class EntityManagerImpl implements EntityManager {
+
+    @Override
+    public void persist(Object entity) {
+
+    }
+
+    @Override
+    public <T> T merge(T entity) {
+        return null;
+    }
+
+    @Override
+    public void remove(Object entity) {
+
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey) {
+        return null;
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, Map<String, Object> properties) {
+        return null;
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode) {
+        return null;
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode, Map<String, Object> properties) {
+        return null;
+    }
+
+    @Override
+    public <T> T getReference(Class<T> entityClass, Object primaryKey) {
+        return null;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void setFlushMode(FlushModeType flushMode) {
+
+    }
+
+    @Override
+    public FlushModeType getFlushMode() {
+        return null;
+    }
+
+    @Override
+    public void lock(Object entity, LockModeType lockMode) {
+
+    }
+
+    @Override
+    public void lock(Object entity, LockModeType lockMode, Map<String, Object> properties) {
+
+    }
+
+    @Override
+    public void refresh(Object entity) {
+
+    }
+
+    @Override
+    public void refresh(Object entity, Map<String, Object> properties) {
+
+    }
+
+    @Override
+    public void refresh(Object entity, LockModeType lockMode) {
+
+    }
+
+    @Override
+    public void refresh(Object entity, LockModeType lockMode, Map<String, Object> properties) {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public void detach(Object entity) {
+
+    }
+
+    @Override
+    public boolean contains(Object entity) {
+        return false;
+    }
+
+    @Override
+    public LockModeType getLockMode(Object entity) {
+        return null;
+    }
+
+    @Override
+    public void setProperty(String propertyName, Object value) {
+
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return null;
+    }
+
+    @Override
+    public Query createQuery(String qlString) {
+        return null;
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(CriteriaQuery<T> criteriaQuery) {
+        return null;
+    }
+
+    @Override
+    public Query createQuery(CriteriaUpdate updateQuery) {
+        return null;
+    }
+
+    @Override
+    public Query createQuery(CriteriaDelete deleteQuery) {
+        return null;
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(String qlString, Class<T> resultClass) {
+        return null;
+    }
+
+    @Override
+    public Query createNamedQuery(String name) {
+        return null;
+    }
+
+    @Override
+    public <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass) {
+        return null;
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString) {
+        return null;
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString, Class resultClass) {
+        return null;
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString, String resultSetMapping) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String name) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName, Class... resultClasses) {
+        return null;
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName, String... resultSetMappings) {
+        return null;
+    }
+
+    @Override
+    public void joinTransaction() {
+
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return false;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) {
+        return null;
+    }
+
+    @Override
+    public Object getDelegate() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public EntityTransaction getTransaction() {
+        return null;
+    }
+
+    @Override
+    public EntityManagerFactory getEntityManagerFactory() {
+        return null;
+    }
+
+    @Override
+    public CriteriaBuilder getCriteriaBuilder() {
+        return null;
+    }
+
+    @Override
+    public Metamodel getMetamodel() {
+        return null;
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> rootType) {
+        return null;
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String graphName) {
+        return null;
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String graphName) {
+        return null;
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
+        return null;
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/PersistenceProviderImpl.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/provider/PersistenceProviderImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.provider;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.spi.PersistenceProvider;
+import jakarta.persistence.spi.PersistenceUnitInfo;
+import jakarta.persistence.spi.ProviderUtil;
+
+import java.util.Map;
+
+public class PersistenceProviderImpl implements PersistenceProvider {
+
+    @Override
+    public EntityManagerFactory createEntityManagerFactory(String name, Map properties) {
+        return null;
+    }
+
+    @Override
+    public EntityManagerFactory createContainerEntityManagerFactory(PersistenceUnitInfo persistenceUnitInfo, Map properties) {
+        return new EntityManagerFactoryImpl(persistenceUnitInfo);
+    }
+
+    @Override
+    public void generateSchema(PersistenceUnitInfo persistenceUnitInfo, Map properties) {
+
+    }
+
+    @Override
+    public boolean generateSchema(String persistenceUnitName, Map properties) {
+        return false;
+    }
+
+    @Override
+    public ProviderUtil getProviderUtil() {
+        return null;
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/webapp/ClassTransformerApplication.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/webapp/ClassTransformerApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.webapp;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import java.util.Set;
+
+@ApplicationPath("")
+public class ClassTransformerApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(ClassTransformerResource.class);
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/webapp/ClassTransformerResource.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/persistence/transform/webapp/ClassTransformerResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform.webapp;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/")
+public class ClassTransformerResource {
+
+    @PersistenceUnit(unitName = "transformPU")
+    private EntityManagerFactory persistenceUnit;
+
+    @GET
+    public Response getResponse() {
+        if (persistenceUnit.createEntityManager() == null) {
+            return Response.serverError().build();
+        }
+        return Response.ok().build();
+    }
+}

--- a/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/persistence/transform/persistence.xml
+++ b/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/persistence/transform/persistence.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+    <persistence-unit name="transformPU" transaction-type="JTA">
+        <provider>org.glassfish.main.test.app.persistence.transform.provider.PersistenceProviderImpl</provider>
+    </persistence-unit>
+</persistence>

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/persistence/transform/ClassTransformerEjbWebAppTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/persistence/transform/ClassTransformerEjbWebAppTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.glassfish.main.test.app.persistence.transform.ejb.ClassTransformerBean;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests bytecode preprocessing in ASURLClassLoader.
+ */
+public class ClassTransformerEjbWebAppTest extends ClassTransformerTestBase {
+
+    private static final System.Logger LOG = System.getLogger(ClassTransformerEjbWebAppTest.class.getName());
+
+    private static final String APP_NAME = "TransformEjbWebApp";
+
+    @Test
+    public void testDeploy() throws IOException {
+        File warFile = createDeployment();
+        try {
+            assertThat(ASADMIN.exec("deploy", warFile.getAbsolutePath()), asadminOK());
+            assertThat(ASADMIN.exec("undeploy", APP_NAME), asadminOK());
+        } finally {
+            try {
+                Files.deleteIfExists(warFile.toPath());
+            } catch (IOException e){
+                LOG.log(WARNING, "An error occurred while remove temp file " + warFile.getAbsolutePath(), e);
+            }
+        }
+    }
+
+    private static File createDeployment() throws IOException {
+        WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(createProvider())
+            .addClass(ClassTransformerBean.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsResource(
+                new File("src/main/resources/org/glassfish/main/test/app/persistence/transform/persistence.xml"),
+                "META-INF/persistence.xml");
+
+        LOG.log(INFO, webArchive.toString(true));
+
+        return createDeploymentFile(webArchive, APP_NAME);
+    }
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/persistence/transform/ClassTransformerTestBase.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/persistence/transform/ClassTransformerTestBase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform;
+
+import jakarta.persistence.spi.PersistenceProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.test.app.persistence.transform.provider.ClassTransformerImpl;
+import org.glassfish.main.test.app.persistence.transform.provider.Enhancer;
+import org.glassfish.main.test.app.persistence.transform.provider.EnhancerContext;
+import org.glassfish.main.test.app.persistence.transform.provider.EntityManagerFactoryImpl;
+import org.glassfish.main.test.app.persistence.transform.provider.EntityManagerImpl;
+import org.glassfish.main.test.app.persistence.transform.provider.PersistenceProviderImpl;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getAsadmin;
+
+public class ClassTransformerTestBase {
+
+    private static final String PROVIDER_FILE_NAME = "provider.jar";
+
+    protected static final Asadmin ASADMIN = getAsadmin();
+
+    protected static JavaArchive createProvider() {
+        return ShrinkWrap.create(JavaArchive.class, PROVIDER_FILE_NAME)
+            .addClass(ClassTransformerImpl.class)
+            .addClass(Enhancer.class)
+            .addClass(EnhancerContext.class)
+            .addClass(EntityManagerImpl.class)
+            .addClass(EntityManagerFactoryImpl.class)
+            .addClass(PersistenceProviderImpl.class)
+            .addAsServiceProvider(PersistenceProvider.class, PersistenceProviderImpl.class);
+    }
+
+    protected static File createDeploymentFile(Archive<?> archive, String appName) throws IOException {
+        File tempDir = Files.createTempDirectory(appName).toFile();
+        tempDir.deleteOnExit();
+        File deploymentFile = new File(tempDir, appName + extensionFor(archive));
+        archive.as(ZipExporter.class).exportTo(deploymentFile, true);
+        return deploymentFile;
+    }
+
+    private static String extensionFor(Archive<?> archive) {
+        String extension = ".jar";
+        if (archive instanceof WebArchive) {
+            extension = ".war";
+        } else if (archive instanceof EnterpriseArchive) {
+            extension = ".ear";
+        }
+        return extension;
+    }
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/persistence/transform/ClassTransformerWebAppTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/persistence/transform/ClassTransformerWebAppTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.persistence.transform;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.file.Files;
+
+import org.glassfish.main.test.app.persistence.transform.webapp.ClassTransformerApplication;
+import org.glassfish.main.test.app.persistence.transform.webapp.ClassTransformerResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.openConnection;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests bytecode preprocessing in WebappClassLoader.
+ */
+public class ClassTransformerWebAppTest extends ClassTransformerTestBase {
+
+    private static final System.Logger LOG = System.getLogger(ClassTransformerWebAppTest.class.getName());
+
+    private static final String APP_NAME = "TransformWebApp";
+
+    private static final String CONTEXT_ROOT = "/" + APP_NAME;
+
+    @Test
+    public void testDeploy() throws IOException {
+        File warFile = createDeployment();
+        try {
+            assertThat(ASADMIN.exec("deploy", warFile.getAbsolutePath()), asadminOK());
+        } finally {
+            try {
+                Files.deleteIfExists(warFile.toPath());
+            } catch (IOException e) {
+                LOG.log(WARNING, "An error occurred while remove temp file " + warFile.getAbsolutePath(), e);
+            }
+        }
+
+        HttpURLConnection connection = openConnection(8080, CONTEXT_ROOT);
+        connection.setRequestMethod("GET");
+        try {
+            assertThat(connection.getResponseCode(), equalTo(200));
+        } finally {
+            connection.disconnect();
+        }
+
+        assertThat(ASADMIN.exec("undeploy", APP_NAME), asadminOK());
+    }
+
+    private static File createDeployment() throws IOException {
+        WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
+            .addAsLibrary(createProvider())
+            .addClass(ClassTransformerResource.class)
+            .addClass(ClassTransformerApplication.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsResource(
+                new File("src/main/resources/org/glassfish/main/test/app/persistence/transform/persistence.xml"),
+                "META-INF/persistence.xml");
+
+        LOG.log(INFO, webArchive.toString(true));
+
+        return createDeploymentFile(webArchive, APP_NAME);
+    }
+}


### PR DESCRIPTION
Covers by tests issue described in #24414 and fixed in #24448 and #24451.

For this test we create simplified mostly no-op version of the `jakarta.persistence.spi.PersistenceProvider` with `jakarta.persistence.spi.ClassTransformer` implementation produces circular transformation calls.

This tests must be passed with GlassFish 7.0.6 and above.
