### PR TITLE
Updated artifactId of gf docs in the website publisher

### DIFF
--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -104,9 +104,8 @@
                             <excludes>META-INF/**</excludes>
                             <artifactItems>
                                 <artifactItem>
-                                    <!-- TODO: 2/2 Update groupId+artifactId after 7.0.11 -->
                                     <groupId>org.glassfish.docs</groupId>
-                                    <artifactId>distribution</artifactId>
+                                    <artifactId>glassfish-documentation</artifactId>
                                     <version>${glassfish.version.7x.artifact}</version>
                                     <outputDirectory>${docs.7x.dir}</outputDirectory>
                                 </artifactItem>


### PR DESCRIPTION
- fixed the todo after we changed the id in previous versions.
- the publisher looks for past versions, that is why this had to be done this way.

This should fix this failure:
- https://ci.eclipse.org/glassfish/job/glassfish-website-publish-docs/1217/consoleFull
- https://ci.eclipse.org/glassfish/job/glassfish-website-publish-docs/
