### PR TITLE
Fixes issue #24762 Use AMXLoggerInfo io System.out and add attribute info in toString method.

### DIFF
--- a/appserver/common/amx-jakartaee/src/main/java/org/glassfish/admin/amx/impl/j2ee/loader/AMXJ2EEStartupService.java
+++ b/appserver/common/amx-jakartaee/src/main/java/org/glassfish/admin/amx/impl/j2ee/loader/AMXJ2EEStartupService.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -60,10 +61,6 @@ public final class AMXJ2EEStartupService
         implements org.glassfish.hk2.api.PostConstruct,
         org.glassfish.hk2.api.PreDestroy,
         AMXLoader, ConfigListener {
-
-    private static void debug(final String s) {
-        System.out.println(s);
-    }
 
     @Inject
     private MBeanServer mMBeanServer;

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/GlassFishConfigBean.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/GlassFishConfigBean.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,6 +18,8 @@
 package org.glassfish.config.support;
 
 import java.lang.reflect.Proxy;
+import java.util.StringJoiner;
+
 import javax.xml.stream.XMLStreamReader;
 
 import org.glassfish.hk2.api.ServiceLocator;
@@ -96,7 +99,10 @@ public final class GlassFishConfigBean extends ConfigBean {
     }
 
     public String toString() {
-        //final Set<String> attrNames = getAttributeNames();
-        return "GlassFishConfigBean." + getProxyType().getName();
+        StringJoiner attributeJoiner = new StringJoiner(",");
+        for (String attributeName : getAttributeNames()) {
+            attributeJoiner.add(attributeName + "=" + attribute(attributeName));
+        }
+        return "GlassFishConfigBean." + getProxyType().getName() + "(" + attributeJoiner.toString() + ")";
     }
 }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/base/MBeanTracker.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/base/MBeanTracker.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -38,9 +39,6 @@ import org.glassfish.external.arc.Taxonomy;
 @AMXMBeanMetadata(singleton = true, globalSingleton = true, leaf = true)
 public final class MBeanTracker implements NotificationListener, MBeanRegistration, MBeanTrackerMBean {
 
-    private static void debug(final Object o) {
-        System.out.println("" + o);
-    }
     /**
      * maps a parent ObjectName to a Set of children
      */

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/PathnameParser.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/PathnameParser.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,10 +15,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.glassfish.admin.amx.core;
 
 import java.util.ArrayList;
@@ -40,11 +37,6 @@ import org.glassfish.external.arc.Taxonomy;
 @Taxonomy(stability = Stability.UNCOMMITTED)
 public final class PathnameParser
 {
-    private static void debug(final Object o)
-    {
-        System.out.println("" + o);
-    }
-
     private final char mDelim;
 
     private final char mNameLeft;

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/Util.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/core/Util.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -50,10 +51,6 @@ import static org.glassfish.external.amx.AMX.TYPE_KEY;
 public final class Util {
 
     private static final String QUOTE_CHAR = "\"";
-
-    private static void debug(final String s) {
-        System.out.println(s);
-    }
 
     public static String quoteIfNeeded(String name) {
         if(name.indexOf(":") > 1) {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/AMXStartupService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -65,10 +65,6 @@ public final class AMXStartupService
         implements org.glassfish.hk2.api.PostConstruct,
         org.glassfish.hk2.api.PreDestroy,
         AMXStartupServiceMBean {
-
-    private static void debug(final String s) {
-        System.out.println(s);
-    }
 
     @Inject
     ServiceLocator mHabitat;

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigLoader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -53,9 +54,6 @@ Responsible for loading ConfigBeanProxy MBeans (com.sun.enterprise.config.server
 public final class AMXConfigLoader
         implements TransactionListener {
 
-    private static void debug(final String s) {
-        System.out.println(s);
-    }
     private volatile AMXConfigLoaderThread mLoaderThread;
     private final Transactions mTransactions;
     private final Logger mLogger = AMXLoggerInfo.getLogger();
@@ -209,7 +207,7 @@ public final class AMXConfigLoader
                         issueAttributeChange(cb, propertyName, oldValue, newValue, whenChanged);
                     }
                 } else {
-                    debug("AMXConfigLoader.sortAndDispatch: WARNING: source is not a ConfigBean");
+                    mLogger.fine("AMXConfigLoader.sortAndDispatch: WARNING: source is not a ConfigBean");
                 }
             }
         }
@@ -482,8 +480,7 @@ public final class AMXConfigLoader
             //System.out.println( "AMXConfigLoader.createAndRegister(): REGISTERED: " + objectName + " at " + System.currentTimeMillis() );
             //System.out.println( JMXUtil.toString( mServer.getMBeanInfo(objectName) ) );
         } catch (final JMException e) {
-            debug(ExceptionUtil.toString(e));
-
+            mLogger.log(Level.WARNING, AMXLoggerInfo.cantRegister, new Object[]{getType(cb), getKey(cb), e});
             objectName = null;
         }
         return objectName;

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigStartupService.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AMXConfigStartupService.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -55,9 +56,6 @@ public final class AMXConfigStartupService
         org.glassfish.hk2.api.PreDestroy,
         AMXLoader {
 
-    private static void debug(final String s) {
-        System.out.println(s);
-    }
     @Inject
     InjectedValues mInjectedValues;
     @Inject//(name=AppserverMBeanServerFactory.OFFICIAL_MBEANSERVER)

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AttributeResolverHelper.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/AttributeResolverHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,10 +43,6 @@ import org.jvnet.hk2.config.VariableResolver;
  */
 @Taxonomy( stability = Stability.UNCOMMITTED)
 public class AttributeResolverHelper extends VariableResolver {
-
-    private static void debug(final String s) {
-        System.out.println("##### " + s);
-    }
 
     public AttributeResolverHelper(final AMXConfigProxy amx) {
     }

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/ConfigBeanJMXSupport.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/ConfigBeanJMXSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1601,12 +1601,6 @@ class ConfigBeanJMXSupport
         }
         return m;
     }
-
-    private static void debug(final String s)
-    {
-        System.out.println("### " + s);
-    }
-
 }
 
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/ConfigBeanRegistry.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/config/ConfigBeanRegistry.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -13,12 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
-
 package org.glassfish.admin.amx.impl.config;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,7 +30,6 @@ import org.jvnet.hk2.config.Dom;
  */
 @Taxonomy( stability=Stability.NOT_AN_INTERFACE )
 public final class ConfigBeanRegistry {
-    private static void debug( final String s ) { System.out.println(s); }
 
     public static final class MBeanInstance
     {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/ComplianceMonitor.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/mbean/ComplianceMonitor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -213,10 +214,6 @@ public final class ComplianceMonitor implements NotificationListener {
                 }
             }
         }
-    }
-
-    private static void debug(final Object o) {
-        System.out.println(o.toString());
     }
 }
 

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/ImplUtil.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/ImplUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -23,10 +24,6 @@ import org.glassfish.admin.amx.core.AMXProxy;
 import org.glassfish.admin.amx.core.proxy.ProxyFactory;
 
 public final class ImplUtil {
-
-    private static void debug(final String s) {
-        System.out.println(s);
-    }
 
     /**
     Unload this AMX MBean and all its children.

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/MBeanInfoSupport.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/MBeanInfoSupport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -12,11 +13,6 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- */
-
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
  */
 package org.glassfish.admin.amx.impl.util;
 
@@ -61,9 +57,6 @@ public final class MBeanInfoSupport {
     private MBeanInfoSupport() {
     }
 
-    private static void debug(final Object o) {
-        System.out.println(o.toString());
-    }
     private static MBeanInfo amxspiMBeanInfo = null;
 
     public static synchronized MBeanInfo getAMX_SPIMBeanInfo() {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/ObjectNameBuilder.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/ObjectNameBuilder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -53,11 +54,6 @@ public final class ObjectNameBuilder {
 
         mParent = parent;
         mJMXDomain = parent.getDomain();
-    }
-
-    private static void debug(final Object o) {
-        System.out.println("" + o);
-        //AMXDebug.getInstance().getOutput( "org.glassfish.admin.amx.support.ObjectNameBuilder" ).println( o );
     }
 
     public String getJMXDomain() {

--- a/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/UnregistrationListener.java
+++ b/nucleus/common/amx-core/src/main/java/org/glassfish/admin/amx/impl/util/UnregistrationListener.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -48,10 +49,6 @@ public final class UnregistrationListener implements NotificationListener {
                 mLatch.countDown();
             }
         }
-    }
-
-    private static void cdebug(final String s) {
-        System.out.println(s);
     }
 
     /**


### PR DESCRIPTION
Replaces 2 debug locations to use AMXLoggerInfo instead instead of System.out. Removed all debug System out methods to avoid using them in the future. No system.out used anymore in amx-core module.

Improves "ResourceRef refers to non-existent
resource" exception by logging the attributes of the ResourceRef that was incorrect.