### PR TITLE
Bump nimbus-jose-jwt from 9.37 to 9.37.3

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,7 +99,7 @@
         <soteria.version>3.0.3</soteria.version>
         <exousia.version>2.1.1</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>9.37</nimbus.version>
+        <nimbus.version>9.37.3</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->


### PR DESCRIPTION
- https://github.com/eclipse-ee4j/glassfish/security/dependabot/29