### PR TITLE
Fixed for CDI 4.1 TCK. Now passes all tests.

### DIFF
--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -205,6 +205,12 @@
             <version>${htmlunit.version}</version>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+            <version>${weld.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
@@ -351,7 +357,6 @@
                     <excludedGroups>${excluded.groups}</excludedGroups>
                     <dependenciesToScan>
                         <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
-                        <dependency>jakarta.enterprise:cdi-tck-web-impl</dependency>
                     </dependenciesToScan>
                     <properties>
                         <property>

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -227,9 +227,13 @@ public class DeploymentImpl implements CDI11Deployment {
             LOG.log(FINE, LOAD_BEAN_DEPLOYMENT_ARCHIVE_ADD_NEW_BDA_TO_ROOTS, new Object[] {});
         }
 
+        // Add the new archive to all existing archives
         for (BeanDeploymentArchive beanDeploymentArchive : beanDeploymentArchives) {
             beanDeploymentArchive.getBeanDeploymentArchives().add(newBeanDeploymentArchive);
         }
+
+        // Add the existing archives archives to the new archive
+        newBeanDeploymentArchive.getBeanDeploymentArchives().addAll(beanDeploymentArchives);
 
         if (LOG.isLoggable(FINE)) {
             LOG.log(FINE, LOAD_BEAN_DEPLOYMENT_ARCHIVE_RETURNING_NEWLY_CREATED_BDA,


### PR DESCRIPTION
Fixes https://github.com/jakartaee/cdi-tck/issues/593

Result of running CDI TCK 4.1.0:

```
===============================================
CDI TCK
Total tests run: 1334, Passes: 1334, Failures: 0, Skips: 0
===============================================

[INFO] Tests run: 1334, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 354.5 s -- in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1334, Failures: 0, Errors: 0, Skipped: 0
```