### PR TITLE
Fixes GlassFish home in the REST CDI TCK

### DIFF
--- a/appserver/tests/tck/rest_cdi/pom.xml
+++ b/appserver/tests/tck/rest_cdi/pom.xml
@@ -140,7 +140,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <finalName>${project.build.finalName}</finalName>
-                        <glassfish.home>${session.executionRootDirectory}/target/glassfish7</glassfish.home>
+                        <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
                         <glassfish.enableDerby>true</glassfish.enableDerby>
                         <glassfish.suspend>${suspend}</glassfish.suspend>
                     </systemPropertyVariables>


### PR DESCRIPTION
REST CDI TCK failed when started from GlassFish source root:

```sh
cd glassfish
mvn clean install -Ptck -pl :glassfish-internal-tck-rest-cdi
```
