### PR TITLE
Classloader matching for BeanDeploymentArchives

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -321,8 +321,9 @@ public class DeploymentImpl implements CDI11Deployment {
      * @param beanClass The beanClass to get the BeanDeploymentArchive for.
      *
      * @return If the beanClass is in the archive represented by the BeanDeploymentArchive then return that BeanDeploymentArchive.
-     * Otherwise if the class loader of the beanClass matches the module class loader of any of the root BeanDeploymentArchives
-     * then return that root BeanDeploymentArchive.
+     * If the class is represented by more than one, than perform matching by classloader of the bean class
+     * to return the appropriate one. Otherwise if the class loader of the beanClass matches the module class
+     * loader of any of the root BeanDeploymentArchives then return that root BeanDeploymentArchive.
      * Otherwise return null.
      */
     @Override
@@ -331,16 +332,17 @@ public class DeploymentImpl implements CDI11Deployment {
             return null;
         }
 
+        ClassLoader classLoader = beanClass.getClassLoader();
+
         for (BeanDeploymentArchive beanDeploymentArchive : beanDeploymentArchives) {
             BeanDeploymentArchiveImpl beanDeploymentArchiveImpl = (BeanDeploymentArchiveImpl) beanDeploymentArchive;
-            if (beanDeploymentArchiveImpl.getKnownClasses().contains(beanClass.getName())) {
+            if (beanDeploymentArchiveImpl.getKnownClasses().contains(beanClass.getName()) &&
+                beanDeploymentArchiveImpl.getModuleClassLoaderForBDA().equals(classLoader)) {
                 return beanDeploymentArchive;
             }
         }
 
         // Find a root BeanDeploymentArchive
-        ClassLoader classLoader = beanClass.getClassLoader();
-
         RootBeanDeploymentArchive rootBda = findRootBda(classLoader, ejbRootBdas);
         if (rootBda == null) {
             rootBda = findRootBda(classLoader, warRootBdas);


### PR DESCRIPTION
The same beanClass may be within several BeanDeploymentArchives. In it's current form, it returns the first matching BDA by checking if the beanClass is can be found within that BDA. If the incorrect BDA is returned, for example in:

https://github.com/eclipse-ee4j/glassfish/blob/5d59bb6a60301341125438bebe36aac35c0337ae/appserver/web/weld-integration/src/main/java/org/glassfish/weld/services/CDIServiceImpl.java#L418

then the classloader of the instantiated object in `createManagedObject` will belong (based on https://github.com/weld/core/blob/aab0ff03a84ea5718a515e9193a64b190e8f8479/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java#L1176) to the initiating class loader which first created the managed bean. This results in a `classcastexception` if subsequent requests for the same beanclass is coming from a different classloader (i.e. the classloader of the `managedClass` is disregarded).

The change here tightens the condition for returning the correct BDA, by matching it's module class loader to the incoming beanClass to ensure no `classcastexception` is thrown when the generated objected is cast back to beanClass.