### PR TITLE
Website: Adds TOC to docs page. Fixes the search bar appearing on page load

### DIFF
--- a/docs/website/src/main/resources/_includes/documentation-toc.html
+++ b/docs/website/src/main/resources/_includes/documentation-toc.html
@@ -1,0 +1,12 @@
+<aside id="toc-sidebar" class="hidden-print">
+    <ul>
+      <li><i class="fa fa-caret-right fa-fw"></i><a href="#current">GlassFish Guides</a>
+      </li>
+      <li><i class="fa fa-caret-right fa-fw"></i><a href="#jakarta-ee">Jakarta EE Documentation</a>
+      </li>
+      <li><i class="fa fa-caret-right fa-fw"></i><a href="#microprofile">MicroProfile Documentation</a>
+      </li>
+      <li><i class="fa fa-caret-right fa-fw"></i><a href="#open-mq">Open MQ Documentation</a>
+      </li>
+    </ul>
+  </aside>            

--- a/docs/website/src/main/resources/_includes/eclipse-search-bar-fix.html
+++ b/docs/website/src/main/resources/_includes/eclipse-search-bar-fix.html
@@ -1,0 +1,4 @@
+<script type="text/javascript">
+    /* hide search bar on load, it's set to be open in the theme */
+    document.querySelector('.main-menu-search').classList.remove("open");
+  </script>

--- a/docs/website/src/main/resources/_includes/topnav.html
+++ b/docs/website/src/main/resources/_includes/topnav.html
@@ -1,4 +1,4 @@
-<div class="nav top-nav">
+<div class="nav top-nav hidden-print">
     <ul>
         <li class="icon download">
             <a href="/download.html">Download<p>Distributions, Release Notes</p></a>

--- a/docs/website/src/main/resources/_layouts/documentation.html
+++ b/docs/website/src/main/resources/_layouts/documentation.html
@@ -35,7 +35,10 @@
       <div class="container">
         <div class="row">
           {% include topnav.html %}
-          <div class="col-md-18 padding-bottom-30">
+          <div class="col-md-4 padding-bottom-30">
+            {% include documentation-toc.html %}
+          </div>
+          <div class="col-md-14 padding-bottom-30">
             {{ content }}
           </div>
           <div class="col-md-6  padding-bottom-30">

--- a/docs/website/src/main/resources/assets/css/style.scss
+++ b/docs/website/src/main/resources/assets/css/style.scss
@@ -68,3 +68,37 @@
 .top-nav ul li.icon.support a::before {
     background-image: url('../../img/life-ring.svg');
 }
+
+#toc-sidebar {
+  position: relative;
+  margin-bottom: 0;
+  color: #fff;
+}
+
+#toc-sidebar ul {
+  background: #3f7b96;
+  padding: 15px;
+  position: relative;
+  list-style-type: none;
+  margin-left: 0;
+}
+
+#toc-sidebar li {
+  border-bottom: 1px solid #5297b6;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+}
+
+#toc-sidebar a, #toc-sidebar a:hover {
+  color: #fff;
+}
+
+/*
+ Hide non-printable items
+*/
+
+@media print {
+  #btn-call-for-action, div.social-media, div.wrapper-logo-default {
+    display: none !important;
+  }
+}

--- a/docs/website/src/main/resources/documentation.md
+++ b/docs/website/src/main/resources/documentation.md
@@ -1,6 +1,10 @@
+---
+layout: documentation
+---
+
 # Eclipse GlassFish Documentation
 
-## <a name="current">Current Release - ${glassfish.version.latest}</a>
+## Current Release - ${glassfish.version.latest} {#current}
 
 * [Add On Component Development Guide](docs/latest/add-on-component-development-guide.html)
   ([pdf](docs/latest/add-on-component-development-guide.pdf))
@@ -35,12 +39,12 @@
 * [Upgrade Guide](docs/latest/upgrade-guide.html)
   ([pdf](docs/latest/upgrade-guide.pdf))
 
-### Documentation for other GlassFish versions
+### Documentation for other GlassFish versions {#older}
 
 * [Development version (${project.version})](docs#development)
 * [${glassfish.version.5x} release](docs#${glassfish.version.5x})
 
-## Jakarta EE Documentation
+## Jakarta EE Documentation {#jakarta-ee}
 
 Eclipse GlassFish ${glassfish.version.latest} provides the following Jakarta EE APIs:
 
@@ -52,11 +56,11 @@ Eclipse GlassFish ${glassfish.version.latest} Web Profile provides the following
 * [Jakarta EE Web Profile 10 APIs](https://jakarta.ee/specifications/webprofile/10/)
 * [Jakarta MVC 2.1](https://jakarta.ee/specifications/mvc/2.1/)
 
-### More Jakarta EE resources
+### More Jakarta EE resources {#more-jakarta-ee}
 
 * [Jakarta EE Documentation](https://jakarta.ee/resources/#documentation)
 
-## MicroProfile Documentation
+## MicroProfile Documentation {#microprofile}
 
 Eclipse GlassFish ${glassfish.version.latest} provides the following MicroProfile APIs:
 
@@ -67,7 +71,6 @@ Eclipse GlassFish ${glassfish.version.latest} provides the following MicroProfil
 Eclipse GlassFish ${glassfish.version.latest} Web Profile doesn't provide any MicroProfile APIs.
 
 
-## Eclipse Open MQ Documentation
+## Eclipse Open MQ Documentation {#open-mq}
 
 * See the [Open MQ Project](https://eclipse-ee4j.github.io/openmq/guides)
-


### PR DESCRIPTION
Preview here: https://ondromih-glassfish.github.io/documentation.html

Here's how the docs page looks like now:

![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/823deb74-8dda-4875-bc54-a377c016b1b1)
