### PR TITLE
Fixed IllegalArgumentException + refactoring

### DIFF
--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/GlassfishNamingManagerImpl.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/GlassfishNamingManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -83,7 +83,7 @@ public final class GlassfishNamingManagerImpl implements GlassfishNamingManager 
     private static final Logger LOG = System.getLogger(GlassfishNamingManagerImpl.class.getName());
 
     @Inject
-    private ServiceLocator habitat;
+    private ServiceLocator serviceLocator;
 
     private final InitialContext initialContext;
 
@@ -684,7 +684,7 @@ public final class GlassfishNamingManagerImpl implements GlassfishNamingManager 
     private String getComponentId() throws NamingException {
         final ComponentInvocation ci;
         if (invMgr == null) {
-            ci = habitat.<InvocationManager> getService(InvocationManager.class).getCurrentInvocation();
+            ci = serviceLocator.<InvocationManager> getService(InvocationManager.class).getCurrentInvocation();
         } else {
             ci = invMgr.getCurrentInvocation();
         }

--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/GlassfishNamingManagerImpl.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/GlassfishNamingManagerImpl.java
@@ -682,28 +682,22 @@ public final class GlassfishNamingManagerImpl implements GlassfishNamingManager 
      * @return the component id as a string.
      */
     private String getComponentId() throws NamingException {
-        final ComponentInvocation ci;
+        final ComponentInvocation invocation;
         if (invMgr == null) {
-            ci = serviceLocator.<InvocationManager> getService(InvocationManager.class).getCurrentInvocation();
+            invocation = serviceLocator.<InvocationManager> getService(InvocationManager.class).getCurrentInvocation();
         } else {
-            ci = invMgr.getCurrentInvocation();
+            invocation = invMgr.getCurrentInvocation();
         }
 
-        if (ci == null) {
-            throw new NamingException("Invocation exception: Got null ComponentInvocation ");
+        if (invocation == null) {
+            throw new NamingException("Invocation exception: Got null ComponentInvocation!");
         }
 
-        try {
-            String id = ci.getComponentId();
-            if (id == null) {
-                throw new NamingException("Invocation exception: ComponentId is null");
-            }
-            return id;
-        } catch (Throwable th) {
-            NamingException ine = new NamingException("Invocation exception: " + th);
-            ine.initCause(th);
-            throw ine;
+        String id = invocation.getComponentId();
+        if (id == null) {
+            throw new NamingException("Invocation exception: Got null ComponentId!");
         }
+        return id;
     }
 
 

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1172,7 +1172,7 @@ public class Application extends CommonResourceBundleDescriptor
      */
     @Override
     public void addBundleDescriptor(BundleDescriptor bundleDescriptor) {
-        ModuleDescriptor newModule = bundleDescriptor.getModuleDescriptor();
+        ModuleDescriptor<BundleDescriptor> newModule = bundleDescriptor.getModuleDescriptor();
         addModule(newModule);
     }
 
@@ -1249,7 +1249,7 @@ public class Application extends CommonResourceBundleDescriptor
      * @param id unique id for this application
      */
     public void setUniqueId(long id) {
-        LOG.log(Level.FINE, "[Application] " + getName() + " , uid: " + id);
+        LOG.log(Level.FINE, () -> "setUniquiId: [Application] " + getName() + " , uid: " + id);
         this.uniqueId = id;
 
         EjbDescriptor[] descs = getSortedEjbDescriptors();

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -1152,7 +1152,8 @@ public class Application extends CommonResourceBundleDescriptor
         for (ModuleDescriptor<BundleDescriptor> aModule : getModules()) {
             BundleDescriptor bundleDesc = aModule.getDescriptor();
             if (bundleDesc == null) {
-                throw new IllegalArgumentException("Null descriptor for module " + aModule);
+                LOG.log(Level.FINE, () -> "Null descriptor for module " + aModule);
+                continue;
             }
             bundleSet.add(bundleDesc);
             for (RootDeploymentDescriptor rd : bundleDesc.getExtensionsDescriptors()) {

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/Application.java
@@ -1250,7 +1250,7 @@ public class Application extends CommonResourceBundleDescriptor
      * @param id unique id for this application
      */
     public void setUniqueId(long id) {
-        LOG.log(Level.FINE, () -> "setUniquiId: [Application] " + getName() + " , uid: " + id);
+        LOG.log(Level.FINE, () -> "setUniqueId called for application " + getName() + " with value: " + id);
         this.uniqueId = id;
 
         EjbDescriptor[] descs = getSortedEjbDescriptors();

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecurityContainer.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/SecurityContainer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,36 +19,30 @@ package com.sun.enterprise.security.ee;
 
 import com.sun.enterprise.deployment.interfaces.SecurityRoleMapperFactoryMgr;
 import com.sun.logging.LogDomains;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.glassfish.api.container.Container;
 import org.glassfish.api.deployment.Deployer;
 import org.glassfish.deployment.common.SecurityRoleMapperFactory;
-import org.glassfish.hk2.api.PostConstruct;
 import org.jvnet.hk2.annotations.Service;
 
 /**
  * Security container service
- *
  */
 @Service(name = "com.sun.enterprise.security.ee.SecurityContainer")
-public class SecurityContainer implements Container, PostConstruct {
+public class SecurityContainer implements Container {
 
-    private static final Logger LOGGER = LogDomains.getLogger(SecurityContainer.class, LogDomains.SECURITY_LOGGER);
+    private static final Logger LOG = LogDomains.getLogger(SecurityContainer.class, LogDomains.SECURITY_LOGGER, false);
 
     /**
      * The system-assigned default web module's name/identifier.
-     *
      */
     public static final String DEFAULT_WEB_MODULE_NAME = "__default-web-module";
 
     static {
         initRoleMapperFactory();
-    }
-
-    @Override
-    public void postConstruct() {
-
     }
 
     @Override
@@ -60,8 +55,8 @@ public class SecurityContainer implements Container, PostConstruct {
         return SecurityDeployer.class;
     }
 
+    /** This should never ever fail. */
     private static void initRoleMapperFactory() {
-        // This should never ever fail.
         try {
             Class<?> c = Class.forName("com.sun.enterprise.security.ee.acl.RoleMapperFactory");
             if (c != null) {
@@ -71,9 +66,9 @@ public class SecurityContainer implements Container, PostConstruct {
                 }
             }
         } catch (Exception cnfe) {
-            LOGGER.log(Level.SEVERE, "The impossible has happened.", cnfe);
+            LOG.log(Level.SEVERE,
+                "The RoleMapperFactory could not be initialized, initialization of the SecurityContainer failed.",
+                cnfe);
         }
     }
-
-
 }

--- a/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/JarArchive.java
+++ b/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/JarArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -110,9 +110,8 @@ public abstract class JarArchive implements Archive {
     static String getName(URI uri) {
         String path = Util.getURIName(uri);
         int lastDot = path.lastIndexOf('.');
-        int endOfName = (lastDot != -1) ? lastDot : path.length();
-        String name = path.substring(0, endOfName);
-        return name;
+        int endOfName = lastDot == -1 ? path.length() : lastDot;
+        return path.substring(0, endOfName);
     }
 
     /**

--- a/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/Util.java
+++ b/nucleus/deployment/common/src/main/java/com/sun/enterprise/deployment/deploy/shared/Util.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,8 +18,8 @@
 package com.sun.enterprise.deployment.deploy.shared;
 
 import java.net.URI;
-import java.net.URL;
 import java.net.URISyntaxException;
+import java.net.URL;
 
 /**
  * Utility logic.
@@ -39,21 +40,16 @@ public class Util {
     * @return the name portion of the URI
     */
     public static String getURIName(URI uri) {
-        String name = null;
         String path = uri.getSchemeSpecificPart();
-        if (path != null) {
-            /*
-             * Strip the path up to and including the last slash, if there is one.
-             * A directory URI may end in a slash, so be sure to remove it if it
-             * is there.
-             */
-            if (path.endsWith("/")) {
-                path = path.substring(0, path.length() - 1);
-            }
-            int startOfName = path.lastIndexOf('/') + 1; // correct whether a / appears or not
-            name = path.substring(startOfName);
+         // Strip the path up to and including the last slash, if there is one.
+         // A directory URI may end in a slash, so be sure to remove it if it
+         // is there.
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
         }
-        return name;
+        // correct whether a / appears or not
+        int startOfName = path.lastIndexOf('/') + 1;
+        return path.substring(startOfName);
     }
 
    /**

--- a/nucleus/deployment/common/src/test/java/com/sun/enterprise/deployment/deploy/shared/JarArchiveTest.java
+++ b/nucleus/deployment/common/src/test/java/com/sun/enterprise/deployment/deploy/shared/JarArchiveTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@
 package com.sun.enterprise.deployment.deploy.shared;
 
 import java.net.URI;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,10 +28,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class JarArchiveTest {
 
-    /**
-     * Test of getName method, of class JarArchive.
-     * @throws Exception
-     */
+    @Test
+    void noname() throws Exception {
+        URI uri = new URI("jar:///");
+        assertEquals("", JarArchive.getName(uri));
+    }
+
+    @Test
+    void justSuffix() throws Exception {
+        URI uri = new URI("jar:///.war");
+        assertEquals("", JarArchive.getName(uri));
+    }
+
     @Test
     public void shortSubPaths() throws Exception {
         URI uri = new URI("jar:///a/b/c/d.war");


### PR DESCRIPTION
* The fix is just this: https://github.com/eclipse-ee4j/glassfish/commit/3b4e132a81fd8b3a3de44b92f44146c6e38decd2
* When I tried to find the cause (log message with unresolved parameters) I touched some other things
  * renamed habitat in the naming manager
  * fixed few warnings in DOL
  * LogDomains printed warning about missing (and unused) resource bundle for the SecurityContainer
  * Originally I suspected JarArchive to make some silly exception when trying to resolve the file name. I was wrong, but I added two unit tests and did some trivial cleanup.
* These two commits were originally created in different branch, but I think they should go to master first.