### PR TITLE
Fixes cross-references in Administration Guide

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/general-administration.adoc
+++ b/docs/administration-guide/src/main/asciidoc/general-administration.adoc
@@ -35,7 +35,7 @@ instead of the Administration Console interface.
 The following topics are addressed here:
 
 * <<Path to the `asadmin` Utility>>
-* <<`asadmin` Utility Syntax>>
+* <<asadmin-utility-syntax,`asadmin` Utility Syntax>>
 * <<To Run an `asadmin` Utility Subcommand in Single Mode>>
 * xref:#to-display-help-information-for-the-asadmin-utility-or-a-subcommand[To Display Help Information for the `asadmin` Utility or a
 Subcommand]

--- a/docs/administration-guide/src/main/asciidoc/logging.adoc
+++ b/docs/administration-guide/src/main/asciidoc/logging.adoc
@@ -371,7 +371,7 @@ The `GlassFishLogHandler` can roll the output log file under following condition
 
 The last two conditions are exclusive, the date change has higher priority.
 
-The <<`flushFrequency`>> parameter affects how many log records will be formatted
+The `flushFrequency` parameter affects how many log records will be formatted
 into the log file before the file is rolled out even after the file size exceeded it's configured
 limit.
 
@@ -415,7 +415,7 @@ The handler configuration properties:
 
 * `encoding` - output character encoding. Default is null which means it will use the system default.
 * `formatter` - a formatter class to be used for formatting log records as strings.
-Default value is <<`org.glassfish.main.jul.formatter.OneLineFormatter`>>
+Default value is <<OneLineFormatter,`org.glassfish.main.jul.formatter.OneLineFormatter`>>
 * `formatter.*` - can be used for custom settings of the formatter.
 This works only for <<ODLLogFormatter>>, <<UniformLogFormatter>> and <<OneLineFormatter>>.
 * `level` - Level used to filter log records. Less important log records will be ignored.
@@ -448,7 +448,7 @@ but it will ignore incoming records. Default is `true`.
 * `encoding` - output character encoding used to send data to the Syslog service.
 Default is `UTF-8`.
 * `formatter` - a formatter class to be used for formatting log records as strings.
-Default value is <<`java.util.logging.SimpleFormatter`>>
+Default value is <<SimpleFormatter,`java.util.logging.SimpleFormatter`>>
 * `host` - a host name or IP address used of the UDP endpoint.
 Default is an autodetected name of the local host.
 * `level` - Level used to filter log records. Less important log records will be ignored.

--- a/docs/administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/administration-guide/src/main/asciidoc/overview.adoc
@@ -532,10 +532,10 @@ however, there are exceptions.
 The following {productName} administration tools are described here:
 
 * <<Administration Console>>
-* <<`asadmin` Utility>>
+* <<asadmin-utility,`asadmin` Utility>>
 * <<REST Interfaces>>
 * <<OSGi Module Management Subsystem>>
-* <<`keytool` Utility>>
+* <<keytool-utility,`keytool` Utility>>
 * <<Java Monitoring and Management Console (JConsole)>>
 
 [[administration-console]]


### PR DESCRIPTION
Fixes wrong cross-references like this one:
![image](https://github.com/eclipse-ee4j/glassfish/assets/57197113/0135b7d2-86d1-4574-8e8c-8650322be085)


