### PR TITLE
Minor Fixes and Improvements in AdminGUI

### DIFF
--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterNew.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterNew.jsf
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -110,18 +111,28 @@
         />
     </event>
 
-    <sun:table id="basicTable" style="padding: 10pt" deselectMultipleButton="$boolean{true}" selectMultipleButton="$boolean{true}"
+    <sun:table id="basicTable" style="padding: 10pt"
+               deselectMultipleButton="$boolean{true}"
+               deselectMultipleButtonOnClick="setTimeout('admingui.table.changeOneTableButton(\\\\\'#{pageSession.topActionGroup}\\\\\', \\\\\'#{pageSession.tableId}\\\\\');', 0)"
+               selectMultipleButton="$boolean{true}"
+               selectMultipleButtonOnClick="setTimeout('admingui.table.changeOneTableButton(\\\\\'#{pageSession.topActionGroup}\\\\\', \\\\\'#{pageSession.tableId}\\\\\');', 0)"
                title="$resource{i18ncs.clusterNew.TableTitle}">
+        <!afterCreate
+            getClientId(component="$this{component}" clientId=>$page{tableId});
+        />
         <!-- Actions (Top) -->
         <!facet actionsTop>
         <sun:panelGroup id="topActionsGroup1">
+            <!afterCreate
+                getClientId(component="$this{component}" clientId=>$page{topActionGroup});
+            />
             <sun:button id="addSharedTableButton" disabled="#{false}" text="$resource{i18n.button.New}" primary="#{true}">
                 <!command
                 getUIComponent(clientId="$pageSession{clusterTableRowGroupId}", component="#{requestScope.tableRowGroup}" );
                 addRowToTable(TableRowGroup="$attribute{tableRowGroup}", NameList={"name", "weight", "node"});
                 />
             </sun:button>
-            <sun:button id="deleteSharedTableButton" disabled="#{false}" text="$resource{i18n.button.Delete}" primary="#{false}">
+            <sun:button id="button1" disabled="#{true}" text="$resource{i18n.button.Delete}" primary="#{false}">
                 <!command
                 getUIComponent(clientId="$pageSession{clusterTableRowGroupId}", component=>$attribute{trg});
                 getSelectedTableRowKeys(tableRowGroup="${trg}" rowKeys=>$attribute{rowKeys});
@@ -136,7 +147,9 @@
             getClientId(component="$this{component}" clientId=>$page{clusterTableRowGroupId});
             />
             <sun:tableColumn headerText="$resource{i18n.common.SelectHeader}" selectId="select" rowHeader="$boolean{false}" id="col1">
-                <sun:checkbox id="select" selected="#{td.value.selected}" selectedValue="$boolean{true}" />
+                <sun:checkbox id="select" selected="#{td.value.selected}" selectedValue="$boolean{true}"
+                     onClick="setTimeout('admingui.table.changeOneTableButton(\\\\\'#{pageSession.topActionGroup}\\\\\', \\\\\'#{pageSession.tableId}\\\\\'); admingui.table.initAllRows(\\\\\'#{pageSession.tableId}\\\\\');', 0);"
+                 />
             </sun:tableColumn>
             <sun:tableColumn headerText="$resource{i18ncs.clusterNew.InstanceNameCol}" rowHeader="$boolean{false}" id="col2">
                 <sun:textField columns="$int{35}" maxLength="#{sessionScope.fieldLengths['maxLength.cluster.instanceName']}" id="name" value="#{td.value.name}" />

--- a/appserver/admingui/cluster/src/main/resources/cluster/clusterResources.jsf
+++ b/appserver/admingui/cluster/src/main/resources/cluster/clusterResources.jsf
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -43,7 +44,6 @@
     />
     
     </event>
-"    <script type="text/javascript">admingui.nav.selectTreeNodeById(admingui.nav.TREE_ID+"resources");</script>
 <sun:form id="propertyForm">
 
 #include "/cluster/cluster/clusterTabs.inc"

--- a/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -37,6 +38,7 @@
             getClientId(component="$this{component}" clientId=>$page{fileuploadId});
         />
     </sun:upload>
