### PR TITLE
Make `@RestrictTo` annotation repeatable

### DIFF
--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/RestrictTo.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/event/RestrictTo.java
@@ -18,6 +18,7 @@
 package org.glassfish.api.event;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -35,7 +36,15 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(RestrictTo.List.class)
 public @interface RestrictTo {
 
     String value();
+
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface List {
+
+        RestrictTo[] value();
+    }
 }

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsImpl.java
@@ -86,10 +86,18 @@ public class EventsImpl implements Events {
                 continue;
             }
 
-            RestrictTo restrictTo = eventMethod.getParameters()[0].getAnnotation(RestrictTo.class);
-            if (restrictTo != null) {
-                EventTypes<?> interested = EventTypes.create(restrictTo.value());
-                if (!event.is(interested)) {
+            RestrictTo[] restrictTo = eventMethod.getParameters()[0].getAnnotationsByType(RestrictTo.class);
+            if (restrictTo.length > 0) {
+                boolean isInterested = false;
+                for (RestrictTo restrict : restrictTo) {
+                    EventTypes<?> interestedEvent = EventTypes.create(restrict.value());
+                    if (event.is(interestedEvent)) {
+                        isInterested = true;
+                        break;
+                    }
+                }
+
+                if (!isInterested) {
                     continue;
                 }
             }


### PR DESCRIPTION
Preserves backward compatibility. All existing code should works without modification.


