### PR TITLE
Dev profile to update modules without building the whole GlassFish distribution

### DIFF
--- a/appserver/admingui/cluster/pom.xml
+++ b/appserver/admingui/cluster/pom.xml
@@ -33,10 +33,6 @@
     <name>Admin Console Clustering Support Plugin</name>
     <description>Clustering support plugin bundle for GlassFish Admin Console</description>
 
-    <properties>
-        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>
@@ -51,4 +47,13 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/admingui/cluster/pom.xml
+++ b/appserver/admingui/cluster/pom.xml
@@ -33,6 +33,10 @@
     <name>Admin Console Clustering Support Plugin</name>
     <description>Clustering support plugin bundle for GlassFish Admin Console</description>
 
+    <properties>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -33,6 +33,10 @@
     <name>Admin Console Common</name>
     <description>This bundle contains common code that may be shared across plugins.</description>
 
+    <properties>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/appserver/admingui/community-theme/pom.xml
+++ b/appserver/admingui/community-theme/pom.xml
@@ -32,7 +32,7 @@
 
     <name>Admin Console Community Edition Theme Plugin</name>
     <description>Custom Theme Plugin for GlassFish Admin Console</description>
-
+    
     <developers>
         <!-- See parent POM -->
     </developers>
@@ -103,4 +103,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>    
 </project>

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -34,8 +34,8 @@
     <name>Admin Console Core Jar</name>
 
     <properties>
-        <copy.modules.to-distribution.skip>false</copy.modules.to-distribution.skip>
-        <copy.modules.to-distribution.destFile>${basedir}/../../distributions/glassfish/target/stage/glassfish7/glassfish/lib/install/applications/__admingui/WEB-INF/lib/console-core-${project.version}.jar</copy.modules.to-distribution.destFile>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+        <copy.modules.to.distribution.destFile>${basedir}/../../../${glassfish.distribution.dir}/lib/install/applications/__admingui/WEB-INF/lib/console-core-${project.version}.jar</copy.modules.to.distribution.destFile>
     </properties>
 
     <dependencies>

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,11 @@
     <packaging>glassfish-jar</packaging>
 
     <name>Admin Console Core Jar</name>
+
+    <properties>
+        <copy.modules.to-distribution.skip>false</copy.modules.to-distribution.skip>
+        <copy.modules.to-distribution.destFile>${basedir}/../../distributions/glassfish/target/stage/glassfish7/glassfish/lib/install/applications/__admingui/WEB-INF/lib/console-core-${project.version}.jar</copy.modules.to-distribution.destFile>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -71,4 +76,5 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
     </dependencies>
+
 </project>

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -33,11 +33,6 @@
 
     <name>Admin Console Core Jar</name>
 
-    <properties>
-        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
-        <copy.modules.to.distribution.destFile>${basedir}/../../../${glassfish.distribution.dir}/lib/install/applications/__admingui/WEB-INF/lib/console-core-${project.version}.jar</copy.modules.to.distribution.destFile>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
@@ -77,4 +72,13 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+                <copy.modules.to.distribution.destFile>${basedir}/../../../${glassfish.distribution.dir}/lib/install/applications/__admingui/WEB-INF/lib/console-core-${project.version}.jar</copy.modules.to.distribution.destFile>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/admingui/jca/pom.xml
+++ b/appserver/admingui/jca/pom.xml
@@ -33,6 +33,10 @@
     <name>Admin Console Connectors Plugin</name>
     <description>Connectors plugin bundle for GlassFish Admin Console</description>
 
+    <properties>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -36,6 +36,10 @@
         <!-- See parent POM -->
     </developers>
 
+    <properties>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.admingui</groupId>

--- a/appserver/admingui/plugin-service/pom.xml
+++ b/appserver/admingui/plugin-service/pom.xml
@@ -54,4 +54,13 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -171,4 +171,33 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-main-artifact</id>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <delete dir="${basedir}/../../../${glassfish.distribution.dir}/lib/install/applications/__admingui"/>
+                                        <unzip src="${project.build.directory}/${project.build.finalName}.war" dest="${basedir}/../../../${glassfish.distribution.dir}/lib/install/applications/__admingui" />
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/connectors/connectors-runtime/pom.xml
+++ b/appserver/connectors/connectors-runtime/pom.xml
@@ -211,4 +211,13 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/deployment/dol/pom.xml
+++ b/appserver/deployment/dol/pom.xml
@@ -194,4 +194,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/microprofile/config/pom.xml
+++ b/appserver/microprofile/config/pom.xml
@@ -122,4 +122,12 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/persistence/jpa-container/pom.xml
+++ b/appserver/persistence/jpa-container/pom.xml
@@ -117,4 +117,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/web/web-core/pom.xml
+++ b/appserver/web/web-core/pom.xml
@@ -150,4 +150,13 @@
             </plugin>
         </plugins>
     </build>
