### PR TITLE
Fix #24693 Fail to deploy a app when the app's material files remain and if there is a lifecycle module

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -340,6 +340,9 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                 final File reposDir = new File(env.getApplicationRepositoryPath(), VersioningUtils.getRepositoryName(name));
                 if (reposDir.exists()) {
                     for (int i = 0; i < domain.getApplications().getApplications().size(); i++) {
+                        if (domain.getApplications().getApplications().get(i).isLifecycleModule()) {
+                            continue;
+                        }
                         File existrepos = new File(new URI(domain.getApplications().getApplications().get(i).getLocation()));
                         String appname = domain.getApplications().getApplications().get(i).getName();
                         if (!appname.equals(name) && existrepos.getAbsoluteFile().equals(reposDir.getAbsoluteFile())) {

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -72,25 +73,24 @@ import org.glassfish.deployment.versioning.VersioningUtils;
 
 import org.glassfish.deployment.versioning.VersioningService;
 
-
 /**
  * Deploy command
  *
  * @author Jerome Dochez
  */
-@Service(name="deploy")
+@Service(name = "deploy")
 @I18n("deploy.command")
 @PerLookup
-@ExecuteOn(value={RuntimeType.DAS})
-@TargetType(value={CommandTarget.DOMAIN, CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER})
+@ExecuteOn(value = { RuntimeType.DAS })
+@TargetType(value = { CommandTarget.DOMAIN, CommandTarget.DAS, CommandTarget.STANDALONE_INSTANCE, CommandTarget.CLUSTER })
 @RestEndpoints({
-    @RestEndpoint(configBean=Applications.class,opType=RestEndpoint.OpType.POST, path="deploy"),
-    @RestEndpoint(configBean=Cluster.class,opType=RestEndpoint.OpType.POST, path="deploy", params={
-        @RestParam(name="target", value="$parent")
-    }),
-    @RestEndpoint(configBean=Server.class,opType=RestEndpoint.OpType.POST, path="deploy", params={
-        @RestParam(name="target", value="$parent")
-    })
+        @RestEndpoint(configBean = Applications.class, opType = RestEndpoint.OpType.POST, path = "deploy"),
+        @RestEndpoint(configBean = Cluster.class, opType = RestEndpoint.OpType.POST, path = "deploy", params = {
+                @RestParam(name = "target", value = "$parent")
+        }),
+        @RestEndpoint(configBean = Server.class, opType = RestEndpoint.OpType.POST, path = "deploy", params = {
+                @RestParam(name = "target", value = "$parent")
+        })
 })
 public class DeployCommand extends DeployCommandParameters implements AdminCommand, EventListener,
         AdminCommandSecurity.Preauthorization, AdminCommandSecurity.AccessCheckProvider {
@@ -154,42 +154,39 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
     public boolean preAuthorization(AdminCommandContext context) {
         events.register(this);
 
-      suppInfo =
-              new DeployCommandSupplementalInfo();
-      context.getActionReport().
-              setResultType(DeployCommandSupplementalInfo.class, suppInfo);
+        suppInfo = new DeployCommandSupplementalInfo();
+        context.getActionReport().setResultType(DeployCommandSupplementalInfo.class, suppInfo);
 
-          timing = new DeploymentTracing();
-          tracing=null;
-          if (System.getProperty("org.glassfish.deployment.trace")!=null) {
+        timing = new DeploymentTracing();
+        tracing = null;
+        if (System.getProperty("org.glassfish.deployment.trace") != null) {
             tracing = new DeploymentTracing();
-          }
+        }
 
         report = context.getActionReport();
         logger = context.getLogger();
 
         originalPathValue = path;
         if (!path.exists()) {
-            report.setMessage(localStrings.getLocalString("fnf","File not found", path.getAbsolutePath()));
+            report.setMessage(localStrings.getLocalString("fnf", "File not found", path.getAbsolutePath()));
             report.setActionExitCode(ActionReport.ExitCode.FAILURE);
             return false;
         }
         if (!path.canRead()) {
-            report.setMessage(localStrings.getLocalString("fnr","File {0} does not have read permission", path.getAbsolutePath()));
+            report.setMessage(localStrings.getLocalString("fnr", "File {0} does not have read permission", path.getAbsolutePath()));
             report.setActionExitCode(ActionReport.ExitCode.FAILURE);
             return false;
         }
 
         if (snifferManager.hasNoSniffers()) {
             String msg = localStrings.getLocalString("nocontainer", "No container services registered, done...");
-            report.failure(logger,msg);
+            report.failure(logger, msg);
             return false;
         }
 
-
         try {
             archive = archiveFactory.openArchive(path, this);
-            if (tracing!=null) {
+            if (tracing != null) {
                 tracing.addMark(DeploymentTracing.Mark.ARCHIVE_OPENED);
             }
         } catch (IOException e) {
@@ -210,45 +207,45 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
         if (runtimealtdd != null) {
             archive.addArchiveMetaData(DeploymentProperties.RUNTIME_ALT_DD,
-                runtimealtdd);
+                    runtimealtdd);
         }
 
-        expansionDir=null;
+        expansionDir = null;
         deploymentContext = null;
         try {
 
             deployment.validateSpecifiedTarget(target);
 
             archiveHandler = deployment.getArchiveHandler(archive, type);
-            if (tracing!=null) {
+            if (tracing != null) {
                 tracing.addMark(DeploymentTracing.Mark.ARCHIVE_HANDLER_OBTAINED);
             }
-            if (archiveHandler==null) {
-                report.failure(logger,localStrings.getLocalString("deploy.unknownarchivetype","Archive type of {0} was not recognized",path));
+            if (archiveHandler == null) {
+                report.failure(logger, localStrings.getLocalString("deploy.unknownarchivetype", "Archive type of {0} was not recognized", path));
                 return false;
             }
 
-            // create an initial  context
+            // create an initial context
             initialContext = new DeploymentContextImpl(report, archive, this, env);
             initialContext.setArchiveHandler(archiveHandler);
 
-            if (tracing!=null) {
+            if (tracing != null) {
                 initialContext.addModuleMetaData(tracing);
                 tracing.addMark(DeploymentTracing.Mark.INITIAL_CONTEXT_CREATED);
             }
             events.send(new Event<DeploymentContext>(Deployment.INITIAL_CONTEXT_CREATED, initialContext), false);
-            if (name==null) {
+            if (name == null) {
                 name = archiveHandler.getDefaultApplicationName(initialContext.getSource(), initialContext);
             } else {
                 DeploymentUtils.validateApplicationName(name);
             }
-            if (tracing!=null) {
+            if (tracing != null) {
                 tracing.addMark(DeploymentTracing.Mark.APPNAME_DETERMINED);
             }
 
             boolean isUntagged = VersioningUtils.isUntagged(name);
             // no GlassFish versioning support for OSGi budles
-            if ( name != null && !isUntagged && type != null && type.equals("osgi") ) {
+            if (name != null && !isUntagged && type != null && type.equals("osgi")) {
                 ActionReport.MessagePart msgPart = context.getActionReport().getTopMessagePart();
                 msgPart.setChildrenType("WARNING");
                 ActionReport.MessagePart childPart = msgPart.addChild();
@@ -260,14 +257,12 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
             // if no version information embedded as part of application name
             // we try to retrieve the version-identifier element's value from DD
-            if ( isUntagged ){
+            if (isUntagged) {
                 String versionIdentifier = archiveHandler.getVersionIdentifier(initialContext.getSource());
 
-                if ( versionIdentifier != null && !versionIdentifier.isEmpty() ) {
-                  StringBuilder sb = new StringBuilder(name).
-                          append(VersioningUtils.EXPRESSION_SEPARATOR).
-                          append(versionIdentifier);
-                  name = sb.toString();
+                if (versionIdentifier != null && !versionIdentifier.isEmpty()) {
+                    StringBuilder sb = new StringBuilder(name).append(VersioningUtils.EXPRESSION_SEPARATOR).append(versionIdentifier);
+                    name = sb.toString();
                 }
             }
 
@@ -282,7 +277,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             events.unregister(this);
             if (initialContext != null && initialContext.getSource() != null) {
                 try {
-                  initialContext.getSource().close();
+                    initialContext.getSource().close();
                 } catch (IOException ioex) {
                     throw new RuntimeException(ioex);
                 }
@@ -291,7 +286,6 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
         }
     }
 
-
     @Override
     public Collection<? extends AccessCheck> getAccessChecks() {
         final List<AccessCheck> accessChecks = new ArrayList<AccessCheck>();
@@ -299,8 +293,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
         accessChecks.add(new AccessCheck(DeploymentCommandUtils.getTargetResourceNameForNewAppRef(domain, target), "create"));
 
         /*
-         * If this app is already deployed then this operation also represents
-         * an undeployment - a delete - of that app.
+         * If this app is already deployed then this operation also represents an undeployment - a delete - of that app.
          */
         if (isredeploy) {
             final String appResource = DeploymentCommandUtils.getResourceNameForNewApp(domain, name);
@@ -314,51 +307,50 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
     /**
      * Entry point from the framework into the command execution
+     *
      * @param context context for the command.
      */
     @Override
     public void execute(AdminCommandContext context) {
         try {
-          // needs to be fixed in hk2, we don't generate the right innerclass index. it should use $
+            // needs to be fixed in hk2, we don't generate the right innerclass index. it should use $
             Collection<Interceptor> interceptors = habitat.getAllServices(Interceptor.class);
-            if (interceptors!=null) {
+            if (interceptors != null) {
                 for (Interceptor interceptor : interceptors) {
                     interceptor.intercept(this, initialContext);
                 }
             }
 
-
             deployment.validateDeploymentTarget(target, name, isredeploy);
-            if (tracing!=null) {
+            if (tracing != null) {
                 tracing.addMark(DeploymentTracing.Mark.TARGET_VALIDATED);
             }
 
             ActionReport.MessagePart part = report.getTopMessagePart();
             part.addProperty(DeploymentProperties.NAME, name);
 
-            ApplicationConfigInfo savedAppConfig =
-                    new ApplicationConfigInfo(apps.getModule(Application.class, name));
+            ApplicationConfigInfo savedAppConfig = new ApplicationConfigInfo(apps.getModule(Application.class, name));
             Properties undeployProps = handleRedeploy(name, report, context);
             if (enabled == null) {
                 enabled = Boolean.TRUE;
             }
 
             // clean up any left over repository files
-            if ( ! keepreposdir.booleanValue()) {
+            if (!keepreposdir.booleanValue()) {
                 final File reposDir = new File(env.getApplicationRepositoryPath(), VersioningUtils.getRepositoryName(name));
                 if (reposDir.exists()) {
-                    for (int i=0 ; i<domain.getApplications().getApplications().size() ; i++) {
+                    for (int i = 0; i < domain.getApplications().getApplications().size(); i++) {
                         File existrepos = new File(new URI(domain.getApplications().getApplications().get(i).getLocation()));
                         String appname = domain.getApplications().getApplications().get(i).getName();
                         if (!appname.equals(name) && existrepos.getAbsoluteFile().equals(reposDir.getAbsoluteFile())) {
-                            report.failure(logger,localStrings.getLocalString("deploy.dupdeployment","Application {0} is trying to use the same repository directory as application {1}, please choose a different application name to deploy",name,appname));
+                            report.failure(logger, localStrings.getLocalString("deploy.dupdeployment",
+                                    "Application {0} is trying to use the same repository directory as application {1}, please choose a different application name to deploy",
+                                    name, appname));
                             return;
                         }
                     }
                     /*
-                     * Delete the repository directory as an archive to allow
-                     * any special processing (such as stale file handling)
-                     * to run.
+                     * Delete the repository directory as an archive to allow any special processing (such as stale file handling) to run.
                      */
                     final FileArchive arch = DeploymentUtils.openAsFileArchive(reposDir, archiveFactory);
                     arch.delete();
@@ -368,7 +360,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             if (!DeploymentUtils.isDomainTarget(target) && enabled) {
                 // try to disable the enabled version, if exist
                 try {
-                    versioningService.handleDisable(name,target, report, context.getSubject());
+                    versioningService.handleDisable(name, target, report, context.getSubject());
                 } catch (VersioningSyntaxException e) {
                     report.failure(logger, e.getMessage());
                     return;
@@ -383,30 +375,28 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                 path = expansionDir;
             } else {
                 // test if a version is already directory deployed from this dir
-                String versionFromSameDir =
-                        versioningService.getVersionFromSameDir(source);
+                String versionFromSameDir = versioningService.getVersionFromSameDir(source);
                 if (!force && versionFromSameDir != null) {
                     report.failure(logger,
                             VersioningUtils.LOCALSTRINGS.getLocalString(
-                                "versioning.deployment.dual.inplace",
-                                "GlassFish do not support versioning for directory deployment when using the same directory. The directory {0} is already assigned to the version {1}.",
-                                source.getPath(),
-                                versionFromSameDir));
+                                    "versioning.deployment.dual.inplace",
+                                    "GlassFish do not support versioning for directory deployment when using the same directory. The directory {0} is already assigned to the version {1}.",
+                                    source.getPath(),
+                                    versionFromSameDir));
                     return;
                 }
             }
 
             // create the parent class loader
-            deploymentContext =
-                    deployment.getBuilder(logger, this, report).
-                            source(initialContext.getSource()).archiveHandler(archiveHandler).build(initialContext);
-            if (tracing!=null) {
+            deploymentContext = deployment.getBuilder(logger, this, report).source(initialContext.getSource()).archiveHandler(archiveHandler)
+                    .build(initialContext);
+            if (tracing != null) {
                 tracing.addMark(DeploymentTracing.Mark.CONTEXT_CREATED);
                 deploymentContext.addModuleMetaData(tracing);
             }
 
             // reset the properties (might be null) set by the deployers when undeploying.
-            if (undeployProps!=null) {
+            if (undeployProps != null) {
                 deploymentContext.getAppProps().putAll(undeployProps);
             }
 
@@ -432,19 +422,17 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
             Properties appProps = deploymentContext.getAppProps();
             /*
-             * If the app's location is within the domain's directory then
-             * express it in the config as ${com.sun.aas.instanceRootURI}/rest-of-path
-             * so users can relocate the entire installation without having
-             * to modify the app locations.  Leave the location alone if
-             * it does not fall within the domain directory.
+             * If the app's location is within the domain's directory then express it in the config as
+             * ${com.sun.aas.instanceRootURI}/rest-of-path so users can relocate the entire installation without having to modify
+             * the app locations. Leave the location alone if it does not fall within the domain directory.
              */
-            String appLocation = DeploymentUtils.relativizeWithinDomainIfPossible( deploymentContext.getSource().getURI());
+            String appLocation = DeploymentUtils.relativizeWithinDomainIfPossible(deploymentContext.getSource().getURI());
 
             appProps.setProperty(ServerTags.LOCATION, appLocation);
             // set to default "user", deployers can override it
             // during processing
             appProps.setProperty(ServerTags.OBJECT_TYPE, "user");
-            if (contextroot!=null) {
+            if (contextroot != null) {
                 appProps.setProperty(ServerTags.CONTEXT_ROOT, contextroot);
             }
             appProps.setProperty(ServerTags.DIRECTORY_DEPLOYED, String.valueOf(isDirectoryDeployed));
@@ -460,24 +448,20 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             deploymentContext.addTransientAppMetaData(DeploymentProperties.PREVIOUS_ENABLED_ATTRIBUTES, previousEnabledAttributes);
 
             Transaction t = deployment.prepareAppConfigChanges(deploymentContext);
-            if (tracing!=null) {
+            if (tracing != null) {
                 tracing.addMark(DeploymentTracing.Mark.DEPLOY);
             }
             ApplicationInfo appInfo;
             appInfo = deployment.deploy(deploymentContext);
 
             /*
-             * Various deployers might have added to the downloadable or
-             * generated artifacts.  Extract them and, if the command succeeded,
-             * persist both into the app properties (which will be recorded
-             * in domain.xml).
+             * Various deployers might have added to the downloadable or generated artifacts. Extract them and, if the command
+             * succeeded, persist both into the app properties (which will be recorded in domain.xml).
              */
-            final Artifacts downloadableArtifacts =
-                    DeploymentUtils.downloadableArtifacts(deploymentContext);
-            final Artifacts generatedArtifacts =
-                    DeploymentUtils.generatedArtifacts(deploymentContext);
+            final Artifacts downloadableArtifacts = DeploymentUtils.downloadableArtifacts(deploymentContext);
+            final Artifacts generatedArtifacts = DeploymentUtils.generatedArtifacts(deploymentContext);
 
-            if (report.getActionExitCode()==ActionReport.ExitCode.SUCCESS) {
+            if (report.getActionExitCode() == ActionReport.ExitCode.SUCCESS) {
                 try {
                     moveAppFilesToPermanentLocation(
                             deploymentContext, logger);
@@ -488,22 +472,22 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
                     // register application information in domain.xml
                     deployment.registerAppInDomainXML(appInfo, deploymentContext, t);
-                    if (tracing!=null) {
+                    if (tracing != null) {
                         tracing.addMark(DeploymentTracing.Mark.REGISTRATION);
                     }
                     if (retrieve != null) {
                         retrieveArtifacts(context, downloadableArtifacts.getArtifacts(), retrieve, false, name);
                     }
                     suppInfo.setDeploymentContext(deploymentContext);
-                    //Fix for issue 14442
-                    //We want to report the worst subreport value.
+                    // Fix for issue 14442
+                    // We want to report the worst subreport value.
                     ActionReport.ExitCode worstExitCode = ExitCode.SUCCESS;
                     for (ActionReport subReport : report.getSubActionsReport()) {
                         ActionReport.ExitCode actionExitCode = subReport.getActionExitCode();
 
-                        if ( actionExitCode.isWorse(worstExitCode) ){
-                           worstExitCode = actionExitCode;
-                       }
+                        if (actionExitCode.isWorse(worstExitCode)) {
+                            worstExitCode = actionExitCode;
+                        }
                     }
                     report.setActionExitCode(worstExitCode);
                     report.setResultType(String.class, name);
@@ -515,7 +499,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                     throw e;
                 }
             }
-        } catch(Throwable e) {
+        } catch (Throwable e) {
             report.setActionExitCode(ActionReport.ExitCode.FAILURE);
             report.setMessage(e.getMessage());
             report.setFailureCause(e);
@@ -523,21 +507,21 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             events.unregister(this);
             try {
                 archive.close();
-            } catch(IOException e) {
+            } catch (IOException e) {
                 logger.log(Level.FINE, localStrings.getLocalString(
                         "errClosingArtifact",
                         "Error while closing deployable artifact : ",
                         path.getAbsolutePath()), e);
             }
 
-            if (tracing!=null) {
+            if (tracing != null) {
                 tracing.print(System.out);
             }
 
             if (report.getActionExitCode().equals(ActionReport.ExitCode.SUCCESS)) {
                 // Set the app name in the result so that embedded deployer can retrieve it.
                 report.setResultType(String.class, name);
-                report.setMessage(localStrings.getLocalString("deploy.command.success","Application deployed with name {0}", name));
+                report.setMessage(localStrings.getLocalString("deploy.command.success", "Application deployed with name {0}", name));
 
                 logger.info(localStrings.getLocalString(
                         "deploy.done",
@@ -550,7 +534,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                 if (cause != null) {
                     String causeMessage = cause.getMessage();
                     if (causeMessage != null &&
-                        !causeMessage.equals(errorMessage)) {
+                            !causeMessage.equals(errorMessage)) {
                         errorMessage = errorMessage + " : " + cause.getMessage();
                     }
                     logger.log(Level.SEVERE, errorMessage, cause.getCause());
@@ -559,22 +543,21 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                 // reset the failure cause so command framework will not try
                 // to print the same message again
                 report.setFailureCause(null);
-                if (expansionDir!=null) {
+                if (expansionDir != null) {
                     final FileArchive arch;
-                        try {
-                            /*
-                             * Open and then delete the expansion directory as
-                             * a file archive so stale file handling can run.
-                             */
-                            arch = DeploymentUtils.openAsFileArchive(expansionDir, archiveFactory);
-                            arch.delete();
-                        } catch (IOException ex) {
-                            final String msg = localStrings.getLocalString(
-                                    "deploy.errDelRepos",
-                                    "Error deleting repository directory {0}",
-                                    expansionDir.getAbsolutePath());
-                            report.failure(logger, msg, ex);
-                        }
+                    try {
+                        /*
+                         * Open and then delete the expansion directory as a file archive so stale file handling can run.
+                         */
+                        arch = DeploymentUtils.openAsFileArchive(expansionDir, archiveFactory);
+                        arch.delete();
+                    } catch (IOException ex) {
+                        final String msg = localStrings.getLocalString(
+                                "deploy.errDelRepos",
+                                "Error deleting repository directory {0}",
+                                expansionDir.getAbsolutePath());
+                        report.failure(logger, msg, ex);
+                    }
 
                 }
             }
@@ -585,13 +568,12 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
     }
 
     /**
-     * Makes safe copies of the archive, deployment plan, alternate dd,
-     * runtime alternate dd for later use during instance sync activity.
+     * Makes safe copies of the archive, deployment plan, alternate dd, runtime alternate dd for later use during instance
+     * sync activity.
      * <p>
-     * We rename any uploaded files from the temp directory to the permanent
-     * place, and we copy any archive files that were not uploaded.  This
-     * prevents any confusion that could result if the developer modified the
-     * archive file - changing its lastModified value - before redeploying it.
+     * We rename any uploaded files from the temp directory to the permanent place, and we copy any archive files that were
+     * not uploaded. This prevents any confusion that could result if the developer modified the archive file - changing its
+     * lastModified value - before redeploying it.
      *
      * @param deploymentContext
      * @param logger logger
@@ -602,73 +584,69 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             final Logger logger) throws IOException {
         final File finalUploadDir = deploymentContext.getAppInternalDir();
         final File finalAltDDDir = deploymentContext.getAppAltDDDir();
-        if ( ! finalUploadDir.mkdirs()) {
-            logger.log(Level.FINE," Attempting to create upload directory {0} was reported as failed; attempting to continue",
-                    new Object[] {finalUploadDir.getAbsolutePath()});
+        if (!finalUploadDir.mkdirs()) {
+            logger.log(Level.FINE, " Attempting to create upload directory {0} was reported as failed; attempting to continue",
+                    new Object[] { finalUploadDir.getAbsolutePath() });
         }
-        safeCopyOfApp = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile( finalUploadDir, originalPathValue, logger, env);
-        safeCopyOfDeploymentPlan = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile( finalUploadDir, deploymentplan, logger, env);
-        safeCopyOfAltDD = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile( finalAltDDDir, altdd, logger, env);
-        safeCopyOfRuntimeAltDD = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile( finalAltDDDir, runtimealtdd, logger, env);
+        safeCopyOfApp = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile(finalUploadDir, originalPathValue, logger, env);
+        safeCopyOfDeploymentPlan = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile(finalUploadDir, deploymentplan, logger, env);
+        safeCopyOfAltDD = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile(finalAltDDDir, altdd, logger, env);
+        safeCopyOfRuntimeAltDD = DeploymentCommandUtils.renameUploadedFileOrCopyInPlaceFile(finalAltDDDir, runtimealtdd, logger, env);
     }
 
     private void recordFileLocations(
             final Properties appProps) throws URISyntaxException {
         /*
-         * Setting the properties in the appProps now will cause them to be
-         * stored in the domain.xml elements along with other properties when
-         * the entire config is saved.
+         * Setting the properties in the appProps now will cause them to be stored in the domain.xml elements along with other
+         * properties when the entire config is saved.
          */
         if (safeCopyOfApp != null) {
             appProps.setProperty(Application.APP_LOCATION_PROP_NAME,
                     DeploymentUtils.relativizeWithinDomainIfPossible(
-                    safeCopyOfApp.toURI()));
+                            safeCopyOfApp.toURI()));
         }
         if (safeCopyOfDeploymentPlan != null) {
-                appProps.setProperty(Application.DEPLOYMENT_PLAN_LOCATION_PROP_NAME,
-                        DeploymentUtils.relativizeWithinDomainIfPossible(
-                        safeCopyOfDeploymentPlan.toURI()));
+            appProps.setProperty(Application.DEPLOYMENT_PLAN_LOCATION_PROP_NAME,
+                    DeploymentUtils.relativizeWithinDomainIfPossible(
+                            safeCopyOfDeploymentPlan.toURI()));
         }
         if (safeCopyOfAltDD != null) {
-                appProps.setProperty(Application.ALT_DD_LOCATION_PROP_NAME,
-                        DeploymentUtils.relativizeWithinDomainIfPossible(
-                        safeCopyOfAltDD.toURI()));
+            appProps.setProperty(Application.ALT_DD_LOCATION_PROP_NAME,
+                    DeploymentUtils.relativizeWithinDomainIfPossible(
+                            safeCopyOfAltDD.toURI()));
         }
         if (safeCopyOfRuntimeAltDD != null) {
-                appProps.setProperty(
-                        Application.RUNTIME_ALT_DD_LOCATION_PROP_NAME,
-                        DeploymentUtils.relativizeWithinDomainIfPossible(
-                        safeCopyOfRuntimeAltDD.toURI()));
+            appProps.setProperty(
+                    Application.RUNTIME_ALT_DD_LOCATION_PROP_NAME,
+                    DeploymentUtils.relativizeWithinDomainIfPossible(
+                            safeCopyOfRuntimeAltDD.toURI()));
         }
     }
 
     /**
-     *  Check if the application is deployed or not.
-     *  If force option is true and appInfo is not null, then undeploy
-     *  the application and return false.  This will force deployment
-     *  if there's already a running application deployed.
+     * Check if the application is deployed or not. If force option is true and appInfo is not null, then undeploy the
+     * application and return false. This will force deployment if there's already a running application deployed.
      *
-     *  @param name application name
-     *  @param report ActionReport, report object to send back to client.
-     * @return context properties that might have been set by the deployers
-     * while undeploying the application
+     * @param name application name
+     * @param report ActionReport, report object to send back to client.
+     * @return context properties that might have been set by the deployers while undeploying the application
      *
      */
     private Properties handleRedeploy(final String name, final ActionReport report, final AdminCommandContext context)
-        throws Exception {
-        if (isredeploy)
-        {
-            //preserve settings first before undeploy
+            throws Exception {
+        if (isredeploy) {
+            // preserve settings first before undeploy
             Application app = apps.getModule(Application.class, name);
-            if (app.isLifecycleModule()){
-                throw new IllegalArgumentException(localStrings.getLocalString("lifecyclemodule_withsamename_exists", "Lifecycle module with same name {0} already exists, please pick a different name for the application. ", name));
+            if (app.isLifecycleModule()) {
+                throw new IllegalArgumentException(localStrings.getLocalString("lifecyclemodule_withsamename_exists",
+                        "Lifecycle module with same name {0} already exists, please pick a different name for the application. ", name));
             }
 
             // we save some of the old registration information in our deployment parameters
             settingsFromDomainXML(app);
 
-            //if application is already deployed and force=true,
-            //then undeploy the application first.
+            // if application is already deployed and force=true,
+            // then undeploy the application first.
 
             // Use ParameterMap till we have a better way
             // to invoke a command on both DAS and instance with the
@@ -718,6 +696,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
     /**
      * Places into the outgoing payload the downloadable artifacts for an application.
+     *
      * @param context the admin command context for the command requesting the artifacts download
      * @param app the application of interest
      * @param targetLocalDir the client-specified local directory to receive the downloaded files
@@ -730,6 +709,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
 
     /**
      * Places into the outgoing payload the downloadable artifacts for an application.
+     *
      * @param context the admin command context for the command currently running
      * @param app the application of interest
      * @param targetLocalDir the client-specified local directory to receive the downloaded files
@@ -756,10 +736,10 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             final ActionReport report = context.getActionReport();
             final ActionReport subReport = report.addSubActionsReport();
             subReport.setMessage(localStrings.getLocalString(
-                DeployCommand.class,
-                "get-client-stubs.noStubApp",
-                "There are no files to retrieve for application {0}",
-            new Object[] {appname}));
+                    DeployCommand.class,
+                    "get-client-stubs.noStubApp",
+                    "There are no files to retrieve for application {0}",
+                    new Object[] { appname }));
             subReport.setActionExitCode(ExitCode.SUCCESS);
             return;
         }
@@ -781,11 +761,11 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
              */
             props.setProperty("file-xfer-root", targetLocalDir.replace('\\', '/'));
             for (Artifacts.FullAndPartURIs uriPair : artifactInfo) {
-                if(logger.isLoggable(Level.FINE)) {
+                if (logger.isLoggable(Level.FINE)) {
                     logger.log(Level.FINE, "About to download artifact {0}", uriPair.getFull());
                 }
                 outboundPayload.attachFile("application/octet-stream",
-                        uriPair.getPart(),"files",props,
+                        uriPair.getPart(), "files", props,
                         new File(uriPair.getFull().getSchemeSpecificPart()));
             }
             if (retrieveArtifacts) {
@@ -821,11 +801,11 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
     private static void handleRetrieveException(final Exception e,
             final AdminCommandContext context, final boolean reportErrorsInTopReport) {
         final String errorMsg = localStrings.getLocalString(
-                    "download.errDownloading", "Error while downloading generated files");
+                "download.errDownloading", "Error while downloading generated files");
         final Logger logger = context.getLogger();
         logger.log(Level.SEVERE, errorMsg, e);
         ActionReport report = context.getActionReport();
-        if ( ! reportErrorsInTopReport) {
+        if (!reportErrorsInTopReport) {
             report = report.addSubActionsReport();
             report.setActionExitCode(ExitCode.WARNING);
         } else {
@@ -835,16 +815,15 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
         report.setFailureCause(e);
     }
 
-
     /**
-     *  Get settings from domain.xml and preserve the values.
-     *  This is a private api and its invoked when --force=true and if the app is registered.
+     * Get settings from domain.xml and preserve the values. This is a private api and its invoked when --force=true and if
+     * the app is registered.
      *
-     *  @param app is the registration information about the previously deployed application
+     * @param app is the registration information about the previously deployed application
      *
      */
     private void settingsFromDomainXML(Application app) {
-            //if name is null then cannot get the application's setting from domain.xml
+        // if name is null then cannot get the application's setting from domain.xml
         if (name != null) {
             if (contextroot == null) {
                 if (app.getContextRoot() != null) {
@@ -866,7 +845,7 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                     }
                 } else {
                     virtualservers = domain.getVirtualServersForApplication(
-                        target, name);
+                            target, name);
                 }
             }
 
@@ -882,12 +861,12 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
                     enabled = deployment.isAppEnabled(app);
                 } else {
                     enabled = Boolean.valueOf(domain.getEnabledForApplication(
-                        target, name));
+                            target, name));
                 }
             }
 
             String compatProp = app.getDeployProperties().getProperty(
-                DeploymentProperties.COMPATIBILITY);
+                    DeploymentProperties.COMPATIBILITY);
             if (compatProp != null) {
                 if (properties == null) {
                     properties = new Properties();
@@ -907,12 +886,12 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
         if (event.is(Deployment.DEPLOYMENT_BEFORE_CLASSLOADER_CREATION)) {
             // this is where we have processed metadata and
             // haven't created the application classloader yet
-            DeploymentContext context = (DeploymentContext)event.hook();
+            DeploymentContext context = (DeploymentContext) event.hook();
             if (verify) {
                 Verifier verifier = habitat.getService(Verifier.class);
                 if (verifier != null) {
                     verifier.verify(context);
-                } else  {
+                } else {
                     context.getLogger().warning("Verifier is not installed yet. Install verifier module.");
                 }
             }
@@ -920,12 +899,13 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
     }
 
     private void validateDeploymentProperties(Properties properties,
-        DeploymentContext context) {
+            DeploymentContext context) {
         String compatProp = properties.getProperty(
-            DeploymentProperties.COMPATIBILITY);
+                DeploymentProperties.COMPATIBILITY);
         if (compatProp != null && !compatProp.equals("v2")) {
             // this only allowed value for property compatibility is v2
-            String warningMsg = localStrings.getLocalString("compat.value.not.supported", "{0} is not a supported value for compatibility property.", compatProp);
+            String warningMsg = localStrings.getLocalString("compat.value.not.supported", "{0} is not a supported value for compatibility property.",
+                    compatProp);
             ActionReport subReport = context.getActionReport().addSubActionsReport();
             subReport.setActionExitCode(ActionReport.ExitCode.WARNING);
             subReport.setMessage(warningMsg);

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -339,12 +339,13 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             if (!keepreposdir.booleanValue()) {
                 final File reposDir = new File(env.getApplicationRepositoryPath(), VersioningUtils.getRepositoryName(name));
                 if (reposDir.exists()) {
-                    for (int i = 0; i < domain.getApplications().getApplications().size(); i++) {
-                        if (domain.getApplications().getApplications().get(i).isLifecycleModule()) {
+                    List<Application> applications = domain.getApplications().getApplications();
+                    for (Application app : applications) {
+                        if (app.isLifecycleModule()) {
                             continue;
                         }
-                        File existrepos = new File(new URI(domain.getApplications().getApplications().get(i).getLocation()));
-                        String appname = domain.getApplications().getApplications().get(i).getName();
+                        File existrepos = new File(new URI(app.getLocation()));
+                        String appname = app.getName();
                         if (!appname.equals(name) && existrepos.getAbsoluteFile().equals(reposDir.getAbsoluteFile())) {
                             report.failure(logger, localStrings.getLocalString("deploy.dupdeployment",
                                     "Application {0} is trying to use the same repository directory as application {1}, please choose a different application name to deploy",


### PR DESCRIPTION
* Fixes #24693

When deploy an application, if a directory with the same name already exists under the application repository, process the following route.  
https://github.com/eclipse-ee4j/glassfish/blob/f0c6f77245e2ec2466601eefbb506bb965f875b7/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java#L349-L365  
The lifecycle module is managed by GlassFish as one of the `Applications`, but its archive file is not managed as an application. so `getLocation()` on L351 returns null.  
Thus, passing null to the URI's constructor causes `NullPointerException` and the deployment fails.