### PR TITLE
Fix #24686 "Properties specific to this Class" is not displayed in Edit Realm Page

### DIFF
--- a/appserver/admingui/common/src/main/resources/security/realms/realmjs.inc
+++ b/appserver/admingui/common/src/main/resources/security/realms/realmjs.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -23,9 +24,9 @@
     var selectedOption = getSelectedValueFromForm(document.forms['form1'], 'classnameOption');
     enableClassnameFields(option, createFlag);
     if (option == 'input'){ 
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{rbPropId}:optB', true);  
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{rbPropId}:optB', true); });
     }else{  
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{rbPropId}:optA', true);  
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{rbPropId}:optA', true); });
     }  
   }
 
@@ -35,14 +36,14 @@
         if (createFlag){
             getTextElement('#{classnameTextId}').focus();
         }
-	#{themeJavascript.JS_PREFIX}.dropDown.setDisabled('#{classnameDropdownId}', true); 
+	require(['webui/suntheme/dropDown'], function (dropDown) { dropDown.setDisabled('#{classnameDropdownId}', true); });
         showDisplay('none'); 
         document.getElementById('form1:option').value='input'; 
     }else{
         //We need to set a timeout to delay the call to getTextElement inside disable component.
         //otherwise getTextElement will always return null, causing JS error.
 	window.setTimeout("disableComponent('#{classnameTextId}', 'text')", 1); 
-	#{themeJavascript.JS_PREFIX}.dropDown.setDisabled('#{classnameDropdownId}', false); 
+	require(['webui/suntheme/dropDown'], function (dropDown) { dropDown.setDisabled('#{classnameDropdownId}', false); });
         showDisplay(''); 
         document.getElementById('form1:option').value='predefine'; 
     }

--- a/appserver/admingui/full/src/main/resources/jndijs.inc
+++ b/appserver/admingui/full/src/main/resources/jndijs.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -23,9 +24,9 @@
     var selectedOption = getSelectedValueFromForm(document.forms['form1'], 'classnameOption');
     enableClassnameFields(option);   
     if (option == 'input'){ 
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{rbPropId}:optB', true);  
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{rbPropId}:optB', true); });
     }else{  
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{rbPropId}:optA', true);  
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{rbPropId}:optA', true); });
     }  
   }
 
@@ -33,14 +34,14 @@
     if(opt == 'input') {
 	enableComponent('#{classnameTextId}', 'text');  
 	getTextElement('#{classnameTextId}').focus(); 
-	#{themeJavascript.JS_PREFIX}.dropDown.setDisabled('#{classnameDropdownId}', true); 
+	require(['webui/suntheme/dropDown'], function (dropDown) { dropDown.setDisabled('#{classnameDropdownId}', true); });
         //showDisplay('none');
         document.getElementById('form1:option').value='input'; 
     }else{
         //We need to set a timeout to delay the call to getTextElement inside disable component.
         //otherwise getTextElement will always return null, causing JS error.
 	window.setTimeout("disableComponent('#{classnameTextId}', 'text')", 1); 
-	#{themeJavascript.JS_PREFIX}.dropDown.setDisabled('#{classnameDropdownId}', false); 
+	require(['webui/suntheme/dropDown'], function (dropDown) { dropDown.setDisabled('#{classnameDropdownId}', false); });
         //showDisplay('');
         document.getElementById('form1:option').value='predefine';
     }

--- a/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAdvance.jsf
+++ b/appserver/admingui/jca/src/main/resources/connectorConnectionPoolAdvance.jsf
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -96,7 +97,7 @@
         var c = getTextElement(la);
         var selected = c.checked;
         if(selected) {
-            #{themeJavascript.JS_PREFIX}.checkbox.setChecked('#{enlistId}', true);
+            require(['webui/suntheme/checkbox'], function (checkbox) { checkbox.setChecked('#{enlistId}', true); });
             disableComponent('#{enlistId}', 'text');
         }
         if(!selected) {

--- a/appserver/admingui/jca/src/main/resources/connectorSecurityMapjs.inc
+++ b/appserver/admingui/jca/src/main/resources/connectorSecurityMapjs.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,13 +25,13 @@
         getTextElement('#{userGroupsId}').value='';  \
         disableComponent('#{userGroupsId}', 'text'); \
 	getTextElement('#{principalsId}').focus();  \
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{pPropId}:optB', true); \
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{pPropId}:optB', true); }); \
     }else{ \
         getTextElement('#{principalsId}').value='';  \
 	disableComponent('#{principalsId}', 'text'); \
         enableComponent('#{userGroupsId}', 'text');  \
         getTextElement('#{userGroupsId}').focus();  \
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{grpPropId}:optA', true);  \
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{grpPropId}:optA', true); }); \
     }\
  }
 "</SCRIPT>          