+    
+        <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/web/web-glue/pom.xml
+++ b/appserver/web/web-glue/pom.xml
@@ -277,4 +277,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/web/weld-integration/pom.xml
+++ b/appserver/web/weld-integration/pom.xml
@@ -203,4 +203,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -217,4 +217,13 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/admin/config-api/pom.xml
+++ b/nucleus/admin/config-api/pom.xml
@@ -154,4 +154,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/admin/launcher/pom.xml
+++ b/nucleus/admin/launcher/pom.xml
@@ -63,4 +63,13 @@
             <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -35,6 +35,8 @@
 
     <properties>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+        <copy.modules.to.distribution.path.to.root>../../../..</copy.modules.to.distribution.path.to.root>
     </properties>
 
     <dependencies>

--- a/nucleus/admin/rest/rest-service/pom.xml
+++ b/nucleus/admin/rest/rest-service/pom.xml
@@ -35,8 +35,6 @@
 
     <properties>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
-        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
-        <copy.modules.to.distribution.path.to.root>../../../..</copy.modules.to.distribution.path.to.root>
     </properties>
 
     <dependencies>
@@ -203,4 +201,14 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+                <copy.modules.to.distribution.path.to.root>../../../..</copy.modules.to.distribution.path.to.root>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/admin/server-mgmt/pom.xml
+++ b/nucleus/admin/server-mgmt/pom.xml
@@ -214,4 +214,14 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+                <copy.modules.to.distribution.destFile>${basedir}/../../..//${glassfish.distribution.dir}/lib/asadmin/server-mgmt.jar </copy.modules.to.distribution.destFile>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/admin/util/pom.xml
+++ b/nucleus/admin/util/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <command.security.maven.plugin.isFailureFatal>false</command.security.maven.plugin.isFailureFatal>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
     </properties>
 
     <dependencies>

--- a/nucleus/cluster/common/pom.xml
+++ b/nucleus/cluster/common/pom.xml
@@ -32,7 +32,6 @@
     <name>cluster-common</name>
 
     <properties>
-        <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
         <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
     </properties>
 

--- a/nucleus/cluster/common/pom.xml
+++ b/nucleus/cluster/common/pom.xml
@@ -31,6 +31,11 @@
 
     <name>cluster-common</name>
 
+    <properties>
+        <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -44,10 +44,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main</groupId>
@@ -112,4 +108,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -45,7 +45,6 @@
     </developers>
 
     <properties>
-        <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
         <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
     </properties>
 

--- a/nucleus/common/common-util/pom.xml
+++ b/nucleus/common/common-util/pom.xml
@@ -44,6 +44,11 @@
         </developer>
     </developers>
 
+    <properties>
+        <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main</groupId>

--- a/nucleus/common/internal-api/pom.xml
+++ b/nucleus/common/internal-api/pom.xml
@@ -112,4 +112,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/core/bootstrap/pom.xml
+++ b/nucleus/core/bootstrap/pom.xml
@@ -158,4 +158,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -62,6 +62,11 @@
         </developer>
     </developers>
 
+    <properties>
+        <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
+        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -62,10 +62,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
@@ -275,4 +271,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -63,7 +63,6 @@
     </developers>
 
     <properties>
-        <findbugs.exclude>${project.basedir}/exclude.xml</findbugs.exclude>
         <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
     </properties>
 

--- a/nucleus/extras/command-logger/pom.xml
+++ b/nucleus/extras/command-logger/pom.xml
@@ -42,4 +42,13 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -114,4 +114,31 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>dev-echo</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <echo level="info">To patch the GlassFish build, build the parent "nucleus-grizzly" artifact with submodules instead</echo>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -144,5 +144,11 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -189,7 +189,6 @@
         <test.logManager>java.util.logging.LogManager</test.logManager>
         <test.logLevel>INFO</test.logLevel>
         <test.enableDefaultLogCfg>true</test.enableDefaultLogCfg>
-
         <glassfish.distribution.dir>appserver/distributions/glassfish/target/stage/glassfish7/glassfish</glassfish.distribution.dir>
     </properties>
 
@@ -848,7 +847,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
-                    <version>4.0.2</version>
+                    <version>4.1.0</version>
                     <!-- Adds support for glassfish-jar and it's customized lifecycle-->
                     <extensions>true</extensions>
                     <dependencies>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -2323,7 +2323,7 @@
                             <executions>
                                 <execution>
                                     <id>copy-module-to-distribution</id>
-                                    <phase>package</phase>
+                                    <phase>install</phase>
                                     <goals>
                                         <goal>copy-file</goal>
                                     </goals>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -189,6 +189,8 @@
         <test.logManager>java.util.logging.LogManager</test.logManager>
         <test.logLevel>INFO</test.logLevel>
         <test.enableDefaultLogCfg>true</test.enableDefaultLogCfg>
+
+        <glassfish.distribution.dir>appserver/distributions/glassfish/target/stage/glassfish7/glassfish</glassfish.distribution.dir>
     </properties>
 
     <dependencyManagement>
