### PR TITLE
Refactor CDI TCK

### DIFF
--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -396,6 +396,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <reportsDirectories>${project.build.directory}/failsafe-reports/junitreports</reportsDirectories>
                     <outputDirectory>${project.build.directory}/surefire-reports</outputDirectory>
                     <outputName>test-report</outputName>
                 </configuration>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>glassfish-external-tck-cdi</artifactId>
 
     <name>CDI TCK Full runner 4.0 for Weld (GlassFish)</name>
-    <description>Aggregates dependencies and runs the CDI TCK (both standalone and on GlassFish)</description>
+    <description>Aggregates dependencies and runs the CDI TCK on GlassFish</description>
 
     <dependencies>
 
@@ -398,115 +398,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>cdi-signature-test</id>
-            <!-- API jars from the GlassFish distribution -->
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${glassfish.home}/glassfish/modules/jakarta.annotation-api.jar</systemPath>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${glassfish.home}/glassfish/modules/jakarta.el-api.jar</systemPath>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.interceptor</groupId>
-                    <artifactId>jakarta.interceptor-api</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${glassfish.home}/glassfish/modules/jakarta.interceptor-api.jar</systemPath>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.inject</groupId>
-                    <artifactId>jakarta.inject-api</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${glassfish.home}/glassfish/modules/jakarta.inject-api.jar</systemPath>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.enterprise</groupId>
-                    <artifactId>jakarta.enterprise.lang-model</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${glassfish.home}/glassfish/modules/jakarta.enterprise.lang-model.jar</systemPath>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.enterprise</groupId>
-                    <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                    <scope>system</scope>
-                    <systemPath>${glassfish.home}/glassfish/modules/jakarta.enterprise.cdi-api.jar</systemPath>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-jars-sigtest</id>
-                                <phase>validate</phase>
-                                <goals>
-                                    <goal>unpack-dependencies</goal>
-                                </goals>
-                                <configuration>
-                                    <overWriteReleases>true</overWriteReleases>
-                                    <outputDirectory>target/cdi-sigtest-classes</outputDirectory>
-                                    <includeScope>system</includeScope>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>copy-cdi-sigtest</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <!-- Signature test file for CDI -->
-                                        <artifactItem>
-                                            <groupId>jakarta.enterprise</groupId>
-                                            <artifactId>cdi-tck-core-impl</artifactId>
-                                            <version>${cdi.tck-4-0.version}</version>
-                                            <type>sig</type>
-                                            <classifier>sigtest-jdk11</classifier>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}/sigtest</outputDirectory>
-                                            <destFileName>cdi-tck-core-impl-sigtest-jdk11.sig</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.netbeans.tools</groupId>
-                        <artifactId>sigtest-maven-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sigtest</id>
-                                <phase>process-test-sources</phase>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <sigfile>target/sigtest/cdi-tck-core-impl-sigtest-jdk11.sig</sigfile>
-                            <packages>jakarta.decorator,jakarta.enterprise,jakarta.interceptor</packages>
-                            <classes>target/cdi-sigtest-classes</classes>
-                            <report>target/cdi-sig-report.txt</report>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
         <profile>
             <id>full</id>
             <activation>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -220,6 +220,7 @@
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
             <version>1.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -306,7 +307,7 @@
                      </execution>
 
                      <!-- Install a jar with a few amount of test classes, for which some of the tests are looking -->
-                     <execution>
+                    <execution>
                         <id>install-cdi-tck-ext-lib</id>
                         <phase>pre-integration-test</phase>
                         <goals>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -183,7 +183,14 @@
             <groupId>org.glassfish.expressly</groupId>
             <artifactId>expressly</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -30,79 +30,100 @@
     <name>CDI TCK Full runner 4.0 for Weld (GlassFish)</name>
     <description>Aggregates dependencies and runs the CDI TCK (both standalone and on GlassFish)</description>
 
