### PR TITLE
Fixes #24816 Non-ASCII characters are not saved correctly in JVM options added using the JVM Options page

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
@@ -278,7 +278,7 @@ public class SecurityHandler {
                 continue;
             }
             sb.append(oneProp.get("name")).append("=");
-            String value = ((String) oneProp.get("value"));
+            String value = (String) oneProp.get("value");
             value = UtilHandlers.escapePropertyValue(value);
             sb.append(value).append(":");
         }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -277,7 +278,7 @@ public class SecurityHandler {
                 continue;
             }
             sb.append(oneProp.get("name")).append("=");
-            String value = ((String) oneProp.get("value")).replaceAll("\\\\", "\\\\\\\\");
+            String value = ((String) oneProp.get("value"));
             value = UtilHandlers.escapePropertyValue(value);
             sb.append(value).append(":");
         }

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1094,19 +1095,7 @@ public class UtilHandlers {
                     builder.append(ch);
                     break;
                 default:
-                    // Check if we should unicode escape this...
-                    if ((ch > 0x7e) || (ch < 0x20)) {
-                        builder.append("\\u");
-                        chStr = Integer.toHexString(ch);
-                        len = chStr.length();
-                        for (int idx=4; idx > len; idx--) {
-                            // Add leading 0's
-                            builder.append('0');
-                        }
-                        builder.append(chStr);
-                    } else {
-                        builder.append(ch);
-                    }
+                    builder.append(ch);
                     break;
             }
             ch = it.next();


### PR DESCRIPTION
* Fixes #24816

Escaping non-ASCII strings is unnecessary in HTTP and was causing the issue.  

also I found a bug around the call to `UtilHandlers.escapePropertyValue()` and fixed it.  
`replaceAll("\\\\", "\\\\\\\\")` on line 280 in `SecurityHandler.java` is unnecessary.  
https://github.com/eclipse-ee4j/glassfish/blob/d322a5705f498a16210ceee9e6b7762a9cfa739c/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/SecurityHandler.java#L280  
Because the char `\` is escaped in `escapePropertyValue` after that.  
https://github.com/eclipse-ee4j/glassfish/blob/d322a5705f498a16210ceee9e6b7762a9cfa739c/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/UtilHandlers.java#L1089  
This line was causing the following redundant escapes when the realm was created with the property such as windows paths:
![realm_backslash](https://github.com/eclipse-ee4j/glassfish/assets/89768092/637526a2-6826-420c-a6f5-db9a39b9af7a)
![realm_backslash2](https://github.com/eclipse-ee4j/glassfish/assets/89768092/65332f66-eb63-4d6e-b1d8-1fed1c06836c)
