### PR TITLE
Integrate Weld 5.1.2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -144,7 +144,7 @@
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.0.1</jakarta.cdi-api.version>
-        <weld.version>5.1.1.SP2</weld.version>
+        <weld.version>5.1.2.Final</weld.version>
         <jboss.classfilewriter.version>1.3.0.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.10</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.11</cdi.tck-4-0.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>


### PR DESCRIPTION
Also update CDI TCK accordingly

Changes: https://weld.cdi-spec.org/news/2023/10/05/weld-512Final/

(CDI TCK run locally passes)
