### PR TITLE
Integrate Woodstox 6.6.2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -138,7 +138,7 @@
 
         <!-- Used for Jakarta SOAP (XML Web Services) -->
         <xmlsec.version>4.0.2</xmlsec.version>
-        <woodstox.version>6.6.0</woodstox.version>
+        <woodstox.version>6.6.2</woodstox.version>
         <stax2-api.version>4.2.2</stax2-api.version>
 
         <!-- Jakarta CDI -->


### PR DESCRIPTION
Changes: https://github.com/FasterXML/woodstox/blob/master/release-notes/VERSION

```
6.6.2 (26-Mar-2024)

#200: Fix shading of `isorelax` dependency (and other msv-core components)
 (reported, fix contributed by Jeremy N)

6.6.1 (26-Feb-2024)

#193: Module `com.ctc.wstx` does not read a module that exports
  `com.ctc.wstx.shaded.msv.org_isorelax.verifier`
 (reported by Alexey G)
```
