### PR TITLE
Build of documentation revisited

### DIFF
--- a/docs/add-on-component-development-guide/pom.xml
+++ b/docs/add-on-component-development-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/administration-guide/pom.xml
+++ b/docs/administration-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/application-deployment-guide/pom.xml
+++ b/docs/application-deployment-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/application-development-guide/pom.xml
+++ b/docs/application-development-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/deployment-planning-guide/pom.xml
+++ b/docs/deployment-planning-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/distribution/pom.xml
+++ b/docs/distribution/pom.xml
@@ -20,30 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>org.glassfish.main.docs</groupId>
         <artifactId>docs</artifactId>
         <version>7.0.11-SNAPSHOT</version>
     </parent>
-    <artifactId>distribution</artifactId>
+    <artifactId>glassfish-documentation</artifactId>
     <packaging>jar</packaging>
     <name>Eclipse GlassFish Documentation Distribution</name>
-    <description>
-        Combine the Eclipse GlassFish documentation into one bundle
-        for distribution.
-    </description>
-
-    <properties>
-        <maven.site.skip>true</maven.site.skip>
-    </properties>
-
-    <profiles>
-        <profile>
-            <id>release-phase2</id>
-            <properties>
-                <maven.deploy.skip>false</maven.deploy.skip>
-            </properties>
-        </profile>
-    </profiles>
+    <description>Combine the Eclipse GlassFish documentation into one bundle for distribution.</description>
 
     <build>
         <plugins>
