### PR TITLE
Fixes `applications-tests` on Windows

### DIFF
--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jmac/http/servlet/basic/HttpServletBasicAuthTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jmac/http/servlet/basic/HttpServletBasicAuthTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -67,9 +68,10 @@ public class HttpServletBasicAuthTest {
     @BeforeAll
     public static void prepareDeployment() {
         keyFile = getDomain1Directory().resolve(Path.of("config", "keyfile123.txt")).toFile();
-        assertThat(ASADMIN.exec("create-auth-realm", "--classname",
-            "com.sun.enterprise.security.auth.realm.file.FileRealm", "--property",
-            "file=" + keyFile.getAbsolutePath() + ":jaas-context=fileRealm", "--target", "server", FILE_REALM_NAME),
+        assertThat(ASADMIN.exec("create-auth-realm",
+            "--classname", "com.sun.enterprise.security.auth.realm.file.FileRealm",
+            "--property", "file=" + keyFile.getAbsolutePath().replaceAll("([\\\\:])", "\\\\$1") + ":jaas-context=fileRealm",
+            "--target", "server", FILE_REALM_NAME),
             asadminOK());
         createFileUser(FILE_REALM_NAME, USER_NAME, USER_PASSWORD, "mygroup");
 

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jmac/http/servlet/challenge/HttpServletChallengeAuthTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jmac/http/servlet/challenge/HttpServletChallengeAuthTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -72,9 +73,10 @@ public class HttpServletChallengeAuthTest {
     @BeforeAll
     public static void prepareDeployment() {
         keyFile = getDomain1Directory().resolve(Path.of("config", "file123.txt")).toFile();
-        assertThat(ASADMIN.exec("create-auth-realm", "--classname",
-            "com.sun.enterprise.security.auth.realm.file.FileRealm", "--property",
-            "file=" + keyFile.getAbsolutePath() + ":jaas-context=fileRealm", "--target", "server", FILE_REALM_NAME),
+        assertThat(ASADMIN.exec("create-auth-realm",
+            "--classname", "com.sun.enterprise.security.auth.realm.file.FileRealm",
+            "--property", "file=" + keyFile.getAbsolutePath().replaceAll("([\\\\:])", "\\\\$1") + ":jaas-context=fileRealm",
+            "--target", "server", FILE_REALM_NAME),
             asadminOK());
         createFileUser(FILE_REALM_NAME, USER_NAME, USER_PASSWORD, "mygroup");
         createFileUser(FILE_REALM_NAME, USER_NAME2, USER_PASSWORD2, "mygroup");

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jmac/http/soap/embedded/HttpSoapEmbeddedAuthTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jmac/http/soap/embedded/HttpSoapEmbeddedAuthTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -76,9 +77,10 @@ public class HttpSoapEmbeddedAuthTest {
     @BeforeAll
     public static void prepareDeployment() {
         keyFile = getDomain1Directory().resolve(Path.of("config", "file123.txt")).toFile();
-        assertThat(ASADMIN.exec("create-auth-realm", "--classname",
-            "com.sun.enterprise.security.auth.realm.file.FileRealm", "--property",
-            "file=" + keyFile.getAbsolutePath() + ":jaas-context=fileRealm", "--target", "server", FILE_REALM_NAME),
+        assertThat(ASADMIN.exec("create-auth-realm",
+            "--classname", "com.sun.enterprise.security.auth.realm.file.FileRealm",
+            "--property", "file=" + keyFile.getAbsolutePath().replaceAll("([\\\\:])", "\\\\$1") + ":jaas-context=fileRealm",
+            "--target", "server", FILE_REALM_NAME),
             asadminOK());
         createFileUser(FILE_REALM_NAME, USER_NAME, USER_PASSWORD, "mygroup");
         createFileUser(FILE_REALM_NAME, USER_NAME2, USER_PASSWORD2, "mygroup");

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/multirolemapping/MultiRoleMappingTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/multirolemapping/MultiRoleMappingTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -231,7 +232,7 @@ public class MultiRoleMappingTest {
         try {
             assertThat(connection.getResponseCode(), equalTo(200));
             final String text = readResponseBody(connection);
-            assertThat(text, equalTo("Hello " + relativePath + "\n"));
+            assertThat(text, equalTo("Hello " + relativePath + System.lineSeparator()));
         } finally {
             connection.disconnect();
         }


### PR DESCRIPTION
Summary:

* Escape all occurrences of `:` and `\` in the `keyfile` file path.
* Uses platform line separator instead of `\n` when test server response.
