### PR TITLE
The set-version-id profile updated to respect the current reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,10 +160,8 @@
                 <module>qa</module>
                 <module>nucleus</module>
                 <module>appserver</module>
-                <module>appserver/extras/embedded/common</module>
-                <module>appserver/tests/appserv-tests/util/reportbuilder</module>
-                <module>appserver/tests/tck</module>
                 <module>docs</module>
+                <module>docs/publish</module>
             </modules>
         </profile>
 

--- a/updateVersion.sh
+++ b/updateVersion.sh
@@ -13,7 +13,7 @@ oldVersion="$(mvn help:evaluate -Dexpression=project.version -N -q -DforceStdout
 implicitVersionParams="-DgenerateBackupPoms=false -DprocessAllModules=true -DoldVersion=${oldVersion}"
 
 # change version of the aggregator and keep consistency
-mvn versions:set ${implicitVersionParams} -DnewVersion=${version} -Pembedded,set-version-id;
+mvn versions:set ${implicitVersionParams} -DnewVersion=${version} -Pset-version-id;
 
 # these folders are broken now, but we keep updating version ids at least
 find "./appserver/tests" -type f -name "pom.xml" -print0 | while IFS= read -r -d '' file; do
@@ -24,3 +24,4 @@ find "./appserver/tests" -type f -name "pom.xml" -print0 | while IFS= read -r -d
     mv "${file}.temporary" "${file}";
     chmod $fileMode "${file}";
 done
+


### PR DESCRIPTION
- The update of the version id is more simple than year ago when I created the script
- The script should be used for the release process, but can be used also locally

### Changes
- embedded is already a part of the main reactor
- reportbuilder is processed by `sed` too; in #24626 it will become a part of the main reactor
- docs/publish is completely outside and in the future it should be probably in an own repository used for the GlassFish website management. Now it is used to publish changes to the gh-pages branch and just inherits the GF version. The version could even be 0.0.0 and we should just disable deploy and install plugins.

### Direction
- Crawl to the state where GlassFish would have completely standard build without Ant usages and without hacks ;-)