### PR TITLE
Integrate Nimbus 9.35

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -98,7 +98,7 @@
         <!-- Jakarta Security + Authentication/Authorization -->
         <soteria.version>3.0.3</soteria.version>
         <exousia.version>2.1.1</exousia.version>
-        <nimbus.version>9.31</nimbus.version>
+        <nimbus.version>9.35</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->


### PR DESCRIPTION
Changes: https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt

    * Adds JWEObjectJSON class to support general and flattened JSON
      serialisation.
    * Adds MultiEncrypter and MultiDecrypter classes for multi-recipient JWE.
    * Updates JWEHeader to support "enc" header parameter only construction for
      multi-recipient JWE.
    * Updates the BaseJWEProvider classes to support multi-recipient JWE.
    * Updates ContentCryptoProvider to support passing of an optional AAD. If
      no AAD is specified the JWE header becomes the AAD (default behaviour).
    * Updates the RSAEncrypter and RSADecrypter to support passing of an
      optional AAD. If no AAD is specified the JWE header becomes the AAD
      (default behaviour). Intended to support JWE JSON serialisation to
      multiple recipients.
    * Updates the ECDHEncrypter and ECDHDecrypter to support passing of an
      optional AAD. If no AAD is specified the JWE header becomes the AAD
      (default behaviour). Intended to support JWE JSON serialisation to
      multiple recipients.
    * Adds a getInitializedSignature method to the CompletableJWSObjectSigning
      interface. Enables the binding of a user verification to a specific
      instance of a java.security.Signature.
    * Updates the ECDSASigner for the ESxxx JWS algorithms to support the
      UserAuthenticationRequired option, originally introduced in the
      RSASSASigner for the RSxxx and PSxxx JWS algorithms.
    * Adds a new RSASSASigner(RSAKey, Set<JWSSignerOption>) constructor.
    * Updates JSONObjectUtils.parse(String,int) to ensure generic types are not
      erased by obfuscation tools (iss #518).
    * Updates GSon to 2.10.1.
    * Updates Google Tink to 1.10.0.
    * Updates the MACSigner to support JCE providers, such as PKCS#11 providers
      or Amazon's CloudHSM, that don't expose the underlying SecretKey
      material (iss #520).
    * Refactors the HMAC class to support PKCS#11 providers.
    * Adds new MACProvider.MACProvider(SecretKey,Set<JWSAlgorithm>)
      constructor.
    * The MACProvider.getSecret and getSecretString methods will return null
      when the provider was constructed with a SecretKey that doesn't expose
      its key material.
    * Updates the MACVerifier to support JCE providers, such as PKCS#11
      providers or Amazon's CloudHSM, that don't expose the underlying
      SecretKey material (iss #520).
    * Fixes the MACSigner.sign method for SecretKey instances that don't expose
      their key material (iss #520).
    * Deprecates HMAC.compute(String,byte[],byte[],Provider), use
      HMAC.compute(String,SecretKey,byte[],Provider) instead.
    * Makes the abstract class BaseJWEProvider public (iss #521).



