### PR TITLE
8 0 cdi 4 1 0 tck

### DIFF
--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -209,7 +209,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>glassfish-external-tck-cdi</artifactId>
 
-    <name>CDI TCK Full runner 4.0 for Weld (GlassFish)</name>
+    <name>CDI TCK Full runner 4.1 for Weld (GlassFish)</name>
     <description>Aggregates dependencies and runs the CDI TCK on GlassFish</description>
 
     <dependencies>
@@ -36,6 +36,11 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -134,7 +139,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-api</artifactId>
-            <version>${cdi.tck-4-0.version}</version>
+            <version>${cdi.tck-4-1.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -151,7 +156,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-core-impl</artifactId>
-            <version>${cdi.tck-4-0.version}</version>
+            <version>${cdi.tck-4-1.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -161,14 +166,12 @@
             </exclusions>
         </dependency>
 
-        <!--
-            The TCK Web implementation contains test helper code such as the WebArchiveBuilder,
-            as well as a large amount of additional tests.
-        -->
         <dependency>
             <groupId>jakarta.enterprise</groupId>
-            <artifactId>cdi-tck-web-impl</artifactId>
-            <version>${cdi.tck-4-0.version}</version>
+            <artifactId>cdi-tck-core-impl</artifactId>
+            <version>${cdi.tck-4-1.version}</version>
+            <type>xml</type>
+            <classifier>suite</classifier>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -177,7 +180,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
 
         <dependency>
             <groupId>org.glassfish.expressly</groupId>
@@ -226,7 +228,7 @@
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -271,19 +273,19 @@
                         <configuration>
                             <artifactItems>
                                 <!--
-                                    Contains what becomes the tck-web-suite.xml; the TestNG suite file that dictates
+                                    Contains what becomes the tck-core-suite.xml; the TestNG suite file that dictates
                                     which tests from the TCK Web implementation are executed and which are excluded.
                                     Note that this file is essentially a superset of the suite file from the TCK Core,
                                     so we don't need that one separately here.
                                 -->
                                 <artifactItem>
                                     <groupId>jakarta.enterprise</groupId>
-                                    <artifactId>cdi-tck-web-impl</artifactId>
-                                    <version>${cdi.tck-4-0.version}</version>
+                                    <artifactId>cdi-tck-core-impl</artifactId>
+                                    <version>${cdi.tck-4-1.version}</version>
                                     <type>xml</type>
                                     <classifier>suite</classifier>
-                                    <overWrite>false</overWrite>
-                                    <destFileName>tck-web-suite.xml</destFileName>
+                                    <overWrite>false</overWrite> 
+                                    <destFileName>tck-core-suite.xml</destFileName>
                                 </artifactItem>
                             </artifactItems>
                             <outputDirectory>target/suites</outputDirectory>
@@ -313,7 +315,7 @@
                         </configuration>
                      </execution>
 
-                     <!-- Install a jar with a few amount of test classes, for which some of the tests are looking -->
+                    <!-- Install a jar with a few amount of test classes, for which some of the tests are looking -->
                     <execution>
                         <id>install-cdi-tck-ext-lib</id>
                         <phase>pre-integration-test</phase>
@@ -325,7 +327,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>cdi-tck-ext-lib</artifactId>
-                                    <version>${cdi.tck-4-0.version}</version>
+                                    <version>${cdi.tck-4-1.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${glassfish.root}/glassfish8/glassfish/domains/domain1/lib/applibs</outputDirectory>
@@ -344,7 +346,7 @@
                     <!-- Surefire / TestNG Properties -->
                     <!-- The suite, the exclude and the test dependencies together determine which tests are being run -->
                     <suiteXmlFiles>
-                        <suiteXmlFile>target/suites/tck-web-suite.xml</suiteXmlFile>
+                        <suiteXmlFile>target/suites/tck-core-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <excludedGroups>${excluded.groups}</excludedGroups>
                     <dependenciesToScan>

--- a/appserver/tests/tck/cdi/cdi-full/src/test/java/org/jboss/weld/tck/glassfish/GlassFishContextualsImpl.java
+++ b/appserver/tests/tck/cdi/cdi-full/src/test/java/org/jboss/weld/tck/glassfish/GlassFishContextualsImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.jboss.weld.tck.glassfish;
+
+import jakarta.enterprise.context.spi.Context;
+import jakarta.enterprise.context.spi.CreationalContext;
+import org.jboss.cdi.tck.spi.Contextuals;
+
+public class GlassFishContextualsImpl implements Contextuals {
+
+    @Override
+    public <T> Inspectable<T> create(T instance, Context context) {
+        return new InspectableContextual<>(instance);
+    }
+
+    static class InspectableContextual<T> implements Inspectable<T> {
+
+        private T instancePassedToConstructor;
+        private T instancePassedToDestroy;
+
+        private CreationalContext<T> creationalContextPassedToCreate;
+        private CreationalContext<T> creationalContextPassedToDestroy;
+
+        InspectableContextual(T instance) {
+            this.instancePassedToConstructor = instance;
+        }
+
+        @Override
+        public T create(CreationalContext<T> creationalContext) {
+            this.creationalContextPassedToCreate = creationalContext;
+            return instancePassedToConstructor;
+        }
+
+        @Override
+        public void destroy(T instance, CreationalContext<T> creationalContext) {
+            instancePassedToDestroy = instance;
+            creationalContextPassedToDestroy = creationalContext;
+        }
+
+        @Override
+        public CreationalContext<T> getCreationalContextPassedToCreate() {
+            return creationalContextPassedToCreate;
+        }
+
+        @Override
+        public T getInstancePassedToDestroy() {
+            return instancePassedToDestroy;
+        }
+
+        @Override
+        public CreationalContext<T> getCreationalContextPassedToDestroy() {
+            return creationalContextPassedToDestroy;
+        }
+    }
+
+}

--- a/appserver/tests/tck/cdi/cdi-full/src/test/java/org/jboss/weld/tck/glassfish/GlassFishCreationalContextsImpl.java
+++ b/appserver/tests/tck/cdi/cdi-full/src/test/java/org/jboss/weld/tck/glassfish/GlassFishCreationalContextsImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.jboss.weld.tck.glassfish;
+
+import jakarta.enterprise.context.spi.Contextual;
+import org.jboss.cdi.tck.spi.CreationalContexts;
+import org.jboss.weld.contexts.CreationalContextImpl;
+
+/**
+ * This returns the Weld (and thus GlassFish) specific CreationalContextImpl with added methods
+ * for inspection.
+ */
+public class GlassFishCreationalContextsImpl implements CreationalContexts {
+
+    @Override
+    public <T> Inspectable<T> create(Contextual<T> contextual) {
+        return new InspectableCreationalContext<>(contextual);
+    }
+
+    static class InspectableCreationalContext<T> extends CreationalContextImpl<T> implements Inspectable<T> {
+
+        private T lastBeanPushed;
+        private boolean pushCalled;
+        private boolean releaseCalled;
+
+        public InspectableCreationalContext(Contextual<T> contextual) {
+            super(contextual);
+        }
+
+        @Override
+        public void push(T incompleteInstance) {
+            lastBeanPushed = incompleteInstance;
+
+            pushCalled = true;
+            super.push(incompleteInstance);
+        }
+
+        @Override
+        public Object getLastBeanPushed() {
+            return lastBeanPushed;
+        }
+
+        @Override
+        public boolean isPushCalled() {
+            return pushCalled;
+        }
+
+        @Override
+        public boolean isReleaseCalled() {
+            return releaseCalled;
+        }
+
+        @Override
+        public void release(Contextual<T> contextual, T instance) {
+            releaseCalled = true;
+            super.release(contextual, instance);
+        }
+
+        @Override
+        public void release() {
+            releaseCalled = true;
+            super.release();
+        }
+
+    }
+
+}

--- a/appserver/tests/tck/cdi/cdi-full/src/test/resources/META-INF/cdi-tck.properties
+++ b/appserver/tests/tck/cdi/cdi-full/src/test/resources/META-INF/cdi-tck.properties
@@ -1,5 +1,7 @@
 org.jboss.cdi.tck.spi.Beans=org.jboss.weld.tck.glassfish.GlassFishBeansImpl
+org.jboss.cdi.tck.spi.CreationalContexts=org.jboss.weld.tck.glassfish.GlassFishCreationalContextsImpl
 org.jboss.cdi.tck.spi.Contexts=org.jboss.weld.tck.glassfish.GlassFishContextImpl
+org.jboss.cdi.tck.spi.Contextuals=org.jboss.weld.tck.glassfish.GlassFishContextualsImpl
 org.jboss.cdi.tck.spi.EL=org.jboss.weld.tck.glassfish.GlassFishELImpl
 org.jboss.cdi.tck.testDataSource=jdbc/__default
 org.jboss.cdi.tck.testJmsConnectionFactory=java:comp/DefaultJMSConnectionFactory

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -18,7 +18,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    
     <parent>
         <groupId>org.glassfish.main.tests.tck</groupId>
         <artifactId>glassfish-external-tck-cdi-parent</artifactId>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-lang-model</artifactId>
-            <version>${cdi.tck-4-0.version}</version>
+            <version>${cdi.tck-4-1.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -94,7 +94,7 @@
                     </execution>
                 </executions>
             </plugin>
-
+            
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -120,7 +120,7 @@
                      </execution>
                 </executions>
             </plugin>
-
+            
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -129,7 +129,7 @@
                     <reuseForks>true</reuseForks>
                     <!-- System Properties -->
                     <systemPropertyVariables>
-                        <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
+                        <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
                         <glassfish.enableAssertions>:org.jboss.cdi...</glassfish.enableAssertions>
                     </systemPropertyVariables>
                     <includes>
@@ -156,7 +156,7 @@
             </plugin>
         </plugins>
     </build>
-
+    
     <profiles>
         <profile>
             <id>full</id>

--- a/appserver/tests/tck/cdi/cdi-model/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-model/pom.xml
@@ -129,7 +129,7 @@
                     <reuseForks>true</reuseForks>
                     <!-- System Properties -->
                     <systemPropertyVariables>
-                        <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
+                        <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
                         <glassfish.enableAssertions>:org.jboss.cdi...</glassfish.enableAssertions>
                     </systemPropertyVariables>
                     <includes>

--- a/appserver/tests/tck/cdi/cdi-signature/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-signature/pom.xml
@@ -48,7 +48,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.enterprise</groupId>
                                     <artifactId>cdi-tck-core-impl</artifactId>
-                                    <version>${cdi.tck-4-0.version}</version>
+                                    <version>${cdi.tck-4-1.version}</version>
                                     <type>sig</type>
                                     <classifier>sigtest-jdk11</classifier>
                                     <outputDirectory>${project.build.directory}/sigtest</outputDirectory>

--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.13</cdi.tck-4-0.version>
+        <cdi.tck-4-1.version>4.1.0</cdi.tck-4-1.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>

--- a/appserver/tests/tck/cdi/pom.xml
+++ b/appserver/tests/tck/cdi/pom.xml
@@ -51,7 +51,7 @@
 
         <glassfish.version>${project.version}</glassfish.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
+        <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Update CDI TCK to 4.1.0.

We have 8 failures at the moment:

```
[ERROR] Failures: 
[ERROR]   ArgumentArraySizeWithLookupTest>Arquillian.arquillianBeforeClass:99 » Deployment Could not deploy ArgumentArraySizeWithLookupTest731093ffe4ebf3f9125ba36f0e8234a887e35.war
[ERROR]   ArgumentLookupBeanManagerTest>Arquillian.run:138->test:82 » UnsatisfiedResolution WELD-001334: Unsatisfied dependencies for type MyDependency with qualifiers  
[ERROR]   ArgumentLookupDependentTest>Arquillian.arquillianBeforeClass:99 » Deployment Could not deploy ArgumentLookupDependentTestb95addc2718d50c0364769cec7e6a1a7205710cf.war
[ERROR]   ArgumentLookupInstanceTest>Arquillian.run:138->test:77 » UnsatisfiedResolution WELD-001334: Unsatisfied dependencies for type MyDependency with qualifiers @Default 
[ERROR]   ArgumentLookupTest>Arquillian.arquillianBeforeClass:99 » Deployment Could not deploy ArgumentLookupTest57f83d3934eb5932ee628b7150c9ce24914edfbb.war
[ERROR]   InstanceLookupDependentTest>Arquillian.arquillianBeforeClass:99 » Deployment Could not deploy InstanceLookupDependentTest8527acf915e0c33bd744171613a58189f92a2458.war
[ERROR]   InstanceLookupStaticMethodTest>Arquillian.arquillianBeforeClass:99 » Deployment Could not deploy InstanceLookupStaticMethodTestcdbe3c553d1749fd46473244ddd717bc97eb9b6.war
[ERROR]   InstanceLookupTest>Arquillian.arquillianBeforeClass:99 » Deployment Could not deploy InstanceLookupTest956cf868d7f18f4baea611635812642cc94d9cd.war
[INFO] 
[ERROR] Tests run: 1346, Failures: 8, Errors: 0, Skipped: 12
```