### PR TITLE
The catch is not required to stop GF instance

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -82,13 +82,7 @@ public class GlassFishTestEnvironment {
             asadmin.withEnv("AS_START_TIMEOUT", Integer.toString(ASADMIN_START_DOMAIN_TIMEOUT - 5000));
         }
         // This is the absolutely first start - if it fails, all other starts will fail too.
-        try {
-            assertThat(asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "start-domain", "--debug"), asadminOK());
-        } catch (AssertionError e) {
-            // stop domain if the domain is running from a previous test
-            asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "stop-domain");
-            throw e;
-        }
+        assertThat(asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "start-domain", "--debug"), asadminOK());
     }
 
 


### PR DESCRIPTION
- There is already the shutdown hook registered few lines above even with more "radical" parameters (kill, force).
