### PR TITLE
Fix: Display Cluster Monitoring Data in Admin Console

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/MonitoringResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/MonitoringResource.java
@@ -56,6 +56,10 @@ import static org.glassfish.admin.rest.provider.ProviderUtil.getElementLink;
 import static org.glassfish.admin.rest.provider.ProviderUtil.getStatistic;
 import static org.glassfish.admin.rest.provider.ProviderUtil.jsonValue;
 
+import com.sun.enterprise.util.Utility;
+import jakarta.inject.Inject;
+import org.glassfish.internal.api.ServerContext;
+
 /**
  * @author rajeshwar patil
  * @author Mitesh Meswani
@@ -71,6 +75,9 @@ public class MonitoringResource {
 
     @Context
     protected LocatorBridge habitat;
+
+    @Inject
+    private ServerContext serverContext;
 
     @GET
     @Path("domain{path:.*}")
@@ -154,10 +161,13 @@ public class MonitoringResource {
             } else { //firstPathElement != currentInstanceName => A proxy request
                 if (isRunningOnDAS) { //Attempt to forward to instance if running on Das
                     //TODO validate that firstPathElement corresponds to a valid server name
-                    // FIXME: As of 03.04.2022 Utils.getJerseyClient here throws exception:
-                    // java.lang.ClassNotFoundException: Provider for jakarta.ws.rs.client.ClientBuilder cannot be found
-                    Properties proxiedResponse = new MonitoringProxyImpl().proxyRequest(uriInfo, Util.getJerseyClient(),
-                            habitat.getRemoteLocator());
+
+                    // Jersey client is not accessible from the current context classloader, which is kernel OSGi bundle CL
+                    Properties proxiedResponse = Utility.runWithContextClassLoader(serverContext.getCommonClassLoader(),
+                            () -> {
+                                return new MonitoringProxyImpl()
+                                        .proxyRequest(uriInfo, Util.getJerseyClient(), habitat.getRemoteLocator());
+                            });
                     ar.setExtraProperties(proxiedResponse);
                     responseBuilder.entity(new ActionReportResult(ar));
                 } else { // Not running on DAS and firstPathElement != currentInstanceName => Reject the request as invalid

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/MonitoringResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/MonitoringResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -162,7 +162,10 @@ public class MonitoringResource {
                 if (isRunningOnDAS) { //Attempt to forward to instance if running on Das
                     //TODO validate that firstPathElement corresponds to a valid server name
 
-                    // Jersey client is not accessible from the current context classloader, which is kernel OSGi bundle CL
+                    /* Jersey client is not accessible from the current context classloader,
+                        which is kernel OSGi bundle CL. We need to run it within the common classloader as
+                        the context classloader
+                    */
                     Properties proxiedResponse = Utility.runWithContextClassLoader(serverContext.getCommonClassLoader(),
                             () -> {
                                 return new MonitoringProxyImpl()

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/ManagementProxyResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/custom/ManagementProxyResource.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -62,7 +63,10 @@ public class ManagementProxyResource {
 
         ActionReportResult result = new ActionReportResult(ar);
 
-        // Jersey client is not accessible from the current context classloader, which is kernel OSGi bundle CL
+        /* Jersey client is not accessible from the current context classloader,
+            which is kernel OSGi bundle CL. We need to run it within the common classloader as
+            the context classloader
+        */
         Properties proxiedResponse = Utility.runWithContextClassLoader(serverContext.getCommonClassLoader(),
                 () -> {
                     return new ManagementProxyImpl()

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/ProxyImpl.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/ProxyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -117,6 +117,7 @@ public abstract class ProxyImpl implements Proxy {
 
             }
         } catch (ProcessingException ex) {
+            // couldn't contact remote instance
             throw new WebApplicationException(ex, Response.Status.GONE);
         } catch (Exception ex) {
             throw new WebApplicationException(ex, Response.Status.INTERNAL_SERVER_ERROR);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/ProxyImpl.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/ProxyImpl.java
@@ -21,6 +21,7 @@ import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.SecureAdmin;
 import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.security.ssl.SSLUtils;
+import jakarta.ws.rs.ProcessingException;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -115,6 +116,8 @@ public abstract class ProxyImpl implements Proxy {
                 // TODO error to user. Can not locate server for whom data is being looked for
 
             }
+        } catch (ProcessingException ex) {
+            throw new WebApplicationException(ex, Response.Status.GONE);
         } catch (Exception ex) {
             throw new WebApplicationException(ex, Response.Status.INTERNAL_SERVER_ERROR);
         }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/Utility.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/Utility.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -544,6 +545,20 @@ public final class Utility {
             AccessController.doPrivileged(action);
         }
         return original;
+    }
+
+    public static <T> T runWithContextClassLoader(ClassLoader contextClassLoader, Supplier<T> action) {
+        ClassLoader originalClassLoader = null;
+        try {
+            if (contextClassLoader != null) {
+                originalClassLoader = setContextClassLoader(contextClassLoader);
+            }
+            return action.get();
+        } finally {
+            if (originalClassLoader != null) {
+                setContextClassLoader(originalClassLoader);
+            }
+        }
     }
 
     public static void setEnvironment() {

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/Utility.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/Utility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -547,17 +547,51 @@ public final class Utility {
         return original;
     }
 
+    /**
+     * Run an action with a specific classloader as the context classloader. Sets the context classloader, calls the method, resets the context classloader to the previous classloader.
+     * @param Type of a value returned from the supplied action and from this method
+     * @param contextClassLoader Classloader to be used as the context classloader during thi method call
+     * @param action A mathod to call with the classloader as the context classloader.
+     * @return Value returned by the action method
+     */
     public static <T> T runWithContextClassLoader(ClassLoader contextClassLoader, Supplier<T> action) {
         ClassLoader originalClassLoader = null;
         try {
-            if (contextClassLoader != null) {
-                originalClassLoader = setContextClassLoader(contextClassLoader);
-            }
+            originalClassLoader = setContextClassLoader(contextClassLoader, originalClassLoader);
             return action.get();
         } finally {
-            if (originalClassLoader != null) {
-                setContextClassLoader(originalClassLoader);
-            }
+            resetContextClassLoder(originalClassLoader);
+        }
+    }
+
+    public static interface RunnableWithException<E extends Exception> {
+        void run() throws E;
+    }
+
+    /**
+     * Same as {@link Utility#runWithContextClassLoader(java.lang.ClassLoader, java.util.function.Supplier)} but with an action that doesn't return anything
+     */
+    public static <E extends Exception> void runWithContextClassLoader(ClassLoader contextClassLoader,
+            RunnableWithException<E> action) throws E {
+        ClassLoader originalClassLoader = null;
+        try {
+            originalClassLoader = setContextClassLoader(contextClassLoader, originalClassLoader);
+            action.run();
+        } finally {
+            resetContextClassLoder(originalClassLoader);
+        }
+    }
+
+    private static ClassLoader setContextClassLoader(ClassLoader contextClassLoader, ClassLoader originalClassLoader) {
+        if (contextClassLoader != null) {
+            originalClassLoader = setContextClassLoader(contextClassLoader);
+        }
+        return originalClassLoader;
+    }
+
+    private static void resetContextClassLoder(ClassLoader originalClassLoader) {
+        if (originalClassLoader != null) {
+            setContextClassLoader(originalClassLoader);
         }
     }
 


### PR DESCRIPTION
Fixes #24619.

Force using common classloader as context classloader when calling Jersey REST client.

The original cause is still there - the Jersey REST client classes are in an OSGi bundle classloader which is not accessible from the current context classloader. I couldn't manage to fix this so that OSGi automatically wires those classloaders. That would be even better, because this boiler plate code wouldn't be needed and all would work automatically, and not only in these places but everywhere in Admin Console.