### PR TITLE
Store the DistinguishedPrincipalCredential in the Subject principals

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -128,6 +128,16 @@ public class SecurityContext extends AbstractSecurityContext {
                         DistinguishedPrincipalCredential distinguishedPrincipalCredential = (DistinguishedPrincipalCredential) publicCredential;
                         principal = distinguishedPrincipalCredential.getPrincipal();
                         break;
+                    }
+                }
+
+                if (principal == null) {
+                    for (Principal publicCredential : finalSubject.getPrincipals()) {
+                        if (publicCredential instanceof DistinguishedPrincipalCredential) {
+                            DistinguishedPrincipalCredential distinguishedPrincipalCredential = (DistinguishedPrincipalCredential) publicCredential;
+                            principal = distinguishedPrincipalCredential.getPrincipal();
+                            break;
+                        }
                     }
                 }
 

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/login/DistinguishedPrincipalCredential.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/login/DistinguishedPrincipalCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,9 +17,12 @@
 
 package com.sun.enterprise.security.auth.login;
 
+import java.io.Serializable;
 import java.security.Principal;
 
-public class DistinguishedPrincipalCredential {
+public class DistinguishedPrincipalCredential implements Principal, Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final Principal principal;
 
@@ -34,5 +37,14 @@ public class DistinguishedPrincipalCredential {
     @Override
     public String toString() {
         return "DistingushedPrincipal[" + principal + "]";
+    }
+
+    @Override
+    public String getName() {
+        if (principal == null) {
+            return null;
+        }
+
+        return principal.getName();
     }
 }

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/certificate/CertificateRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/certificate/CertificateRealm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -139,7 +139,9 @@ public final class CertificateRealm extends Realm {
         }
 
         if (!subject.getPrincipals().isEmpty()) {
-            subject.getPublicCredentials().add(new DistinguishedPrincipalCredential(principal));
+            DistinguishedPrincipalCredential distinguishedPrincipal = new DistinguishedPrincipalCredential(principal);
+            subject.getPrincipals().add(distinguishedPrincipal);
+            subject.getPublicCredentials().add(distinguishedPrincipal);
         }
 
         SecurityContext.setCurrent(new SecurityContext(name, subject));


### PR DESCRIPTION
This is needed since for SSO where the `Subject` is serialized and restored at another node. But, the credential collection is transient, so it wont be saved/restored.

The effect is that when using SSO the roles would be missing on the other node.
