### PR TITLE
Context root doesn't include a random string

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/GuiUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/GuiUtil.java
@@ -395,7 +395,8 @@ public class GuiUtil {
      */
     public static void prepareException(HandlerContext handlerCtx, Throwable ex) {
         Throwable rootException = getRootCause(ex);
-        prepareAlert("error", GuiUtil.getMessage("msg.Error"), rootException.getMessage());
+        prepareAlert("error", GuiUtil.getMessage("msg.Error"), rootException.getClass().getSimpleName()
+                + ": " + rootException.getMessage());
         GuiUtil.getLogger().info(GuiUtil.getCommonMessage("LOG_EXCEPTION_OCCURED") + ex.getLocalizedMessage());
         if (GuiUtil.getLogger().isLoggable(Level.FINE)){
             ex.printStackTrace();


### PR DESCRIPTION
For apps deployed via Admin Console, the uploaded file was copied to a temp file,  which contained a random string. Now, the temp directory has a random string,  but the file in it has the same name.
Context root is generated from the file name and doesn't include any random string with this commit.

Before, when an app was deployed with default values:
![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/b1273f49-e11b-4642-b243-0ddcdbf79bbc)

Now:
![image](https://github.com/eclipse-ee4j/glassfish/assets/2195988/1da375b3-3d02-4632-99aa-1f46cfef3bfd)