-    <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <cdi.tck-4-0.version>4.0.13</cdi.tck-4-0.version>
-
-        <!-- This matches the htmlunit version in TCK -->
-        <htmlunit.version>2.50.0</htmlunit.version>
-        <excluded.groups>se</excluded.groups>
-
-        <glassfish.version>${project.version}</glassfish.version>
-        <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
-    </properties>
-
     <dependencies>
 
         <!-- Jakarta EE APIs -->
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.faces</groupId>
             <artifactId>jakarta.faces-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Weld (CDI implementation) -->
         <dependency>
             <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-impl</artifactId>
-            <version>${weld.version}</version>
+            <artifactId>weld-api</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-lite-extension-translator</artifactId>
-            <version>${weld.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.weld.module</groupId>
-            <artifactId>weld-jsf</artifactId>
-            <version>${weld.version}</version>
+            <artifactId>weld-spi</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
-            <groupId>org.jboss.weld.module</groupId>
-            <artifactId>weld-ejb</artifactId>
-            <version>${weld.version}</version>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.module</groupId>
             <artifactId>weld-web</artifactId>
-            <version>${weld.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!--
@@ -114,10 +135,11 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-api</artifactId>
             <version>${cdi.tck-4-0.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -133,24 +155,8 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.faces</groupId>
-                    <artifactId>jakarta.faces-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>container-se-api</artifactId>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-impl</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -166,102 +172,47 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.faces</groupId>
-                    <artifactId>jakarta.faces-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>container-se-api</artifactId>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-impl</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
 
-        <!--
-            Contains what becomes the tck-web-suite.xml; the TestNG suite file that dictates which tests from
-            the TCK Web implementation are executed and which are excluded. Note that this file is essentially
-            a superset of the suite file from the TCK Core, so we don't need that one separately here.
-        -->
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>cdi-tck-web-impl</artifactId>
-            <version>${cdi.tck-4-0.version}</version>
-            <type>xml</type>
-            <classifier>suite</classifier>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.el</groupId>
-                    <artifactId>jakarta.el-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.faces</groupId>
-                    <artifactId>jakarta.faces-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>container-se-api</artifactId>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-impl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- Signature test file for CDI -->
-        <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>cdi-tck-core-impl</artifactId>
-            <version>${cdi.tck-4-0.version}</version>
-            <type>sig</type>
-            <classifier>sigtest-jdk11</classifier>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.test-audit</groupId>
-                    <artifactId>jboss-test-audit-impl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>org.glassfish.expressly</groupId>
             <artifactId>expressly</artifactId>
+            <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.common</groupId>
-            <artifactId>container-common</artifactId>
-            <version>${glassfish.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>${htmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!--
             The Arquillian connector that starts GlassFish and deploys archives to it.
         -->
@@ -269,11 +220,6 @@
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
             <version>1.4</version>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.el</groupId>
-            <artifactId>jakarta.el-api</artifactId>
         </dependency>
     </dependencies>
 
@@ -316,6 +262,12 @@
                         </goals>
                         <configuration>
                             <artifactItems>
+                                <!--
+                                    Contains what becomes the tck-web-suite.xml; the TestNG suite file that dictates
+                                    which tests from the TCK Web implementation are executed and which are excluded.
+                                    Note that this file is essentially a superset of the suite file from the TCK Core,
+                                    so we don't need that one separately here.
+                                -->
                                 <artifactItem>
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>cdi-tck-web-impl</artifactId>
@@ -508,16 +460,22 @@
                                 <id>copy-cdi-sigtest</id>
                                 <phase>process-resources</phase>
                                 <goals>
-                                    <goal>copy-dependencies</goal>
+                                    <goal>copy</goal>
                                 </goals>
                                 <configuration>
-                                    <includeGroupIds>jakarta.enterprise</includeGroupIds>
-                                    <includeArtifactIds>cdi-tck-core-impl</includeArtifactIds>
-                                    <type>sig</type>
-                                    <classifier>sigtest-jdk11</classifier>
-                                    <stripVersion>true</stripVersion>
-                                    <overWriteReleases>true</overWriteReleases>
-                                    <outputDirectory>${project.build.directory}/sigtest</outputDirectory>
+                                    <artifactItems>
+                                        <!-- Signature test file for CDI -->
+                                        <artifactItem>
+                                            <groupId>jakarta.enterprise</groupId>
+                                            <artifactId>cdi-tck-core-impl</artifactId>
+                                            <version>${cdi.tck-4-0.version}</version>
+                                            <type>sig</type>
+                                            <classifier>sigtest-jdk11</classifier>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/sigtest</outputDirectory>
+                                            <destFileName>cdi-tck-core-impl-sigtest-jdk11.sig</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
                                 </configuration>
                             </execution>
                         </executions>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -349,7 +349,8 @@
                             <value>1</value>
                         </property>
                     </properties>
-                    <forkMode>once</forkMode>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
                     <!-- System Properties -->
                     <systemPropertyVariables>
                         <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -124,7 +124,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Xmx768m</argLine>
-                    <forkMode>once</forkMode>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
                     <!-- System Properties -->
                     <systemPropertyVariables>
                         <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -63,6 +63,7 @@
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
             <version>1.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -28,33 +28,7 @@
     <artifactId>glassfish-external-tck-cdi-model</artifactId>
 
     <name>CDI TCK Model runner 4.0 for Weld (GlassFish)</name>
-    <description>Aggregates dependencies and runs the CDI TCK (both standalone and on GlassFish)</description>
-
-    <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <cdi.tck-4-0.version>4.0.13</cdi.tck-4-0.version>
-
-        <!-- This matches the htmlunit version in TCK -->
-        <htmlunit.version>2.50.0</htmlunit.version>
-        <excluded.groups>se</excluded.groups>
-
-        <glassfish.version>${project.version}</glassfish.version>
-        <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>jakarta.enterprise</groupId>
-                <artifactId>cdi-tck-lang-model</artifactId>
-                <version>${cdi.tck-4-0.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <description>Aggregates dependencies and runs the CDI TCK on GlassFish</description>
 
     <dependencies>
         <dependency>
@@ -66,13 +40,13 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.7.0.Final</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-lang-model</artifactId>
+            <version>${cdi.tck-4-0.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -93,8 +67,7 @@
         </dependency>
     </dependencies>
 
-
-       <build>
+    <build>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -160,7 +160,7 @@
     
     <profiles>
         <profile>
-            <id>javaee-full</id>
+            <id>full</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -169,7 +169,7 @@
             </properties>
         </profile>
         <profile>
-            <id>webprofile</id>
+            <id>web</id>
             <properties>
                 <glassfish-artifact-id>web</glassfish-artifact-id>
             </properties>

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -38,8 +38,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -51,9 +51,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -28,7 +28,7 @@
     <artifactId>glassfish-external-tck-cdi-model</artifactId>
 
     <name>CDI TCK Model runner 4.0 for Weld (GlassFish)</name>
-    <description>Aggregates dependencies and runs the CDI TCK on GlassFish</description>
+    <description>Aggregates dependencies and runs the CDI Lang Model TCK on GlassFish</description>
 
     <dependencies>
         <dependency>
@@ -137,8 +137,7 @@
                     </includes>
                 </configuration>
             </plugin>
-            
-            
+
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <executions>

--- a/appserver/tests/tck/cdi/cdi-model/src/test/java/org/glassfish/tck/cdi/lang/model/CDILangModelTCKRunner.java
+++ b/appserver/tests/tck/cdi/cdi-model/src/test/java/org/glassfish/tck/cdi/lang/model/CDILangModelTCKRunner.java
@@ -18,19 +18,19 @@ package org.glassfish.tck.cdi.lang.model;
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.cdi.lang.model.tck.LangModelVerifier;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static java.lang.System.Logger.Level.INFO;
 import static org.glassfish.tck.cdi.lang.model.LangModelVerifierBuildCompatibleExtension.langModelVerifierBuildCompatibleExtensionPassed;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class CDILangModelTCKRunner {
 
     private static final System.Logger LOG = System.getLogger(CDILangModelTCKRunner.class.getName());

--- a/appserver/tests/tck/cdi/cdi-signature/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-signature/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.tests.tck</groupId>
+        <artifactId>glassfish-external-tck-cdi-parent</artifactId>
+        <version>7.0.15-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>glassfish-external-tck-cdi-signature</artifactId>
+
+    <name>CDI TCK Signature runner 4.0 for Weld (GlassFish)</name>
+    <description>Aggregates dependencies and runs the CDI Signature TCK on GlassFish</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-cdi-sigtest</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <!-- Signature test file for CDI -->
+                                <artifactItem>
+                                    <groupId>jakarta.enterprise</groupId>
+                                    <artifactId>cdi-tck-core-impl</artifactId>
+                                    <version>${cdi.tck-4-0.version}</version>
+                                    <type>sig</type>
+                                    <classifier>sigtest-jdk11</classifier>
+                                    <outputDirectory>${project.build.directory}/sigtest</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <overWriteReleases>true</overWriteReleases>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-glassfish</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <markersDirectory>${glassfish.root}/dependency-maven-plugin-markers</markersDirectory>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.distributions</groupId>
+                                    <artifactId>${glassfish-artifact-id}</artifactId>
+                                    <version>${glassfish.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${glassfish.root}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+                <execution>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                    <configuration>
+                        <target>
+                            <!-- API jars from the GlassFish distribution -->
+                            <unzip dest="target/cdi-sigtest-classes">
+                                <fileset dir="${glassfish.home}/glassfish/modules">
+                                    <include name="jakarta.annotation-api.jar" />
+                                    <include name="jakarta.el-api.jar" />
+                                    <include name="jakarta.interceptor-api.jar" />
+                                    <include name="jakarta.inject-api.jar" />
+                                    <include name="jakarta.enterprise.lang-model.jar" />
+                                    <include name="jakarta.enterprise.cdi-api.jar" />
+                                </fileset>
+                            </unzip>
+                        </target>
+                    </configuration>
+                </execution>
+            </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.netbeans.tools</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sigtest</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sigfile>target/sigtest/cdi-tck-core-impl-sigtest-jdk11.sig</sigfile>
+                    <packages>jakarta.decorator,jakarta.enterprise,jakarta.interceptor</packages>
+                    <classes>target/cdi-sigtest-classes</classes>
+                    <report>target/cdi-sig-report.txt</report>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>full</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
+            </properties>
+        </profile>
+        <profile>
+            <id>web</id>
+            <properties>
+                <glassfish-artifact-id>web</glassfish-artifact-id>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -30,11 +30,12 @@
     <packaging>pom</packaging>
 
     <name>CDI TCK Parent runner 4.0 for Weld (GlassFish)</name>
-    <description>Aggregates the two separate TCK runs for CDI Full and CDI Lang Model</description>
+    <description>Aggregates the three separate TCK runs for CDI Full, CDI Lang Model and TCK Signature</description>
 
     <modules>
         <module>cdi-full</module>
         <module>cdi-model</module>
+        <module>cdi-signature</module>
     </modules>
 
     <properties>

--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,4 +36,40 @@
         <module>cdi-full</module>
         <module>cdi-model</module>
     </modules>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <cdi.tck-4-0.version>4.0.13</cdi.tck-4-0.version>
+
+        <!-- This matches the htmlunit version in TCK -->
+        <htmlunit.version>2.50.0</htmlunit.version>
+        <excluded.groups>se</excluded.groups>
+
+        <glassfish.version>${project.version}</glassfish.version>
+        <glassfish.root>${project.build.directory}</glassfish.root>
+        <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-core-bom</artifactId>
+                <version>${weld.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.8.0.Final</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
 
     <name>CDI TCK Parent runner 4.0 for Weld (GlassFish)</name>
-    <description>Aggregates the three separate TCK runs for CDI Full, CDI Lang Model and TCK Signature</description>
+    <description>Aggregates the three separate TCK runs for CDI Full, CDI Lang Model and CDI Signature</description>
 
     <modules>
         <module>cdi-full</module>


### PR DESCRIPTION
What is done:

* Organized dependencies to reduce the impact of transitive dependencies.
* Used JUnit5 instead of JUnit4 in CDI Lang Model TCK.
* Replaced obsoleted `forkMode` Maven parameter.
* Used consistent profiles naming in all CDI TCKs.
* Moved CDI Signature TCK to the separate module.
* Fixed CDI Full TCK test report generation.
