### PR TITLE
Fixes around logging

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -83,7 +84,7 @@ public abstract class GFLauncher {
      * parameters (GF DAS or Instance).
      *
      */
-    private GFLauncherInfo callerParameters;
+    private final GFLauncherInfo callerParameters;
 
     /**
      * Properties from asenv.conf, such as <code>AS_DEF_DOMAINS_PATH="../domains"</code>
@@ -119,7 +120,7 @@ public abstract class GFLauncher {
     /**
      * Same data as domainXMLjvmOptions, but as list
      */
-    private List<String> domainXMLJvmOptionsAsList = new ArrayList<>();
+    private final List<String> domainXMLJvmOptionsAsList = new ArrayList<>();
 
     /**
      * The <code>profiler<code> from <code>java-config</code> in domain.xml
@@ -160,7 +161,7 @@ public abstract class GFLauncher {
     /**
      * The full commandline string used to start GlassFish in process <code<>glassFishProcess</code>
      */
-    private List<String> commandLine = new ArrayList<>();
+    private final List<String> commandLine = new ArrayList<>();
 
     /**
      * Time when GlassFish was launched
@@ -469,6 +470,10 @@ public abstract class GFLauncher {
         // Run the glassFishProcess and attach Stream Drainers
         try {
             closeStandardStreamsMaybe();
+
+            // We have to abandon server.log file to avoid file locking issues on Windows.
+            // From now on the server.log file is owned by the server, not by launcher.
+            GFLauncherLogger.removeLogFileHandler();
 
             // Startup GlassFish
             glassFishProcess = processBuilder.start();
@@ -1108,7 +1113,7 @@ public abstract class GFLauncher {
     ///////////////////////////////////////////////////////////////////////////
     private static class ProcessWhacker implements Runnable {
 
-        private String message;
+        private final String message;
         private Process process;
 
         ProcessWhacker(Process p, String msg) {

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -114,9 +114,6 @@ Domain.badDomainDir=CLI301: There is no such domain directory: {0}
 Domain.noDomainXml=CLI304: Cannot find domain.xml.  It should be here: {0}
 
 ## stop-domain command
-StopDomain.dasNotRunning=CLI306: Warning - The server located at {0} is not running.
-StopDomain.dasNotRunningRemotely=CLI307: Warning - remote server is not running, unable to force it to stop.\n\
-Try running stop-domain on the remote server.
 StopDomain.WaitDASDeath=Waiting for the domain to stop
 StopDomain.DASNotDead=Timed out ({0} seconds) waiting for the domain to stop.
 StopDomain.noDomainNameAllowed=No domain name allowed with --host option.

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogFacade.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LogFacade.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -56,8 +57,16 @@ public class LogFacade {
     @LogMessageInfo(message = "Updated logger levels successfully.", level="INFO")
     public static final String UPDATED_LOG_LEVELS = "NCLS-LOGGING-00003";
 
-    @LogMessageInfo(message = "The logging configuration file {0} has been deleted.", level="WARNING")
+    @LogMessageInfo(
+        message = "The logging configuration file {0} has been deleted."
+        + " The server will wait until the file reappears.",
+        cause="The file was deleted.",
+        action="Create the file again using the Admin Console or asadmin command.",
+        level="SEVERE")
     public static final String CONF_FILE_DELETED = "NCLS-LOGGING-00004";
+
+    @LogMessageInfo(message = "The logging configuration file {0} has reappeared.", level="INFO")
+    public static final String CONF_FILE_REAPPEARED = "NCLS-LOGGING-00004-1";
 
     @LogMessageInfo(message = "Error executing query to fetch log records.", level="SEVERE",
             cause="There was an exception thrown while executing log query.",

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/rotation/LogFileArchiver.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/rotation/LogFileArchiver.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.jul.rotation;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.System.Logger;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.zip.GZIPOutputStream;
+
+import org.glassfish.main.jul.tracing.GlassFishLoggingTracer;
+
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.INFO;
+
+/**
+ * LogFileArchiver manages history of log files, compresses them into gz files, removes old files.
+ */
+class LogFileArchiver {
+    private static final Logger LOG = System.getLogger(LogFileArchiver.class.getName());
+    private static final String GZIP_EXTENSION = ".gz";
+
+    private final File mainLogFile;
+    private final boolean compressOldLogFiles;
+    private final int maxCountOfOldLogFiles;
+
+
+    LogFileArchiver(File mainLogFile, boolean compressOldLogFiles, final int maxCountOfOldLogFiles) {
+        this.mainLogFile = mainLogFile;
+        this.compressOldLogFiles = compressOldLogFiles;
+        this.maxCountOfOldLogFiles = maxCountOfOldLogFiles;
+    }
+
+
+    /**
+     * @return file with a name ie. server.log_2024-01-13T11-45-37.gz
+     */
+    File getGzArchiveFile(final File rotatedFile) {
+        return new File(rotatedFile.getParentFile(), rotatedFile.getName() + GZIP_EXTENSION);
+    }
+
+
+    /**
+     * There is no need to block processing of new log records with this time consuming action,
+     * so this starts a parallel thread.
+     * However the cleanup is done in synchronized method to avoid collisions in a case when
+     * there would be more parallel slow threads.
+     *
+     * @param archivedFile
+     */
+    void archive(File archivedFile) {
+        final Runnable cleanup = () -> cleanUpHistoryLogFiles(archivedFile);
+        new Thread(cleanup, "old-log-files-cleanup-" + mainLogFile.getName()).start();
+    }
+
+
+    private synchronized void cleanUpHistoryLogFiles(final File rotatedFile) {
+        if (this.compressOldLogFiles) {
+            compressFile(rotatedFile);
+        }
+        deleteOldLogFiles();
+    }
+
+
+    private void compressFile(final File rotatedFile) {
+        final long start = System.currentTimeMillis();
+        final File outFile = getGzArchiveFile(rotatedFile);
+        final boolean compressed = gzipFile(rotatedFile, outFile);
+        if (!compressed) {
+            logError("Could not compress log file: " + rotatedFile.getAbsolutePath());
+            return;
+        }
+        final long time = System.currentTimeMillis() - start;
+        LOG.log(INFO, "File {0} of size {1} has been archived to file {2} of size {3} in {4} ms",
+            rotatedFile, rotatedFile.length(), outFile, outFile.length(), time);
+        final boolean deleted = rotatedFile.delete();
+        if (!deleted) {
+            logError("Could not delete uncompressed log file: " + rotatedFile.getAbsolutePath());
+        }
+    }
+
+
+    private boolean gzipFile(final File inputFile, final File outputFile) {
+        try (
+            FileInputStream fis = new FileInputStream(inputFile);
+            FileOutputStream fos = new FileOutputStream(outputFile);
+            GZIPOutputStream gzos = new GZIPOutputStream(fos)
+        ) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = fis.read(buffer)) != -1) {
+                gzos.write(buffer, 0, len);
+            }
+            gzos.finish();
+            return true;
+        } catch (IOException e) {
+            final String message = "Error gzipping log file " + inputFile;
+            GlassFishLoggingTracer.error(getClass(), message, e);
+            LOG.log(ERROR, message, e);
+            return false;
+        }
+    }
+
+
+    private void deleteOldLogFiles() {
+        if (this.maxCountOfOldLogFiles == 0) {
+            return;
+        }
+
+        final File dir = this.mainLogFile.getParentFile();
+        final String logFileName = this.mainLogFile.getName();
+        if (dir == null) {
+            return;
+        }
+        final FileFilter filter = f -> f.isFile() && !f.getName().equals(logFileName)
+            && f.getName().startsWith(logFileName);
+        Arrays.stream(dir.listFiles(filter)).sorted(Comparator.comparing(File::getName).reversed())
+            .skip(this.maxCountOfOldLogFiles).forEach(this::deleteFile);
+    }
+
+
+    private void deleteFile(final File file) {
+        final boolean delFile = file.delete();
+        if (!delFile) {
+            logError("Could not delete the log file: " + file);
+        }
+    }
+
+
+    private void logError(final String message) {
+        GlassFishLoggingTracer.error(getClass(), message);
+        LOG.log(ERROR, message);
+    }
+}

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/rotation/MeteredFileWriter.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/rotation/MeteredFileWriter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.jul.rotation;
+
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+
+/**
+ * {@link OutputStreamWriter} knowing how much bytes was already written to the output stream.
+ */
+class MeteredFileWriter extends OutputStreamWriter {
+
+    private final MeteredStream output;
+    private final Charset encoding;
+
+    /**
+     * Creates the writer.
+     *
+     * @param output stream
+     * @param encoding {@link Charset} used for encoding.
+     */
+    public MeteredFileWriter(final MeteredStream output, final Charset encoding) {
+        super(output, encoding);
+        this.output = output;
+        this.encoding = encoding;
+    }
+
+
+    @Override
+    public String getEncoding() {
+        return this.encoding.name();
+    }
+
+
+    /**
+     * @return count of bytes written by this stream instance plus number given in constructor
+     */
+    public long getBytesWritten() {
+        return output.getBytesWritten();
+    }
+
+
+    /**
+     * Returns short info about this class.
+     */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[charset=" + getEncoding() + ", writtenBytes=" + getBytesWritten() + ']';
+    }
+}

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -36,10 +36,10 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.glassfish.main.jul.env.LoggingSystemEnvironment.getOriginalStdErr;
 import static org.glassfish.main.jul.env.LoggingSystemEnvironment.getOriginalStdOut;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -143,14 +143,14 @@ public class GlassFishLogHandlerTest {
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
             () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
-            () -> assertThat("size of file two", handler.getConfiguration().getLogFile().length(), equalTo(0L))
+            () -> assertThat("size of file two", handler.getConfiguration().getLogFile().length(), lessThan(260L))
         );
-        handler.publish(new GlassFishLogRecord(Level.SEVERE, "File two, line one"));
+        handler.publish(new GlassFishLogRecord(Level.SEVERE, "File two, line two"));
         Thread.sleep(MILLIS_FOR_PUMP);
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
             () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
-            () -> assertThat("size of file two", handler.getConfiguration().getLogFile().length(), greaterThan(0L))
+            () -> assertThat("size of file two", handler.getConfiguration().getLogFile().length(), greaterThan(260L))
         );
     }
 


### PR DESCRIPTION
- The stop-domain did not print that the domain is not running, but just some method name instead.
- When rolling the server.log file, several messages was lost. Closes #24737 
- Reduced using method handles as parameters, better separation of features.
- Some editors (Vim) delete before save, sometimes GF noticed the logging.properties vanished and then GF stopped its monitoring and reloading. As the file is critical, on this event now GF creates a special thread which resets everything to correct state after the file reappears.
- Rolling the server.log file did not work on Windows when used with --verbose or --watch (also used by Windows Services), because Launcher had it's own handle to the file and Windows blocked attempts to move the file. Now Launcher removed its handler right before it starts the server which configures its own logging and continues writing to the server.log. This relates to #24065 .