### PR TITLE
Fixes resources leak in `WebappClassLoader`

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -24,6 +24,7 @@ import com.sun.enterprise.security.integration.PermsHolder;
 import com.sun.enterprise.util.io.FileUtils;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FilePermission;
 import java.io.IOException;
@@ -1188,6 +1189,17 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
 
     public void preDestroy() {
         LOG.log(TRACE, "preDestroy()");
+
+        // Close deployment time libraries.
+        ClassLoader parent = getParent();
+        if (parent instanceof Closeable) {
+            try {
+                ((Closeable) parent).close();
+            } catch (IOException e) {
+                LOG.log(ERROR, "There were issues with closing deploy time libraries", e);
+            }
+        }
+
         try {
             close();
         } catch (Exception e) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -64,8 +64,6 @@ public class AppLibClassLoaderServiceImpl {
     @Inject
     CommonClassLoaderServiceImpl commonCLS;
 
-    private final Map<URI, DelegatingClassLoader.ClassFinder> classFinderRegistry = new HashMap<>();
-
     /**
      * @see org.glassfish.internal.api.ClassLoaderHierarchy#getAppLibClassLoader(String, List<URI>)
      */
@@ -102,14 +100,8 @@ public class AppLibClassLoaderServiceImpl {
 
         ClassLoader commonCL = commonCLS.getCommonClassLoader();
         for (URI libURI : libURIs) {
-            synchronized (this) {
-                DelegatingClassLoader.ClassFinder libCF = classFinderRegistry.get(libURI);
-                if (libCF == null) {
-                    libCF = new URLClassFinder(new URL[]{libURI.toURL()}, commonCL);
-                    classFinderRegistry.put(libURI, libCF);
-                }
-                holder.addDelegate(libCF);
-            }
+            DelegatingClassLoader.ClassFinder libCF = new URLClassFinder(new URL[]{libURI.toURL()}, commonCL);
+            holder.addDelegate(libCF);
         }
     }
 


### PR DESCRIPTION
When we undeploy a web application that uses deploy time libraries, these libraries remain open until the domain stops/restart.

Now we disable deploy time libraries caching and close their associated class loaders during undeploy.
