### PR TITLE
Fixes issue #24746 replaces all http://www.oracle.com/technetwork links with their https://jakarta.ee/ counterpart where possible. 

### DIFF
--- a/appserver/admingui/cluster/src/main/help/en/help/ref-standaloneinstancegeneral.html
+++ b/appserver/admingui/cluster/src/main/help/en/help/ref-standaloneinstancegeneral.html
@@ -68,7 +68,7 @@
 </dd>
 <dt>Debug</dt>
 <dd>
-<p>An indication of whether Java Platform Debugger Architecture (JPDA) (<code><a href="http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html/">http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html/</a></code>) debugging is enabled for the instance. This field is read only.</p>
+<p>An indication of whether Java Platform Debugger Architecture (JPDA) (<code><a href="https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html/">https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html/</a></code>) debugging is enabled for the instance. This field is read only.</p>
 <p>If an instance is started from the Administration Console, JPDA debugging is not enabled for the instance. To start an instance with JPDA debugging enabled, use the <a href="http://www.oracle.com/pls/topic/lookup?ctx=E26576_01&id=GSRFM00236"><code>start-instance</code>(1)</a> subcommand.</p>
 </dd>
 <dt>HTTP Ports</dt>

--- a/appserver/admingui/common/src/main/help/en/help/ref-predefinedconfigsysproperties.html
+++ b/appserver/admingui/common/src/main/help/en/help/ref-predefinedconfigsysproperties.html
@@ -48,7 +48,7 @@
 </dd>
 <dt><code>JAVA_DEBUGGER_PORT</code></dt>
 <dd>
-<p>This property specifies the port number of the port that is used for connections to the Java Platform Debugger Architecture (JPDA) (<code><a href="http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html/">http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html/</a></code>) debugger. Valid values are 1-65535. On UNIX, creating sockets that listen on ports 1-1024 requires superuser privileges.</p>
+<p>This property specifies the port number of the port that is used for connections to the Java Platform Debugger Architecture (JPDA) (<code><a href="https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html/">https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html/</a></code>) debugger. Valid values are 1-65535. On UNIX, creating sockets that listen on ports 1-1024 requires superuser privileges.</p>
 </dd>
 <dt><code>JMS_PROVIDER_PORT</code></dt>
 <dd>

--- a/docs/administration-guide/src/main/asciidoc/transactions.adoc
+++ b/docs/administration-guide/src/main/asciidoc/transactions.adoc
@@ -27,10 +27,8 @@ Instructions for accomplishing the tasks in this chapter by using the
 Administration Console are contained in the Administration Console
 online help.
 
-For more information about the Java Transaction API (JTA) and Java
-Transaction Service (JTS), see the following sites:
-`http://www.oracle.com/technetwork/java/javaee/tech/jta-138684.html` and
-`http://www.oracle.com/technetwork/java/javaee/tech/jts-140022.html`.
+For more information about the Java Transaction API (JTA) see the following site:
+`https://jakarta.ee/specifications/transactions/`.
 
 You might also want to read
 "https://eclipse-ee4j.github.io/jakartaee-tutorial/#transactions[Transactions]"

--- a/docs/application-deployment-guide/src/main/asciidoc/overview.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/overview.adoc
@@ -149,9 +149,9 @@ The Jakarta EE specification permits the use of alternate top-level
 standard deployment descriptors that reside outside of the application
 archive using the `alt-dd` mechanism (alternate module-level deployment
 descriptors were permitted prior to Jakarta EE 7). Alternate deployment
-descriptors are described in the Jakarta EE 7 specification. You can find
+descriptors are described in the Jakarta EE specification. You can find
 the specification at
-`http://www.oracle.com/technetwork/java/javaee/tech/`. Alternate
+`https://jakarta.ee/specifications/platform/`. Alternate
 deployment descriptors override the top-level deployment descriptors
 packaged in an application archive. For example, for EAR files, an
 alternate deployment descriptor overrides `application.xml`. For
@@ -696,17 +696,14 @@ xref:reference-manual.adoc#asadmin[`asadmin`(1M)] help page.
 ==== NetBeans IDE
 
 You can use the NetBeans Integrated Development Environment (IDE), or
