### PR TITLE
Fixes issue #24782, cannot run eclipse:eclipse on module nucleus-dtds on Windows

### DIFF
--- a/nucleus/deployment/dtds/pom.xml
+++ b/nucleus/deployment/dtds/pom.xml
@@ -60,7 +60,6 @@
                 <excludes>
                     <exclude>**/.ade_path/**</exclude>
                 </excludes>
-                <targetPath>${project.build.outputDirectory}</targetPath>
             </resource>
         </resources>
     </build>


### PR DESCRIPTION
Fixes issue #24782, cannot run eclipse:eclipse on module nucleus-dtds on Windows
ECA username 'rmisingnamesda'
