### PR TITLE
Add debug option to start-cluster, to start all instances in debug mode

### DIFF
--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ClusterCommandHelper.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ClusterCommandHelper.java
@@ -185,9 +185,9 @@ class ClusterCommandHelper {
             // Set the instance name as the operand for the commnd
             instanceParameterMap.set("DEFAULT", iname);
             if (debug) {
-            	instanceParameterMap.set("debug", "true");
+                instanceParameterMap.set("debug", "true");
             }
-            
+
 
             ActionReport instanceReport = runner.getActionReport("plain");
             instanceReport.setActionExitCode(ExitCode.SUCCESS);

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ClusterCommandHelper.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ClusterCommandHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -97,6 +98,7 @@ class ClusterCommandHelper {
             ParameterMap map,
             String  clusterName,
             AdminCommandContext context,
+            boolean debug,
             boolean verbose) throws CommandException {
 
         // When we started
@@ -182,6 +184,10 @@ class ClusterCommandHelper {
             ParameterMap instanceParameterMap = new ParameterMap(map);
             // Set the instance name as the operand for the commnd
             instanceParameterMap.set("DEFAULT", iname);
+            if (debug) {
+            	instanceParameterMap.set("debug", "true");
+            }
+            
 
             ActionReport instanceReport = runner.getActionReport("plain");
             instanceReport.setActionExitCode(ExitCode.SUCCESS);

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartClusterCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartClusterCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -61,6 +62,9 @@ public class StartClusterCommand implements AdminCommand {
 
     @Param(optional = false, primary = true)
     private String clusterName;
+    
+    @Param(optional = true, defaultValue = "false")
+    private boolean debug;
 
     @Param(optional = true, defaultValue = "false")
     private boolean verbose;
@@ -88,7 +92,7 @@ public class StartClusterCommand implements AdminCommand {
         try {
             // Run start-instance against each instance in the cluster
             String commandName = "start-instance";
-            clusterHelper.runCommand(commandName, null, clusterName, context,
+            clusterHelper.runCommand(commandName, null, clusterName, context, debug,
                     verbose);
         }
         catch (CommandException e) {

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartClusterCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartClusterCommand.java
@@ -62,7 +62,7 @@ public class StartClusterCommand implements AdminCommand {
 
     @Param(optional = false, primary = true)
     private String clusterName;
-    
+
     @Param(optional = true, defaultValue = "false")
     private boolean debug;
 

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopClusterCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopClusterCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -92,7 +93,7 @@ public class StopClusterCommand implements AdminCommand {
         try {
             // Run start-instance against each instance in the cluster
             String commandName = "stop-instance";
-            clusterHelper.runCommand(commandName, map, clusterName, context,
+            clusterHelper.runCommand(commandName, map, clusterName, context, false,
                     verbose);
         } catch (CommandException e) {
             String msg = e.getLocalizedMessage();

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-cluster.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-cluster.1
@@ -4,7 +4,8 @@ NAME
        start-cluster - starts a cluster
 
 SYNOPSIS
-           start-cluster [--help] [--autohadboverride={true|false}]
+           start-cluster [--help] 
+           [--debug={false|true}] [--autohadboverride={true|false}]
            [--verbose={false|true}] cluster-name
 
 DESCRIPTION
@@ -38,6 +39,23 @@ DESCRIPTION
 OPTIONS
        --help, -?
            Displays the help text for the subcommand.
+       
+       --debug
+           Specifies whether each instance in the cluster is started with Java Platform
+           Debugger Architecture (JPDA)
+
+           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+
+           debugging enabled.
+
+           Possible values are as follows:
+
+           true
+               Each instance is started with JPDA debugging enabled and the
+               port number for JPDA debugging is displayed.
+
+           false
+               Each instance is started with JPDA debugging disabled (default).
 
        --autohadboverride
            Do not specify this option. This option is retained for


### PR DESCRIPTION
This adds a "--debug" option to the "start-cluster" command, analogous to the "start-domain" command, and "start-instance" command. It will pass the "--debug" option to each individual "start-instance" command that will be called from  "start-domain".

e.g.

```
./asadmin start-cluster --debug clusterA
```