### PR TITLE
Fix #24593 Error message is not displayed when Undeploy fails in Admin Console.

### DIFF
--- a/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
+++ b/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
@@ -1,7 +1,7 @@
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
+++ b/appserver/admingui/common/src/main/resources/applications/deployTableButtons.inc
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2023 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +36,7 @@
                 getUIComponent(clientId="$pageSession{tableRowGroupId}", component=>$attribute{tableRowGroup});
                 getSelectedSingleMapRows(TableRowGroup="$attribute{tableRowGroup}" selectedRows=>$attribute{selectedRows});
                 gf.undeploy(selectedRows="${selectedRows}" );
-                gf.redirect(page="#{listPageLink}");
+                gf.navigate(page="#{listPageLink}");
             />
          </sun:button>
         <sun:button id="button2" text="$resource{i18n.button.Enable}" rendered="#{pageSession.onlyDASExist}" disabled="#{true}" primary="#{false}"


### PR DESCRIPTION
* Fixes #24593

This method was replaced on https://github.com/eclipse-ee4j/glassfish/commit/d64fe7d005c8fff2311fbb7c1053d26f70c54531 .  
At that time, `gf.navigate` had a bug, but it is fixed now on https://github.com/eclipse-ee4j/glassfish-jsftemplating/pull/93 .