### PR TITLE
Display debug port

### DIFF
--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -590,7 +590,7 @@ public abstract class GFLauncher {
 
     /**
      *
-     * look for an option of this form: <code>-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009</code> and
+     * look for an option of this form: <code>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9009</code> and
      * extract the suspend and port values.
      *
      */

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -590,7 +590,7 @@ public abstract class GFLauncher {
 
     /**
      *
-     * look for an option of this form: <code>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9009</code> and
+     * look for an option of this form: <code>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9009</code> and
      * extract the suspend and port values.
      *
      */
@@ -604,7 +604,7 @@ public abstract class GFLauncher {
             for (String attribute : attributes) {
                 if (attribute.startsWith("address=")) {
                     try {
-                        debugPort = Integer.parseInt(attribute.substring(8));
+                        debugPort = Integer.parseInt(attribute.substring(10));
                     } catch (NumberFormatException ex) {
                         debugPort = -1;
                     }


### PR DESCRIPTION
Test:
1. get https://ci.eclipse.org/glassfish/job/glassfish_build-and-test-using-jenkinsfile/job/PR-24955/1/artifact/bundles/glassfish.zip and unpack
2. execute and inspect output:
```
$ ./glassfish7/glassfish/bin/asadmin start-domain --debug=true
Waiting for domain1 to start ...........
Waiting finished after 10,150 ms.
Successfully started the domain : domain1
domain  Location: .../glassfish7/glassfish/domains/domain1
Log File: .../glassfish7/glassfish/domains/domain1/logs/server.log
Admin Port: 4,848
Debugging is enabled.  The debugging port is: 9,009
Command start-domain executed successfully.
```