+    <sun:message for="#{fileuploadId}"/>
 
 
     "<br /><br/><br/>

--- a/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
+++ b/appserver/admingui/common/src/main/resources/applications/fileComponent.jsf
@@ -24,6 +24,7 @@
     <!afterCreate
         getClientId(component="$this{component}" clientId=>$page{locationPropId});
     />
+    <sun:textField id="hiddenText" visible="#{false}" text="required" required="#{true}"/>
     <sun:radioButton id="uploadRdBtn" name="uploadRdBtn" label="$resource{i18n.deploy.chooseJarLabel}" selected="#{uploadRdBtn}" selectedValue="client"
         onClick="admingui.deploy.uploadRdBtnAction('#{dirPathId}','#{dirSelectBtnId}','#{filSelectBtnId}','#{fileuploadId}','#{pageSession.radioChoosenId}')"
     >

--- a/appserver/admingui/common/src/main/resources/resourceNode/targetResourceTableButtons.inc
+++ b/appserver/admingui/common/src/main/resources/resourceNode/targetResourceTableButtons.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2023 Contributors to the Eclipse Foundation
     Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -99,7 +100,7 @@
                 labels="$attribute{filterLabels}" values="$attribute{filterValues}">
                 <!beforeCreate
                     getContentOfIntegrationPoints(type="org.glassfish.admingui:resFilterDropdown" labels="#{requestScope.filterLabels}" values="#{requestScope.filterValues}" );
-                    listAdd(list="#{requestScope.filterLabels}" value="$resource{i18n.common.showAll}",  index="0", sort="true");
+                    listAdd(list="#{requestScope.filterLabels}" value="$resource{i18n.common.showAll}",  index="0");
                     listAdd(list="#{requestScope.filterValues}" value=""  index="0" );
                 />
                 <!command


### PR DESCRIPTION
1. Remove 'sort="true"' set in `filterLabels` in `targetResourceTableButtons.inc`

This sort makes the `priority` attribute of each item wasted.  
I checked other filters, but none of them had 'sort="true"'.  
For implementation consistency, remove the 'sort="true"'.  

2. Disable the delete button if no instance is selected in New Cluster Page

In other similar tables in GlassFish, the Delete button is disabled when no items are selected.  
For functional consistency, disable the Delete button in New Cluster Page when no instance is selected.  
Before:  
![admingui_improve1](https://github.com/eclipse-ee4j/glassfish/assets/89768092/9d65928e-8e47-4c20-b03e-46fc11ffb2db)  
After:  
![admingui_improve3](https://github.com/eclipse-ee4j/glassfish/assets/89768092/eb1815bd-4ea3-4027-bf69-33fdd8221385)  

3. Fix When opening any Cluster's Resource page, all items in menu tree are highlighted

Before:  
![admingui_improve4](https://github.com/eclipse-ee4j/glassfish/assets/89768092/1ca9314a-79c2-47a2-9c92-a463124150c7)  
![admingui_improve5](https://github.com/eclipse-ee4j/glassfish/assets/89768092/c3212a09-41c5-454b-b2b0-8a0c6240da9f)  
After:  
![admingui_improve6](https://github.com/eclipse-ee4j/glassfish/assets/89768092/65282945-e287-4c06-919b-b081fce221cf)  

4. Add a display area for error messages when file upload fails  

Up to now, user can't know why failed when file upload was failed on the web console.   
Before:  
![admingui_improve7](https://github.com/eclipse-ee4j/glassfish/assets/89768092/95b9ab59-f552-4501-86e0-ed4b896c8231)  
After:  
![admingui_improve8](https://github.com/eclipse-ee4j/glassfish/assets/89768092/98ae5351-8ead-49a6-8ddf-6c84c8162230)  

5. Fix the symbol for the required field is not displayed with Location

Before:  
![admingui_improve11](https://github.com/eclipse-ee4j/glassfish/assets/89768092/f5e1f0b0-2c29-4f6b-9706-8d30b91598e7)  
After:  
![admingui_improve12](https://github.com/eclipse-ee4j/glassfish/assets/89768092/8738e9af-e898-44f9-a735-d16ab8dec170)  

