### PR TITLE
Fix for the RecoveryManager's Resync Timeout

### DIFF
--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
@@ -67,7 +67,7 @@ public class EJBContainerTransactionManager {
     private final JavaEETransactionManager transactionManager;
     private final BaseContainer container;
     private final EjbDescriptor ejbDescriptor;
-    private int cmtTimeoutInSeconds = 120;
+    private int cmtTimeoutInSeconds = 0;
 
     /**
      * Construct new instance and set basic references

--- a/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/config/TransactionService.java
+++ b/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/config/TransactionService.java
@@ -75,7 +75,7 @@ public interface TransactionService extends ConfigBeanProxy, PropertyBag, Config
      * @return possible object is
      *         {@link String }
      */
-    @Attribute (defaultValue="120",dataType=Integer.class)
+    @Attribute (defaultValue="0",dataType=Integer.class)
     public String getTimeoutInSeconds();
 
     /**

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/RecoveryManager.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/RecoveryManager.java
@@ -1402,19 +1402,17 @@ public class RecoveryManager {
     }
 
     /**
-     * Waits for resync to complete with timeout.
-     *
-     * @param cmtTimeout Container managed transaction timeout
+     * Waits for the resync between the resource and the transaction manager to complete with timeout.
      *
      * @return
      *
      * @see
      */
-    public static void waitForResync(int cmtTimeOut) {
-
+    public static void waitForResyncWithTimeout(){
         if (resyncInProgress != null) {
+            int resyncTimeout = Integer.getInteger("org.glassfish.jts.CosTransactions.resyncTimeoutInSeconds", 120);
             try {
-                resyncInProgress.waitTimeoutEvent(cmtTimeOut);
+                resyncInProgress.waitTimeoutEvent(resyncTimeout);
             } catch (InterruptedException exc) {
                 _logger.log(Level.SEVERE,"jts.wait_for_resync_complete_interrupted");
                 String msg = LogFormatter.getLocalizedMessage(_logger,

--- a/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/TransactionFactoryImpl.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/jts/CosTransactions/TransactionFactoryImpl.java
@@ -144,9 +144,10 @@ class TransactionFactoryImpl extends TransactionFactoryPOA implements Transactio
             throw exc;
         }
 
-        // Ensure that resync has completed.
+        // Ensure that the resync between the resource and the transaction
+        // manager has completed.
 
-        RecoveryManager.waitForResync(timeOut);
+        RecoveryManager.waitForResyncWithTimeout();
 
         // Create a new top-level Coordinator, and initialise it
         // with the given time-out value.  If the operation fails,


### PR DESCRIPTION
Follow-up: #24702 and [fix GLASSFISH-21175](https://github.com/javaee/glassfish/commit/4e8ae2867cb2fcd971920ff71b83e9056ecc07eb)

In the past, a timeout was added to the process where the GlassFish RecoveryManager resynchronizes the state of the resource and the transaction manager as a fix for the hang issue (#21175).
However, that change was not about adding a new timeout period value, but reusing the timeout value of the container-managed transaction. Then, the change introduced a problem into the setting of the container-managed transaction timeout.

Since it is advisable to avoid using the same timeout period for different purposes, I've hidden the timeout period for RecoveryManager's resynchronization as an internal parameter, and separated it from the value of the container-managed transaction timeout period.

By doing this, the issue of not being able to disable transaction timeout will no longer occur, so I've reverted the default value of the transaction timeout that was changed in the recent fix (#24702).
