### PR TITLE
Draft: Adds lookup in system properties for WAR contextRoot in EAR

### DIFF
--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/ModuleDescriptor.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/ModuleDescriptor.java
@@ -24,6 +24,8 @@ import java.util.jar.Manifest;
 
 import org.glassfish.api.deployment.archive.ArchiveType;
 import org.glassfish.deployment.versioning.VersioningUtils;
+import org.jvnet.hk2.config.TranslationException;
+import org.jvnet.hk2.config.VariableResolver;
 
 /**
  * This class describes a module information for an applicaiton module
@@ -145,7 +147,13 @@ public class ModuleDescriptor<T extends RootDeploymentDescriptor> extends Descri
      * @param contextRoot the contextRoot
      */
     public void setContextRoot(String contextRoot) {
-        this.contextRoot = contextRoot;
+        VariableResolver resolver = new VariableResolver() {
+            @Override
+            protected String getVariableValue(String varName) throws TranslationException {
+                return System.getProperty(varName, "");
+            }
+        };
+        this.contextRoot = resolver.translate(contextRoot);
     }
 
     /**


### PR DESCRIPTION
Hi GlassFish team !

I'm looking up to implement a simple system property lookup in GlassFish so we can externalize `contextRoot` and `urlPattern` (and more, such as JNDI names, EJB persistance unit names, ...).

This is mainly a prototype to see how this can be implemented since I don't know how it would be the most correct place to put this translation, neither if this is the correct way to do it (for instance, in Payara it only looks for the properties declared in the `domain.xml`). The goal of this PR is to get some input to see in which way this can go.

Based on my [example](https://github.com/ctabin/gf-test-lucene), the goal is to have a definition like below, so we can build an EAR where the URLs can be configured outside the application itself (so we could eventually have the EAR/WAR/JAR file signed):
```xml
<modules>
  <webModule>
    <groupId>ch.astorm.gf-embedded</groupId>
    <artifactId>war</artifactId>
    <contextRoot>/${ch.astorm.root}</contextRoot>
    <bundleFileName>sample-war.war</bundleFileName>
  </webModule>
  <ejbModule>
    <groupId>ch.astorm.gf-embedded</groupId>
    <artifactId>ejb</artifactId>
    <bundleFileName>sample-ejb.jar</bundleFileName>
  </ejbModule>
</modules>
```

Here are some places that I'd like to see this implemented:
- context root WAR in the EAR
- URL patterns in `@WebServlet`
- `jta-data-source` in `persistence.xml`

Any feedback is welcome :-)