### PR TITLE
Integrate Maven Compiler plugin 3.13.0

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -797,7 +797,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <source>11</source>
                         <target>11</target>


### PR DESCRIPTION
Changes: [3.12.0](https://github.com/apache/maven-compiler-plugin/releases/tag/maven-compiler-plugin-3.12.0), [3.12.1](https://github.com/apache/maven-compiler-plugin/releases/tag/maven-compiler-plugin-3.12.1), [3.13.0](https://github.com/apache/maven-compiler-plugin/releases/tag/maven-compiler-plugin-3.13.0).
