### PR TITLE
Fix #24641 Cannot filter deployed applications by Engines in Admin Console

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -2717,49 +2717,48 @@ admingui.woodstock = {
     },
 
     dropDownChanged: function(jumpDropdown) {
-    	    	
-        if (typeof(jumpDropdown) === "string") {
             
-            require(['webui/suntheme/dropDown'], function (dropDown) {
+        require(['webui/suntheme/dropDown'], function (dropDown) {
+            if (typeof(jumpDropdown) === "string") {
                 jumpDropdown = dropDown.getSelectElement(jumpDropdown);
-                
-                // Force WS "submitter" flag to true
-                var submitterFieldId = jumpDropdown.id + "_submitter";
-                var submitterField = document.getElementById(submitterFieldId);
+            }
+
+            // Force WS "submitter" flag to true
+            var submitterFieldId = jumpDropdown.id + "_submitter";
+            var submitterField = document.getElementById(submitterFieldId);
+            if (!submitterField) {
+                submitterFieldId = jumpDropdown.parentNode.id + "_submitter";
+                submitterField = document.getElementById(submitterFieldId);
                 if (!submitterField) {
-                    submitterFieldId = jumpDropdown.parentNode.id + "_submitter";
-                    submitterField = document.getElementById(submitterFieldId);
-                    if (!submitterField) {
-                        admingui.util.log("Unable to find dropDown submitter for: "
-                            + jumpDropdown.id);
-                        return false;
+                    admingui.util.log("Unable to find dropDown submitter for: "
+                        + jumpDropdown.id);
+                    return false;
+                }
+            }
+            submitterField.value = "true";
+
+            require(['webui/suntheme/props'], function (props) {
+                // FIXME: Not sure why the following is done...
+                var listItem = jumpDropdown.options;
+                for (var cntr=0; cntr < listItem.length; ++cntr) {
+                    if (listItem[cntr].className == props.jumpDropDown.optionSeparatorClassName
+                        || listItem[cntr].className == props.jumpDropDown.optionGroupClassName) {
+                        continue;
+                    } else if (listItem[cntr].disabled) {
+                        // Regardless if the option is currently selected or not,
+                        // the disabled option style should be used when the option
+                        // is disabled. So, check for the disabled item first.
+                        // See CR 6317842.
+                     	listItem[cntr].className = props.jumpDropDown.optionDisabledClassName;
+                    } else if (listItem[cntr].selected) {
+                       	listItem[cntr].className = props.jumpDropDown.optionSelectedClassName;
+                    } else {
+                        listItem[cntr].className = props.jumpDropDown.optionClassName;
                     }
                 }
-                submitterField.value = "true";
-
-                require(['webui/suntheme/props'], function (props) {
-                    // FIXME: Not sure why the following is done...
-                    var listItem = jumpDropdown.options;
-                    for (var cntr=0; cntr < listItem.length; ++cntr) {
-                        if (listItem[cntr].className == props.jumpDropDown.optionSeparatorClassName
-                            || listItem[cntr].className == props.jumpDropDown.optionGroupClassName) {
-                            continue;
-                        } else if (listItem[cntr].disabled) {
-                            // Regardless if the option is currently selected or not,
-                            // the disabled option style should be used when the option
-                            // is disabled. So, check for the disabled item first.
-                            // See CR 6317842.
-                        	listItem[cntr].className = props.jumpDropDown.optionDisabledClassName;
-                        } else if (listItem[cntr].selected) {
-                        	listItem[cntr].className = props.jumpDropDown.optionSelectedClassName;
-                        } else {
-                        	listItem[cntr].className = props.jumpDropDown.optionClassName;
-                        }
-                    }
-                    admingui.ajax.postAjaxRequest(jumpDropdown);
-                });
+                admingui.ajax.postAjaxRequest(jumpDropdown);
             });
-        }
+        });
 
         return false;
 


### PR DESCRIPTION
* Fixes #24641  

The following commits may be the cause of the bug.  
* https://github.com/eclipse-ee4j/glassfish/commit/376083a8ee107b8ebfc08595793086f8c5e13fc6
* https://github.com/eclipse-ee4j/glassfish/commit/b00844fd80822ee90781653e3e9120bd155bcc5c

The filtering process has been changed position by these commits.  
before  
```
if (typeof(jumpDropdown) === "string") {
   jumpDropdown = dropDown.getSelectElement(jumpDropdown);
}
----- filtering process -----
```
after  
```
if (typeof(jumpDropdown) === "string") {
   jumpDropdown = dropDown.getSelectElement(jumpDropdown);
   ----- filtering process -----
}
```
This change causes the filter to work only in the case of string, so revert the position of the filtering process.