-another IDE, to assemble Jakarta EE applications and modules. The NetBeans
-IDE is included in the tools bundle of the Jakarta EE Software Development
-Kit (SDK). To download, see
-`http://www.oracle.com/technetwork/java/javaee/downloads/index.html`.
-For additional information, see `http://www.netbeans.org`.
+another IDE, to assemble Jakarta EE applications and modules.
+For additional information, see `https://netbeans.apache.org/`.
 
 [[eclipse-ide]]
 
 ==== Eclipse IDE
 
-In addition to the bundled NetBeans IDE, a plug-in for the Eclipse IDE
+In addition to the NetBeans IDE, a plug-in for the Eclipse IDE
 extends GlassFish to the Eclipse community.
 
 [[jsr-88-client]]

--- a/docs/application-development-guide/src/main/asciidoc/java-clients.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/java-clients.adoc
@@ -317,9 +317,7 @@ Application Client Using the `appclient` Script].
 ==== Using Java Web Start
 
 Java Web Start allows your application client to be easily launched and
-automatically downloaded and updated. General information about Java Web
-Start is available at
-`http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136112.html`.
+automatically downloaded and updated.
 
 The following topics are addressed here:
 

--- a/docs/application-development-guide/src/main/asciidoc/jdbc.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/jdbc.adoc
@@ -16,10 +16,10 @@ also provides high level JDBC implementation instructions for servlets
 and EJB components using the {productName}.
 
 The JDBC specifications are available at
-`http://www.oracle.com/technetwork/java/javase/jdbc/index.html`.
+`https://www.oracle.com/java/technologies/javase/javase-tech-database.html`.
 
 A useful JDBC tutorial is located at
-`http://docs.oracle.com/javase/tutorial/jdbc/index.html`.
+`https://docs.oracle.com/javase/tutorial/jdbc/index.html`.
 
 
 [NOTE]

--- a/docs/application-development-guide/src/main/asciidoc/jndi.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/jndi.adoc
@@ -15,8 +15,8 @@ objects. The Jakarta EE naming service is based on the Java Naming and
 Directory Interface (JNDI) API. The JNDI API allows application
 components and clients to look up distributed resources, services, and
 EJB components. For general information about the JNDI API, see
-`http://www.oracle.com/technetwork/java/jndi/index.html`. You can also
-see the JNDI tutorial at `http://docs.oracle.com/javase/jndi/tutorial/`.
+`https://docs.oracle.com/javase/tutorial/jndi/overview/index.html`. You can also
+see the JNDI tutorial at `https://docs.oracle.com/javase/jndi/tutorial/`.
 
 The following topics are addressed here:
 

--- a/docs/application-development-guide/src/main/asciidoc/securing-apps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/securing-apps.adoc
@@ -404,9 +404,9 @@ JAAS is a set of APIs that enable services to authenticate and enforce
 access controls upon users. JAAS provides a pluggable and extensible
 framework for programmatic user authentication and authorization. JAAS
 is a core API and an underlying technology for Jakarta EE security
-mechanisms. For more information about JAAS, refer to the JAAS
-specification for Java SDK, available at
-`http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136007.html`.
+mechanisms. For more information about JAAS, refer to the specification, 
+available at `https://jakarta.ee/specifications/authentication/` and 
+`https://jakarta.ee/specifications/authorization/`.
 
 For general information about realms and login modules, see the section
 about working with realms, users, groups, and roles in
@@ -1545,9 +1545,9 @@ or in a directory of your choice. For easy reference throughout the rest
 of this section, this directory is referred to as simply app-dir.
 
 1. Go to the
-http://www.oracle.com/technetwork/java/javaee/download-141771.html[J2EE
+https://www.oracle.com/java/technologies/java-archive-eesdk-downloads.html[J2EE
 1.4 download URL]
-(`http://www.oracle.com/technetwork/java/javaee/download-141771.html`)
+(`https://www.oracle.com/java/technologies/java-archive-eesdk-downloads.html`)
 in your browser.
 2. Click on the Download button for the Samples Bundle.
 3. Click on Accept License Agreement.

--- a/docs/application-development-guide/src/main/asciidoc/transaction-service.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/transaction-service.adoc
@@ -23,12 +23,9 @@ The following topics are addressed here:
 * xref:#the-transaction-manager-the-transaction-synchronization-registry-and-usertransaction[The Transaction Manager, the Transaction Synchronization
 Registry, and `UserTransaction`]
 
