### PR TITLE
Updated glassfish.version.7x to 7.0.10

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <glassfish.version.5x>5.1.0</glassfish.version.5x>
         <glassfish.version.6x>6.2.5</glassfish.version.6x>
-        <glassfish.version.7x>7.0.7</glassfish.version.7x>
+        <glassfish.version.7x>7.0.10</glassfish.version.7x>
         <glassfish.version.latest>${glassfish.version.7x}</glassfish.version.latest>
         <glassfish.version.7x.artifact>${glassfish.version.7x}</glassfish.version.7x.artifact>
     </properties>


### PR DESCRIPTION
This should fix https://ci.eclipse.org/glassfish/job/glassfish-docs-publish/ issues - 7.0.7 is not in staging any more.
