### PR TITLE
Fix an issue with bin/startserv --suspend

### DIFF
--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -29,21 +29,27 @@ if [ ${AS_JAVA} ]; then
 fi
 
 start_as_main_process () {
-    local COMMAND
-
     if [[ "$@" == "--help" ]] || [[ "$@" == "--help=true" ]] || [[ "$@" == "-?" ]]; then
       exec java -jar "$ASADMIN_JAR" start-domain --help
     fi
 
     # Execute start-domain --dry-run and store the output line by line into an array.
-    # The first and last line will not be part of the command to execute, we'll remove them later.
+    # All lines before and including a line that starts with Dump (Dump of JVM Invocation line...) will be ignored.
+    # The last line will not be part of the command to execute, we'll it them later.
     # If command fails, the last item in the array will be "FAILED"
-    DRY_RUN_OUTPUT=()
+    local DRY_RUN_OUTPUT=()
+    local SKIP_LINES_UNTIL_DUMP=y
     while read COM; do
-      DRY_RUN_OUTPUT+=("$COM");
+      if [[ "$SKIP_LINES_UNTIL_DUMP" == y ]]; then
+        if [[ "$COM" == Dump* ]]; then
+          SKIP_LINES_UNTIL_DUMP=n
+        fi
+      else
+        DRY_RUN_OUTPUT+=("$COM");
+      fi
     done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" 2> /dev/null || echo "FAILED" )
-    OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
-    LAST_LINE=${DRY_RUN_OUTPUT[${OUTPUT_LENGTH}-1]}
+    local OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
+    local LAST_LINE=${DRY_RUN_OUTPUT[${OUTPUT_LENGTH}-1]}
 
     # If asadmin command failed (last line is FAILED), we execute it again to show
     #   the output to the user and exit
@@ -52,8 +58,8 @@ start_as_main_process () {
         exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --dry-run "$@"
       else
         # If all OK, execute the command to start GlassFish.
-        # Remove the first and last line as they aren't part of the command.
-        FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:1:${OUTPUT_LENGTH}-2})
+        # Remove the last line as they aren't part of the command.
+        local FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:0:${OUTPUT_LENGTH}-2})
         exec "${FINAL_COMMAND[@]}"
     fi
 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -64,9 +64,8 @@ import static com.sun.enterprise.util.SystemPropertyConstants.INSTALL_ROOT_PROPE
 import static com.sun.enterprise.util.SystemPropertyConstants.INSTANCE_ROOT_PROPERTY;
 import static com.sun.enterprise.util.SystemPropertyConstants.JAVA_ROOT_PROPERTY;
 import static java.lang.Boolean.TRUE;
+import static java.lang.System.Logger.Level.INFO;
 import static java.util.Collections.emptyList;
