### PR TITLE
Fix an error message with unnecessary pattern string

### DIFF
--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/annotation/impl/ModuleScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -92,7 +92,7 @@ public abstract class ModuleScanner<T extends Descriptor> extends JavaEEScanner<
         level = "SEVERE")
     private static final String NO_CLASSLOADER = "AS-DEPLOYMENT-00010";
 
-    @LogMessageInfo(message = "Error in annotation processing: {0}.", level = "WARNING")
+    @LogMessageInfo(message = "Error in annotation processing:", level = "WARNING")
     private static final String ANNOTATION_ERROR = "AS-DEPLOYMENT-00011";
 
     @LogMessageInfo(message = "Cannot load {0}  reason : {1}.", level = "WARNING")


### PR DESCRIPTION
* Follow‐up: https://github.com/javaee/glassfish/commit/aa033e8b79b17a5913959f590435d2b5831db0ba  

The error message has the unnecessary pattern string.  
```
[2023-11-07T13:30:45.942074+09:00] [GF 7.0.10-SNAPSHOT] [WARNING] [AS-DEPLOYMENT-00011] [jakarta.enterprise.system.tools.deployment.dol] [tid: _ThreadID=41 _ThreadName=admin-listener(2)] [
levelValue: 900] [[
  Error in annotation processing: {0}.
java.lang.NoClassDefFoundError: javaeetutorial/cart/ejb/Cart
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
org.glassfish.common.util.GlassfishUrlClassLoader.loadClass(GlassfishUrlClassLoader.java:115)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 81 more
]]
```