### PR TITLE
Update Jakarta RESTful Web Services TCK to 3.1.5

### DIFF
--- a/appserver/tests/tck/rest/pom.xml
+++ b/appserver/tests/tck/rest/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ Usage:
 
 Run full TCK:
 
-mvn clean clean
+mvn clean install
 
 
 Run all tests in test class
@@ -65,7 +65,7 @@ mvn clean install -Dgroups=security
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <tck.version>3.1.1</tck.version>
+        <tck.version>3.1.5</tck.version>
 
         <glassfish.version>${project.version}</glassfish.version>
         <glassfish.root>${project.build.directory}</glassfish.root>

--- a/appserver/tests/tck/tck-download/jakarta-rest-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-rest-tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,9 +31,9 @@
     <name>TCK: Install Jakarta REST TCK</name>
 
     <properties>
-        <tck.rest.rest.version>3.1.1</tck.rest.rest.version>
-        <tck.test.rest.file>restful-ws-tck-${tck.rest.rest.version}</tck.test.rest.file>
-        <tck.test.rest.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/epl/${tck.test.rest.file}.zip</tck.test.rest.url>
+        <tck.rest.rest.version>3.1.5</tck.rest.rest.version>
+        <tck.test.rest.file>jakarta-restful-ws-tck-${tck.rest.rest.version}</tck.test.rest.file>
+        <tck.test.rest.url>https://download.eclipse.org/jakartaee/restful-ws/3.1/${tck.test.rest.file}.zip</tck.test.rest.url>
     </properties>
 
     <build>


### PR DESCRIPTION
Standalone TCK results:

```
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 2789, Failures: 0, Errors: 0, Skipped: 132
[INFO] 
```
