### PR TITLE
fix cmtTimeoutInSeconds config, it can't take effect when set value 0 in admin UI.

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
@@ -81,7 +81,7 @@ public class EJBContainerTransactionManager {
         TransactionService txnService = ejbContainerUtilImpl.getServices().getService(TransactionService.class,
                 ServerEnvironment.DEFAULT_INSTANCE_NAME);
         int transactionTimeout = Integer.parseInt(txnService.getTimeoutInSeconds());
-        if (transactionTimeout != 0) {
+        if (transactionTimeout >= 0) {
             cmtTimeoutInSeconds = transactionTimeout;
         }
 

--- a/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/config/TransactionService.java
+++ b/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/config/TransactionService.java
@@ -75,7 +75,7 @@ public interface TransactionService extends ConfigBeanProxy, PropertyBag, Config
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="0",dataType=Integer.class)
+    @Attribute (defaultValue="120",dataType=Integer.class)
     public String getTimeoutInSeconds();
 
     /**


### PR DESCRIPTION
in adminUI server-config--->Transaction Service page, if I set Transaction Timeout to value 0, accoring to the description, we should disable timeout setting. but now, it is set to 120s in hard code. I fix the bug. 
after this refactor, the default values is 120s, if we set 0, timeout setting will be disabled.

![image](https://github.com/eclipse-ee4j/glassfish/assets/4328187/5728c900-e11f-4faa-ae1a-7827ec1924f6)