-For more information about the Java Transaction API (JTA) and Java
-Transaction Service (JTS), see "xref:administration-guide.adoc#administering-transactions[Administering
-Transactions]" in {productName} Administration
-Guide and the following sites:
-`http://www.oracle.com/technetwork/java/javaee/jta/index.html` and
-`http://www.oracle.com/technetwork/java/javaee/tech/index.html`.
+For more information about the Java Transaction API (JTA), see "xref:administration-guide.adoc#administering-transactions[Administering Transactions]" in {productName} Administration
+Guide and the following site:
+`https://jakarta.ee/specifications/transactions/`.
 
 You might also want to read
 "https://eclipse-ee4j.github.io/jakartaee-tutorial/#transactions[Transactions]"

--- a/docs/application-development-guide/src/main/asciidoc/webapps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/webapps.adoc
@@ -53,7 +53,7 @@ modification or recompilation.
 
 To develop servlets, use the Java Servlet API. For information about
 using the Java Servlet API, see the documentation at
-`http://www.oracle.com/technetwork/java/javaee/servlet/index.html`.
+`https://jakarta.ee/specifications/servlet/`.
 
 The {productName} provides the `wscompile` and `wsdeploy` tools to
 help you implement a web service endpoint as a servlet. For more
@@ -317,10 +317,7 @@ servers
 * JSP tag libraries and standard portable tags
 
 For information about creating JSP files, see the JavaServer Pages web
-site at `http://www.oracle.com/technetwork/java/javaee/jsp/index.html`.
-
-For information about Java Beans, see the JavaBeans web page at
-`http://www.oracle.com/technetwork/java/javase/tech/index-jsp-138795.html`.
+site at `https://jakarta.ee/specifications/pages/`.
 
 This section describes how to use JavaServer Pages (JSP files) as page
 templates in a {productName} web application.
@@ -337,7 +334,7 @@ The following topics are addressed here:
 
 {productName} supports tag libraries and standard portable tags. For
 more information, see the JavaServer Pages Standard Tag Library (JSTL)
-page at `http://www.oracle.com/technetwork/java/index-jsp-135995.html`.
+page at `https://jakarta.ee/specifications/tags/`.
 
 Web applications don't need to bundle copies of the `jsf-impl.jar` or
 `appserv-jstl.jar` JSP tag libraries (in as-install``/lib``) to use

--- a/docs/deployment-planning-guide/src/main/asciidoc/checklist.adoc
+++ b/docs/deployment-planning-guide/src/main/asciidoc/checklist.adoc
@@ -135,8 +135,6 @@ a|
 a|
 * Initially set the minimum and maximum heap sizes to be the same, and
   at least one GB for each instance.
-* See http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html[
-  Java Hotspot VM Options] for more information.
 * When running multiple instances of {productName}, consider creating
   a processor set and bind {productName} to it. This helps in cases
   where the CMS collector is used to sweep the old generation.

--- a/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
@@ -1629,13 +1629,10 @@ Maven with the EJB 3.1 Embeddable API and Embedded {productName}].
 
 The EJB 3.1 Embeddable API is described in
 http://jcp.org/en/jsr/detail?id=318[Java Specification Request (JSR) 318]
-(`http://jcp.org/en/jsr/detail?id=318`). An `ejb-embedded` sample
-is included in the samples available at
-http://www.oracle.com/technetwork/java/javaee/downloads/index.html[Java EE 7 Downloads]
-(`http://www.oracle.com/technetwork/java/javaee/downloads/index.html`)
-or
-http://www.oracle.com/technetwork/java/javaee/documentation/index.html[Code Samples]
-(`http://www.oracle.com/technetwork/java/javaee/documentation/index.html`).
+(`http://jcp.org/en/jsr/detail?id=318`). An `ejb-embedded` example
+is available at
+https://jakarta.ee/learn/docs/jakartaee-tutorial/9.1/entbeans/ejb-embedded/ejb-embedded.html[Code Samples]
+(`https://jakarta.ee/learn/docs/jakartaee-tutorial/9.1/entbeans/ejb-embedded/ejb-embedded.html`).
 
 The EJB 3.1 Embeddable API supports all EJB 3.1 Lite features with
 addition of the EJB timer service and testing of EJB modules packaged in

