### PR TITLE
Integrate Nimbus 9.39.1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,7 +99,7 @@
         <soteria.version>3.0.3</soteria.version>
         <exousia.version>2.1.2</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>9.37.3</nimbus.version>
+        <nimbus.version>9.39.1</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->


### PR DESCRIPTION
Changes: https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt

```
version 9.38 (2024-05-08)
    * Creates two build profiles, a "default" profile and a "fips" profile
      depending on the BouncyCastle FIPS JCA provider and the BouncyCastle FIPS
      PKIX.
    * Adds a modular Java 9 build.
    * Makes the JCIP annotation dependency optional and shades it.
    * Adds support for the Ed25519 and Ed448 JWS algorithm identifiers
      (draft-ietf-jose-fully-specified-algorithms-02).
    * Adds KeyRevocation class to support OpenID Federation 1.0.
    * Adds Payload.toPayload(boolean) with argument controlling the inclusion
      of claims with null values.
    * Exposes the DefaultJWTProcessor extractJWTClaimsSet, verifyJWTClaimsSet
      and selectKeys as protected.
    * Adds JWKSet.containsNonPublicKeys helper method.
    * Makes package private ForceRefreshJWKSetCacheEvaluator and
      NoRefreshJWKSetCacheEvaluator singleton classes.
    * Switches to Object.requireNonNull where appropriate to reduce code and
      use of exception message strings.
    * Removes the LegacyAESGCM which was intended for Java 6 runtimes without a
      JCA GCMParameterSpec (iss #529).
    * Adds Android "SHA{256|384|512}withRSA/PSS" JCA algorithm support (iss
      #541).
    * The RSAKey and ECKey.Builder.privateKey methods must accept and correctly
      apply null arguments (iss #543).
    * SignedJWT, EncryptedJWT and PlainJWT must serialise JWTClaimsSet claims
      with null values (iss #519).
    * JWEObject.decrypt must reject cipher texts of compressed plain text that
      are too large to conserve resources. A limit of 100K cipher text
      characters is enforced (iss #545).
    * Updates to BouncyCastle 1.78 (JDK 1.8 on)
    * Updates to BouncyCastle FIPS 1.0.2.4
    * Updates to com.google.crypto.tink:tink:1.13.0

version 9.39 (2024-05-10)
    * Adds JSONObjectUtils.getEpochSecondAsDate static method.
    * JWTClaimsSet.parse must handle null "nbf", "iat" and "exp" claims (iss
      #547).

version 9.39.1 (2024-05-14)
    * Adds a multi-release declaration to pom.xml (iss #548).
    * Sets the Java source to 7 in the maven-javadoc-plugin configuration.
```
