### PR TITLE
Print processes before the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ def dumpSysInfo() {
     \${JAVA_HOME}/bin/jcmd || true
     mvn -version || true
     ant -version || true
+    ps -e -o start,etime,pid,rss,drs,command || true
     cat /proc/cpuinfo || true
     cat /proc/meminfo || true
   """


### PR DESCRIPTION
On master branch builds are failing because something uses port 4848. We assume it is an instance from some older build, but we don't know for sure.

Other useful commands as ss, netstat, fuser, lsof are not supported on Jenkins.

```
21:36:16  + ps -e -o start,etime,pid,rss,drs,command
21:36:16   STARTED     ELAPSED     PID   RSS   DRS COMMAND
21:36:16  20:35:41       00:35       1  1056  5892 cat
21:36:16  20:36:15       00:01      14   116  2813 sh -c ({ while [ -d '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50' -a \! -f '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt' ]; do touch '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-log.txt'; sleep 3; done } & jsc=durable-05a4d0071da94f367db544c461591981ac5833ecc88a0bc74c399aea2102f244; JENKINS_SERVER_COOKIE=$jsc 'sh' -xe  '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/script.sh' > '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-log.txt' 2>&1; echo $? > '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt.tmp'; mv '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt.tmp' '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt'; wait) >&- 2>&- &
21:36:16  20:36:15       00:01      15   180  2813 sh -c ({ while [ -d '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50' -a \! -f '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt' ]; do touch '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-log.txt'; sleep 3; done } & jsc=durable-05a4d0071da94f367db544c461591981ac5833ecc88a0bc74c399aea2102f244; JENKINS_SERVER_COOKIE=$jsc 'sh' -xe  '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/script.sh' > '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-log.txt' 2>&1; echo $? > '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt.tmp'; mv '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt.tmp' '/home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/jenkins-result.txt'; wait) >&- 2>&- &
21:36:16  20:36:15       00:01      16   992  2813 sh -xe /home/jenkins/agent/workspace/_test-using-jenkinsfile_PR-24770@tmp/durable-26b53b50/script.sh
21:36:16  20:36:15       00:01      19  1096  5759 sleep 3
21:36:16  20:36:16       00:00      83  1572 10021 ps -e -o start,etime,pid,rss,drs,command
```
