### PR TITLE
Performance test and fix for logger part of the logging system

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/logging.adoc
+++ b/docs/administration-guide/src/main/asciidoc/logging.adoc
@@ -271,6 +271,22 @@ If you edit `logging.properties` manually on an instance managed by the node, it
 overwritten on the next synchronization with DAS.
 ====
 
+[[log-records]]
+
+=== Log Records
+
+Because the automatic detection of caller class and method from stacktrace significantly affects
+performance of the logging system, we added the `org.glassfish.main.jul.classAndMethodDetection.enabled`
+property which affects the `*.printSource` property of formatters.
+
+* If this key is set to true, GJULE will detect the caller class and method from stacktrace,
+which is quite expensive operation affecting logging throughput.
+* If it is set to false, GJULE will not perform such detection. Formatters which use `getSourceClassName`
+or `getSourceMethodName` of the record will receive `null` unless the log record has set these values explicitly.
+* If the property is not set, GJULE makes the decision based on the (`*.printSource` property) - if
+any formatter requires this feature, the feature is enabled. Note that the `*.printSource` property
+must be explicitly set to true in `logging.properties`.
+* It is disabled otherwise.
 
 [[loggers]]
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogger.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogger.java
@@ -157,7 +157,7 @@ public class GlassFishLogger extends Logger {
         if (!isProcessible(level, status)) {
             return;
         }
-        final LogRecord record = new GlassFishLogRecord(level, msg);
+        final LogRecord record = new GlassFishLogRecord(level, msg, isClassAndMethodDetectionEnabled());
         record.setLoggerName(getName());
         record.setResourceBundle(getResourceBundle());
         record.setResourceBundleName(getResourceBundleName());
@@ -171,7 +171,7 @@ public class GlassFishLogger extends Logger {
         if (!isProcessible(level, status)) {
             return;
         }
-        final LogRecord record = new GlassFishLogRecord(level, msgSupplier.get());
+        final LogRecord record = new GlassFishLogRecord(level, msgSupplier.get(), isClassAndMethodDetectionEnabled());
         record.setLoggerName(getName());
         logOrQueue(record, status);
     }
@@ -189,7 +189,7 @@ public class GlassFishLogger extends Logger {
         if (!isProcessible(level, status)) {
             return;
         }
-        final LogRecord record = new GlassFishLogRecord(level, msg);
+        final LogRecord record = new GlassFishLogRecord(level, msg, isClassAndMethodDetectionEnabled());
         record.setLoggerName(getName());
         record.setResourceBundle(getResourceBundle());
         record.setResourceBundleName(getResourceBundleName());
@@ -204,7 +204,7 @@ public class GlassFishLogger extends Logger {
         if (!isProcessible(level, status)) {
             return;
         }
-        final LogRecord record = new GlassFishLogRecord(level, msg);
+        final LogRecord record = new GlassFishLogRecord(level, msg, isClassAndMethodDetectionEnabled());
         record.setLoggerName(getName());
         record.setResourceBundle(getResourceBundle());
         record.setResourceBundleName(getResourceBundleName());
@@ -219,7 +219,7 @@ public class GlassFishLogger extends Logger {
         if (!isProcessible(level, status)) {
             return;
         }
-        final LogRecord record = new GlassFishLogRecord(level, msgSupplier.get());
+        final LogRecord record = new GlassFishLogRecord(level, msgSupplier.get(), isClassAndMethodDetectionEnabled());
         record.setLoggerName(getName());
         record.setThrown(thrown);
         logOrQueue(record, status);
@@ -337,7 +337,7 @@ public class GlassFishLogger extends Logger {
         if (!isProcessible(level, status)) {
             return;
         }
-        final LogRecord record = new GlassFishLogRecord(level, msg);
+        final LogRecord record = new GlassFishLogRecord(level, msg, isClassAndMethodDetectionEnabled());
         record.setLoggerName(getName());
         if (params != null && params.length != 0) {
             record.setParameters(params);
@@ -431,6 +431,12 @@ public class GlassFishLogger extends Logger {
 
     private boolean isToQueue(final GlassFishLoggingStatus status) {
         return status == GlassFishLoggingStatus.UNCONFIGURED || status == GlassFishLoggingStatus.CONFIGURING;
+    }
+
+
+    private boolean isClassAndMethodDetectionEnabled() {
+        final GlassFishLogManager manager = GlassFishLogManager.getLogManager();
+        return manager == null ? false : manager.getConfiguration().isClassAndMethodDetectionEnabled();
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogger.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -323,6 +323,25 @@ public class GlassFishLogger extends Logger {
         record.setSourceClassName(sourceClass);
         record.setSourceMethodName(sourceMethod);
         record.setThrown(thrown);
+        if (bundle != null) {
+            record.setResourceBundleName(bundle.getBaseBundleName());
+            record.setResourceBundle(bundle);
+        }
+        logOrQueue(record, status);
+    }
+
+
+    @Override
+    public void logrb(Level level, ResourceBundle bundle, String msg, Object... params) {
+        final GlassFishLoggingStatus status = getLoggingStatus();
+        if (!isProcessible(level, status)) {
+            return;
+        }
+        final LogRecord record = new GlassFishLogRecord(level, msg);
+        record.setLoggerName(getName());
+        if (params != null && params.length != 0) {
+            record.setParameters(params);
+        }
         if (bundle != null) {
             record.setResourceBundleName(bundle.getBaseBundleName());
             record.setResourceBundle(bundle);

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLogManagerConfiguration.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLogManagerConfiguration.java
@@ -100,13 +100,14 @@ public class GlassFishLogManagerConfiguration implements Serializable, Cloneable
      * GJULE will detect the caller class and method from stacktrace,
      * which is quite expensive operation affecting logging throughput.
      * <p>
-     * If it is set to null, GJULE will not perform such detection.
+     * If it is set to false, GJULE will not perform such detection.
      * <p>
-     * If the property is not set, GJULE makes the decision based on known handlers
-     * (<code>*.printSource</code> value) - if any handler requires this feature, it is enabled.
-     * It is disabled otherwise or you can forcibly enable it by setting the value to true or false.
+     * If the property is not set, GJULE makes the decision based on the(<code>*.printSource</code>
+     * property) - if any formatter requires this feature, the feature is enabled.
+     * <p>
+     * It is disabled otherwise.
      *
-     * @return true if handlers can use source class and method in formatters.
+     * @return true if formatters can use autodetected source class and method in formatters.
      */
     public boolean isClassAndMethodDetectionEnabled() {
         return classAndMethodDetectionEnabled;

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLogManagerConfiguration.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLogManagerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,6 +27,8 @@ import java.util.stream.Stream;
 
 import org.glassfish.main.jul.tracing.GlassFishLoggingTracer;
 
+import static org.glassfish.main.jul.cfg.GlassFishLoggingConstants.KEY_CLASS_AND_METHOD_DETECTION_ENABLED;
+import static org.glassfish.main.jul.cfg.GlassFishLoggingConstants.KEY_FORMATTER_PRINT_SOURCE_SUFFIX;
 import static org.glassfish.main.jul.cfg.GlassFishLoggingConstants.KEY_TRACING_ENABLED;
 
 /**
@@ -39,6 +41,7 @@ public class GlassFishLogManagerConfiguration implements Serializable, Cloneable
     private static final long serialVersionUID = 1L;
     private final LoggingProperties properties;
     private final boolean tracingEnabled;
+    private final boolean classAndMethodDetectionEnabled;
 
     /**
      * @param properties configuration to clone
@@ -46,6 +49,7 @@ public class GlassFishLogManagerConfiguration implements Serializable, Cloneable
     public GlassFishLogManagerConfiguration(final LoggingProperties properties) {
         this.properties = properties.clone();
         this.tracingEnabled = Boolean.parseBoolean(this.properties.getProperty(KEY_TRACING_ENABLED));
+        this.classAndMethodDetectionEnabled = resolveClassAndMethodDetectionEnabled(this.properties);
     }
 
 
@@ -92,6 +96,24 @@ public class GlassFishLogManagerConfiguration implements Serializable, Cloneable
 
 
     /**
+     * If {@link GlassFishLoggingConstants#KEY_CLASS_AND_METHOD_DETECTION_ENABLED} is set to true,
+     * GJULE will detect the caller class and method from stacktrace,
+     * which is quite expensive operation affecting logging throughput.
+     * <p>
+     * If it is set to null, GJULE will not perform such detection.
+     * <p>
+     * If the property is not set, GJULE makes the decision based on known handlers
+     * (<code>*.printSource</code> value) - if any handler requires this feature, it is enabled.
+     * It is disabled otherwise or you can forcibly enable it by setting the value to true or false.
+     *
+     * @return true if handlers can use source class and method in formatters.
+     */
+    public boolean isClassAndMethodDetectionEnabled() {
+        return classAndMethodDetectionEnabled;
+    }
+
+
+    /**
      * Creates clone of this instance.
      */
     @Override
@@ -133,6 +155,21 @@ public class GlassFishLogManagerConfiguration implements Serializable, Cloneable
      */
     public static GlassFishLogManagerConfiguration parse(final InputStream inputStream) throws IOException {
         return new GlassFishLogManagerConfiguration(LoggingProperties.loadFrom(inputStream));
+    }
+
+
+    private static boolean resolveClassAndMethodDetectionEnabled(final LoggingProperties properties) {
+        String value = properties.getProperty(KEY_CLASS_AND_METHOD_DETECTION_ENABLED);
+        if (Boolean.TRUE.toString().equalsIgnoreCase(value)) {
+            return true;
+        }
+        if (Boolean.FALSE.toString().equalsIgnoreCase(value)) {
+            return false;
+        }
+        return properties.stringPropertyNames().stream()
+            .filter(name -> name.endsWith(KEY_FORMATTER_PRINT_SOURCE_SUFFIX))
+            .anyMatch(name -> properties.getProperty(name, Boolean.FALSE.toString())
+                .equalsIgnoreCase(Boolean.TRUE.toString()));
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLoggingConstants.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLoggingConstants.java
@@ -72,11 +72,12 @@ public class GlassFishLoggingConstants {
      * If this key is set to true, GJULE will detect the caller class and method from stacktrace,
      * which is quite expensive operation affecting logging throughput.
      * <p>
-     * If it is set to null, GJULE will not perform such detection.
+     * If it is set to false, GJULE will not perform such detection.
      * <p>
-     * If the property is not set, GJULE makes the decision based on known handlers
-     * (<code>*.printSource</code> value) - if any handler requires this feature, it is enabled.
-     * It is disabled otherwise or you can forcibly enable it by setting the value to true or false.
+     * If the property is not set, GJULE makes the decision based on the (<code>*.printSource</code>
+     * property) - if any formatter requires this feature, the feature is enabled.
+     * <p>
+     * It is disabled otherwise.
      */
     public static final String KEY_CLASS_AND_METHOD_DETECTION_ENABLED = "org.glassfish.main.jul.classAndMethodDetection.enabled";
     /**

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLoggingConstants.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLoggingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,7 @@
 
 package org.glassfish.main.jul.cfg;
 
+import java.util.logging.LogRecord;
 
 /**
  * Constants used to configure the Java Util Logging.
@@ -66,6 +67,23 @@ public class GlassFishLoggingConstants {
 
     /** If this key is set to true, GJULE will print really detailed tracing info to the standard output */
     public static final String KEY_TRACING_ENABLED = "org.glassfish.main.jul.tracing.enabled";
+
+    /**
+     * If this key is set to true, GJULE will detect the caller class and method from stacktrace,
+     * which is quite expensive operation affecting logging throughput.
+     * <p>
+     * If it is set to null, GJULE will not perform such detection.
+     * <p>
+     * If the property is not set, GJULE makes the decision based on known handlers
+     * (<code>*.printSource</code> value) - if any handler requires this feature, it is enabled.
+     * It is disabled otherwise or you can forcibly enable it by setting the value to true or false.
+     */
+    public static final String KEY_CLASS_AND_METHOD_DETECTION_ENABLED = "org.glassfish.main.jul.classAndMethodDetection.enabled";
+    /**
+     * Enable printing the source class and method of the LogRecord.
+     * See {@link LogRecord#getSourceClassName()} and {@link LogRecord#getSourceMethodName()}
+     */
+    public static final String KEY_FORMATTER_PRINT_SOURCE_SUFFIX = "printSource";
 
     /** 1 000 000 */
     public static final long BYTES_PER_MEGABYTES = 1_000_000;

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/GlassFishLogFormatter.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/GlassFishLogFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,6 +31,7 @@ import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static org.glassfish.main.jul.cfg.GlassFishLoggingConstants.KEY_FORMATTER_PRINT_SOURCE_SUFFIX;
 import static org.glassfish.main.jul.formatter.GlassFishLogFormatter.GlassFishLogFormatterProperty.PRINT_SEQUENCE_NUMBER;
 import static org.glassfish.main.jul.formatter.GlassFishLogFormatter.GlassFishLogFormatterProperty.PRINT_SOURCE;
 import static org.glassfish.main.jul.formatter.GlassFishLogFormatter.GlassFishLogFormatterProperty.TIMESTAMP_FORMAT;
@@ -249,7 +250,7 @@ public abstract class GlassFishLogFormatter extends Formatter {
          * Enable printing the source class and method of the LogRecord.
          * See {@link LogRecord#getSourceClassName()} and {@link LogRecord#getSourceMethodName()}
          */
-        PRINT_SOURCE("printSource"),
+        PRINT_SOURCE(KEY_FORMATTER_PRINT_SOURCE_SUFFIX),
         ;
 
         private final String propertyName;

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogCollectorHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogCollectorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,14 +41,28 @@ public class LogCollectorHandler extends Handler {
     private final Logger logger;
 
     /**
+     * Creates a {@link LogRecord} collector handler with the capacity of 100 records and maximal
+     * wait time 5 seconds.
+     *
      * @param loggerToFollow this handler will be added to this logger.
+     * @see LogRecordBuffer
      */
     public LogCollectorHandler(final Logger loggerToFollow) {
-        buffer = new LogRecordBuffer(100, 5);
+        this(loggerToFollow, 100, 5);
+    }
+
+    /**
+     * @param loggerToFollow this handler will be added to this logger.
+     * @param capacity capacity of the buffer.
+     * @param maxWait maximal time in seconds to wait for the free capacity. If &lt; 1, can wait
+     *            forever.
+     * @see LogRecordBuffer
+     */
+    public LogCollectorHandler(final Logger loggerToFollow, int capacity, int maxWait) {
+        buffer = new LogRecordBuffer(capacity, maxWait);
         logger = loggerToFollow;
         logger.addHandler(this);
     }
-
 
     @Override
     public void publish(LogRecord record) {

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -144,7 +144,7 @@ class LogRecordBuffer {
             this + ": The buffer was forcibly cleared after " + maxWait + " s timeout for adding another log record." //
                 + " Log records were lost." //
                 + " It might be caused by a recursive deadlock," //
-                + " you can increase the capacity or the timeout to avoid this."));
+                + " you can increase the capacity or the timeout to avoid this.", false));
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import org.glassfish.main.jul.GlassFishLogManager;
 import org.glassfish.main.jul.record.GlassFishLogRecord;
 
 
@@ -68,10 +69,10 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
         if (closed.get()) {
             return;
         }
-        final GlassFishLogRecord logRecord = new GlassFishLogRecord(logRecordLevel, "");
-        logRecord.setThrown(throwable);
-        logRecord.setLoggerName(this.loggerName);
-        logRecordBuffer.add(logRecord);
+        final GlassFishLogRecord record = new GlassFishLogRecord(logRecordLevel, "", isSourceDetectionEnabled());
+        record.setThrown(throwable);
+        record.setLoggerName(this.loggerName);
+        logRecordBuffer.add(record);
     }
 
 
@@ -86,14 +87,14 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
         if (closed.get()) {
             return;
         }
-        final String logMessage = getMessage();
-        if (logMessage.isEmpty() || lineSeparator.equals(logMessage)) {
+        final String message = getMessage();
+        if (message.isEmpty() || lineSeparator.equals(message)) {
             // avoid empty records
             return;
         }
-        final GlassFishLogRecord logRecord = new GlassFishLogRecord(logRecordLevel, logMessage);
-        logRecord.setLoggerName(this.loggerName);
-        logRecordBuffer.add(logRecord);
+        final GlassFishLogRecord record = new GlassFishLogRecord(logRecordLevel, message, isSourceDetectionEnabled());
+        record.setLoggerName(this.loggerName);
+        logRecordBuffer.add(record);
     }
 
     private synchronized String getMessage() throws IOException {
@@ -101,6 +102,12 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
         final String logMessage = super.toString(charset).trim();
         super.reset();
         return logMessage;
+    }
+
+
+    private boolean isSourceDetectionEnabled() {
+        final GlassFishLogManager manager = GlassFishLogManager.getLogManager();
+        return manager == null ? false : manager.getConfiguration().isClassAndMethodDetectionEnabled();
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/record/GlassFishLogRecord.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/record/GlassFishLogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,16 +41,6 @@ public class GlassFishLogRecord extends LogRecord {
     private final LogRecord record;
     private final String threadName;
     private String messageKey;
-
-    /**
-     * Creates new record. Source class and method will be autodetected.
-     *
-     * @param level
-     * @param message
-     */
-    public GlassFishLogRecord(final Level level, final String message) {
-        this(new LogRecord(level, message), true);
-    }
 
 
     /**
@@ -298,23 +288,21 @@ public class GlassFishLogRecord extends LogRecord {
     }
 
 
-    private boolean detectClassAndMethod(final LogRecord wrappedRecord) {
-        final StackTraceElement[] stack = new Throwable().getStackTrace();
-        boolean found = false;
+    private void detectClassAndMethod(final LogRecord wrappedRecord) {
+        final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        boolean ignoredClass = false;
         for (final StackTraceElement element : stack) {
             final String className = element.getClassName();
-            if (!found) {
-                found = isIgnoredStackTraceElement(className);
+            if (!ignoredClass) {
+                ignoredClass = isIgnoredStackTraceElement(className);
                 continue;
             }
             if (!isIgnoredStackTraceElement(className)) {
                 wrappedRecord.setSourceClassName(className);
                 wrappedRecord.setSourceMethodName(element.getMethodName());
-                return true;
+                return;
             }
         }
-        // don't try it again.
-        return true;
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLoggerPerformanceTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLoggerPerformanceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.jul;
+
+import java.lang.System.Logger;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.glassfish.main.jul.handler.LogCollectorHandler;
+import org.glassfish.main.jul.record.GlassFishLogRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * This tests serves as a reproducer for some known issues with message formatting
+ * and level handling.
+ */
+@Timeout(value = 2, unit = TimeUnit.SECONDS)
+public class GlassFishLoggerPerformanceTest {
+
+    private static final Logger LOG = System.getLogger(GlassFishLoggerPerformanceTest.class.getName());
+    private static final int COUNT_OF_RECORDS = 100_000;
+    private static final Random RND = new Random(System.currentTimeMillis());
+
+    private static LogCollectorHandler collector;
+    private long start;
+
+    @BeforeAll
+    static void collect() {
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger(LOG.getName());
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.INFO);
+        collector = new LogCollectorHandler(logger, COUNT_OF_RECORDS, 10);
+    }
+
+
+    @BeforeEach
+    void saveTime(TestInfo info) {
+        System.out.println("Starting test: " + info.getTestMethod().get().getName());
+        start = System.currentTimeMillis();
+    }
+
+
+    @AfterEach
+    void resetCollector(TestInfo info) {
+        System.out
+            .println(info.getTestMethod().get().getName() + " time: " + (System.currentTimeMillis() - start) + " ms");
+        List<GlassFishLogRecord> records = collector.getAll();
+        assertThat(records, hasSize(COUNT_OF_RECORDS));
+        for (LogRecord record : records) {
+            assertThat("message", record.getMessage(), startsWith("Ororok orebuh, random: "));
+        }
+        collector.reset();
+    }
+
+
+    @RepeatedTest(value = 5)
+    void testConcat() throws Exception {
+        int i = 0;
+        while (i++ < COUNT_OF_RECORDS) {
+            LOG.log(INFO, "Ororok orebuh, random: " + RND.nextInt());
+        }
+    }
+
+
+    @RepeatedTest(value = 5)
+    void testSupplierWithStringFormat() throws Exception {
+        int i = 0;
+        while (i++ < COUNT_OF_RECORDS) {
+            LOG.log(INFO, () -> String.format("Ororok orebuh, random: %s", RND.nextInt()));
+        }
+    }
+
+
+    @RepeatedTest(value = 5)
+    void testSupplierWithStringBuilder() throws Exception {
+        int i = 0;
+        while (i++ < COUNT_OF_RECORDS) {
+            LOG.log(INFO, () -> new StringBuilder(128).append("Ororok orebuh, random: ").append(RND.nextInt()).toString());
+        }
+    }
+
+
+    @RepeatedTest(value = 5)
+    void testSupplierWithConcat() throws Exception {
+        int i = 0;
+        while (i++ < COUNT_OF_RECORDS) {
+            LOG.log(INFO, () -> "Ororok orebuh, random: " + RND.nextInt());
+        }
+    }
+
+
+    @RepeatedTest(value = 5)
+    void testMessageFormatter() throws Exception {
+        int i = 0;
+        while (i++ < COUNT_OF_RECORDS) {
+            LOG.log(INFO, "Ororok orebuh, random: {0}", RND.nextInt());
+        }
+    }
+}

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -133,7 +133,7 @@ public class GlassFishLogHandlerTest {
     @Order(30)
     public void roll() throws Exception {
         assertTrue(handler.isReady(), "handler.ready");
-        handler.publish(new GlassFishLogRecord(Level.SEVERE, "File one, record one"));
+        handler.publish(new GlassFishLogRecord(Level.SEVERE, "File one, record one", false));
         // pump is now to play
         Thread.sleep(MILLIS_FOR_PUMP);
         assertAll(
@@ -155,18 +155,18 @@ public class GlassFishLogHandlerTest {
             () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
             () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
                 contains(
-                    stringContainsInOrder("INFO", "main", "roll Archived file:", "if null, action failed.")
+                    stringContainsInOrder("INFO", "main", "Archived file:", "if null, action failed.")
                 )
             )
         );
-        handler.publish(new GlassFishLogRecord(Level.SEVERE, "File two, line two"));
+        handler.publish(new GlassFishLogRecord(Level.SEVERE, "File two, line two", false));
         Thread.sleep(MILLIS_FOR_PUMP);
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
             () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
             () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
                 contains(
-                    stringContainsInOrder("INFO", "main", "roll Archived file:", "if null, action failed."),
+                    stringContainsInOrder("INFO", "main", "Archived file:", "if null, action failed."),
                     stringContainsInOrder("SEVERE", "main", "File two, line two")
                 )
             )

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -98,7 +98,7 @@ public class LoggingPrintStreamTest {
             () -> assertEquals(1L, record.getThreadID()),
             () -> assertEquals(Thread.currentThread().getName(), record.getThreadName()),
             () -> assertSame(exception, record.getThrown()),
-            () -> assertEquals("testPrintStacktrace", record.getSourceMethodName())
+            () -> assertNull(record.getSourceMethodName())
         );
     }
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/SimpleLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/SimpleLogHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@ public class SimpleLogHandlerTest {
     @Test
     void standardMessage() throws Exception {
         final SimpleLogHandler handler = new SimpleLogHandler(logCollector);
-        final GlassFishLogRecord record = new GlassFishLogRecord(Level.INFO, "This should log.");
+        final GlassFishLogRecord record = new GlassFishLogRecord(Level.INFO, "This should log.", false);
         record.setSourceClassName("FakeClass");
         record.setSourceMethodName("fakeMethod");
         handler.publish(record);
@@ -83,7 +83,7 @@ public class SimpleLogHandlerTest {
     @Test
     void exception() throws Exception {
         final SimpleLogHandler handler = new SimpleLogHandler(logCollector);
-        final GlassFishLogRecord record = new GlassFishLogRecord(Level.SEVERE, "This should log.");
+        final GlassFishLogRecord record = new GlassFishLogRecord(Level.SEVERE, "This should log.", false);
         record.setSourceClassName("FakeClass");
         record.setSourceMethodName("fakeMethod");
         record.setThrown(new IllegalStateException("Something broke."));

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/SyslogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/SyslogHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -57,7 +57,7 @@ public class SyslogHandlerTest {
         manager.reconfigure(new GlassFishLogManagerConfiguration(properties));
 
         SyslogHandler handler = new SyslogHandler();
-        handler.publish(new GlassFishLogRecord(Level.SEVERE, "This is a test."));
+        handler.publish(new GlassFishLogRecord(Level.SEVERE, "This is a test.", false));
         Thread.sleep(100L);
     }
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/record/GlassFishLogRecordTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/record/GlassFishLogRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,7 +45,7 @@ public class GlassFishLogRecordTest {
      */
     @Test
     void nullParameters() throws Exception {
-        final GlassFishLogRecord record = new GlassFishLogRecord(Level.ALL, null);
+        final GlassFishLogRecord record = new GlassFishLogRecord(Level.ALL, null, false);
         record.setLevel(Level.INFO);
         record.setMessage(null);
         record.setLoggerName(null);
@@ -63,7 +63,7 @@ public class GlassFishLogRecordTest {
 
     @Test
     void emptyParameters() throws Exception {
-        final GlassFishLogRecord record = new GlassFishLogRecord(Level.CONFIG, "");
+        final GlassFishLogRecord record = new GlassFishLogRecord(Level.CONFIG, "", false);
         record.setMessage("");
         record.setLoggerName("");
         record.setParameters(new Object[] {});
@@ -75,7 +75,7 @@ public class GlassFishLogRecordTest {
 
     @Test
     void serialization() throws Exception {
-        final GlassFishLogRecord record = new GlassFishLogRecord(Level.CONFIG, "message");
+        final GlassFishLogRecord record = new GlassFishLogRecord(Level.CONFIG, "message", false);
         record.setLevel(Level.FINEST);
         record.setMessage("message2");
         record.setLoggerName("loggerNameX");

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/record/MessageResolverTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/record/MessageResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -34,7 +34,7 @@ public class MessageResolverTest {
     @Test
     public void testResolve() {
         final GlassFishLogRecord originalRecord = new GlassFishLogRecord(Level.INFO,
-            "This number {0,number,#} is greater than this one {1,number,#}");
+            "This number {0,number,#} is greater than this one {1,number,#}", false);
         originalRecord.setParameters(new Object[] {50L, 33L});
         final GlassFishLogRecord record = resolver.resolve(originalRecord);
         assertAll(() -> assertNull(record.getMessageKey()),


### PR DESCRIPTION
Years ago I made some comparisons for JUL logging, but I never pushed those tests.
Yesterday I had some doubts about the best way to format log messages, so I created a test. Meanwhile I noticed that one method in logger was not overridden and when I overrode it, it started failing the test. Long story short, GlassFish usually uses multiple handlers in parallel, so GJULE pushes common parts to caller threads to avoid duplicating and even blocking on handlers and formatters. But that means that the early resolution should not do work which is not required later - especially it should not analyze stacktraces when the detected class and method is not used in any output.

Oh, the original idea - yeah, MessageFormat is really slow compared to "+", StringBuilder, even behind suppliers. String.format is quiet slow too.