### PR TITLE
Stop server on failed start in tests

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -82,7 +82,13 @@ public class GlassFishTestEnvironment {
             asadmin.withEnv("AS_START_TIMEOUT", Integer.toString(ASADMIN_START_DOMAIN_TIMEOUT - 5000));
         }
         // This is the absolutely first start - if it fails, all other starts will fail too.
-        assertThat(asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "start-domain", "--debug"), asadminOK());
+        try {
+            assertThat(asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "start-domain", "--debug"), asadminOK());
+        } catch (AssertionError e) {
+            // stop domain if the domain is running from a previous test
+            asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "stop-domain");
+            throw e;
+        }
     }
 
 


### PR DESCRIPTION
If a previous test was killed before the server was started, the server remained running. This change will attempt to stop it if any test is started again and fails to start a server. Another attempt to run the test should start a server and run the test as it shoul.