### PR TITLE
Fix the link to the example hello.war

### DIFF
--- a/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
@@ -322,7 +322,7 @@ The following topics are addressed here:
 ==== To Obtain the Sample Application
 
 1. Download a copy of the `hello.war` sample application from
-`https://github.com/eclipse-ee4j/glassfishdownloads/quickstart/hello.war`.
+`https://raw.githubusercontent.com/eclipse-ee4j/glassfish/master/appserver/tests/appserv-tests/devtests/cluster/apps/helloworld.war`.
 
 2. Save the `hello.war` file in the directory of your choice.
 +


### PR DESCRIPTION
The old link is defunct.  Updated the link.
Fixed #24801.