### PR TITLE
Fixed deadlock when rolling the file under a heavy load

### DIFF
--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
@@ -147,9 +147,7 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
         // parent StreamHandler already set level, filter, encoding and formatter.
         setLevel(configuration.getLevel());
         setEncoding(configuration.getEncoding());
-
-        this.logRecordBuffer = new LogRecordBuffer(
-            configuration.getBufferCapacity(), configuration.getBufferTimeout());
+        this.logRecordBuffer = new LogRecordBuffer(configuration.getBufferCapacity(), configuration.getBufferTimeout());
 
         reconfigure(configuration);
     }
@@ -191,6 +189,7 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
         trace(GlassFishLogHandler.class, () -> "reconfigure(configuration=" + newConfiguration + ")");
         // stop using output, but allow collecting records. Logging system can continue to work.
         this.status = GlassFishLogHandlerStatus.ACCEPTING;
+        this.logRecordBuffer.reconfigure(newConfiguration.getBufferCapacity(), newConfiguration.getBufferTimeout());
         if (this.rotationTimerTask != null) {
             // to avoid another task from last configuration runs it's action.
             this.rotationTimerTask.cancel();

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
@@ -23,6 +23,7 @@ import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Timer;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.ErrorManager;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -84,6 +85,8 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
     private static final Logger STDOUT_LOGGER = Logger.getLogger(LOGGER_NAME_STDOUT);
     private static final Logger STDERR_LOGGER = Logger.getLogger(LOGGER_NAME_STDERR);
     private static final MessageResolver MSG_RESOLVER = new MessageResolver();
+
+    private final ReentrantLock lock = new ReentrantLock();
 
     private LoggingPrintStream stdoutStream;
     private LoggingPrintStream stderrStream;
@@ -185,26 +188,31 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
      *
      * @param newConfiguration
      */
-    public synchronized void reconfigure(final GlassFishLogHandlerConfiguration newConfiguration) {
+    public void reconfigure(final GlassFishLogHandlerConfiguration newConfiguration) {
         trace(GlassFishLogHandler.class, () -> "reconfigure(configuration=" + newConfiguration + ")");
-        // stop using output, but allow collecting records. Logging system can continue to work.
-        this.status = GlassFishLogHandlerStatus.ACCEPTING;
-        this.logRecordBuffer.reconfigure(newConfiguration.getBufferCapacity(), newConfiguration.getBufferTimeout());
-        if (this.rotationTimerTask != null) {
-            // to avoid another task from last configuration runs it's action.
-            this.rotationTimerTask.cancel();
-            this.rotationTimerTask = null;
-        }
-        // stop pump. If reconfiguration would fail, it is better to leave it down.
-        // records from the buffer will be processed if the last configuration was valid.
-        stopPump();
-        this.configuration = newConfiguration;
-
+        lock.lock();
         try {
-            this.status = startLoggingIfPossible();
-        } catch (final Exception e) {
-            this.status = GlassFishLogHandlerStatus.OFF;
-            throw e;
+            // stop using output, but allow collecting records. Logging system can continue to work.
+            this.status = GlassFishLogHandlerStatus.ACCEPTING;
+            this.logRecordBuffer.reconfigure(newConfiguration.getBufferCapacity(), newConfiguration.getBufferTimeout());
+            if (this.rotationTimerTask != null) {
+                // to avoid another task from last configuration runs it's action.
+                this.rotationTimerTask.cancel();
+                this.rotationTimerTask = null;
+            }
+            // stop pump. If reconfiguration would fail, it is better to leave it down.
+            // records from the buffer will be processed if the last configuration was valid.
+            stopPump();
+            this.configuration = newConfiguration;
+
+            try {
+                this.status = startLoggingIfPossible();
+            } catch (final Exception e) {
+                this.status = GlassFishLogHandlerStatus.OFF;
+                throw e;
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -253,14 +261,19 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
     /**
      * Explicitly rolls the log file.
      */
-    public synchronized void roll() {
+    public void roll() {
         trace(GlassFishLogHandler.class, "roll()");
         final PrivilegedAction<Void> action = () -> {
             this.logFileManager.roll();
             updateRollSchedule();
             return null;
         };
-        AccessController.doPrivileged(action);
+        lock.lock();
+        try {
+            AccessController.doPrivileged(action);
+        } finally {
+            lock.unlock();
+        }
     }
 
 
@@ -270,30 +283,35 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
      * by this handler and finally closes the output stream.
      */
     @Override
-    public synchronized void close() {
+    public void close() {
         trace(GlassFishLogHandler.class, "close()");
-        this.status = GlassFishLogHandlerStatus.OFF;
-        if (this.rotationTimerTask != null) {
-            this.rotationTimerTask.cancel();
-            this.rotationTimerTask = null;
-        }
-        this.rotationTimer.cancel();
+        lock.lock();
         try {
-            LoggingSystemEnvironment.resetStandardOutputs();
-            if (this.stdoutStream != null) {
-                this.stdoutStream.close();
-                this.stdoutStream = null;
+            this.status = GlassFishLogHandlerStatus.OFF;
+            if (this.rotationTimerTask != null) {
+                this.rotationTimerTask.cancel();
+                this.rotationTimerTask = null;
+            }
+            this.rotationTimer.cancel();
+            try {
+                LoggingSystemEnvironment.resetStandardOutputs();
+                if (this.stdoutStream != null) {
+                    this.stdoutStream.close();
+                    this.stdoutStream = null;
+                }
+
+                if (this.stderrStream != null) {
+                    this.stderrStream.close();
+                    this.stderrStream = null;
+                }
+            } catch (final RuntimeException e) {
+                error(GlassFishLogHandler.class, "close partially failed!", e);
             }
 
-            if (this.stderrStream != null) {
-                this.stderrStream.close();
-                this.stderrStream = null;
-            }
-        } catch (final RuntimeException e) {
-            error(GlassFishLogHandler.class, "close partially failed!", e);
+            stopPump();
+        } finally {
+            lock.unlock();
         }
-
-        stopPump();
     }
 
 
@@ -343,8 +361,9 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
     }
 
 
-    private synchronized void stopPump() {
+    private void stopPump() {
         trace(GlassFishLogHandler.class, "stopPump()");
+
         if (this.pump != null) {
             this.pump.interrupt();
             this.pump = null;
@@ -405,9 +424,14 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
     /**
      * If the file is not empty, rolls. Then updates the next roll schedule.
      */
-    private synchronized void scheduledRoll() {
-        this.logFileManager.rollIfFileNotEmpty();
-        updateRollSchedule();
+    private void scheduledRoll() {
+        lock.lock();
+        try {
+            this.logFileManager.rollIfFileNotEmpty();
+            updateRollSchedule();
+        } finally {
+            lock.unlock();
+        }
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java
@@ -59,7 +59,7 @@ class LogRecordBuffer {
      *
      * @param capacity capacity of the buffer.
      */
-    public LogRecordBuffer(final int capacity) {
+    LogRecordBuffer(final int capacity) {
         this(capacity, 0);
     }
 
@@ -84,7 +84,7 @@ class LogRecordBuffer {
      * @param maxWait maximal time in seconds to wait for the free capacity. If &lt; 1, can wait
      *            forever.
      */
-    public LogRecordBuffer(final int capacity, final int maxWait) {
+    LogRecordBuffer(final int capacity, final int maxWait) {
         this.capacity = capacity;
         this.maxWait = maxWait;
         this.pendingRecords = new ArrayBlockingQueue<>(capacity, true);
@@ -101,8 +101,13 @@ class LogRecordBuffer {
     // R/W locks - only this method locks everything, because it has to recreate the queue using
     // the original pending records.
     public void reconfigure(final int newCapacity, final int newMaxWait) {
-        if (this.capacity == newCapacity && this.maxWait == newMaxWait) {
-            return;
+        this.lock.readLock().lock();
+        try {
+            if (this.capacity == newCapacity && this.maxWait == newMaxWait) {
+                return;
+            }
+        } finally {
+            this.lock.readLock().unlock();
         }
         this.lock.writeLock().lock();
         try {

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -150,12 +150,15 @@ public class GlassFishLogHandlerTest {
             )
         );
         handler.roll();
+        // There will be an asynchronous thread.
+        Thread.sleep(10L);
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
             () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
             () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
                 contains(
-                    stringContainsInOrder("INFO", "main", "Archived file:", "if null, action failed.")
+                    stringContainsInOrder("INFO", "Rolling the file ", ".log", "output was originally enabled: true"),
+                    stringContainsInOrder("INFO", "Archiving file ", ".log", " to ", ".log_")
                 )
             )
         );
@@ -166,7 +169,8 @@ public class GlassFishLogHandlerTest {
             () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
             () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
                 contains(
-                    stringContainsInOrder("INFO", "main", "Archived file:", "if null, action failed."),
+                    stringContainsInOrder("INFO", "Rolling the file ", ".log", "output was originally enabled: true"),
+                    stringContainsInOrder("INFO", "Archiving file ", ".log", " to ", ".log_"),
                     stringContainsInOrder("SEVERE", "main", "File two, line two")
                 )
             )


### PR DESCRIPTION
* Fixed LogRecordBuffer configuration - it always used defaults
  *  That caused overload without any possibility to configure maxWaitTime or increase the buffer size
* Fixed deadlock - don't use loggers in critical section.
  * Deadlock can be caused when we are rolling the file with the full log record buffer AND we log anything from this thread.
  * Solution: if you really need to log something, use asynchronous thread.
  * Under a heavy load (1 record every 3 microseconds) such log record can occur even after another 5000 other records in the buffer or trying to be added to the buffer. It is just another one. Usually it will be the first one.
* Moving from synchronized to reentrant locks + fixed deadlock
    
