### PR TITLE
Try the application classloader to restore the Principal for HA.

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/SingleSignOn.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/authenticator/SingleSignOn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -251,7 +251,7 @@ public class SingleSignOn extends ValveBase implements SessionListener {
         if (isVersioningSupported() && versionCookie != null) {
             version = Long.parseLong(versionCookie.getValue());
         }
-        SingleSignOnEntry entry = lookup(cookie.getValue(), version);
+        SingleSignOnEntry entry = lookup(cookie.getValue(), version, request.getContext().getLoader().getClassLoader());
         if (entry != null) {
             if (debug >= 1) {
                 String msg = MessageFormat.format(rb.getString(LogFacade.FOUND_CACHED_PRINCIPAL_AUTH_TYPE_INFO),
@@ -314,7 +314,7 @@ public class SingleSignOn extends ValveBase implements SessionListener {
             log(rb.getString(ASSOCIATE_SSO_WITH_SESSION_INFO));
         }
 
-        SingleSignOnEntry sso = lookup(ssoId, ssoVersion);
+        SingleSignOnEntry sso = lookup(ssoId, ssoVersion, null);
         if (sso != null) {
             session.setSsoId(ssoId);
             session.setSsoVersion(ssoVersion);
@@ -417,7 +417,7 @@ public class SingleSignOn extends ValveBase implements SessionListener {
      * @param ssoId Single sign on identifier to look up
      * @param ssoVersion Single sign on version to look up
      */
-    protected SingleSignOnEntry lookup(String ssoId, long ssoVersion) {
+    protected SingleSignOnEntry lookup(String ssoId, long ssoVersion, ClassLoader appClassLoader) {
         return lookup(ssoId);
     }
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/security/web/GlassFishSingleSignOn.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -374,7 +375,7 @@ public class GlassFishSingleSignOn
         if (isVersioningSupported() && versionCookie != null) {
             version = Long.parseLong(versionCookie.getValue());
         }
-        SingleSignOnEntry entry = lookup(cookie.getValue(), version);
+        SingleSignOnEntry entry = lookup(cookie.getValue(), version, request.getContext().getLoader().getClassLoader());
         if (entry != null) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, LogFacade.FOUND_CACHED_PRINCIPAL,
@@ -443,7 +444,7 @@ public class GlassFishSingleSignOn
         // Look up and remove the corresponding SingleSignOnEntry
         SingleSignOnEntry sso = null;
         synchronized (cache) {
-            sso = (SingleSignOnEntry) cache.remove(ssoId);
+            sso = cache.remove(ssoId);
         }
 
         if (sso == null)
@@ -492,7 +493,7 @@ public class GlassFishSingleSignOn
                 Iterator<String> it = cache.keySet().iterator();
                 while (it.hasNext()) {
                     String key = it.next();
-                    SingleSignOnEntry sso = (SingleSignOnEntry) cache.get(key);
+                    SingleSignOnEntry sso = cache.get(key);
                     if (sso.isEmpty() && sso.getLastAccessTime() < tooOld) {
                         removals.add(key);
                     }
@@ -581,6 +582,7 @@ public class GlassFishSingleSignOn
     /**
      * The background thread that checks for SSO timeouts and shutdown.
      */
+    @Override
     public void run() {
 
         // Loop until the termination semaphore is set
@@ -626,6 +628,7 @@ public class GlassFishSingleSignOn
      *
      * @return Number of sessions participating in SSO
      */
+    @Override
     public int getActiveSessionCount() {
         return cache.size();
     }
@@ -636,6 +639,7 @@ public class GlassFishSingleSignOn
      *
      * @return Number of SSO cache hits
      */
+    @Override
     public int getHitCount() {
         return hitCount.intValue();
     }
@@ -646,6 +650,7 @@ public class GlassFishSingleSignOn
      *
      * @return Number of SSO cache misses
      */
+    @Override
     public int getMissCount() {
         return missCount.intValue();
     }

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/authenticator/HASingleSignOn.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/authenticator/HASingleSignOn.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -113,7 +114,7 @@ public class HASingleSignOn extends GlassFishSingleSignOn {
         if (debug >= 1)
             log("Associate sso id " + ssoId + " with session " + session);
 
-        HASingleSignOnEntry sso = (HASingleSignOnEntry)lookup(ssoId, ssoVersion);
+        HASingleSignOnEntry sso = (HASingleSignOnEntry)lookup(ssoId, ssoVersion, null);
         if (sso != null) {
             session.setSsoId(ssoId);
             sso.addSession(this, session);
@@ -127,8 +128,8 @@ public class HASingleSignOn extends GlassFishSingleSignOn {
     }
 
     @Override
-    protected SingleSignOnEntry lookup(String ssoId, long ssoVersion) {
-        SingleSignOnEntry ssoEntry = super.lookup(ssoId, ssoVersion);
+    protected SingleSignOnEntry lookup(String ssoId, long ssoVersion, ClassLoader appClassLoader) {
+        SingleSignOnEntry ssoEntry = super.lookup(ssoId, ssoVersion, appClassLoader);
         if (ssoEntry != null && ssoVersion > ssoEntry.getVersion()) {
             // clean the old cache
             synchronized(cache) {
@@ -142,7 +143,7 @@ public class HASingleSignOn extends GlassFishSingleSignOn {
                 HASingleSignOnEntryMetadata mdata =
                     ssoEntryMetadataBackingStore.load(ssoId, null);
                 if (mdata != null) {
-                    ssoEntry = new HASingleSignOnEntry(getContainer(), mdata, ioUtils);
+                    ssoEntry = new HASingleSignOnEntry(getContainer(), mdata, ioUtils, appClassLoader);
                     cache.put(ssoId, ssoEntry);
                 }
             } catch(BackingStoreException ex) {

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/authenticator/HASingleSignOnEntry.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/authenticator/HASingleSignOnEntry.java
@@ -190,8 +190,7 @@ public class HASingleSignOnEntry extends SingleSignOnEntry {
 
             try {
                 return (Principal) ois.readObject();
-            }
-            catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException e) {
                 closeSafely(bais);
                 closeSafely(bis);
                 closeSafely(ois);

--- a/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/authenticator/HASingleSignOnEntry.java
+++ b/appserver/web/web-ha/src/main/java/org/glassfish/web/ha/authenticator/HASingleSignOnEntry.java
@@ -192,8 +192,8 @@ public class HASingleSignOnEntry extends SingleSignOnEntry {
                 return (Principal) ois.readObject();
             }
             catch (ClassNotFoundException e) {
+                closeSafely(bais);
                 closeSafely(bis);
-                closeSafely(ois);
                 closeSafely(ois);
 
                 bais = new ByteArrayInputStream(pbytes);


### PR DESCRIPTION
Fixes #24752 

This allows a custom Principal to be used that's defined by the application (the .class file resides in a .war).

The application classloader is tried last so that the existing behaviour is preserved as much as possible.
