### PR TITLE
Fixes GlassFish event filtering

### DIFF
--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
@@ -82,7 +82,7 @@ public class EventsImpl implements Events {
                 logger.log(Level.SEVERE, KernelLoggerInfo.exceptionSendEvent, ex);
             }
             if (m!=null) {
-                RestrictTo fooBar = m.getParameterTypes()[0].getAnnotation(RestrictTo.class);
+                RestrictTo fooBar = m.getParameters()[0].getAnnotation(RestrictTo.class);
                 if (fooBar!=null) {
                     EventTypes interested = EventTypes.create(fooBar.value());
                     if (!event.is(interested)) {


### PR DESCRIPTION
Event filtering with `RestrictTo` annotation does not works.
