### PR TITLE
Improve application-specific libraries loading

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -212,6 +212,7 @@
         <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
@@ -408,6 +409,7 @@
              <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
+             <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/applib/lib/LibraryResource.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/applib/lib/LibraryResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.applib.lib;
+
+import java.util.ResourceBundle;
+import java.util.UUID;
+
+public class LibraryResource {
+
+    private static final ResourceBundle bundle = ResourceBundle.getBundle("org.glassfish.main.test.app.applib.Version");
+
+    private static final UUID uuid = UUID.randomUUID();
+
+    public String getUUID() {
+        return uuid.toString();
+    }
+
+    public String getVersion() {
+        return bundle.getString("version");
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/applib/webapp/LibraryApplication.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/applib/webapp/LibraryApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.applib.webapp;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import java.util.Set;
+
+@ApplicationPath("")
+public class LibraryApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(LibraryEndpoint.class);
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/applib/webapp/LibraryEndpoint.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/applib/webapp/LibraryEndpoint.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.applib.webapp;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+
+import org.glassfish.main.test.app.applib.lib.LibraryResource;
+
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+
+@Path("/")
+public class LibraryEndpoint {
+
+    @GET
+    @Path("version")
+    @Produces(TEXT_PLAIN)
+    public Response getVersion() {
+        try {
+            LibraryResource resource = new LibraryResource();
+            String version = resource.getVersion();
+            return Response.ok(version).build();
+        } catch (Throwable t) {
+            return Response.serverError().build();
+        }
+    }
+
+    @GET
+    @Path("uuid")
+    @Produces(TEXT_PLAIN)
+    public Response getUUID() {
+        try {
+            LibraryResource resource = new LibraryResource();
+            String uuid = resource.getUUID();
+            return Response.ok(uuid).build();
+        } catch (Throwable t) {
+            return Response.serverError().build();
+        }
+    }
+
+    @GET
+    @Path("resource")
+    @Produces(TEXT_PLAIN)
+    public Response findResource() throws IOException {
+        URL resource = getClass().getResource("/org/glassfish/main/test/app/applib/Version.properties");
+        if (resource == null) {
+            return Response.serverError().build();
+        }
+
+        Properties version = new Properties();
+        try (InputStream inputStream = resource.openStream()) {
+            version.load(inputStream);
+        }
+        return Response.ok(version.toString()).build();
+    }
+}

--- a/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/applib/v1/Version.properties
+++ b/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/applib/v1/Version.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Contributors to the Eclipse Foundation.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+version=1

--- a/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/applib/v2/Version.properties
+++ b/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/applib/v2/Version.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2024 Contributors to the Eclipse Foundation.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+version=2

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/applib/ApplicationLibraryTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/applib/ApplicationLibraryTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.applib;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.nio.file.Files;
+import java.text.MessageFormat;
+
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.glassfish.main.test.app.applib.lib.LibraryResource;
+import org.glassfish.main.test.app.applib.webapp.LibraryApplication;
+import org.glassfish.main.test.app.applib.webapp.LibraryEndpoint;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.openConnection;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ApplicationLibraryTest {
+
+    private static final System.Logger LOG = System.getLogger(ApplicationLibraryTest.class.getName());
+
+    private static final String VERSION_RESOURCE = "src/main/resources/org/glassfish/main/test/app/applib/v{0}/Version.properties";
+
+    private static final String APPLIB_FILE_NAME = "applib.jar";
+
+    private static final String WEBAPP_FILE_NAME = "webapp.war";
+
+    private static final String WEBAPP1_NAME = "webapp1";
+
+    private static final String WEBAPP2_NAME = "webapp2";
+
+    private static final String WEBAPP3_NAME = "webapp3";
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @TempDir
+    private static File appLibDir;
+
+    @TempDir
+    private static File webAppDir;
+
+    @BeforeAll
+    public static void deployAll() throws IOException {
+        File webApp = createWebApp();
+
+        File appLib = createAppLib(1);
+
+        // The 'webapp1' and 'webapp2' uses the same version
+        // of the application library, whereas 'webapp3' uses
+        // its own new version.
+
+        AsadminResult result = ASADMIN.exec("deploy",
+            "--contextroot", "/" + WEBAPP1_NAME,
+            "--name", WEBAPP1_NAME,
+            "--libraries", appLib.getAbsolutePath(),
+            webApp.getAbsolutePath());
+        assertThat(result, asadminOK());
+
+        result = ASADMIN.exec("deploy",
+            "--contextroot", "/" + WEBAPP2_NAME,
+            "--name", WEBAPP2_NAME,
+            "--libraries", appLib.getAbsolutePath(),
+            webApp.getAbsolutePath());
+        assertThat(result, asadminOK());
+
+        // Remove old version of the application library
+        Files.deleteIfExists(appLib.toPath());
+
+        // Create the new one
+        appLib = createAppLib(2);
+
+        result = ASADMIN.exec("deploy",
+            "--contextroot", "/" + WEBAPP3_NAME,
+            "--name", WEBAPP3_NAME,
+            "--libraries", appLib.getAbsolutePath(),
+            webApp.getAbsolutePath());
+        assertThat(result, asadminOK());
+    }
+
+    @AfterAll
+    public static void undeployAll() {
+        assertAll(
+            () -> assertThat(ASADMIN.exec("undeploy", WEBAPP1_NAME), asadminOK()),
+            () -> assertThat(ASADMIN.exec("undeploy", WEBAPP2_NAME), asadminOK()),
+            () -> assertThat(ASADMIN.exec("undeploy", WEBAPP3_NAME), asadminOK())
+        );
+    }
+
+    @Test
+    public void testFindClass() throws IOException {
+        String version1 = getEntity(WEBAPP1_NAME, "version");
+        String version2 = getEntity(WEBAPP2_NAME, "version");
+        String version3 = getEntity(WEBAPP3_NAME, "version");
+
+        assertAll(
+            () -> assertThat(Integer.parseInt(version1), equalTo(1)),
+            () -> assertThat(Integer.parseInt(version2), equalTo(1)),
+            () -> assertThat(Integer.parseInt(version3), equalTo(2))
+        );
+    }
+
+    @Test
+    public void testFindResource() throws IOException {
+        String version1 = getEntity(WEBAPP1_NAME, "resource");
+        String version2 = getEntity(WEBAPP2_NAME, "resource");
+        String version3 = getEntity(WEBAPP3_NAME, "resource");
+
+        assertAll(
+            () -> assertThat(version1, equalTo("{version=1}")),
+            () -> assertThat(version2, equalTo("{version=1}")),
+            () -> assertThat(version3, equalTo("{version=2}"))
+        );
+    }
+
+    @Test
+    public void testApplicationLibrarySharing() throws IOException {
+        String uuid1 = getEntity(WEBAPP1_NAME, "uuid");
+        String uuid2 = getEntity(WEBAPP2_NAME, "uuid");
+        String uuid3 = getEntity(WEBAPP3_NAME, "uuid");
+
+        assertAll(
+            // Both 'webapp1' and 'webapp2' share the same library
+            () -> assertEquals(uuid1, uuid2),
+            // The 'webapp3' uses its own version
+            () -> assertNotEquals(uuid1, uuid3)
+        );
+    }
+
+    private String getEntity(String contextRoot, String endpoint) throws IOException {
+        HttpURLConnection connection = openConnection(8080, "/" + contextRoot + "/" + endpoint);
+        connection.setRequestMethod("GET");
+        try {
+            assertThat(connection.getResponseCode(), equalTo(200));
+            return readResponse(connection);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private String readResponse(HttpURLConnection connection) throws IOException {
+        try (InputStream inputStream = connection.getInputStream()) {
+            return new String(inputStream.readAllBytes()).trim();
+        }
+    }
+
+    private static File createAppLib(int version) throws IOException {
+        JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(LibraryResource.class)
+            .addAsResource(
+                new File(MessageFormat.format(VERSION_RESOURCE, version)),
+                "/org/glassfish/main/test/app/applib/Version.properties"
+            );
+
+        LOG.log(INFO, javaArchive.toString(true));
+
+        File appLib = new File(appLibDir, APPLIB_FILE_NAME);
+        javaArchive.as(ZipExporter.class).exportTo(appLib, true);
+        return appLib;
+    }
+
+    private static File createWebApp() throws IOException {
+        WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
+            .addClass(LibraryEndpoint.class)
+            .addClass(LibraryApplication.class);
+
+        LOG.log(INFO, webArchive.toString(true));
+
+        File webApp = new File(webAppDir, WEBAPP_FILE_NAME);
+        webArchive.as(ZipExporter.class).exportTo(webApp, true);
+        return webApp;
+    }
+}

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -172,6 +173,7 @@
         <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
@@ -330,6 +332,7 @@
              <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
+             <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ServerSynchronizer.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ServerSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -529,6 +529,7 @@ public final class ServerSynchronizer implements PostConstruct {
                                     throws URISyntaxException {
         List<String> skip = new ArrayList<>();
         skip.add("databases");
+        skip.add("snapshots");
         synchronizeDirectory(payload, server, sr,
                                 env.getLibPath(), skip, SyncLevel.RECURSIVE);
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -254,6 +254,45 @@ public final class FileUtils {
         return f.getName().toLowerCase(Locale.ENGLISH).endsWith(ext.toLowerCase(Locale.ENGLISH));
     }
 
+    /**
+     * Gets the extension of the {@code file}.
+     * <p>
+     * This method returns the extension of the {@code file} <strong>with</strong> the leading dot.
+     *
+     * @param file the file
+     * @return the file extension
+     */
+    public static String getExtension(File file) {
+        if (file == null) {
+            return null;
+        }
+        String fileName = file.getName();
+        int extensionIndex = fileName.lastIndexOf('.');
+        if (extensionIndex == -1) {
+            return "";
+        }
+        return fileName.substring(extensionIndex);
+    }
+
+    /**
+     * Removes the extension from a file name for the {@code file}.
+     * <p>
+     * This method returns the textual part of the file name before last dot.
+     *
+     * @param file the file
+     * @return the file name without extension or {@code null} if {@code file} is {@code null}
+     */
+    public static String removeExtension(File file) {
+        if (file == null) {
+            return null;
+        }
+        String fileName = file.getName();
+        int extensionIndex = fileName.lastIndexOf('.');
+        if (extensionIndex == -1) {
+            return fileName;
+        }
+        return fileName.substring(0, extensionIndex);
+    }
 
     public static boolean isLegalFilename(String filename) {
         if (!isValidString(filename)) {

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/DelegatingClassLoader.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/DelegatingClassLoader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,58 +22,83 @@ import com.sun.enterprise.module.common_impl.CompositeEnumeration;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.Collections;
 import java.net.URL;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import static java.util.Collections.unmodifiableList;
+
 /**
- * This classloader has a list of classloaders called as delegates
- * that it uses to find classes. All those delegates must have the
- * same parent as this classloader in order to have a consistent class space.
- * By consistent class space, I mean a class space where no two loaded class
- * have same name. An inconsistent class space can lead to ClassCastException.
- * This classloader does not define any class, classes are always loaded
- * either by its parent or by one of the delegates.
+ * This class loader has a list of class loaders called as delegates
+ * that it uses to find classes.
+ * <p>
+ * All those delegates must have the same parent as this class loader in order to
+ * have a consistent class space. By consistent class space, we mean a class space
+ * where no two loaded class have same name. An inconsistent class space can lead
+ * to {@link ClassCastException}.
+ * <p>
+ * This class loader does not define any class, classes are always loaded either by
+ * its parent or by one of the delegates.
  *
  * @author Sanjeeb.Sahoo@Sun.COM
  */
 public class DelegatingClassLoader extends ClassLoader {
-    /*
-     * TODO(Sahoo):
-     * 1. I18N
-     * 2. Move to a more common package, as it has no dependency on kernel.
-     */
 
     /**
-     * findClass method of ClassLoader is usually a protected method.
-     * Calling loadClass on a ClassLoader is expenssive, as it searches
+     * This interface is an optimization.
+     * <p>
+     * The {@code findClass} method of {@link ClassLoader} is usually a protected method.
+     * Calling {@code loadClass} on a {@link ClassLoader} is expensive, as it searches
      * the delegation hierarchy before searching in its private space.
-     * Hence we add this interface as an optimization.
      */
     public interface ClassFinder {
 
         /**
+         * Returns the paren class loader.
+         * <p>
+         * The parent class loader used to check delegation hierarchy.
+         *
+         * @return the parent classloader
          * @see ClassLoader#getParent()
          */
         ClassLoader getParent();
 
         /**
+         * Finds the class with the specified binary name.
+         *
+         * @param name the binary name of the class
+         * @return the resulting {@link Class} object
+         * @throws ClassNotFoundException if class could not be found
          * @see ClassLoader#findClass(String)
          */
         Class<?> findClass(String name) throws ClassNotFoundException;
 
         /**
+         * Returns the loaded class with the given binary name.
+         *
+         * @param name the binary name of the class
+         * @return the {@link Class} object, or {@code null} if the class has not been loaded
          * @see ClassLoader#findLoadedClass(String)
          */
         Class<?> findExistingClass(String name);
 
         /**
+         * Finds the resource with the given name.
+         *
+         * @param name the resource name
+         * @return a URL object for reading the resource, or {@code null} if the resource
+         * could not be found
          * @see ClassLoader#findResource(String)
          */
         URL findResource(String name);
 
         /**
+         * Returns an enumeration of URL objects representing all resources with the given name.
+         *
+         * @param name the resource name
+         * @return an enumeration of URL objects for the resources
+         * @throws IOException if an I/O error occurs
          * @see ClassLoader#findResources(String)
          */
         Enumeration<URL> findResources(String name) throws IOException;
@@ -81,20 +107,24 @@ public class DelegatingClassLoader extends ClassLoader {
     private final CopyOnWriteArrayList<ClassFinder> delegates = new CopyOnWriteArrayList<>();
 
     /**
-     * Name of this class loader. Used mostly for reporting purpose.
+     * Name of this class loader.
+     * <p>
+     * Used mostly for reporting purpose.
+     * <p>
      * No guarantee about its uniqueness.
      */
     private volatile String name;
 
     /**
+     * Creates new delegating class loader.
+     *
      * @throws IllegalArgumentException when the delegate does not have same parent
-     * as this classloader.
+     * as this class loader
      */
-    public DelegatingClassLoader(ClassLoader parent, List<ClassFinder> delegates)
-            throws IllegalArgumentException{
+    public DelegatingClassLoader(ClassLoader parent, List<ClassFinder> delegates) {
         super(parent);
-        for (ClassFinder d : delegates) {
-            checkDelegate(d);
+        for (ClassFinder classFinder : delegates) {
+            checkDelegate(classFinder);
         }
         this.delegates.addAll(delegates);
     }
@@ -104,53 +134,56 @@ public class DelegatingClassLoader extends ClassLoader {
     }
 
     /**
-     * Adds a ClassFinder to list of delegates. To have a consistent
-     * class space (by consistent class space, I mean a classpace where there
-     * does not exist two class with same name), this method does not allow
+     * Adds a class finder to list of delegates.
+     * <p>
+     * To have a consistent class space (by consistent class space, we mean a class space
+     * where there does not exist two class with same name), this method does not allow
      * a delegate to be added that has a different parent.
-     * @param d ClassFinder to add to the list of delegates
-     * @return true if the delegate is added, false otherwise.
+     *
+     * @param classFinder class finder to add to the list of delegates
+     * @return {@code true} if the delegate is added, {@code false} otherwise
      * @throws IllegalArgumentException when the delegate does not have same parent
-     * as this classloader.
+     * as this class loader
      */
-    public boolean addDelegate(ClassFinder d) throws IllegalArgumentException {
-        checkDelegate(d);
-        return delegates.addIfAbsent(d);
+    public boolean addDelegate(ClassFinder classFinder) {
+        checkDelegate(classFinder);
+        return delegates.addIfAbsent(classFinder);
     }
 
     /**
+     * Checks delegation hierarchy.
+     *
+     * @param classFinder class finder to check
      * @throws IllegalArgumentException when the delegate does not have same parent
-     * as this classloader.
+     * as this class loader
      */
-    private void checkDelegate(ClassFinder d) throws IllegalArgumentException {
-        final ClassLoader dp = d.getParent();
-        final ClassLoader p = getParent();
-        if (dp != p) { // check for equals
-            if ((dp != null && !dp.equals(p)) || !p.equals(dp)) {
-                throw new IllegalArgumentException("Delegation hierarchy mismatch");
-            }
+    private void checkDelegate(ClassFinder classFinder) {
+        final ClassLoader delegateParent = classFinder.getParent();
+        final ClassLoader parent = getParent();
+        if (!Objects.equals(delegateParent, parent)) {
+            throw new IllegalArgumentException("Delegation hierarchy mismatch");
         }
     }
 
     /**
-     * Removes a ClassFinder from list of delegates.
+     * Removes a class finder from list of delegates.
      *
-     * @param d ClassFinder to remove from the list of delegates
-     * @return true if the delegate was removed, false otherwise.
+     * @param classFinder class finder to remove from the list of delegates
+     * @return {@code true} if the delegate was removed, {@code false} otherwise
      */
-    public boolean removeDelegate(ClassFinder d) {
-        return delegates.remove(d);
+    public boolean removeDelegate(ClassFinder classFinder) {
+        return delegates.remove(classFinder);
     }
 
     @Override
     public Class<?> findClass(String name) throws ClassNotFoundException {
-        for (ClassFinder d : delegates) {
+        for (ClassFinder classFinder : delegates) {
             try {
-                Class c = null;
-                synchronized(d){
-                    c = d.findExistingClass(name);
-                    if(c == null){
-                        c = d.findClass(name);
+                Class<?> c;
+                synchronized (classFinder) {
+                    c = classFinder.findExistingClass(name);
+                    if (c == null) {
+                        c = classFinder.findClass(name);
                     }
                 }
                 return c;
@@ -163,18 +196,20 @@ public class DelegatingClassLoader extends ClassLoader {
 
     @Override
     protected URL findResource(String name) {
-        for (ClassFinder d : delegates) {
-            URL u = d.findResource(name);
-            if (u!=null) return u;
+        for (ClassFinder classFinder : delegates) {
+            URL resourceURL = classFinder.findResource(name);
+            if (resourceURL != null) {
+                return resourceURL;
+            }
         }
         return null;
     }
 
     @Override
     protected Enumeration<URL> findResources(String name) throws IOException {
-        List<Enumeration<URL>> enumerators = new ArrayList<Enumeration<URL>>();
-        for (ClassFinder delegate : delegates) {
-            Enumeration<URL> enumerator = delegate.findResources(name);
+        List<Enumeration<URL>> enumerators = new ArrayList<>();
+        for (ClassFinder classFinder : delegates) {
+            Enumeration<URL> enumerator = classFinder.findResources(name);
             enumerators.add(enumerator);
         }
         return new CompositeEnumeration(enumerators);
@@ -189,12 +224,12 @@ public class DelegatingClassLoader extends ClassLoader {
     }
 
     public List<ClassFinder> getDelegates() {
-        return Collections.unmodifiableList(delegates);
+        return unmodifiableList(delegates);
     }
 
     @Override
     public String toString() {
-        if (name!=null) {
+        if (name != null) {
             return name;
         } else {
             return super.toString();

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/DelegatingClassLoader.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/DelegatingClassLoader.java
@@ -86,7 +86,6 @@ public class DelegatingClassLoader extends ClassLoader {
      */
     private volatile String name;
 
-
     /**
      * @throws IllegalArgumentException when the delegate does not have same parent
      * as this classloader.
@@ -111,13 +110,10 @@ public class DelegatingClassLoader extends ClassLoader {
      * a delegate to be added that has a different parent.
      * @param d ClassFinder to add to the list of delegates
      * @return true if the delegate is added, false otherwise.
-     * @throws IllegalStateException when this method is called after the
-     * classloader has been used to load any class.
      * @throws IllegalArgumentException when the delegate does not have same parent
      * as this classloader.
      */
-    public boolean addDelegate(ClassFinder d) throws
-            IllegalStateException, IllegalArgumentException {
+    public boolean addDelegate(ClassFinder d) throws IllegalArgumentException {
         checkDelegate(d);
         return delegates.addIfAbsent(d);
     }
@@ -137,13 +133,10 @@ public class DelegatingClassLoader extends ClassLoader {
     }
 
     /**
-     * Removes a ClassFinder from list of delegates. This method must not be used
-     * once this classloader has beed used to load any class. If attempted to
-     * do so, this method throws IllegalStateException
+     * Removes a ClassFinder from list of delegates.
+     *
      * @param d ClassFinder to remove from the list of delegates
      * @return true if the delegate was removed, false otherwise.
-     * @throws IllegalStateException when this method is called after the
-     * classloader has been used to load any class.
      */
     public boolean removeDelegate(ClassFinder d) {
         return delegates.remove(d);

--- a/nucleus/core/extra-jre-packages/pom.xml
+++ b/nucleus/core/extra-jre-packages/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -124,6 +125,7 @@
                                 sun.misc,
                                 sun.net.www,
                                 sun.nio.cs,
+                                sun.nio.fs,
                                 sun.reflect,
                                 sun.rmi.rmic,
                                 sun.rmi.transport,

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,10 +17,25 @@
 
 package com.sun.enterprise.v3.server;
 
+import com.sun.enterprise.util.OS;
+import com.sun.enterprise.util.io.FileUtils;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
@@ -28,154 +43,478 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.ClassLoaderHierarchy;
 import org.glassfish.internal.api.DelegatingClassLoader;
+import org.glassfish.internal.api.DelegatingClassLoader.ClassFinder;
 import org.jvnet.hk2.annotations.Service;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 
 /**
  * This class is responsible for constructing class loader that has visibility
- * to deploy time libraries (--libraries and EXTENSION_LIST of MANIFEST.MF,
- * provided the library is available in 'applibs' directory) for an application.
- * It is different from CommonClassLoader in a sense that the libraries that are part of
- * common class loader are shared by all applications, where as this class
- * loader adds a scope to a library.
+ * to deploy time libraries ({@code --libraries} and {@code EXTENSION_LIST} of
+ * {@code MANIFEST.MF} for an application.
+ * <p>
+ * It is different from common class loader in a sense that the libraries that are part of
+ * common class loader are shared by all applications, whereas this class loader adds
+ * a scope to a library.
  *
  * @author Sanjeeb.Sahoo@Sun.COM
  */
 @Service
 @Singleton
 public class AppLibClassLoaderServiceImpl {
-    /*
-     * TODO(Sahoo): Not Yet Properly Implemented, as we have to bring in
-     * all the changes from
-     * http://fisheye5.cenqua.com/browse/glassfish/appserv-core/src/java/com/sun/enterprise/loader/EJBClassPathUtils.java
-     * To be specific, we have to bring in createApplicationLibrariesClassLoader().
-     */
-
-    @Inject
-    ServiceLocator habitat;
-
-    @Inject
-    CommonClassLoaderServiceImpl commonCLS;
-
-    private final Map<URI, DelegatingClassLoader.ClassFinder> classFinderRegistry = new HashMap<>();
 
     /**
-     * @see org.glassfish.internal.api.ClassLoaderHierarchy#getAppLibClassLoader(String, List<URI>)
+     * Class finders' registry.
+     * <p>
+     * If multiple applications or modules refer to the same libraries,
+     * share this libraries by reusing the same class loaders.
+     */
+    private final Map<Library, ClassFinder> classFinderRegistry = new HashMap<>();
+
+    @Inject
+    private ServiceLocator serviceLocator;
+
+    @Inject
+    private CommonClassLoaderServiceImpl commonClassLoaderService;
+
+
+    /**
+     * Returns the application libraries class loader.
+     * <p>
+     * This class loader has visibility to deploy time libraries for an application.
+     * <p>
+     * This class loader is different from common class loader in a sense that the libraries
+     * that are part of common class loader are shared by all applications, whereas this
+     * class loader adds a scope to a libraries.
+     *
+     * @param application the application for which class loader is created
+     * @param libURIs the URIs from which to load classes and resources
+     * @return the class loader that has visibility to appropriate application specific libraries
+     * @throws MalformedURLException if some error occurred while constructing the URL
+     * @see org.glassfish.internal.api.ClassLoaderHierarchy#getAppLibClassLoader(String, List)
      */
     public ClassLoader getAppLibClassLoader(String application, List<URI> libURIs) throws MalformedURLException {
-        ClassLoaderHierarchy clh = habitat.getService(ClassLoaderHierarchy.class);
-        DelegatingClassLoader connectorCL = clh.getConnectorClassLoader(application);
+        ClassLoaderHierarchy classLoaderHierarchy = serviceLocator.getService(ClassLoaderHierarchy.class);
+        DelegatingClassLoader connectorClassLoader = classLoaderHierarchy.getConnectorClassLoader(application);
 
         if (libURIs == null || libURIs.isEmpty()) {
             // Optimization: when there are no libraries, why create an empty
-            // class loader in the hierarchy? Instead return the parent.
-            return connectorCL;
+            // class loader in the hierarchy? Instead, return the parent.
+            return connectorClassLoader;
         }
 
-        final ClassLoader commonCL = commonCLS.getCommonClassLoader();
-        PrivilegedAction<DelegatingClassLoader> action = () -> new DelegatingClassLoader(commonCL);
-        DelegatingClassLoader applibCL = AccessController.doPrivileged(action);
+        final ClassLoader commonClassLoader = commonClassLoaderService.getCommonClassLoader();
+        PrivilegedAction<DelegatingClassLoader> action = () -> new DelegatingClassLoader(commonClassLoader);
+        DelegatingClassLoader appLibClassLoader = AccessController.doPrivileged(action);
 
-        // order of classfinders is important here :
-        // connector's classfinders should be added before libraries' classfinders
+        // Order of class finders is important here.
+        // Connector's class finders should be added before libraries' class finders
         // as the delegation hierarchy is appCL->app-libsCL->connectorCL->commonCL->API-CL
-        // since we are merging connector and applib classfinders to be at same level,
-        // connector classfinders need to be be before applib classfinders in the horizontal
+        // since we are merging connector and applib class finders to be at same level,
+        // connector class finders need to be before applib class finders in the horizontal
         // search path
-        for (DelegatingClassLoader.ClassFinder cf : connectorCL.getDelegates()) {
-            applibCL.addDelegate(cf);
+        for (ClassFinder classFinder : connectorClassLoader.getDelegates()) {
+            appLibClassLoader.addDelegate(classFinder);
         }
-        addDelegates(libURIs, applibCL);
+        addDelegates(libURIs, appLibClassLoader);
 
-        return applibCL;
+        return appLibClassLoader;
     }
 
-    private void addDelegates(Collection<URI> libURIs, DelegatingClassLoader holder)
-            throws MalformedURLException {
+    /**
+     * Returns the application libraries class loader.
+     * <p>
+     * This class loader has visibility to deploy time libraries for an application.
+     * <p>
+     * This class loader adds a scope to a libraries and will be used only by the
+     * connector class loader.
+     *
+     * @param libURIs the URIs from which to load classes and resources
+     * @return the class loader that has visibility to appropriate application specific libraries
+     * @throws MalformedURLException if some error occurred while constructing the URL
+     * @see org.glassfish.internal.api.ClassLoaderHierarchy#getAppLibClassFinder(List)
+     */
+    public ClassFinder getAppLibClassFinder(Collection<URI> libURIs) throws MalformedURLException {
+        final ClassLoader commonClassLoader = commonClassLoaderService.getCommonClassLoader();
+        DelegatingClassFinder appLibClassFinder = AccessController.doPrivileged(
+                (PrivilegedAction<DelegatingClassFinder>) () -> new DelegatingClassFinder(commonClassLoader));
+        addDelegates(libURIs, appLibClassFinder);
+        return appLibClassFinder;
+    }
 
-        ClassLoader commonCL = commonCLS.getCommonClassLoader();
+    /**
+     * Adds application libraries class loaders to the delegating class loader.
+     */
+    private void addDelegates(Collection<URI> libURIs, DelegatingClassLoader holder) throws MalformedURLException {
+        ClassLoader commonClassLoader = commonClassLoaderService.getCommonClassLoader();
         for (URI libURI : libURIs) {
             synchronized (this) {
-                DelegatingClassLoader.ClassFinder libCF = classFinderRegistry.get(libURI);
-                if (libCF == null) {
-                    libCF = new URLClassFinder(new URL[]{libURI.toURL()}, commonCL);
-                    classFinderRegistry.put(libURI, libCF);
+                Library library = new Library(libURI);
+                ClassFinder classFinder = classFinderRegistry.get(library);
+                if (classFinder == null) {
+                    classFinder = new URLClassFinder(library.getURI().toURL(), commonClassLoader);
+                    classFinderRegistry.put(library, classFinder);
+                } else {
+                    library.close();
                 }
-                holder.addDelegate(libCF);
+                holder.addDelegate(classFinder);
             }
         }
     }
 
     /**
-     * @see org.glassfish.internal.api.ClassLoaderHierarchy#getAppLibClassFinder(List<URI>)
+     * This class loader is used to load classes and resources from the URL
+     * referring to a JAR file.
      */
-    public DelegatingClassLoader.ClassFinder getAppLibClassFinder(Collection<URI> libURIs)
-            throws MalformedURLException {
-        final ClassLoader commonCL = commonCLS.getCommonClassLoader();
-        DelegatingClassLoader appLibClassFinder = AccessController.doPrivileged(new PrivilegedAction<DelegatingClassLoader>() {
-            @Override
-            public DelegatingClassLoader run() {
-                return new AppLibClassFinder(commonCL);
-            }
-        });
-        addDelegates(libURIs, appLibClassFinder);
-        return (DelegatingClassLoader.ClassFinder)appLibClassFinder;
-    }
+    private static class URLClassFinder extends GlassfishUrlClassLoader implements ClassFinder {
 
-    private static class URLClassFinder extends GlassfishUrlClassLoader
-            implements DelegatingClassLoader.ClassFinder {
-
-        URLClassFinder(URL[] urls, ClassLoader parent) {
-            super(urls, parent);
+        URLClassFinder(URL url, ClassLoader parent) {
+            super(new URL[] {url}, parent);
         }
 
+        /**
+         * Finds the class with the specified binary name.
+         *
+         * @param name the binary name of the class
+         * @return the resulting {@code Class} object
+         * @throws ClassNotFoundException if class could not be found
+         */
         @Override
         public Class<?> findClass(String name) throws ClassNotFoundException {
-            Class<?> c = this.findLoadedClass(name);
-            if (c!=null) {
+            Class<?> c = findLoadedClass(name);
+            if (c != null) {
                 return c;
             }
             return super.findClass(name);
         }
 
+        /**
+         * Returns the loaded class with the given binary name.
+         *
+         * @param name the binary name of the class
+         * @return the {@code Class} object, or {@code null} if the class has not been loaded
+         */
         @Override
         public Class<?> findExistingClass(String name) {
-            return super.findLoadedClass(name);
+            return findLoadedClass(name);
         }
     }
 
-    private static class AppLibClassFinder extends DelegatingClassLoader implements DelegatingClassLoader.ClassFinder {
+    /**
+     * This class loader has a list of class loaders called as delegates
+     * that it uses to find resources and classes.
+     */
+    private static class DelegatingClassFinder extends DelegatingClassLoader implements ClassFinder {
 
-        AppLibClassFinder(ClassLoader parent, List<DelegatingClassLoader.ClassFinder> delegates)
-                throws IllegalArgumentException {
-            super(parent, delegates);
-        }
-
-        AppLibClassFinder(ClassLoader parent) {
+        DelegatingClassFinder(ClassLoader parent) {
             super(parent);
         }
 
+        /**
+         * Always returns {@code null} because delegating class loader will
+         * never be a defining class loader.
+         */
         @Override
         public Class<?> findExistingClass(String name) {
-            // no action needed as parent is delegating classloader which will never be a defining classloader
             return null;
         }
 
+        /**
+         * Finds the resource with the given name.
+         *
+         * @param name the resource name
+         * @return a URL object for reading the resource, or {@code null} if the resource
+         * could not be found
+         */
         @Override
         public URL findResource(String name) {
             return super.findResource(name);
         }
 
+        /**
+         * Returns an enumeration of URL objects representing all resources with the given name.
+         *
+         * @param name the resource name
+         * @return an enumeration of URL objects for the resources, or empty enumeration
+         * if the resources not found
+         * @throws IOException if an I/O error occurs
+         */
         @Override
         public Enumeration<URL> findResources(String name) throws IOException {
             return super.findResources(name);
+        }
+    }
+
+    /**
+     * Represents a deployment time library.
+     */
+    private static class Library {
+
+        /**
+         * Represents a method to read the attributes of an open file.
+         */
+        private static final Method readAttributesMethod;
+
+        /**
+         * Represents a field to access to the native descriptor for an open file.
+         */
+        private static final Field nativeDescriptorField;
+
+        static {
+            Method method;
+            Field field;
+            try {
+                if (OS.isWindows()) {
+                    Class<?> attributesClass = Class.forName("sun.nio.fs.WindowsFileAttributes");
+                    method = attributesClass.getDeclaredMethod("readAttributes", Long.class);
+                    field = FileDescriptor.class.getDeclaredField("handle");
+                } else {
+                    Class<?> attributesClass = Class.forName("sun.nio.fs.UnixFileAttributes");
+                    method = attributesClass.getDeclaredMethod("get", Integer.TYPE);
+                    field = FileDescriptor.class.getDeclaredField("fd");
+                }
+                method.setAccessible(true);
+                field.setAccessible(true);
+            } catch (ReflectiveOperationException e) {
+                method = null;
+                field = null;
+            }
+            readAttributesMethod = method;
+            nativeDescriptorField = field;
+        }
+
+        /**
+         * Original library URI.
+         */
+        private final URI originalSource;
+
+        /**
+         * Library basic file attributes.
+         */
+        private final BasicFileAttributes attributes;
+
+        /**
+         * Library file input stream. Used to create library snapshot.
+         */
+        private FileInputStream fileInputStream;
+
+        /**
+         * Actual library URI.
+         */
+        private URI source;
+
+        Library(URI libURI) {
+            this.originalSource = libURI;
+
+            try {
+                this.fileInputStream = new FileInputStream(new File(libURI));
+            } catch (IOException e) {
+                // do nothing
+            }
+
+            BasicFileAttributes attributes = null;
+            // Try to read file attributes of an open library file
+            if (fileInputStream != null) {
+                Object nativeDescriptor = getNativeDescriptor(fileInputStream);
+                if (nativeDescriptor != null) {
+                    attributes = readAttributes(nativeDescriptor);
+                }
+            }
+            // Fallback to the standard NIO.2 method
+            if (attributes == null) {
+                attributes = readAttributes(libURI);
+            }
+            this.attributes = attributes;
+        }
+
+        /**
+         * Gets a {@code file:} URI that represents this library.
+         * <p>
+         * Creates a library snapshot in the default temporary-file directory.
+         *
+         * @return the deployment time library URI
+         */
+        public URI getURI() {
+            if (source == null) {
+                File snapshot = createSnapshot();
+                if (snapshot != null) {
+                    // Snapshot successfully created.
+                    // Use it URI as a library source.
+                    source = snapshot.toURI();
+                } else {
+                    // Snapshot creation failed.
+                    // Use original library URI.
+                    source = originalSource;
+                }
+            }
+            return source;
+        }
+
+        /**
+         * Closes associated file input stream and releases any system resources
+         * associated with the stream.
+         */
+        public void close() {
+            if (fileInputStream != null) {
+                try {
+                    fileInputStream.close();
+                } catch (IOException e) {
+                    // do nothing
+                }
+            }
+        }
+
+        /**
+         * Tests this library for equality with the given object.
+         * <p>
+         * If the given object is not a {@code Library}, then this method returns {@code false}.
+         *
+         * @param obj the object to which this object to be compared
+         * @return {@code true} if, and only if, the given object is a {@code Library} that is
+         * identical to this {@code Library}
+         */
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (!(obj instanceof Library)) {
+                return false;
+            }
+
+            Library library = (Library) obj;
+            if (!originalSource.equals(library.originalSource)) {
+                return false;
+            }
+            if (attributes == null || library.attributes == null) {
+                return attributes == library.attributes;
+            }
+            if (attributes.size() != library.attributes.size()) {
+                return false;
+            }
+            if (!Objects.equals(attributes.lastModifiedTime(), library.attributes.lastModifiedTime())) {
+                return false;
+            }
+            return Objects.equals(attributes.fileKey(), library.attributes.fileKey());
+        }
+
+        /**
+         * Computes a hash code for this library.
+         *
+         * @return the hash code value for this library
+         */
+        @Override
+        public int hashCode() {
+            int hash = originalSource.hashCode();
+            if (attributes != null) {
+                hash = 31 * hash + Long.hashCode(attributes.size());
+                hash = 31 + hash + Objects.hashCode(attributes.lastModifiedTime());
+                hash = 31 + hash + Objects.hashCode(attributes.fileKey());
+            }
+            return hash;
+        }
+
+        /**
+         * Gets OS-dependent native file descriptor for an open file related to
+         * this application library {@code fileInputStream}.
+         *
+         * @param fileInputStream the application library file input stream
+         * @return the native file descriptor
+         */
+        private Object getNativeDescriptor(FileInputStream fileInputStream) {
+            Object nativeDescriptor = null;
+            if (nativeDescriptorField != null) {
+                try {
+                    FileDescriptor fileDescriptor = fileInputStream.getFD();
+                    if (fileDescriptor.valid()) {
+                        nativeDescriptor = nativeDescriptorField.get(fileDescriptor);
+                    }
+                } catch (IllegalAccessException | IOException e) {
+                    // do nothing
+                }
+            }
+            return nativeDescriptor;
+        }
+
+        /**
+         * Gets the {@link BasicFileAttributes} for an open application library.
+         *
+         * @param nativeDescriptor the open library native descriptor
+         * @return the file attributes or {@code null} if an error occurs
+         */
+        private BasicFileAttributes readAttributes(Object nativeDescriptor) {
+            BasicFileAttributes attributes = null;
+            if (readAttributesMethod != null) {
+                try {
+                    attributes = (BasicFileAttributes) readAttributesMethod.invoke(null, nativeDescriptor);
+                } catch (ReflectiveOperationException e) {
+                    // do nothing
+                }
+            }
+            return attributes;
+        }
+
+        /**
+         * Reads a file's basic attributes as a bulk operation.
+         *
+         * @param libURI an absolute, hierarchical URI with scheme equal to {@code file:},
+         * a non-empty path component, and undefined authority, query and fragment components
+         * @return the file attributes or {@code null} if an error occurs
+         */
+        private BasicFileAttributes readAttributes(URI libURI) {
+            try {
+                return Files.readAttributes(Path.of(libURI), BasicFileAttributes.class);
+            } catch (IOException e) {
+                return null;
+            }
+        }
+
+        /**
+         * Creates a library snapshot in the default temporary-file directory.
+         * <p>
+         * Closes a file input stream associated with library file.
+         *
+         * @return an abstract pathname denoting a newly-created snapshot
+         */
+        private File createSnapshot() {
+            File snapshot = null;
+            try {
+                snapshot = File.createTempFile("applib", ".jar");
+                if (!copy(fileInputStream, snapshot)) {
+                    FileUtils.copy(new File(originalSource), snapshot);
+                }
+                snapshot.deleteOnExit();
+            } catch (IOException e) {
+                FileUtils.deleteFileMaybe(snapshot);
+            } finally {
+                fileInputStream = null;
+            }
+            return snapshot;
+        }
+
+        /**
+         * Copies all bytes from an input stream to a file.
+         * <p>
+         * Closes input stream after completion.
+         *
+         * @param inputStream the input stream to read from
+         * @param file the target output file. If the file already exists, it will be overwritten
+         * @return {@code true} if all bytes copied, {@code false} otherwise
+         */
+        private boolean copy(InputStream inputStream, File file) {
+            if (inputStream == null) {
+                return false;
+            }
+            try (inputStream) {
+                FileUtils.copy(inputStream, file);
+                return true;
+            } catch (IOException e) {
+                return false;
+            }
         }
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -42,7 +42,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -90,7 +89,7 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
      * If multiple applications or modules refer to the same libraries,
      * share this libraries by reusing the same class loaders.
      */
-    private final Map<Library, ClassFinder> classFinderRegistry = new HashMap<>();
+    private final Map<Library, ClassFinder> classFinderRegistry = new ConcurrentHashMap<>();
 
     @Inject
     private ServiceLocator serviceLocator;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -648,11 +648,14 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
         private File createSnapshot(ServerEnvironment serverEnvironment) {
             LOG.log(DEBUG, "createSnapshot()");
             File snapshotsDir = new File(serverEnvironment.getLibPath(), "snapshots");
+            File originalFile = new File(originalSource);
             File snapshot = null;
             try {
-                snapshot = Files.createTempFile(snapshotsDir.toPath(), "applib", ".jar").toFile();
+                String snapshotPrefix = FileUtils.removeExtension(originalFile) + "-";
+                String snapshotSuffix = FileUtils.getExtension(originalFile);
+                snapshot = Files.createTempFile(snapshotsDir.toPath(), snapshotPrefix, snapshotSuffix).toFile();
                 if (!copy(fileInputStream, snapshot)) {
-                    FileUtils.copy(new File(originalSource), snapshot);
+                    FileUtils.copy(originalFile, snapshot);
                 }
                 // Normally snapshots should be removed at server shutdown.
                 // This should remove snapshot if SIGTERM signal received.

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -192,13 +192,6 @@ public class AppLibClassLoaderServiceImpl {
          */
         @Override
         public Class<?> findClass(String name) throws ClassNotFoundException {
-            if (notFoundResources.contains(name)) {
-                throw new ClassNotFoundException(name);
-            }
-            Class<?> c = findLoadedClass(name);
-            if (c != null) {
-                return c;
-            }
             try {
                 return super.findClass(name);
             } catch (ClassNotFoundException e) {
@@ -215,6 +208,9 @@ public class AppLibClassLoaderServiceImpl {
          */
         @Override
         public Class<?> findExistingClass(String name) {
+            if (notFoundResources.contains(name)) {
+                return null;
+            }
             return findLoadedClass(name);
         }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -41,6 +41,7 @@ import java.net.URLStreamHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
@@ -124,7 +125,7 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
                 try {
                     Files.delete(Path.of(library.getURI()));
                 } catch (IOException e) {
-                    LOG.log(WARNING, () -> "Could not delete application library snapshot " + library.getURI(), e);
+                    LOG.log(WARNING, () -> "Could not delete application library snapshot " + library, e);
                 }
             }
         }
@@ -676,6 +677,25 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
             } catch (IOException e) {
                 return false;
             }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder(getClass().getSimpleName());
+            sb.append("[");
+            sb.append("originalSource=").append(originalSource).append(", ");
+            sb.append("source=").append(source);
+            if (attributes != null) {
+                sb.append(", ");
+                sb.append("size=").append(attributes.size());
+                FileTime lastModifiedTime = attributes.lastModifiedTime();
+                if (lastModifiedTime != null) {
+                    sb.append(", ");
+                    sb.append("lastModifiedTime=").append(lastModifiedTime);
+                }
+            }
+            sb.append("]");
+            return sb.toString();
         }
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -347,7 +347,7 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
             try {
                 if (OS.isWindows()) {
                     Class<?> attributesClass = Class.forName("sun.nio.fs.WindowsFileAttributes");
-                    method = attributesClass.getDeclaredMethod("readAttributes", Long.class);
+                    method = attributesClass.getDeclaredMethod("readAttributes", Long.TYPE);
                     field = FileDescriptor.class.getDeclaredField("handle");
                 } else {
                     Class<?> attributesClass = Class.forName("sun.nio.fs.UnixFileAttributes");

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -41,11 +41,11 @@ import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -177,7 +177,7 @@ public class AppLibClassLoaderServiceImpl {
      */
     private static class URLClassFinder extends GlassfishUrlClassLoader implements ClassFinder {
 
-        private final Set<String> notFoundResources = new HashSet<>();
+        private final Set<String> notFoundResources = ConcurrentHashMap.newKeySet();
 
         URLClassFinder(URL url, ClassLoader parent) {
             super(new URL[] {url}, parent);

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -488,7 +488,8 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
             if (source == null) {
                 File snapshot = createSnapshot();
                 if (snapshot != null) {
-                    LOG.log(TRACE, "Created snapshot {0} for application library {1}", snapshot, originalSource);
+                    LOG.log(TRACE, "Created snapshot {0} for application library {1}",
+                            snapshot.getAbsolutePath(), originalSource);
                     // Use snapshot URI as a library source.
                     source = snapshot.toURI();
                 } else {
@@ -513,7 +514,7 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
                 try {
                     fileInputStream.close();
                 } catch (IOException e) {
-                    LOG.log(WARNING, () -> "Could not close input stream for application library " + source, e);
+                    LOG.log(WARNING, () -> "Could not close input stream for application library " + originalSource, e);
                 }
             }
         }
@@ -583,10 +584,10 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
                     if (fileDescriptor.valid()) {
                         nativeDescriptor = nativeDescriptorField.get(fileDescriptor);
                         LOG.log(TRACE, "Returning nativeDescriptor={0} for application library {1}",
-                                nativeDescriptor, source);
+                                nativeDescriptor, originalSource);
                     }
                 } catch (IllegalAccessException | IOException e) {
-                    LOG.log(WARNING, () -> "Could not obtain native descriptor for application library " + source, e);
+                    LOG.log(WARNING, () -> "Could not obtain native descriptor for application library " + originalSource, e);
                 }
             }
             return nativeDescriptor;
@@ -648,7 +649,7 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
                 // This should remove snapshot if SIGTERM signal received.
                 snapshot.deleteOnExit();
             } catch (IOException e) {
-                LOG.log(WARNING, () -> "Could not create snapshot for application library " + source, e);
+                LOG.log(WARNING, () -> "Could not create snapshot for application library " + originalSource, e);
                 FileUtils.deleteFileMaybe(snapshot);
             } finally {
                 fileInputStream = null;

--- a/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
+++ b/nucleus/deployment/common/src/main/java/org/glassfish/deployment/common/DeploymentContextImpl.java
@@ -431,7 +431,7 @@ public class DeploymentContextImpl implements ExtendedDeploymentContext, PreDest
             for (URL url : urls) {
                 File file = new File(url.getFile());
                 deplLogger.log(FINE, "Specified library jar: " + file.getAbsolutePath());
-                if (file.exists()) {
+                if (file.isFile()) {
                     libURIs.add(url.toURI());
                 } else {
                     throw new IllegalArgumentException(localStrings.getLocalString("enterprise.deployment.nonexist.libraries",


### PR DESCRIPTION
When Jakarta EE applications and modules use shared framework classes (such as utility classes and libraries), the classes can be put in the path for an application-specific class loader rather than in an application or module.

Application libraries are included in the *AppLib* class loader.

If multiple applications or modules refer to the same libraries, classes in those libraries are automatically shared.

Since these libraries are external to applications and the GlassFish server itself, they can be deleted or replaced with new versions using operating system tools. The result is system dependent.

It is necessary to make the behavior of application libraries the same on all supported platforms.

The proposed solution attempts to achive this by creating temporary snapshots of the application libraries during application startup.

An application library is identified by its `URI` and some set of basic file attributes (`size`, `lastModifiedTime` and `fileKey`). If a library with the same URI and attributes is already loaded, use it. If not, load it and put in the registry of loaded application libraries for reuse by other applications.

First we try to create a temporary snapshot of the application library:

1. Open the `FileInputStream`, get the native open file descriptor from it and read its basic file attributes.
2. Reading data from the open input stream into temporary file.
3. Closing the input stream.

Performing these steps ensures that the file attributes match exactly the library content. This gives us some degree of atomicity.

A discrepancy is possible, for example, in the following scenario:

1. Read basic file attributes.
2. Replacing a library with an externa process.
3. Create a temporary snapshot of a library

In this case basic fie attributes will not match the library.

If we are unable to create a temporary snapshot of the library using native descriptor, we fall back to using standard NIO.2 functions.

If we cannot create a snapshot of the library for some reason, we fall back to using the original library.

Last but not least, we close application libraries class loaders and delete snapshots when the GlassFish server is stopped.