--- a/appserver/admingui/jca/src/main/resources/securityMapjs.inc
+++ b/appserver/admingui/jca/src/main/resources/securityMapjs.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -25,13 +26,13 @@ function enableSecurityMapFields(opt){
         getTextElement('#{userGroupsId}').value='';
         disableComponent('#{userGroupsId}', 'text');
 	getTextElement('#{principalsId}').focus();
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{pPropId}:optB', true);
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{pPropId}:optB', true); });
     }else{
         getTextElement('#{principalsId}').value='';
 	disableComponent('#{principalsId}', 'text');
         enableComponent('#{userGroupsId}', 'text');
         getTextElement('#{userGroupsId}').focus();
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{grpPropId}:optA', true);
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{grpPropId}:optA', true); });
     }
  }
 
@@ -63,14 +64,14 @@ function enableWorkSecurityMapFields(opt){
         getTextElement('#{eisuserGroupsId}').value=val;
         enableComponent('#{eisprincipalsId}', 'text');
         getTextElement('#{eisprincipalsId}').focus();
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{pPropId}:optB', true);
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{pPropId}:optB', true); });
     }else{
         var val = getTextElement('#{eisprincipalsId}').value;
 	disableComponent('#{eisprincipalsId}', 'text');
         getTextElement('#{eisprincipalsId}').value=val;
         enableComponent('#{eisuserGroupsId}', 'text');
         getTextElement('#{eisuserGroupsId}').focus();
-        #{themeJavascript.JS_PREFIX}.radiobutton.setChecked('#{grpPropId}:optA', true);
+        require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked('#{grpPropId}:optA', true); });
     }
  }
 

--- a/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvanceJS.inc
+++ b/appserver/admingui/jdbc/src/main/resources/jdbcConnectionPoolAdvanceJS.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -164,21 +165,21 @@
                 disableComponent(textId, 'text');
                 document.getElementById(textId).value=textVal;
                 enableComponent(dropdownId, 'select');
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optB', false);
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optA', true);
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optB', false); });
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optA', true); });
                 document.getElementById(optionId).value='dropdown';
             }else{
                 enableComponent(textId, 'text');
                 disableComponent(dropdownId, 'select');
                 getTextElement(textId).focus();
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optB', true);
-                #{themeJavascript.JS_PREFIX}.radiobutton.setChecked(propId+':optA', false);
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optB', true); });
+                require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setChecked(propId+':optA', false); });
                 document.getElementById(optionId).value='text';
             }         
       }
       function disableTwoRadioButtons(opt, propId, optionId){
-          #{themeJavascript.JS_PREFIX}.radiobutton.setDisabled(propId+':optA', opt);
-          #{themeJavascript.JS_PREFIX}.radiobutton.setDisabled(propId+':optB', opt);
+          require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setDisabled(propId+':optA', opt); });
+          require(['webui/suntheme/radiobutton'], function (radiobutton) { radiobutton.setDisabled(propId+':optB', opt); });
           document.getElementById(optionId).value='';
       }
     </script>

--- a/appserver/admingui/jdbc/src/main/resources/lazyConnectionJS.inc
+++ b/appserver/admingui/jdbc/src/main/resources/lazyConnectionJS.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -22,7 +23,7 @@
     var c = getTextElement(la);
     var selected = c.checked;
     if(selected) {
-        #{themeJavascript.JS_PREFIX}.checkbox.setChecked('#{enlistId}', true);
+        require(['webui/suntheme/checkbox'], function (checkbox) { checkbox.setChecked('#{enlistId}', true); });
         disableComponent('#{enlistId}', 'text');
     }
     if(!selected) {


### PR DESCRIPTION
* Fixes #24686

In Chrome Developer Tools, there is an error.  
![edit_realm_error4](https://github.com/eclipse-ee4j/glassfish/assets/89768092/9a91e8d6-9aad-4201-8f27-ce3287a2a394)  
And here is where the message points.  
![edit_realm_error5](https://github.com/eclipse-ee4j/glassfish/assets/89768092/ba95d8a9-eeaa-48e1-9346-1149c4fbf100)  
  
`enableClassName` is implemented as the following.  
https://github.com/eclipse-ee4j/glassfish/blob/6997a5d2e45dedabb6840fdb18dbcedafcd150f2/appserver/admingui/common/src/main/resources/security/realms/realmjs.inc#L32-L49  
Line 45 is where the error occurred.  
  
`#{themeJavascript.JS_PREFIX}` is resolved to `webui.suntheme` by the EL expression.  
However, GlassFish can no longer reference its components directly using `webui.suntheme`.  
so fix it with reference to the following commit: https://github.com/eclipse-ee4j/glassfish/commit/376083a8ee107b8ebfc08595793086f8c5e13fc6  
  
then, the properties that were not displayed are shown as follows.  
![edit_realm_error6](https://github.com/eclipse-ee4j/glassfish/assets/89768092/2d108f09-731f-4d96-b40f-f3144e4d7c8f)  
  
also, I fixed other places where `JS_PREFIX` was used.  

