### PR TITLE
SSL Configurator fix - CertificateRequest not being made in SSL mutual authentication

### DIFF
--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
@@ -78,8 +78,13 @@ public class SSLConfigurator extends SSLEngineConfigurator {
 
         sslImplementation = sslImplementationLocal;
 
-        setNeedClientAuth(isNeedClientAuth(ssl));
-        setWantClientAuth(isWantClientAuth(ssl));
+        if (isWantClientAuth(ssl)) {
+            setWantClientAuth(true);
+        }
+
+        if (isNeedClientAuth(ssl)) {
+            setNeedClientAuth(true);
+        }
 
         clientMode = false;
         sslContextConfiguration = new InternalSSLContextConfigurator();


### PR DESCRIPTION
The call `setWantClientAuth(-)` and `setNeedClientAuth(-)` have an XOR effect in https://github.com/openjdk/jdk17/blob/master/src/java.base/share/classes/javax/net/ssl/SSLParameters.java#L219 and https://github.com/openjdk/jdk/blob/27a03e0dc3e08094aebc3524f68617f7e7fb5c5d/src/java.base/share/classes/javax/net/ssl/SSLParameters.java#L218

That is, setting one will undo the effect of the other, regardless of the boolean value. In it's current form, the setNeedClientAuth value is not respected if it is true, which leads to a missing CertificateRequest in the TLS handshake. The change in this PR only sets the value if indicated to be true, and gives preference to needClientAuth in the case both are set by the user in the configuration. 