### PR TITLE
Remove unsupported Maven option from Jakarta REST TCK installer's POM

### DIFF
--- a/appserver/tests/tck/tck-download/jakarta-rest-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-rest-tck/pom.xml
@@ -72,7 +72,6 @@
                             <artifactId>jakarta-restful-ws-tck</artifactId>
                             <version>${tck.rest.rest.version}</version>
                             <packaging>jar</packaging>
-                            <createChecksum>true</createChecksum>
                             <generatePom>true</generatePom>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Maven Install Plugin [does not support](https://maven.apache.org/plugins/maven-install-plugin/#important-note-for-version-3-0-0) creating checksums anymore via `createChecksum`.
