### PR TITLE
Fixes `stop-local-instance` command

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -119,7 +119,7 @@ public final class ProcessUtils {
             return false;
         }
         Info info = handle.get().info();
-        if (info.commandLine().isEmpty()) {
+        if (info.commandLine().isEmpty() && !(OS.isWindowsForSure() && info.command().isPresent())) {
             LOG.log(TRACE, "Could not retrieve command line for the pid {0},"
                 + " therefore we assume that the process stopped.");
             return false;


### PR DESCRIPTION
This PR fixes #24588 issue.

A workaround for the [JDK-8176725](https://bugs.openjdk.org/browse/JDK-8176725) bug.