@@ -57,7 +41,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeGroupIds>org.glassfish.docs</includeGroupIds>
+                            <includeGroupIds>org.glassfish.main.docs</includeGroupIds>
                             <includeTypes>jar</includeTypes>
                             <excludes>META-INF/**</excludes>
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
@@ -70,7 +54,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeGroupIds>org.glassfish.docs</includeGroupIds>
+                            <includeGroupIds>org.glassfish.main.docs</includeGroupIds>
                             <includeTypes>pdf</includeTypes>
                             <outputDirectory>${project.build.directory}/classes</outputDirectory>
                             <stripVersion>true</stripVersion>
@@ -82,214 +66,210 @@
     </build>
 
     <dependencies>
-        <!--
-            The following items are the current
-            (under development) versions of the
-            documentation.
-        -->
+        <!-- optional: no need to download dependencies of the distribution when referring this artifact -->
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>add-on-component-development-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>add-on-component-development-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>administration-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>administration-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>application-deployment-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>application-deployment-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>application-development-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>application-development-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>deployment-planning-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>deployment-planning-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>embedded-server-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>embedded-server-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>error-messages-reference</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>error-messages-reference</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>ha-administration-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>ha-administration-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>installation-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>installation-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>performance-tuning-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>performance-tuning-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>quick-start-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>quick-start-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>reference-manual</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>reference-manual</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>release-notes</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>release-notes</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>security-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>security-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>troubleshooting-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>troubleshooting-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>upgrade-guide</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.docs</groupId>
+            <groupId>org.glassfish.main.docs</groupId>
             <artifactId>upgrade-guide</artifactId>
             <version>${project.version}</version>
             <type>pdf</type>

--- a/docs/embedded-server-guide/pom.xml
+++ b/docs/embedded-server-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/error-messages-reference/pom.xml
+++ b/docs/error-messages-reference/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/ha-administration-guide/pom.xml
+++ b/docs/ha-administration-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/installation-guide/pom.xml
+++ b/docs/installation-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -20,18 +20,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>org.glassfish.main.docs</groupId>
         <artifactId>docs</artifactId>
         <version>7.0.11-SNAPSHOT</version>
     </parent>
-    <groupId>org.glassfish.docs</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>documentation-generators-parent</artifactId>
     <packaging>pom</packaging>
     <name>Eclipse GlassFish Documentation parent pom</name>
 
     <properties>
         <maven.site.skip>true</maven.site.skip>
-        <maven.deploy.skip>true</maven.deploy.skip>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
@@ -46,10 +44,24 @@
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>default-deploy</id>
+                            <phase>disabled</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.glassfish.doc</groupId>
                 <artifactId>glassfish-doc-maven-plugin</artifactId>
+                <version>1.3</version>
                 <configuration>
                     <sourceDirectory>src/main/asciidoc</sourceDirectory>
                 </configuration>

--- a/docs/performance-tuning-guide/pom.xml
+++ b/docs/performance-tuning-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -21,13 +21,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.9</version>
-        <relativePath />
+        <groupId>org.glassfish.main</groupId>
+        <artifactId>glassfish-parent</artifactId>
+        <version>7.0.11-SNAPSHOT</version>
+        <relativePath>../appserver/parent</relativePath>
     </parent>
-    <version>7.0.11-SNAPSHOT</version>
-    <groupId>org.glassfish.docs</groupId>
+    <groupId>org.glassfish.main.docs</groupId>
     <artifactId>docs</artifactId>
     <packaging>pom</packaging>
     <name>Eclipse GlassFish Documentation</name>
@@ -36,6 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <glassfish.version.5x>5.1.0</glassfish.version.5x>
         <glassfish.version.6x>6.2.5</glassfish.version.6x>
+        <!-- TODO: 1/2 Update after 7.0.11 -->
         <glassfish.version.7x>7.0.10</glassfish.version.7x>
         <glassfish.version.latest>${glassfish.version.7x}</glassfish.version.latest>
         <glassfish.version.7x.artifact>${glassfish.version.7x}</glassfish.version.7x.artifact>
@@ -62,70 +62,4 @@
         <module>upgrade-guide</module>
         <module>distribution</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>publish-site</id>
-            <modules>
-                <module>publish</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>release-phase2</id>
-            <properties>
-                <maven.deploy.skip>true</maven.deploy.skip>
-            </properties>
-        </profile>
-    </profiles>
-
-    <build>
-        <defaultGoal>install</defaultGoal>
-        <plugins>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[11,)</version>
-                                    <message>You need JDK11+</message>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.2.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.glassfish.doc</groupId>
-                    <artifactId>glassfish-doc-maven-plugin</artifactId>
-                    <version>1.3</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.4.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -20,11 +20,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>org.glassfish.main.docs</groupId>
         <artifactId>docs</artifactId>
         <version>7.0.11-SNAPSHOT</version>
     </parent>
-    <artifactId>publish</artifactId>
+    <artifactId>website-publisher</artifactId>
     <packaging>jar</packaging>
     <name>Publish the Eclipse GlassFish Website</name>
 
@@ -38,238 +38,198 @@
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <!-- the directory where the current snapshot is published -->
-        <dir.snap>${site.output.dir}/docs/SNAPSHOT</dir.snap>
+        <docs.snapshot.dir>${site.output.dir}/docs/SNAPSHOT</docs.snapshot.dir>
         <!-- add a new property for each new release -->
         <docs.5x.dir>${site.output.dir}/docs/${glassfish.version.5x}</docs.5x.dir>
         <docs.6x.dir>${site.output.dir}/docs/${glassfish.version.6x}</docs.6x.dir>
         <docs.7x.dir>${site.output.dir}/docs/${glassfish.version.7x}</docs.7x.dir>
-        <!-- the "latest" version; update when a new release is done -->
     </properties>
 
-    <!--
-        This profile is used to publish the entire web site.
-
-        Usage: mvn -Ppublish-site deploy
-    -->
-    <profiles>
-        <profile>
-            <id>publish-site</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <!--
-                                Get the content for the top level web site.
-                            -->
-                            <execution>
-                                <id>get-website</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <excludes>
-                                        META-INF/**
-                                    </excludes>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.docs</groupId>
-                                            <artifactId>website</artifactId>
-                                            <version>${project.version}</version>
-                                            <outputDirectory>
-                                                ${site.output.dir}
-                                            </outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                            <!--
-                                Get the collection of documentation for the
-                                current (under development) release.
-                            -->
-                            <execution>
-                                <id>get-current</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <includeGroupIds>
-                                        org.glassfish.docs
-                                    </includeGroupIds>
-                                    <excludes>META-INF/**</excludes>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.docs</groupId>
-                                            <artifactId>distribution</artifactId>
-                                            <version>${project.version}</version>
-                                            <outputDirectory>
-                                                ${dir.snap}
-                                            </outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                            <!--
-                                Get the collection of documentation for the
-                                6.x release.
-                            -->
-                            <execution>
-                                <id>get-7x</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <includeGroupIds>
-                                        org.glassfish.docs
-                                    </includeGroupIds>
-                                    <excludes>META-INF/**</excludes>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.docs</groupId>
-                                            <artifactId>distribution</artifactId>
-                                            <version>${glassfish.version.7x.artifact}</version>
-                                            <outputDirectory>
-                                                ${docs.7x.dir}
-                                            </outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                            <!--
-                                Get the collection of documentation for the
-                                6.x release.
-                            -->
-                            <execution>
-                                <id>get-6x</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <includeGroupIds>
-                                        org.glassfish.docs
-                                    </includeGroupIds>
-                                    <excludes>META-INF/**</excludes>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.docs</groupId>
-                                            <artifactId>distribution</artifactId>
-                                            <version>${glassfish.version.6x}</version>
-                                            <outputDirectory>
-                                                ${docs.6x.dir}
-                                            </outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                            <!--
-                                Get the collection of documentation for the
-                                5.1.0 release.
-                            -->
-                            <execution>
-                                <id>get-5x</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <includeGroupIds>
-                                        org.glassfish.docs
-                                    </includeGroupIds>
-                                    <excludes>META-INF/**</excludes>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.glassfish.docs</groupId>
-                                            <artifactId>distribution</artifactId>
-                                            <version>${glassfish.version.5x}</version>
-                                            <outputDirectory>
-                                                ${docs.5x.dir}
-                                            </outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                            <!--
-                                Add additional execution blocks here as
-                                new releases are made, using the above
-                                as a template.  Don't forget to update
-                                the glassfish.version.latest property.
-                            -->
-                        </executions>
-                    </plugin>
-
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- Get the content for the top level web site. -->
+                    <execution>
+                        <id>get-website</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>META-INF/**</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.docs</groupId>
+                                    <artifactId>website</artifactId>
+                                    <version>${project.version}</version>
+                                    <outputDirectory>${site.output.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                     <!--
-                        Create a symlink from "latest" to the most recently
-                        released version of the docs.
+                        Get the collection of documentation for
+                        the current (under development) release.
                     -->
-                    <plugin>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>create-latest-link</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <delete
-                                          dir="${site.output.dir}/docs/latest"
-                                          followSymlinks="false"
-                                          removeNotFollowedSymlinks="true"
-                                          />
-                                        <symlink
-                                          link="${site.output.dir}/docs/latest"
-                                          resource="${glassfish.version.latest}"/>
-                                    </target>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>redirect-for-installation-guide</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                                <configuration>
-                                    <target>
-                                        <copy todir="${site.output.dir}">
-                                            <fileset dir="${project.build.outputDirectory}">
-                                            </fileset>
-                                        </copy>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
+                    <execution>
+                        <id>get-current</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>META-INF/**</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.docs</groupId>
+                                    <artifactId>glassfish-documentation</artifactId>
+                                    <version>${project.version}</version>
+                                    <outputDirectory>${docs.snapshot.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                     <!--
-                        Publish the entire web site to the gh-pages branch.
+                        Get the collection of documentation for the 7.x release.
                     -->
-                    <plugin>
-                        <artifactId>maven-scm-publish-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>deploy-site</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>publish-scm</goal>
-                                </goals>
-                                <configuration>
-                                    <scmBranch>gh-pages</scmBranch>
-                                    <skipDeletedFiles>false</skipDeletedFiles>
-                                    <checkinComment>Update docs</checkinComment>
-                                    <ignorePathsToDelete>
-                                        <ignorePathsToDelete>latest</ignorePathsToDelete>
-                                    </ignorePathsToDelete>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+                    <execution>
+                        <id>get-7x</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>META-INF/**</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <!-- TODO: 2/2 Update groupId+artifactId after 7.0.11 -->
+                                    <groupId>org.glassfish.docs</groupId>
+                                    <artifactId>distribution</artifactId>
+                                    <version>${glassfish.version.7x.artifact}</version>
+                                    <outputDirectory>${docs.7x.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Get the collection of documentation for the 6.x release.
+                    -->
+                    <execution>
+                        <id>get-6x</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>META-INF/**</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.docs</groupId>
+                                    <artifactId>distribution</artifactId>
+                                    <version>${glassfish.version.6x}</version>
+                                    <outputDirectory>${docs.6x.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Get the collection of documentation for the 5.1.0 release.
+                    -->
+                    <execution>
+                        <id>get-5x</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>META-INF/**</excludes>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.docs</groupId>
+                                    <artifactId>distribution</artifactId>
+                                    <version>${glassfish.version.5x}</version>
+                                    <outputDirectory>${docs.5x.dir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!--
+                        Add additional execution blocks here as
+                        new releases are made, using the above
+                        as a template.  Don't forget to update
+                        the glassfish.version.latest property.
+                    -->
+                </executions>
+            </plugin>
+
+            <!--
+                Create a symlink from "latest" to the most recently
+                released version of the docs.
+            -->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-latest-link</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <delete
+                                  dir="${site.output.dir}/docs/latest"
+                                  followSymlinks="false"
+                                  removeNotFollowedSymlinks="true"
+                                  />
+                                <symlink
+                                  link="${site.output.dir}/docs/latest"
+                                  resource="${glassfish.version.latest}"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>redirect-for-installation-guide</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy todir="${site.output.dir}">
+                                    <fileset dir="${project.build.outputDirectory}">
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Publish the entire web site to the gh-pages branch. -->
+            <plugin>
+                <artifactId>maven-scm-publish-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>deploy-site</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>publish-scm</goal>
+                        </goals>
+                        <configuration>
+                            <scmBranch>gh-pages</scmBranch>
+                            <skipDeletedFiles>false</skipDeletedFiles>
+                            <checkinComment>Update docs</checkinComment>
+                            <ignorePathsToDelete>
+                                <ignorePathsToDelete>latest</ignorePathsToDelete>
+                            </ignorePathsToDelete>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/docs/quick-start-guide/pom.xml
+++ b/docs/quick-start-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/reference-manual/pom.xml
+++ b/docs/reference-manual/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/release-notes/pom.xml
+++ b/docs/release-notes/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/security-guide/pom.xml
+++ b/docs/security-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/troubleshooting-guide/pom.xml
+++ b/docs/troubleshooting-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/upgrade-guide/pom.xml
+++ b/docs/upgrade-guide/pom.xml
@@ -20,8 +20,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
-        <artifactId>parent</artifactId>
+        <groupId>org.glassfish.main.docs</groupId>
+        <artifactId>documentation-generators-parent</artifactId>
         <version>7.0.11-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>

--- a/docs/website/pom.xml
+++ b/docs/website/pom.xml
@@ -20,25 +20,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.docs</groupId>
+        <groupId>org.glassfish.main.docs</groupId>
         <artifactId>docs</artifactId>
         <version>7.0.11-SNAPSHOT</version>
     </parent>
     <artifactId>website</artifactId>
     <packaging>jar</packaging>
-    <name>Eclipse GlassFish website content</name>
+    <name>Eclipse GlassFish Website Content</name>
 
-    <properties>
-        <maven.site.skip>true</maven.site.skip>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <!--
-        This project doesn't inherit from ../parent because it doesn't
-        need asciidoc, and so the jar plugin needs to be configured here...
-    -->
     <build>
-        <defaultGoal>package</defaultGoal>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -46,12 +42,15 @@
                     <finalName>${project.artifactId}</finalName>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-deploy</id>
+                        <phase>disabled</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
     </build>
 </project>


### PR DESCRIPTION
- removed dependency on profiles
- docs is deployed (parent of distribution)
- docs bound to glassfish instead of eclipse
- parent renamed to documentation-generators-parent; it's children are NOT deployed
- distribution renamed to glassfish-documentation
- glassfish-documentation and docs are both deployed (fixed bug)
- website is not hidden under profile, but is executed explicitly (same on CI)
- website depends on glassfish-documentation
- now it makes sense ;)

### Next Steps
- update release jobs + website docs and verify that everything is correct from now on 
  -  released docs versions should be deployed to [Staging](https://jakarta.oss.sonatype.org/content/repositories/staging/org/glassfish/main/docs/docs/) and to [Maven Central](https://mvnrepository.com/artifact/org.glassfish.main.docs/docs):  - why? Because they are referred from documentation artifacts. To my surprise Maven Central did not verify that, I thought it doesn't permit such deployments.
  - deployed must be also the glassfish-documentation artifact 
  - no other documentation artifact will be deployed
  - publish module will use these artifacts to publish the website
- 2x TODO in poms - next version has to change dependency on the predecessor, this PR does the transition.