--- a/docs/installation-guide/src/main/asciidoc/installing.adoc
+++ b/docs/installation-guide/src/main/asciidoc/installing.adoc
@@ -37,7 +37,7 @@ Issues]" in {productName} Release Notes for known
 issues related to installation.
 
 * On Solaris, Linux, macOS and Windows systems, JDK software is available from the
-http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java SE downloads page].
+https://www.oracle.com/java/technologies/downloads/[Java SE downloads page].
 
 [[javassist-library-license-notice]]
 
@@ -578,13 +578,13 @@ The following topics are addressed here:
 
 Installation files for {productName} 7 are
 available by download from the
-https://github.com/eclipse-ee4j/glassfishdownload[{productName} Downloads]
+https://glassfish.org/download.html[{productName} Downloads]
 page.
 
 {productName} 7 is also part of the Jakarta EE SDK
-distributions. The SDK distributions are available from the
-http://www.oracle.com/technetwork/java/javaee/downloads/index.html[Java
-EE downloads page] and are not described in this document.
+distributions. The specifications are available from
+https://jakarta.ee/specifications/[Jakarta EE specifications page]
+and are not described in this document.
 
 [[glassfish-server-installation-methods]]
 

--- a/docs/performance-tuning-guide/src/main/asciidoc/tuning-apps.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/tuning-apps.adoc
@@ -26,11 +26,7 @@ The following topics are addressed here:
 
 This section covers issues related to Java coding and performance. The
 guidelines outlined are not specific to {productName}, but are
-general rules that are useful in many situations. For a complete
-discussion of Java coding best practices, see the
-http://www.oracle.com/technetwork/java/javaee/blueprints/index.html[Java
-Blueprints]
-(`http://www.oracle.com/technetwork/java/javaee/blueprints/index.html`).
+general rules that are useful in many situations.
 
 The following topics are addressed here:
 

--- a/docs/performance-tuning-guide/src/main/asciidoc/tuning-java.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/tuning-java.adoc
@@ -147,13 +147,13 @@ To do this, add the following JVM options:
 
 ===== Additional Information
 
-Use the `jvmstat` utility to monitor HotSpot garbage collection. (See
+Use the `jstat` utility to monitor Java Virtual Machine statistics. (See
 xref:#further-information[Further Information].)
 
 For detailed information on tuning the garbage collector, see
-http://www.oracle.com/technetwork/java/javase/gc-tuning-6-140523.html[Java
-SE 6 HotSpot Virtual Machine Garbage Collection Tuning]
-(`http://www.oracle.com/technetwork/java/javase/gc-tuning-6-140523.html`).
+https://docs.oracle.com/en/java/javase/17/gctuning/introduction-garbage-collection-tuning.html[Java
+ Garbage Collection Tuning]
+(` https://docs.oracle.com/en/java/javase/17/gctuning/introduction-garbage-collection-tuning.html`).
 
 [[tracing-garbage-collection]]
 
@@ -374,9 +374,9 @@ the maximum heap size. The old generation must be larger than the new
 generation.
 
 For up-to-date defaults, see
-http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html[Java
+https://www.oracle.com/java/technologies/javase/vmoptions-jsp.html[Java
 HotSpot VM Options]
-(`http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html`).
+(`https://www.oracle.com/java/technologies/javase/vmoptions-jsp.html`).
 
 [[fxxpw]]
 Example 4-1 Heap Configuration on Solaris
@@ -498,12 +498,8 @@ documentation for rebase utility]
 
 === Further Information
 
-For more information on tuning the JVM, see:
+For more information on the jstat command, see:
 
-* http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html[
-Java HotSpot VM Options]
-(`http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html`)
-* http://www.oracle.com/technetwork/java/hotspotfaq-138619.html[
-Frequently Asked Questions About the Java HotSpot Virtual Machine]
-(`http://www.oracle.com/technetwork/java/hotspotfaq-138619.html`)
-* http://www.oracle.com/technetwork/java/javase/tech/index-jsp-136373.html[
+* https://docs.oracle.com/en/java/javase/17/docs/specs/man/jstat.html[
+The jstat Command]
+(`https://docs.oracle.com/en/java/javase/17/docs/specs/man/jstat.html`)

