### PR TITLE
Fix auto login admin ui by accidentally changed constant

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/cli/SecurityUtil.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/cli/SecurityUtil.java
@@ -45,7 +45,7 @@ import org.jvnet.hk2.config.types.Property;
 public class SecurityUtil {
     private static final String DAS_CONFIG = "server-config";
     private static String ADMIN_REALM = "admin-realm";
-    private static String FILE_REALM_CLASSNAME = "com.sun.enterprise.security.ee.auth.realm.file.FileRealm";
+    private static String FILE_REALM_CLASSNAME = "com.sun.enterprise.security.auth.realm.file.FileRealm";
 
     private Domain domain;
 


### PR DESCRIPTION
A constant was accidentally changed, which caused the auto login feature for the admin console to be disabled.
