### PR TITLE
Revised Ant exec usages in TCK + TCK 10.0.4

### DIFF
--- a/appserver/tests/tck/activation/pom.xml
+++ b/appserver/tests/tck/activation/pom.xml
@@ -148,11 +148,11 @@
 
 
                                 <!-- Change configuration -->
-                                
+
                                 <tck-setting key="TS_HOME" value="${tck.home}"/>
                                 <tck-setting key="JAVA_HOME" value="${java.home}"/>
                                 <tck-setting key="JARPATH" value="${glassfish.home}/glassfish/modules"/>
-                                
+
                                 <replace file="${tck.home}/build.xml">
                                   <replacetoken><![CDATA[<sysproperty key="testDebug" value="${tests.debug}"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<sysproperty key="testDebug" value="${tests.debug}"/>
@@ -172,12 +172,14 @@
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                                         
+
                                 <echo level="info" message="Start running all tests" />
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}" resultproperty="testResult">
                                     <arg value="run" />
                                     <arg value="run.pluggability" />
                                     <arg value="-DfailOnError=true" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
                                 </exec>
 
@@ -191,7 +193,7 @@
                                         <echo message="${contents}" />
                                     </then>
                                 </if>
-                                
+
                                 <if>
                                     <not>
                                         <equals arg1="${testResult}" arg2="0" />

--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -213,7 +213,7 @@
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <env key="AS_JAVA" value="${java.home}"/>
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
@@ -221,7 +221,7 @@
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <env key="AS_JAVA" value="${java.home}"/>
                                         <arg value="start-domain"/>
                                     </exec>
@@ -229,7 +229,7 @@
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <env key="AS_JAVA" value="${java.home}"/>
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
@@ -237,7 +237,7 @@
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <env key="AS_JAVA" value="${java.home}"/>
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -36,7 +36,7 @@ Run full TCK, debugging client TCK
 mvn clean install -Dsuspend-tck
 
 
-Run full TCK with security manager (deprecated in principal, but still needed for EE 10 to pass) 
+Run full TCK with security manager (deprecated in principal, but still needed for EE 10 to pass)
 
 mvn clean install -Dglassfish.security.manager
 
@@ -222,7 +222,7 @@ mvn clean install -Drun.test="com/sun/ts/tests/jacc/web/toolsContracts/Client.ja
                                 <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
                                     match="work\.dir=.*"
                                     replace="work\.dir=${tck.home}/jacctckwork/jacctck" />
-                                    
+
                                 <replaceregexp file="${tck.home}/bin/ts.jte" byline="true"
                                     match="work\.dir=.*"
                                     replace="work\.dir=${tck.home}/jacctckwork/jacctck" />
@@ -234,50 +234,56 @@ mvn clean install -Drun.test="com/sun/ts/tests/jacc/web/toolsContracts/Client.ja
 
                                 <limit maxwait="60">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" if:set="glassfish.security.manager">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" if:set="glassfish.security.manager" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djava.security.manager&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
                                 <mkdir dir="${tck.home}/jacctckreport"/>
                                 <mkdir dir="${tck.home}/jacctckreport/jacctck"/>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml">
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-Djavatest.security.noSecurityManager=true"/>]]></replacevalue>
                                 </replace>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml" if:set="suspend-tck" >
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
@@ -301,28 +307,35 @@ mvn clean install -Drun.test="com/sun/ts/tests/jacc/web/toolsContracts/Client.ja
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                 <limit maxwait="20">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" failonerror="true">
                                     <arg value="config.vi" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="tck.home" value="${tck.home}"/>
                                 </exec>
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" failonerror="true">
                                     <arg value="enable.jacc"  />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="tck.home" value="${tck.home}"/>
                                 </exec>
-                                
+
                                 <!-- Restart GlassFish in debug mode if so requested -->
                                 <sequential if:set="glassfish.suspend">
-	                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-	                                    <arg value="stop-domain" />
-	                                </exec>
-	                                <echo message="Starting GlassFish in suspended mode, waiting on port 9009" />
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
+                                        <arg value="stop-domain" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                    </exec>
+                                    <echo message="Starting GlassFish in suspended mode, waiting on port 9009" />
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </sequential>
                             </target>
@@ -347,6 +360,13 @@ mvn clean install -Drun.test="com/sun/ts/tests/jacc/web/toolsContracts/Client.ja
                                     <arg value="run.all" unless:set="run.test"/>
                                     <arg value="runclient" if:set="run.test" />
                                     <env key="LC_ALL" value="C" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -356,13 +376,10 @@ mvn clean install -Drun.test="com/sun/ts/tests/jacc/web/toolsContracts/Client.ja
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
 
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
                             </target>
                         </configuration>
                     </execution>

--- a/appserver/tests/tck/connectors-full/pom.xml
+++ b/appserver/tests/tck/connectors-full/pom.xml
@@ -173,7 +173,7 @@
                                 </macrodef>
 
                                 <!-- Change configuration -->
-                                
+
                                 <tck-setting key="connector.home" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="harness.log.traceflag" value="true"/>
                                 <tck-setting key="s1as.jvm.options" value="-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}"/>
@@ -190,7 +190,7 @@
 
                                 <tck-setting key="report.dir" value="${tck.home}/connectorsreport/connectors"/>
                                 <tck-setting key="work.dir" value="${tck.home}/connectorswork/connectors"/>
-                                
+
                                 <replace file="${tck.home}/bin/ts.jte">
                                   <replacetoken><![CDATA[-XX\\\:MaxPermSize=512m:]]></replacetoken>
                                   <replacevalue><![CDATA[]]></replacevalue>
@@ -200,41 +200,47 @@
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djava.security.manager&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <mkdir dir="${tck.home}/connectorsreport"/>
                                 <mkdir dir="${tck.home}/connectorsreport/connectors"/>
 
@@ -249,14 +255,12 @@
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9010"/>]]></replacevalue>
                                 </replace>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml" unless:set="tck.suspend" >
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9010"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacevalue>
                                 </replace>
-                                
-                                
                             </target>
                         </configuration>
                         <goals>
@@ -275,47 +279,56 @@
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                 <limit maxwait="60">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
 
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" failonerror="true">
                                     <arg value="config.vi"  />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                 </exec>
-                                
+
                                 <!-- Deploy single test -->
                                 <sequential if:set="run.test" >
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
-                                    
-                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+
+                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
-                                
+
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
-                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
                                         <arg value="deploy.all"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
-                                
+
                                 <echo level="info" message="Deploying MDB ears" />
-                                
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                     <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                     <arg value="start-domain"/>
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
-                                
+
                                 <fileset dir="${tck.home}/dist/com/sun/ts/tests/connector/mdb" id="deploy.gf.archive.set">
-                                    <filename name="msginflow_mdb.ear"/> 
+                                    <filename name="msginflow_mdb.ear"/>
                                     <!--
                                     <filename name="msginflow_mdb_jca.ear"/> -->
                                 </fileset>
-                                
+
                                 <ant antfile="${tck.home}/bin/xml/impl/glassfish/deploy.xml"
                                      target="-deploy"
                                      inheritRefs="true">
@@ -323,19 +336,21 @@
                                      <reference refid="deploy.gf.archive.set"
                                                 torefid="deploy.archive.set"/>
                                 </ant>
-                                
+
                                 <!-- Restart GlassFish in debug mode if so requested -->
                                 <sequential if:set="glassfish.suspend">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                     <echo message="Starting GlassFish in suspended mode, waiting on port 9009" />
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </sequential>
-                                
+
                             </target>
                         </configuration>
                     </execution>
@@ -351,13 +366,20 @@
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
-                                         
+
                                 <echo level="info" message="Start running all tests" />
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" resultproperty="testResult">
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="runclient.nobinaryfinder" if:set="run.test" />
                                     <arg value="run.all" unless:set="run.test" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -367,22 +389,10 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
 
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
-                                
-                                <if>
-                                    <not>
-                                        <equals arg1="${testResult}" arg2="0" />
-                                    </not>
-                                    <then>
-                                        <fail/>
-                                    </then>
-                                </if>
                             </target>
                         </configuration>
                     </execution>

--- a/appserver/tests/tck/connectors/pom.xml
+++ b/appserver/tests/tck/connectors/pom.xml
@@ -173,7 +173,7 @@
                                 </macrodef>
 
                                 <!-- Change configuration -->
-                                
+
                                 <tck-setting key="connector.home" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="harness.log.traceflag" value="true"/>
                                 <tck-setting key="s1as.jvm.options" value="-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}"/>
@@ -190,7 +190,7 @@
 
                                 <tck-setting key="report.dir" value="${tck.home}/connectorsreport/connectors"/>
                                 <tck-setting key="work.dir" value="${tck.home}/connectorswork/connectors"/>
-                                
+
                                 <replace file="${tck.home}/bin/ts.jte">
                                   <replacetoken><![CDATA[-XX\\\:MaxPermSize=512m:]]></replacetoken>
                                   <replacevalue><![CDATA[]]></replacevalue>
@@ -200,41 +200,47 @@
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djava.security.manager&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <mkdir dir="${tck.home}/connectorsreport"/>
                                 <mkdir dir="${tck.home}/connectorsreport/connectors"/>
 
@@ -249,14 +255,14 @@
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9010"/>]]></replacevalue>
                                 </replace>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml" unless:set="tck.suspend" >
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9010"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacevalue>
                                 </replace>
-                                
-                                
+
+
                             </target>
                         </configuration>
                         <goals>
@@ -275,29 +281,36 @@
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                 <limit maxwait="60">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
 
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" failonerror="true">
                                     <arg value="config.vi"  />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                 </exec>
-                                
+
                                 <!-- Deploy single test -->
                                 <sequential if:set="run.test" >
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
-                                    
-                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+
+                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
-                                
+
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
-                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
                                         <arg value="deploy.all"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
                             </target>
@@ -315,13 +328,20 @@
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
-                                         
+
                                 <echo level="info" message="Start running all tests" />
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" resultproperty="testResult">
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="runclient.nobinaryfinder" if:set="run.test" />
                                     <arg value="run.all" unless:set="run.test" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -331,20 +351,7 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
-                                    </then>
-                                </if>
-
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
-                                
-                                <if>
-                                    <not>
-                                        <equals arg1="${testResult}" arg2="0" />
-                                    </not>
-                                    <then>
-                                        <fail/>
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
                             </target>

--- a/appserver/tests/tck/expression_language/pom.xml
+++ b/appserver/tests/tck/expression_language/pom.xml
@@ -264,6 +264,8 @@ mvn clean install -Drun.test="com/sun/ts/tests/el/api/jakarta_el/methodexpressio
                                         <arg value="run.all" unless:set="run.test"/>
                                         <arg value="runclient" if:set="run.test" />
                                         <arg value="-Dkeywords=all" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                         <env key="LC_ALL" value="C" />
                                     </exec>
 
@@ -272,7 +274,7 @@ mvn clean install -Drun.test="com/sun/ts/tests/el/api/jakarta_el/methodexpressio
                                             <equals arg1="${testResult}" arg2="0" />
                                         </not>
                                         <then>
-                                            <echo message="Running tests failed." />
+                                            <fail status="${testResult}" message="Running tests failed." />
                                         </then>
                                     </if>
                                 </sequential>

--- a/appserver/tests/tck/pages/pom.xml
+++ b/appserver/tests/tck/pages/pom.xml
@@ -194,37 +194,43 @@
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" if:set="glassfish.security.manager">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" if:set="glassfish.security.manager" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djava.security.manager&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
                                 <mkdir dir="${tck.home}/pagesreport"/>
@@ -258,9 +264,10 @@
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
                                 <limit maxwait="20">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
 
@@ -269,15 +276,19 @@
                                   <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                   <echo>Deploying from ${test.dir}</echo>
 
-                                  <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
-                                      <arg value="deploy"  />
+                                  <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
+                                      <arg value="deploy" />
+                                      <env key="AS_JAVA" value="${java.home}" />
+                                      <env key="JAVA_HOME" value="${java.home}"/>
                                   </exec>
                                 </sequential>
 
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
-                                  <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
-                                      <arg value="deploy.all"  />
+                                  <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
+                                      <arg value="deploy.all" />
+                                      <env key="AS_JAVA" value="${java.home}"/>
+                                      <env key="JAVA_HOME" value="${java.home}"/>
                                   </exec>
                                 </sequential>
                             </target>
@@ -299,7 +310,13 @@
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="run.all" unless:set="run.test"/>
                                     <arg value="runclient" if:set="run.test" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
                                 </exec>
 
                                 <if>
@@ -309,13 +326,9 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
-
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
                             </target>
                         </configuration>
                     </execution>

--- a/appserver/tests/tck/pages_debugging/pom.xml
+++ b/appserver/tests/tck/pages_debugging/pom.xml
@@ -34,15 +34,15 @@
     <properties>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
+
         <tck.home>${project.build.directory}</tck.home>
-         
+
         <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
         <glassfish.version>${project.version}</glassfish.version>
         <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
-       
+
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
-        
+
         <port.admin>14848</port.admin>
         <port.derby>11527</port.derby>
         <port.http>18080</port.http>
@@ -143,39 +143,44 @@
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                          
+
                                 <limit maxwait="60">
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    
+
                                   <replace file="${glassfish.home}/glassfish/domains/domain1/config/default-web.xml">
                                   <replacetoken><![CDATA[<servlet-class>org.glassfish.wasp.servlet.JspServlet</servlet-class>]]></replacetoken>
                                   <replacevalue><![CDATA[<servlet-class>org.glassfish.wasp.servlet.JspServlet</servlet-class>
@@ -203,16 +208,18 @@
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
                                 <limit maxwait="20">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
-                                
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                     <arg value="deploy"/>
                                     <arg value="--port=${port.admin}" />
                                     <arg value="${tck.home}/testclient.war" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
                             </target>
                         </configuration>
@@ -229,12 +236,17 @@
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
 
                                 <get src="http://localhost:${port.http}/testclient/Hello.jsp" dest="${project.build.directory}/hello.html"/>
-                                
-                                <exec executable="java" outputproperty="verifyResult" failonerror="true">
+
+                                <exec executable="${java.home}/bin/java" outputproperty="verifyResult" resultproperty="testResult">
                                     <arg value="-cp" />
                                     <arg value="${project.build.directory}/debugging-tck-2.0.0.jar" />
                                     <arg value="VerifySMAP" />
                                     <arg value="${glassfish.home}/glassfish/domains/domain1/generated/jsp/testclient/org/apache/jsp/Hello_jsp.class.smap" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -244,20 +256,7 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
-                                    </then>
-                                </if>
-
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
-                                
-                                <if>
-                                    <not>
-                                        <contains string="${verifyResult}" substring="is a correctly formatted SMAP"/>
-                                    </not>
-                                    <then>
-                                        <fail/>
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
                             </target>

--- a/appserver/tests/tck/pages_tags/pom.xml
+++ b/appserver/tests/tck/pages_tags/pom.xml
@@ -185,8 +185,8 @@
                                 <tck-setting key="impl.vi.deploy.dir" value="${webServerHome}/domains/domain1/autodeploy"/>
                                 <tck-setting key="impl.deploy.timeout.multiplier" value="30"/>
 
-                                <tck-setting key="jspservlet.classes" value="${webServerHome}/modules/jakarta.servlet-api.jar${pathsep}${webServerHome}/modules/wasp.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp-api.jar"/>
-                                <tck-setting key="jstl.classes" value="${webServerHome}/modules/wasp.jar"/>
+                                <tck-setting key="jspservlet.classes" value="${webServerHome}/modules/jakarta.servlet-api.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp-api.jar${pathsep}${webServerHome}/modules/jakarta.el-api.jar" />
+                                <tck-setting key="jstl.classes" value="${webServerHome}/modules/wasp.jar${pathsep}${webServerHome}/modules/jakarta.servlet.jsp.jstl-api.jar"/>
 
                                 <tck-setting key="jstl.db.server" value="localhost"/>
                                 <tck-setting key="jstl.db.port" value="1527"/>

--- a/appserver/tests/tck/pages_tags/pom.xml
+++ b/appserver/tests/tck/pages_tags/pom.xml
@@ -201,58 +201,68 @@
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-database"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" if:set="glassfish.security.manager">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" if:set="glassfish.security.manager" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djava.security.manager&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djavax.xml.accessExternalStylesheet=all&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djavax.xml.accessExternalSchema=all&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djavax.xml.accessExternalDTD=file,http&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
                                 <mkdir dir="${tck.home}/tagsreport"/>
@@ -286,14 +296,17 @@
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
                                 <limit maxwait="20">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
 
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" failonerror="true">
                                     <arg value="init.javadb"  />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                 </exec>
 
                                 <!-- Deploy single test -->
@@ -301,15 +314,19 @@
                                   <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                   <echo>Deploying from ${test.dir}</echo>
 
-                                  <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+                                  <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                       <arg value="deploy"  />
+                                      <env key="AS_JAVA" value="${java.home}"/>
+                                      <env key="JAVA_HOME" value="${java.home}"/>
                                   </exec>
                                 </sequential>
 
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
-                                  <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                  <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
                                       <arg value="deploy.all"  />
+                                      <env key="AS_JAVA" value="${java.home}"/>
+                                      <env key="JAVA_HOME" value="${java.home}"/>
                                   </exec>
                                 </sequential>
                             </target>
@@ -331,7 +348,18 @@
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="run.all" unless:set="run.test"/>
                                     <arg value="runclient" if:set="run.test" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                </exec>
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-database" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -341,16 +369,10 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
 
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-database" />
-                                </exec>
                             </target>
                         </configuration>
                     </execution>

--- a/appserver/tests/tck/servlet/pom.xml
+++ b/appserver/tests/tck/servlet/pom.xml
@@ -187,31 +187,36 @@
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
                                 <mkdir dir="${tck.home}/servletreport"/>
@@ -247,15 +252,18 @@
 
                                 <!-- Start GlassFish -->
                                 <limit maxwait="20">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
 
-                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin">
+                                <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" failonerror="true">
                                     <arg value="-Dutil.dir=${tck.home}"  />
                                     <arg value="config.security"  />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                 </exec>
 
                                 <!-- Deploy single test -->
@@ -263,15 +271,19 @@
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
 
-                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
 
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
-                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
                                         <arg value="deploy.all"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
                             </target>
@@ -293,7 +305,14 @@
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="run.all" unless:set="run.test"/>
                                     <arg value="runclient" if:set="run.test" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -303,13 +322,9 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
-
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
                             </target>
                         </configuration>
                     </execution>

--- a/appserver/tests/tck/tck-download/jakarta-connectors-full-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-connectors-full-tck/pom.xml
@@ -36,7 +36,7 @@ reserved.
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
 
-        <tck.test.platform.url>https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.2.zip</tck.test.platform.url>
+        <tck.test.platform.url>https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.4.zip</tck.test.platform.url>
         <tck.test.platform.src.url>https://github.com/jakartaee/platform-tck/archive/refs/heads/10.0.x.zip</tck.test.platform.src.url>
 
         <tck.test.connectors.file>jakarta-connectors-tck-2.1.0.zip</tck.test.connectors.file>

--- a/appserver/tests/tck/tck-download/jakarta-connectors-full-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-connectors-full-tck/pom.xml
@@ -35,21 +35,21 @@ reserved.
     <properties>
         <ant.home>${project.build.directory}/apache-ant-${ant.version}</ant.home>
         <ant.zip.url>https://archive.apache.org/dist/ant/binaries/apache-ant-${ant.version}-bin.zip</ant.zip.url>
-        
+
         <tck.test.platform.url>https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.2.zip</tck.test.platform.url>
         <tck.test.platform.src.url>https://github.com/jakartaee/platform-tck/archive/refs/heads/10.0.x.zip</tck.test.platform.src.url>
-        
+
         <tck.test.connectors.file>jakarta-connectors-tck-2.1.0.zip</tck.test.connectors.file>
         <tck.test.connectors.url>https://download.eclipse.org/jakartaee/connectors/2.1/${tck.test.connectors.file}</tck.test.connectors.url>
-        
+
         <tck.test.connectors.full.file>jakarta-connectors-full-tck-2.1.0.zip</tck.test.connectors.full.file>
-        
+
         <tck.home>${project.build.directory}/platform-tck-10.0.x</tck.home>
     </properties>
 
     <build>
         <plugins>
-            
+
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
@@ -65,7 +65,7 @@ reserved.
                             <url>${tck.test.platform.url}</url>
                         </configuration>
                     </execution>
-                    
+
                     <!-- Download source platform TCK - around 70mb -->
                     <execution>
                         <id>download-ee-tck-src</id>
@@ -77,7 +77,7 @@ reserved.
                             <url>${tck.test.platform.src.url}</url>
                         </configuration>
                     </execution>
-                    
+
                     <execution>
                         <id>download-connectors-tck</id>
                         <phase>generate-resources</phase>
@@ -88,7 +88,7 @@ reserved.
                             <url>${tck.test.connectors.url}</url>
                         </configuration>
                     </execution>
-                    
+
                     <execution>
                         <id>download-ant</id>
                         <phase>generate-resources</phase>
@@ -150,7 +150,7 @@ reserved.
                                         <include name="lib/**" />
                                     </fileset>
                                 </copy>
-                                
+
                                 <copy
                                     todir="${project.build.directory}/platform-tck-10.0.x">
                                     <fileset
@@ -170,9 +170,11 @@ reserved.
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/release/tools">
                                     <arg value="connector" />
                                     <env key="deliverabledir" value="connector" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
                                 </exec>
-                                
+
                                 <move todir="${project.build.directory}">
                                     <fileset dir="${tck.home}/release/CONNECTOR_BUILD/latest">
                                         <include name="connectors-tck-2.1.0*.zip" />

--- a/appserver/tests/tck/tck-download/jakarta-platform-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-platform-tck/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Be patient, it is over 500 MB -->
-        <tck.test.jee.file>jakarta-jakartaeetck-10.0.2.zip</tck.test.jee.file>
+        <tck.test.jee.file>jakarta-jakartaeetck-10.0.4.zip</tck.test.jee.file>
         <tck.test.jee.url>https://download.eclipse.org/jakartaee/platform/10/${tck.test.jee.file}</tck.test.jee.url>
     </properties>
 

--- a/appserver/tests/tck/websocket/pom.xml
+++ b/appserver/tests/tck/websocket/pom.xml
@@ -177,15 +177,15 @@
                                 <tck-setting key="web.home" value="${glassfish.home}/glassfish"/>
                                 <tck-setting key="webServerPort" value="${port.http}"/>
                                 <tck-setting key="webServerHost" value="localhost"/>
-                                
+
                                 <tck-setting key="impl.vi" value="glassfish"/>
                                 <tck-setting key="websocket.api" value="${web.home}/modules/jakarta.websocket-api.jar${pathsep}${web.home}/modules/jakarta.websocket-client-api.jar${pathsep}${web.home}/modules/jakarta.servlet-api.jar${pathsep}${web.home}/modules/jakarta.enterprise.cdi-api.jar"/>
 
                                 <tck-setting key="report.dir" value="${tck.home}/websocketreport/websocket"/>
                                 <tck-setting key="work.dir" value="${tck.home}/websocketwork/websocket"/>
-                                
+
                                 <tck-setting key="ws_wait" value="50000000" if:set="glassfish.suspend"/>
-                                
+
                                 <replace file="${tck.home}/bin/ts.jte">
                                   <replacetoken><![CDATA[-XX\\\:MaxPermSize=512m:]]></replacetoken>
                                   <replacevalue><![CDATA[]]></replacevalue>
@@ -195,45 +195,51 @@
                                     <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
                                         <arg value="delete-domain"/>
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-domain"/>
                                         <arg value="--domainproperties=domain.adminPort=${port.admin}:domain.instancePort=${port.http}:http.ssl.port=${port.https}:jms.port=${port.jms}:domain.jmxPort=${port.jmx}:orb.listener.port=${port.orb}:orb.ssl.port=${port.orb.ssl}:orb.mutualauth.port=${port.orb.mutual}" />
                                         <arg value="--user=admin" />
                                         <arg value="--nopassword" />
                                         <arg value="domain1" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
 
                                     <if>
                                         <isset property="jacoco.version" />
                                         <then>
-                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                            <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                                 <arg value="create-jvm-options" />
                                                 <arg value="--port=${port.admin}" />
                                                 <arg value="&quot;-javaagent\:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar=destfile=${project.build.directory}/jacoco-it.exec,includes=${jacoco.includes}&quot;" />
+                                                <env key="AS_JAVA" value="${java.home}"/>
                                             </exec>
                                         </then>
                                     </if>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="create-jvm-options" />
                                         <arg value="--port=${port.admin}" />
                                         <arg value="&quot;-Djava.security.manager&quot;" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
-                                    
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain"/>
                                         <arg value="domain1"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <concat destfile="${glassfish.home}/glassfish/domains/domain1/config/server.policy" append="true">
-                                      <filelist dir="${tck.home}/bin" files="server_policy.append"/>
-                                </concat>   
-                               
+                                    <filelist dir="${tck.home}/bin" files="server_policy.append"/>
+                                </concat>
+
                                 <mkdir dir="${tck.home}/websocketreport"/>
                                 <mkdir dir="${tck.home}/websocketreport/websocket"/>
 
@@ -248,14 +254,14 @@
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9010"/>]]></replacevalue>
                                 </replace>
-                                
+
                                 <replace file="${tck.home}/bin/xml/ts.top.import.xml" unless:set="tck.suspend" >
                                   <replacetoken><![CDATA[<jvmarg value="-Xmx512m"/>
                                 <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9010"/>]]></replacetoken>
                                   <replacevalue><![CDATA[<jvmarg value="-Xmx512m"/>]]></replacevalue>
                                 </replace>
-                                
-                                
+
+
                             </target>
                         </configuration>
                         <goals>
@@ -274,37 +280,44 @@
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
                                 <limit maxwait="60">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </limit>
-                                
+
                                 <!-- Deploy single test -->
                                 <sequential if:set="run.test" >
                                     <dirname property="test.dir" file="${tck.home}/src/${run.test}"/>
                                     <echo>Deploying from ${test.dir}</echo>
-                                    
-                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}">
+
+                                    <exec executable="${ant.home}/bin/ant" dir="${test.dir}" failonerror="true">
                                         <arg value="deploy"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
-                                
+
                                 <!-- Deploy all tests -->
                                 <sequential unless:set="run.test" >
-                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}">
+                                    <exec executable="${ant.home}/bin/ant" dir="${tck.tests.home}" failonerror="true">
                                         <arg value="deploy.all"  />
+                                        <env key="AS_JAVA" value="${java.home}"/>
+                                        <env key="JAVA_HOME" value="${java.home}"/>
                                     </exec>
                                 </sequential>
-                                
+
                                 <!-- Restart GlassFish in debug mode if so requested -->
                                 <sequential if:set="glassfish.suspend">
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="stop-domain" />
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                     <echo message="Starting GlassFish in suspended mode, waiting on port 9009" />
-                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin" failonerror="true">
                                         <arg value="start-domain"/>
                                         <arg value="--suspend" if:set="glassfish.suspend"/>
+                                        <env key="AS_JAVA" value="${java.home}"/>
                                     </exec>
                                 </sequential>
                             </target>
@@ -322,13 +335,20 @@
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <taskdef resource="net/sf/antcontrib/antcontrib.properties"
                                          classpathref="maven.plugin.classpath" />
-                                         
+
                                 <echo level="info" message="Start running all tests" />
                                 <exec executable="${ant.home}/bin/ant" dir="${tck.home}/bin" resultproperty="testResult">
                                     <arg value="-Dmultiple.tests=${run.test}" if:set="run.test" />
                                     <arg value="runclient.nobinaryfinder" if:set="run.test" />
                                     <arg value="run.all" unless:set="run.test" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
+                                    <env key="JAVA_HOME" value="${java.home}"/>
                                     <env key="LC_ALL" value="C" />
+                                </exec>
+
+                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
+                                    <arg value="stop-domain" />
+                                    <env key="AS_JAVA" value="${java.home}"/>
                                 </exec>
 
                                 <if>
@@ -338,20 +358,7 @@
                                     <then>
                                         <echo message="Running tests failed." />
                                         <loadfile property="contents" srcFile="${glassfish.home}/glassfish/domains/domain1/logs/server.log" />
-                                        <echo message="${contents}" />
-                                    </then>
-                                </if>
-
-                                <exec executable="${glassfish.asadmin}" dir="${glassfish.home}/glassfish/bin">
-                                    <arg value="stop-domain" />
-                                </exec>
-                                
-                                <if>
-                                    <not>
-                                        <equals arg1="${testResult}" arg2="0" />
-                                    </not>
-                                    <then>
-                                        <fail/>
+                                        <fail status="${testResult}" message="${contents}" />
                                     </then>
                                 </if>
                             </target>


### PR DESCRIPTION
- added AS_JAVA to force all asadmins to use the same JDK as Maven
- added JAVA_HOME to force all ant executions to use the same JDK as Maven
- added full path to java command (based on java.home property)
- fixed result processing in several cases
- added failonerror (false by default); not added just to executions where we don't  care about the result.
- passed all TCK tests