--- a/docs/reference-manual/src/main/asciidoc/copy-config.adoc
+++ b/docs/reference-manual/src/main/asciidoc/copy-config.adoc
@@ -80,7 +80,7 @@ asadmin-options::
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
     connections to the Java Platform Debugger Architecture (JPDA)
-    (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/create-cluster.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-cluster.adoc
@@ -132,7 +132,7 @@ asadmin-options::
     connections to the
     http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
     Platform Debugger Architecture (JPDA)]
-    (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;
@@ -499,6 +499,6 @@ Administration Guide
 Apache Felix Remote Shell
 (http://felix.apache.org/site/apache-felix-remote-shell.html), Java
 Platform Debugger Architecture (JPDA)
-(http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+(https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 

--- a/docs/reference-manual/src/main/asciidoc/create-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-domain.adoc
@@ -211,7 +211,7 @@ When the `--portbase` option is specified, the output of this
     connections to the
     http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
     Platform Debugger Architecture (JPDA)]
-    (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `jms.port`;;
@@ -441,6 +441,6 @@ xref:stop-domain.adoc#stop-domain[`stop-domain`(1)]
 Apache Felix Remote Shell
 (`http://felix.apache.org/site/apache-felix-remote-shell.html`), Java
 Platform Debugger Architecture (JPDA)
-(`http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html`)
+(`https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html`)
 
 

--- a/docs/reference-manual/src/main/asciidoc/create-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-instance.adoc
@@ -214,7 +214,7 @@ When the `--portbase` option is specified, the output of this
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
     connections to the Java Platform Debugger Architecture (JPDA)
-    (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/create-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-local-instance.adoc
@@ -268,7 +268,7 @@ When the `--portbase` option is specified, the output of this
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
     connections to the Java Platform Debugger Architecture (JPDA)
-    (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
@@ -54,7 +54,7 @@ asadmin-options::
   Specifies whether the domain is restarted with
   http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
   Platform Debugger Architecture (JPDA)]
-  (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
   debugging enabled.
   Possible values are as follows:
 
@@ -132,6 +132,6 @@ xref:start-domain.adoc#start-domain[`start-domain`(1)],
 xref:stop-domain.adoc#stop-domain[`stop-domain`(1)]
 
 Java Platform Debugger Architecture (JPDA)
-(`http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html`)
+(`https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html`)
 
 

--- a/docs/reference-manual/src/main/asciidoc/restart-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-instance.adoc
@@ -78,7 +78,7 @@ asadmin-options::
   Specifies whether the instance is restarted with
   http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
   Platform Debugger Architecture
-  (JPDA)](http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+  (JPDA)](https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
   debugging enabled. Possible values are as follows:
 
   `true`;;
@@ -137,6 +137,6 @@ xref:stop-instance.adoc#stop-instance[`stop-instance`(1)],
 xref:stop-local-instance.adoc#stop-local-instance[`stop-local-instance`(1)]
 
 Java Platform Debugger Architecture (JPDA)
-(http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+(https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 

--- a/docs/reference-manual/src/main/asciidoc/restart-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-local-instance.adoc
@@ -88,7 +88,7 @@ asadmin-options::
   Specifies whether the instance is restarted with
   http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
   Platform Debugger Architecture (JPDA)]
-  (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
   debugging enabled.
   Possible values are as follows:
 
@@ -167,6 +167,6 @@ xref:stop-instance.adoc#stop-instance[`stop-instance`(1)],
 xref:stop-local-instance.adoc#stop-local-instance[`stop-local-instance`(1)]
 
 Java Platform Debugger Architecture (JPDA)
-(http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+(https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 

--- a/docs/reference-manual/src/main/asciidoc/start-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-instance.adoc
@@ -59,7 +59,7 @@ asadmin-options::
   Specifies whether the instance is started with
   http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
   Platform Debugger Architecture (JPDA)]
-  (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
   debugging enabled. +
   Possible values are as follows:
 
@@ -177,6 +177,6 @@ xref:stop-local-instance.adoc#stop-local-instance[`stop-local-instance`(1)],
 xref:validate-dcom.adoc#validate-dcom[`validate-dcom`(1)]
 
 Java Platform Debugger Architecture (JPDA)
-(`http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html`)
+(`https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html`)
 
 

--- a/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
@@ -70,7 +70,7 @@ asadmin-options::
   Specifies whether the instance is started with
   http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
   Platform Debugger Architecture (JPDA)]
-  (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
   debugging enabled.
 +
 Possible values are as follows:
@@ -219,6 +219,6 @@ xref:stop-instance.adoc#stop-instance[`stop-instance`(1)],
 xref:stop-local-instance.adoc#stop-local-instance[`stop-local-instance`(1)]
 
 Java Platform Debugger Architecture (JPDA)
-(http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+(https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -612,10 +612,6 @@ the `domain.xml` file to remove the line
 chooses the appropriate kind of VM for the given platform. Note that
 server instances use the Server VM by default.
 
-For more information about platform support, see
-http://www.oracle.com/technetwork/java/ergo5-140223.html[Ergonomics in
-the 5.1 Java Virtual Machine].
-
 [[metro-reliable-messaging-in-inorder-delivery-mode]]
 
 ==== Metro Reliable Messaging in `InOrder` Delivery Mode
@@ -939,10 +935,4 @@ Useful information can be found at the following locations:
 
 * https://github.com/eclipse-ee4j/glassfish[{productName} Community]
 (`https://github.com/eclipse-ee4j/glassfish`)
-* http://www.oracle.com/technetwork/index.html[Oracle Developer
-Information] (`http://www.oracle.com/technetwork/index.html`)
-* http://www.oracle.com/technetwork/indexes/documentation/index.html[Oracle
-product documentation]
-(`http://www.oracle.com/technetwork/indexes/documentation/index.html`)
-
 

--- a/docs/security-guide/src/main/asciidoc/user-security.adoc
+++ b/docs/security-guide/src/main/asciidoc/user-security.adoc
@@ -79,12 +79,7 @@ Certificate realm::
   the HTTPS protocol to authenticate web clients.
 LDAP realm::
   {productName} can get user credentials from a Lightweight Directory
-  Access Protocol (LDAP) server such as Oracle Virtual Directory (OVD)
-  (`http://www.oracle.com/technetwork/middleware/id-mgmt/overview/index.html`),
-  Oracle Internet Directory (OID)
-  (`http://www.oracle.com/technetwork/indexes/products/index.html`), and
-  Oracle Directory Server Enterprise Edition
-  (`http://www.oracle.com/us/products/middleware/identity-management/oracle-directory-services/index.html`).
+  Access Protocol (LDAP) server.
   LDAP is a protocol for enabling anyone to locate organizations,
   individuals, and other resources such as files and devices in a
   network, whether on the public Internet or on a corporate intranet. +

--- a/docs/troubleshooting-guide/src/main/asciidoc/overview.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/overview.adoc
@@ -58,9 +58,9 @@ in {productName} Release Notes for known issues related to installation.
 If necessary, download and install the required JDK software.
 
 On Solaris, Linux, and Windows systems, JDK software is available from the
-http://www.oracle.com/technetwork/java/javase/downloads/index.html[
+https://www.oracle.com/java/technologies/downloads/[
 Java SE downloads page]
-(`http://www.oracle.com/technetwork/java/javase/downloads/index.html`).
+(`https://www.oracle.com/java/technologies/downloads/`).
 
 For Mac OS X systems, {productName} uses the JDK
 that is part of the Macintosh operating system. If necessary, obtain the

--- a/nucleus/admin/config-api/src/main/manpages/com/sun/enterprise/config/serverbeans/create-cluster.1
+++ b/nucleus/admin/config-api/src/main/manpages/com/sun/enterprise/config/serverbeans/create-cluster.1
@@ -123,7 +123,7 @@ OPTIONS
                used for connections to the Java Platform Debugger Architecture
                (JPDA)
 
-               (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+               (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
                debugger. Valid values are 1-65535. On UNIX, creating sockets
                that listen on ports 1-1024 requires superuser privileges.
@@ -523,6 +523,6 @@ SEE ALSO
        Apache Felix Remote Shell
        (http://felix.apache.org/site/apache-felix-remote-shell.html), Java
        Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017                 create-cluster(1)

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/create-domain.1
@@ -231,7 +231,7 @@ OPTIONS
                used for connections to the Java Platform Debugger Architecture
                (JPDA)
 
-               (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+               (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
                debugger. Valid values are 1-65535. On UNIX, creating sockets
                that listen on ports 1-1024 requires superuser privileges.
@@ -450,6 +450,6 @@ SEE ALSO
        Apache Felix Remote Shell
        (http://felix.apache.org/site/apache-felix-remote-shell.html), Java
        Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017                 create-domain(1)

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/restart-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/restart-domain.1
@@ -35,7 +35,7 @@ OPTIONS
            Specifies whether the domain is restarted with Java Platform
            Debugger Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 
@@ -111,6 +111,6 @@ SEE ALSO
        asadmin(1M)
 
        Java Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017                restart-domain(1)

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1
@@ -59,7 +59,7 @@ OPTIONS
            Specifies whether the domain is started with Java Platform Debugger
            Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 
@@ -181,6 +181,6 @@ SEE ALSO
        asadmin(1M)
 
        Java Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017                  start-domain(1)

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/copy-config.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/copy-config.1
@@ -72,7 +72,7 @@ OPTIONS
                This property specifies the port number of the port that is
                used for connections to the Java Platform Debugger Architecture
                (JPDA)
-               (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+               (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
                debugger. Valid values are 1-65535. On UNIX, creating sockets
                that listen on ports 1-1024 requires superuser privileges.
 

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/create-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/create-instance.1
@@ -228,7 +228,7 @@ OPTIONS
                This property specifies the port number of the port that is
                used for connections to the Java Platform Debugger Architecture
                (JPDA)
-               (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+               (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
                debugger. Valid values are 1-65535. On UNIX, creating sockets
                that listen on ports 1-1024 requires superuser privileges.
 

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/restart-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/restart-instance.1
@@ -65,7 +65,7 @@ OPTIONS
            Specifies whether the instance is restarted with Java Platform
            Debugger Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 
@@ -112,6 +112,6 @@ SEE ALSO
        asadmin(1M)
 
        Java Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017              restart-instance(1)

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-cluster.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-cluster.1
@@ -44,7 +44,7 @@ OPTIONS
            Specifies whether each instance in the cluster is started with Java Platform
            Debugger Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-instance.1
@@ -42,7 +42,7 @@ OPTIONS
            Specifies whether the instance is started with Java Platform
            Debugger Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 
@@ -146,6 +146,6 @@ SEE ALSO
        asadmin(1M)
 
        Java Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017                 start-instance(1)

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/create-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/create-local-instance.1
@@ -296,7 +296,7 @@ OPTIONS
                This property specifies the port number of the port that is
                used for connections to the Java Platform Debugger Architecture
                (JPDA)
-               (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+               (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
                debugger. Valid values are 1-65535. On UNIX, creating sockets
                that listen on ports 1-1024 requires superuser privileges.
 

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/restart-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/restart-local-instance.1
@@ -75,7 +75,7 @@ OPTIONS
            Specifies whether the instance is restarted with Java Platform
            Debugger Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 
@@ -150,6 +150,6 @@ SEE ALSO
        asadmin(1M)
 
        Java Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                   21 Aug 2017            restart-local-instance(1)

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/start-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/start-local-instance.1
@@ -51,7 +51,7 @@ OPTIONS
            Specifies whether the instance is started with Java Platform
            Debugger Architecture (JPDA)
 
-           (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+           (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
            debugging enabled.
 
@@ -203,6 +203,6 @@ SEE ALSO
        asadmin(1M)
 
        Java Platform Debugger Architecture (JPDA)
-       (http://www.oracle.com/technetwork/java/javase/tech/jpda-141715.html)
+       (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
 Jakarta EE 10                         21 Aug 2017          start-local-instance(1)


### PR DESCRIPTION
Replaces all http://www.oracle.com/technetwork links with their https://jakarta.ee/ counterpart where possible. Removes some outdated / no longer working links that have no jakarta.ee counterpart but do not affect the documentation.

Some links are updated in chapters that are obsolete/outdated. Like: webstart, sample chapter, and Rebasing DLLs on Windows. This commit does not improve those chapters. Only single thing updated is mentioning jstat instead of jvmstat.