@@ -2309,7 +2311,9 @@
         <profile>
             <id>dev</id>
             <properties>
-                <copy.modules.to-distribution.skip>true</copy.modules.to-distribution.skip>
+                <copy.modules.to.distribution.skip>true</copy.modules.to.distribution.skip>
+                <copy.modules.to.distribution.path.to.root>../../..</copy.modules.to.distribution.path.to.root>
+                <copy.modules.to.distribution.destFile>${basedir}/${copy.modules.to.distribution.path.to.root}/${glassfish.distribution.dir}/modules/${project.build.finalName}.jar</copy.modules.to.distribution.destFile>
             </properties>
             <build>
                 <pluginManagement>
@@ -2325,8 +2329,8 @@
                                         <goal>copy-file</goal>
                                     </goals>
                                     <configuration>
-                                        <skip>${copy.modules.to-distribution.skip}</skip>
-                                        <destFile>${copy.modules.to-distribution.destFile}</destFile>
+                                        <skip>${copy.modules.to.distribution.skip}</skip>
+                                        <destFile>${copy.modules.to.distribution.destFile}</destFile>
                                     </configuration>
                                 </execution>
                             </executions>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -846,7 +846,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>glassfishbuild-maven-plugin</artifactId>
-                    <version>4.0.1</version>
+                    <version>4.0.2</version>
                     <!-- Adds support for glassfish-jar and it's customized lifecycle-->
                     <extensions>true</extensions>
                     <dependencies>
@@ -954,7 +954,7 @@
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <excludes>**/generated-sources/**/*, **/module-info.java</excludes>
                         <!-- build-helper-plugin adds the root as a resource path, but checkstyle overrides the filter and
-                            adds all property files in the tree -->
+                        adds all property files in the tree -->
                         <resourceExcludes>
                             **/appserver/**/src/main/resources/**/*,
                             **/deployment/**/src/main/resources/**/*,
@@ -2049,8 +2049,8 @@
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>osgiversion-maven-plugin</artifactId>
                 <!-- Since we don't want qualifier like b05 or SNAPSHOT to appear in package version attribute, we use the
-                    following goal to populate a project property with an OSGi version which is equivalent to maven version without qualifier
-                    and then use that property in osgi.bundle while exporting. -->
+                following goal to populate a project property with an OSGi version which is equivalent to maven version without qualifier
+                and then use that property in osgi.bundle while exporting. -->
                 <configuration>
                     <dropVersionComponent>qualifier</dropVersionComponent>
                     <versionPropertyName>project.osgi.version</versionPropertyName>
@@ -2302,6 +2302,46 @@
                         <configuration>
                             <testCompilerArgument>-proc:full</testCompilerArgument>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to-distribution.skip>true</copy.modules.to-distribution.skip>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.glassfish.build</groupId>
+                            <artifactId>glassfishbuild-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>copy-module-to-distribution</id>
+                                    <phase>package</phase>
+                                    <goals>
+                                        <goal>copy-file</goal>
+                                    </goals>
+                                    <configuration>
+                                        <skip>${copy.modules.to-distribution.skip}</skip>
+                                        <destFile>${copy.modules.to-distribution.destFile}</destFile>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.glassfish.build</groupId>
+                        <artifactId>glassfishbuild-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-module-to-distribution</id>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This will allow to build a single module and quickly update the GlassFish distribution in `appserver/distributions/glassfish/target/stage/glassfish7/glassfish` so that GlassFish can be started quickly with the code changes applied.

To apply changes in a specific module that suppots the `dev` profile:

* stop GlassFish if running
* cd /path/to/module
* `mvn -Pdev install`
* start GlassFish in `appserver/distributions/glassfish/target/stage/glassfish7/glassfish`

GlassFish distribution module must be first built by building the GlassFish project as usual.

To add support for the `dev` profile in other modules:

* in most cases, just set `copy.modules.to.distribution.skip` property to `false` (if the module is 3 nested directories below root, i.e. the root directory is at `../../..`)
* if the root directory is at a different location, set `copy.modules.to.distribution.path.to.root` property to the root directory (e.g. `copy.modules.to.distribution.path.to.root=../../../..`). An example is in the `nucleus/admin/rest/rest-service/pom.xml` file.
* if the destination file in GlassFish installation is different from `modules/${project.build.finalName}.jar`, then set `copy.modules.to.distribution.destFile` to point to the destination file, e.g. `copy.modules.to.distribution.destFile=${basedir}/../../..//${glassfish.distribution.dir}/lib/somefileinlib.jar`. You can use the `${glassfish.distribution.dir}` property which points to the `glassfish7/glassfish` folder relative to the project root. An example is in the `appserver/admingui/core/pom.xml` file

Note: This depends on the new 4.1.0 version of the `glassfish-build-maven-plugin` with this: https://github.com/eclipse-ee4j/glassfish-build-maven-plugin/pull/204.