### PR TITLE
Upgrade jackson to 2.17.1

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -144,7 +144,7 @@
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.12</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <fasterxml.classmate.version>1.7.0</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>


### PR DESCRIPTION
Jersey 3.1.6 depends on it but GF had an older version. Admin Console failed to load, because it didn't find an OSGi module for version 2.17.x which Jersey and hence Admin Console need.

IMPORTANT: Admin Console wasn't loading for 3 weeks and nobody noticed. There should be an automated test to check at least that the admin console was deployed, either by checking logs or via a HTTP request. 