### PR TITLE
Add console loading option to the domain template

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -86,6 +86,7 @@
       </iiop-service>
       <admin-service auth-realm-name="admin-realm" type="das-and-server" system-jmx-connector-name="system">
         <jmx-connector auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="%%%JMX_SYSTEM_CONNECTOR_PORT%%%" name="system" />
+        <property value="default" name="adminConsoleStartup" />
         <property value="/admin" name="adminConsoleContextRoot" />
         <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
         <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />


### PR DESCRIPTION
Add explicit `adminConsoleStartup` property to the `domain.xml` template.
