### PR TITLE
Fixes keytool executable name on Windows in integration test tools

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -259,7 +259,7 @@ public class GlassFishTestEnvironment {
 
 
     private static File findKeyTool() {
-        return new File(System.getProperty("java.home"), isWindows() ? "bin/keytool.bat" : "bin/keytool");
+        return new File(System.getProperty("java.home"), isWindows() ? "bin/keytool.exe" : "bin/keytool");
     }
 
 


### PR DESCRIPTION
Windows uses `keytool.exe`, not `keytool.bat`.
