### PR TITLE
Documentation artifact was not deployed for 7.0.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ spec:
           dumpSysInfo()
           timeout(time: 1, unit: 'HOURS') {
             sh '''
-                mvn -B -e clean install -Pstaging -P'!docs'
+                mvn -B -e clean install -Pstaging,qa
             '''
           }
         }
@@ -243,7 +243,7 @@ spec:
           dumpSysInfo()
           timeout(time: 1, unit: 'HOURS') {
             sh '''
-                mvn -B -e clean install -Pstaging -Pdocs
+                mvn -B -e clean install -Pstaging -f docs -amd
             '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,7 @@ spec:
       }
       tools {
         jdk 'temurin-jdk17-latest'
-        maven 'apache-maven-3.9.3'
+        maven 'apache-maven-3.9.5'
       }
       steps {
         script {

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ The Zip distributions can be found on following paths:
 
 ### Execution
 
-* `mvn clean install` - Full build including automatic QA and maven managed tests. Typical time: 5 minutes.
-* `mvn clean install -Pfast` - Building all distribution artifacts, running just unit tests, QA and integration tests excluded. Typical time: 3 minutes.
-* `mvn clean install -Pfastest` - Building all distribution artifacts, excluded all QA and testing. Typical time: 1.5 minutes.
+* `mvn clean install` - Full build including documentation, automatic QA and maven managed tests. Excludes just Ant and TCK tests. Typical time: 15 minutes.
+* `mvn clean install -Pqa` - Building all distribution artifacts, running QA and all maven managed tests. Excludes Ant, TCK and documentation. Typical time: 10 minutes.
+* `mvn clean install -Pfast` - Building all distribution artifacts, running just unit tests. Excludes QA, integration tests, Ant, TCK and documentation. Typical time: 7 minutes.
+* `mvn clean install -Pfastest -T4C` - Building all distribution artifacts as fast as possible. Excludes everything not serving this purpose. Typical time: 1.5 minutes.
 
-You can use also some maven optimizations, ie. using `-T4C` to allow parallel build.
+You can use also some maven optimizations, see [Maven documentation](https://maven.apache.org/ref/3.9.5/maven-embedder/cli.html).
+Especially `-am`, `-amd`, `-f`, `-pl`, `-rf` and their combinations are useful.
 
 If you want to see more logs you can use the `-Dtest.logLevel=FINEST` option set to an appropriate log level.
 Note that this applies just for tests which are executed by Maven and which use the **GlassFish Java Util Logging Extension (GJULE)**.

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -136,6 +136,13 @@
             </modules>
         </profile>
         <profile>
+            <id>fast</id>
+            <modules>
+                <!-- Builds compile dependencies for Ant tests executed by runtest.sh/gftest.sh -->
+                <module>appserv-tests</module>
+            </modules>
+        </profile>
+        <profile>
             <id>tck</id>
             <modules>
                 <module>admin</module>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.8</version>
+        <version>1.0.9</version>
         <relativePath />
     </parent>
     <version>7.0.11-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,30 +97,14 @@
 
     <profiles>
         <profile>
-            <id>release-phase2</id>
+            <id>default</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
             </activation>
             <modules>
                 <module>qa</module>
                 <module>nucleus</module>
                 <module>appserver</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>docs</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <modules>
                 <module>docs</module>
             </modules>
         </profile>
@@ -136,23 +120,6 @@
         </profile>
 
         <profile>
-            <!--
-                RE profile for release purposes.
-            -->
-            <id>ips</id>
-            <activation>
-                <property>
-                    <name>release-phase-all</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <modules>
-                <module>qa</module>
-                <module>nucleus</module>
-                <module>appserver</module>
-            </modules>
-        </profile>
-        <profile>
             <id>set-version-id</id>
             <modules>
                 <module>qa</module>
@@ -161,6 +128,7 @@
                 <module>appserver/extras/embedded/common</module>
                 <module>appserver/tests/appserv-tests/util/reportbuilder</module>
                 <module>appserver/tests/tck</module>
+                <module>docs</module>
             </modules>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,10 @@
     </build>
 
     <profiles>
+        <!--
+        This profile is implicit when you run maven clean install and is automatically disabled
+        when you choose another from this set.
+        -->
         <profile>
             <id>default</id>
             <activation>
@@ -109,7 +113,10 @@
             </modules>
         </profile>
 
-        <!-- Ommits a variety of things in order to get the fastest build of a basic full glassfish server -->
+        <!--
+        Build glassfixh.zip as soon as possible.
+        Profile of the same id is also in parent, together they exclude unimportant modules and plugin executions.
+         -->
         <profile>
             <id>fastest</id>
             <modules>
@@ -119,6 +126,21 @@
             </modules>
         </profile>
 
+        <!--
+        Build all distributed binaries except documentation and run all maven tests.
+        -->
+        <profile>
+            <id>qa</id>
+            <modules>
+                <module>qa</module>
+                <module>nucleus</module>
+                <module>appserver</module>
+            </modules>
+        </profile>
+
+        <!--
+        Change version number in all artifacts in the repository.
+        -->
         <profile>
             <id>set-version-id</id>
             <modules>
@@ -132,6 +154,11 @@
             </modules>
         </profile>
 
+        <!--
+        Merges all exec files in the directory tree - useful when you want to se the code coverage
+        produced by integration tests executed by different modules, or exactly opposite - to see
+        not covered by tests at all.
+        -->
         <profile>
             <id>jacoco-merge</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,19 @@
         </profile>
 
         <!--
+        Build glassfixh.zip as soon as possible and runs also unit tests.
+        Profile of the same id is also in parent, together they exclude unimportant modules and plugin executions.
+         -->
+        <profile>
+            <id>fast</id>
+            <modules>
+                <module>qa</module>
+                <module>nucleus</module>
+                <module>appserver</module>
+            </modules>
+        </profile>
+
+        <!--
         Build all distributed binaries except documentation and run all maven tests.
         -->
         <profile>


### PR DESCRIPTION
The amount of profiles and properties was bit confusing and in 25635fbed34f1e42da4541a5d02c42380eeed666 I added another one which caused this situation.
So this is an attempt to simplify that.

After the merge we have to revisit some of builds, escpecially the release.
https://ci.eclipse.org/glassfish/