### PR TITLE
Update MP to Jakarta EE 11 M1 compatible versions.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ kind: Pod
 spec:
   containers:
   - name: maven
-    image: maven:3.9.4-eclipse-temurin-17
+    image: maven:3.9.4-eclipse-temurin-21
     command:
     - cat
     tty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,7 +227,7 @@ spec:
         }
       }
       tools {
-        jdk 'temurin-jdk17-latest'
+        jdk 'temurin-jdk21-latest'
         maven 'apache-maven-3.9.5'
       }
       steps {

--- a/appserver/microprofile/config/pom.xml
+++ b/appserver/microprofile/config/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to Eclipse Foundation.
+    Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,12 +71,17 @@
                         <supportedProjectType>glassfish-jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
+                        <Import-Package>
+                            !io.helidon.inject.runtime,*
+                        </Import-Package>
+                        
                         <!-- A list of packages that are exposed to classes outside the bundle -->
                         <Export-Package>
                             org.glassfish.microprofile.config,
                             io.helidon.config.mp,
-                            io.helidon.config,
+                            io.helidon.config
                         </Export-Package>
+                        
                         <!-- A list of dependencies to include in the bundle (as they're not native OSGI bundles) -->
                         <Embed-Dependency>
                             <!--
@@ -88,6 +93,12 @@
                                     groupId=io.helidon.common;artifactId=helidon-common-service-loader,
                                     groupId=io.helidon.config;artifactId=helidon-config-yaml-mp,
                                     groupId=io.helidon.config;artifactId=helidon-config,
+                                        groupId=io.helidon.inject;artifactId=helidon-inject-api,
+                                        groupId=io.helidon.logging;artifactId=helidon-logging-common,
+                                        groupId=io.helidon.common;artifactId=helidon-common-types,
+                                            groupId=io.helidon.builder;artifactId=helidon-builder-api,
+                                        groupId=io.helidon.common;artifactId=helidon-common-config,
+                                            groupId=io.helidon.common;artifactId=helidon-common-mapper,
                                         <!--
                                         groupId=io.helidon.common;artifactId=helidon-common-reactive,
                                             groupId=io.helidon.common;artifactId=helidon-common-mapper, -->
@@ -102,11 +113,13 @@
                                 groupId=io.helidon.common;artifactId=helidon-common-crypto,
                             groupId=io.helidon.config;artifactId=helidon-config-object-mapping, -->
                         </Embed-Dependency>
+                        
                         <!--
                             Include transitive dependencies (note that this only include compile scoped dependencies,
                             other scoped dependencies still need explicit inclusion)
                         -->
                         <Embed-Transitive>true</Embed-Transitive>
+                        
                         <Multi-Release>true</Multi-Release>
                         <Include-Resource>
                             {maven-resources},

--- a/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -134,7 +134,7 @@ public class ConfigCdiExtension implements Extension {
             return;
         }
 
-        configBeans.put(annotatedType.getJavaClass(), ConfigBeanDescriptor.create(annotatedType.getJavaClass(), configProperties));
+        configBeans.put(annotatedType.getJavaClass(), ConfigBeanDescriptor.create(annotatedType, configProperties));
 
         // We must veto this annotated type, as we need to create a custom bean to create an instance
         event.veto();

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2024 Contributors to Eclipse Foundation.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -151,12 +151,12 @@
         <krazo.version>3.0.1</krazo.version>
 
         <!-- MicroProfile Config -->
-        <microprofile.config-api.version>3.0.3</microprofile.config-api.version>
-        <helidon-config.version>3.2.3</helidon-config.version>
+        <microprofile.config-api.version>3.1</microprofile.config-api.version>
+        <helidon-config.version>4.0.2</helidon-config.version>
 
         <!-- MicroProfile JWT / JWT Authentication Mechanism for Jakarta Security -->
         <microprofile-jwt-auth-api.version>2.1</microprofile-jwt-auth-api.version>
-        <omnifaces-jwt-auth.version>2.0.2</omnifaces-jwt-auth.version>
+        <omnifaces-jwt-auth.version>3.0.0-M1</omnifaces-jwt-auth.version>
 
         <!-- MicroProfile REST Client -->
         <microprofile.rest-client.version>3.0.1</microprofile.rest-client.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
     Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -153,7 +153,7 @@
 
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
-        <easymock.version>4.3</easymock.version>
+        <easymock.version>5.2.0</easymock.version>
         <jmockit.version>1.49</jmockit.version>
         <junit.version>5.10.1</junit.version>
         <jmh.version>1.37</jmh.version>
@@ -807,8 +807,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
                     <configuration>
-                        <source>11</source>
-                        <target>11</target>
+                        <source>21</source>
+                        <target>21</target>
                         <excludes>
                             <exclude>**/.ade_path/**</exclude>
                         </excludes>


### PR DESCRIPTION
Also sets JDK to 21; this was required by Helidon 4, but something that was already planned for GlassFish.

MP JWT and MP Config TCK pass.

