### PR TITLE
Fixes command progress status

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/progress/CommandProgressImpl.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/progress/CommandProgressImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -123,7 +124,9 @@ public class CommandProgressImpl extends ProgressStatusImpl implements CommandPr
     public void setEventBroker(AdminCommandEventBroker eventBroker) {
         this.eventBroker = eventBroker;
         if (eventBroker != null) {
-            eventBroker.fireEvent(EVENT_PROGRESSSTATUS_STATE, this);
+            // Pass an empty progress status to prevent duplicate children creation
+            // on the client side. This status is only used to send a state event.
+            eventBroker.fireEvent(EVENT_PROGRESSSTATUS_STATE, new CommandProgressImpl(name, id));
         }
     }
 


### PR DESCRIPTION
Fixes a long-term bug.

This error can affect any progress status that creates a child statuses.

`ProgressStatusComplexITest.executeVeryComplexCommand()` may fail spuriosly with the next error:

```
[ERROR] org.glassfish.main.admin.test.progress.ProgressStatusComplexITest.executeVeryComplexCommand -- Time elapsed: 7.687 s <<< FAILURE!
java.lang.AssertionError: 

Expected: <5>
     but: was <6>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at org.glassfish.main.admin.test.progress.ProgressStatusComplexITest.executeVeryComplexCommand(ProgressStatusComplexITest.java:88)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

and wrong progress status:

```
...
 62%: complex.child2: progress child2, remaining 2
 62%: complex.child2: progress child2, remaining 1
 63%: complex.child2: progress child2, remaining 0
100%: complex.child2: progress child2, remaining 0
All done
```

The reason is the wrong state event to create progress status parent:

```
InboundEvent{name='ProgressStatus/state', id='null', data={"progress-status":{"name":"complex","id":"17","total-step-count":20,"current-step-count":0,"complete":false,"children":[{"name":"child1","id":"17.1","allocated-steps":5,"total-step-count":10,"current-step-count":0,"complete":false,"children":[{"name":"child12","id":"17.1.2","allocated-steps":5,"total-step-count":-1,"current-step-count":0,"complete":false},{"name":"child11","id":"17.1.1","allocated-steps":5,"total-step-count":5,"current-step-count":0,"complete":false}]},{"name":"child3","id":"17.3","allocated-steps":6,"total-step-count":112,"current-step-count":0,"complete":false},{"name":"child2","id":"17.2","allocated-steps":5,"total-step-count":50,"current-step-count":0,"complete":false,"children":[{"name":"child21","id":"17.2.1","allocated-steps":10,"total-step-count":25,"current-step-count":0,"complete":false},{"name":"child24","id":"17.2.4","allocated-steps":15,"total-step-count":25,"current-step-count":0,"complete":false},{"name":"child22","id":"17.2.2","allocated-steps":10,"total-step-count":25,"current-step-count":0,"complete":false},{"name":"child23","id":"17.2.3","allocated-steps":10,"total-step-count":25,"current-step-count":0,"complete":false}]}]}}}
```
As a result, children are created when state event parsed. Then the same children are created with one of the `ProgressStatus.createChild()` methods. As a consequense, we have more children and the completion percentage is calculated incorrectly.

Whereas a proper state event should look like this:

```
InboundEvent{name='ProgressStatus/state', id='null', data={"progress-status":{"name":"complex","id":"17","total-step-count":-1,"current-step-count":0,"complete":false}}}
```

Wrong state event send when event broker setting up:
https://github.com/eclipse-ee4j/glassfish/blob/d9b7ee74439fad2408894cc6c9609011f457b4b2/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/progress/CommandProgressImpl.java#L126

Due to the asynchronous nature of the event sending by Jersey, multiple children may be added to parent progress status between the state event being queued and the write actually taking place.

As a solution, we pass an empty copy of the parent progress status to send the correct state event.