### PR TITLE
Fixed dependency on OS settings of java

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -182,6 +182,9 @@ public class Asadmin {
         if (System.getenv("AS_TRACE") == null && LOG.isLoggable(Level.FINEST)) {
             processManager.setEnvironment("AS_TRACE", "true");
         }
+        // override any env property to what is used by tests
+        processManager.setEnvironment("JAVA_HOME", System.getProperty("java.home"));
+        processManager.setEnvironment("AS_JAVA", System.getProperty("java.home"));
 
         int exitCode;
         String asadminErrorMessage = "";


### PR DESCRIPTION
It is related to #22678 where I have JDK17 for maven and JDK11 as system default, so windows used 17 for build, but 11 for asadmin. However the same issue can happen on Linux too.