-import static java.util.logging.Level.INFO;
-import static java.util.logging.Level.WARNING;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -79,6 +78,8 @@ import static java.util.stream.Collectors.toList;
  */
 public abstract class GFLauncher {
 
+    private static final LocalStringsImpl I18N = new LocalStringsImpl(GFLauncher.class);
+    protected static final System.Logger LOG = System.getLogger(GFLauncher.class.getName(), I18N.getBundle());
     private final static LocalStringsImpl strings = new LocalStringsImpl(GFLauncher.class);
 
     /**
@@ -197,6 +198,12 @@ public abstract class GFLauncher {
      * @throws com.sun.enterprise.admin.launcher.GFLauncherException
      */
     public final void launch() throws GFLauncherException {
+        if (isDebugSuspend()) {
+            LOG.log(INFO, "ServerStart.DebuggerSuspendedMessage", debugPort);
+        } else if (debugPort >= 0) {
+            LOG.log(INFO, "ServerStart.DebuggerMessage", debugPort);
+        }
+
         try {
             startTime = System.currentTimeMillis();
             if (!setupCalledByClients) {
@@ -1063,9 +1070,9 @@ public abstract class GFLauncher {
 
     private void setupLogLevels() {
         if (callerParameters.isVerbose()) {
-            GFLauncherLogger.setConsoleLevel(INFO);
+            GFLauncherLogger.setConsoleLevel(java.util.logging.Level.INFO);
         } else {
-            GFLauncherLogger.setConsoleLevel(WARNING);
+            GFLauncherLogger.setConsoleLevel(java.util.logging.Level.WARNING);
         }
     }
 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/LocalStrings.properties
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/LocalStrings.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 # Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/LocalStrings.properties
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/LocalStrings.properties
@@ -63,3 +63,7 @@ rename_osgi_cache_failed=Failed to rename OSGi persistence store from {0} to {1}
 rename_osgi_cache_succeeded=Renamed OSGi persistence store from {0} to {1}
 
 no_flashlight_agent=Couldn''t locate the flashlight agent here: {0}
+
+ServerStart.DebuggerMessage=Debugging is enabled.  The debugging port is: {0}
+ServerStart.DebuggerSuspendedMessage=Debugging is enabled and the server is suspended.  \
+Please attach to the debugging port at: {0}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 # Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalStrings.properties
@@ -152,9 +152,6 @@ cause=Cause: {0}
 #start-domain and start-instance
 ServerRunning=There is a process already using the admin port {0} -- it probably is another instance of a GlassFish server.
 ServerStart.SuccessMessage=Successfully started the {0}: {1}\n{0} Location: {2}\nLog File: {3}\nAdmin Port: {4}
-ServerStart.DebuggerMessage=Debugging is enabled.  The debugging port is: {0}
-ServerStart.DebuggerSuspendedMessage=Debugging is enabled and the server is suspended.  \
-Please attach to the debugging port at: {0}
 DomainLocation=Started domain: {0}\nDomain location: {1}\nLog file: {2}
 DomainAdminPort=Admin port for the domain: {0}
 DomainDebugPort=Debug port for the domain: {0}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -68,7 +68,6 @@ public class StartServerHelper {
     private final String masterPassword;
     private final String serverOrDomainName;
     private final int debugPort;
-    private final boolean isDebugSuspend;
 
     public StartServerHelper(boolean terse, ServerDirs serverDirs, GFLauncher launcher, String masterPassword) {
         this(terse, serverDirs, launcher, masterPassword, false);
@@ -93,11 +92,6 @@ public class StartServerHelper {
 
         // it will be < 0 if both --debug is false and debug-enabled=false in jvm-config
         debugPort = launcher.getDebugPort();
-        isDebugSuspend = launcher.isDebugSuspend();
-
-        if (isDebugSuspend && debugPort >= 0) {
-            LOG.log(Level.INFO, "ServerStart.DebuggerSuspendedMessage", debugPort);
-        }
     }
 
 
@@ -193,9 +187,6 @@ public class StartServerHelper {
         }
         LOG.log(Level.INFO, "ServerStart.SuccessMessage", info.isDomain() ? "domain " : "instance",
             serverDirs.getServerName(), serverDirs.getServerDir(), logfile, adminPort);
-        if (debugPort >= 0) {
-            LOG.log(Level.INFO, "ServerStart.DebuggerMessage", debugPort);
-        }
     }
 
 

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -29,21 +29,27 @@ if [ ${AS_JAVA} ]; then
 fi
 
 start_as_main_process () {
-    local COMMAND
-
     if [[ "$@" == "--help" ]] || [[ "$@" == "--help=true" ]] || [[ "$@" == "-?" ]]; then
       exec java -jar "$ASADMIN_JAR" start-domain --help
     fi
 
     # Execute start-domain --dry-run and store the output line by line into an array.
-    # The first and last line will not be part of the command to execute, we'll remove them later.
+    # All lines before and including a line that starts with Dump (Dump of JVM Invocation line...) will be ignored.
+    # The last line will not be part of the command to execute, we'll it them later.
     # If command fails, the last item in the array will be "FAILED"
-    DRY_RUN_OUTPUT=()
+    local DRY_RUN_OUTPUT=()
+    local SKIP_LINES_UNTIL_DUMP=y
     while read COM; do
-      DRY_RUN_OUTPUT+=("$COM");
+      if [[ "$SKIP_LINES_UNTIL_DUMP" == y ]]; then
+        if [[ "$COM" == Dump* ]]; then
+          SKIP_LINES_UNTIL_DUMP=n
+        fi
+      else
+        DRY_RUN_OUTPUT+=("$COM");
+      fi
     done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" 2> /dev/null || echo "FAILED" )
-    OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
-    LAST_LINE=${DRY_RUN_OUTPUT[${OUTPUT_LENGTH}-1]}
+    local OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
+    local LAST_LINE=${DRY_RUN_OUTPUT[${OUTPUT_LENGTH}-1]}
 
     # If asadmin command failed (last line is FAILED), we execute it again to show
     #   the output to the user and exit
@@ -51,9 +57,9 @@ start_as_main_process () {
       then
         exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --dry-run "$@"
       else
-        # If all OK, execute the command to start GlassFish. 
-        # Remove the first and last line as they aren't part of the command.
-        FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:1:${OUTPUT_LENGTH}-2})
+        # If all OK, execute the command to start GlassFish.
+        # Remove the last line as they aren't part of the command.
+        local FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:0:${OUTPUT_LENGTH}-2})
         exec "${FINAL_COMMAND[@]}"
     fi
 


### PR DESCRIPTION
This improves the startserv script to ignore all lines until a line that starts with "Dump", which is followed by the command line to start the server.

At the same time, logging of debug ports is moved right before server starts, instead of logging them before the --dry-run option is processed. That caused the original issue, because it added one more line before the "Dump" line if `--suspend` was used.