### PR TITLE
Move some info logged by the WebApp CL as INFO to DEBUG/FINE level to reduce noise

### DIFF
--- a/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
+++ b/appserver/web/war-util/src/main/java/com/sun/enterprise/glassfish/web/WarHandler.java
@@ -67,6 +67,8 @@ import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
+import org.glassfish.api.deployment.OpsParams;
+
 /**
  * Implementation of the ArchiveHandler for war files.
  *
@@ -125,7 +127,8 @@ public class WarHandler extends AbstractArchiveHandler {
 
     @Override
     public ClassLoader getClassLoader(final ClassLoader parent, DeploymentContext context) {
-        PrivilegedAction<WebappClassLoader> action = () -> new WebappClassLoader(parent);
+        String appName = context.getCommandParameters(OpsParams.class).name();
+        PrivilegedAction<WebappClassLoader> action = () -> new WebappClassLoader(parent, appName);
         WebappClassLoader cloader = AccessController.doPrivileged(action);
         try {
             WebDirContext webDirContext = new WebDirContext();

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -166,6 +166,8 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
     /** The list of not found resources to avoid slow repeated searches. */
     private final Set<String> notFoundResources = ConcurrentHashMap.newKeySet();
 
+    /* Name of the application this class loader is for */
+    private String webappName;
 
     /** Associated directory context giving access to the resources in this webapp. */
     private DirContext jndiResources;
@@ -267,7 +269,12 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
      * but no defined repositories.
      */
     public WebappClassLoader(ClassLoader parent) {
+        this(parent, "unknown");
+    }
+
+    public WebappClassLoader(ClassLoader parent, String webappName) {
         super(new URL[0], parent);
+        this.webappName = webappName;
         this.cleaner = new ReferenceCleaner(this);
         this.system = WebappClassLoader.class.getClassLoader();
         if (SECURITY_MANAGER != null) {
@@ -1131,7 +1138,9 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
         if (status == LifeCycleStatus.CLOSED) {
             return;
         }
-        LOG.log(INFO, "close(), this:\n{0}", this);
+        LOG.log(INFO, () -> "close(), " + this.getClass().getSimpleName()
+                + " classloader for application: " + webappName);
+        LOG.log(DEBUG, () -> "close(), this:\n" + this);
 
         cleaner.clearReferences(clearReferencesStatic ? resourceEntryCache.values() : null);
         status = LifeCycleStatus.CLOSED;
@@ -1171,7 +1180,8 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
     public String toString() {
         StringBuilder sb = new StringBuilder(4096);
         sb.append(super.toString());
-        sb.append("[delegate=").append(delegate);
+        sb.append("[webAppName=").append(webappName);
+        sb.append(", delegate=").append(delegate);
         sb.append(", context=").append(contextName);
         sb.append(", status=").append(status);
         sb.append(", antiJARLocking=").append(antiJARLocking);

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -144,7 +144,7 @@
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.12</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.17.1</jackson.version>
         <fasterxml.classmate.version>1.7.0</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>


### PR DESCRIPTION
- NOTE: This PR includes #24943, otherwise Admin Console failed to start.

With this, the following is logged in INFO during app deployment:

```
[#|2024-05-05T05:23:24.750875+02:00|INFO|GF 7.0.15-SNAPSHOT|org.glassfish.web.loader.WebappClassLoader|_ThreadID=300;_ThreadName=RunLevelControllerThread-1714879404711;_LevelValue=800;|
  close(), WebappClassLoader classloader for application: myapp|#]
```

The following is not logged as INFO anymore, rather as DEBUG/FINE. As INFO is the default log level, it's a noise in logs which is mostly for troubleshooting and it's better to have it in DEBUG level, only if requested:

```
[2024-05-05T05:10:08.836483+02:00] [GF 7.0.15-SNAPSHOT] [FINE] [] [org.glassfish.web.loader.WebappClassLoader] [tid: _ThreadID=64 _ThreadName=admin-listener(4)] [levelValue: 500] [[
  close(), this:
org.glassfish.web.loader.WebappClassLoader@44694e1c[name=unknown], urls=[
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/classes/
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/byte-buddy-1.12.18.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jakarta.activation-api-2.1.0.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/lombok-1.18.28.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/antlr4-runtime-4.10.1.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jboss-logging-3.5.0.Final.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jaxb-runtime-4.0.2.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jakarta.transaction-api-2.0.1.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/commons-logging-1.2.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/txw2-4.0.2.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/classmate-1.5.1.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/hibernate-core-6.2.6.Final.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jaxb-core-4.0.2.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/commons-dbcp2-2.9.0.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/h2-2.1.214.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jakarta.inject-api-2.0.1.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jakarta.xml.bind-api-4.0.0.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/angus-activation-2.0.0.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/hibernate-commons-annotations-6.0.6.Final.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jakarta.persistence-api-3.1.0.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/istack-commons-runtime-4.1.1.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/commons-pool2-2.10.0.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/applications/myapp/WEB-INF/lib/jandex-3.0.5.jar
file:/glassfish/appserver/distributions/glassfish/target/stage/glassfish7/glassfish/domains/domain1/generated/ejb/myapp/
][webAppName=myapp, delegate=true, context=unknown, status=RUNNING, antiJARLocking=false, securityManager=false, packageDefinitionSecurityEnabled=false, repositories=RepositoryManager[WEB-INF/classes/], notFound.size=2, pathTimestamps.size=24, resourceEntryCache.size=5]]]
```