### PR TITLE
Maven config templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mvn/maven.config
 *.ipr
 *.iml
 *.iws

--- a/.mvn/maven.config.template
+++ b/.mvn/maven.config.template
@@ -1,0 +1,81 @@
+############################################
+# Build GlassFish Server Full Distribution #
+############################################
+
+#-Pfastest
+#-T4C
+#-am
+#-pl
+#org.glassfish.main.distributions:glassfish
+
+###########################################
+# Build GlassFish Server Web Distribution #
+###########################################
+
+#-Pfastest 
+#-T4C
+#-am
+#-pl
+#org.glassfish.main.distributions:web
+
+##############################################
+# Build GlassFish Embedded Full Distribution #
+##############################################
+
+#-Pfastest
+#-T4C
+#-am
+#-pl
+#org.glassfish.main.extras:glassfish-embedded-all
+
+##############################################
+# Build GlassFish Embedded Full Distribution #
+##############################################
+
+#-Pfastest
+#-T4C
+#-am
+#-pl
+#org.glassfish.main.extras:glassfish-embedded-web
+
+###########################################################################
+# Repackage GlassFish Server (not for Embedded).                          #
+# Assembles already built GlassFish modules into GlassFish distributions. #
+# Suitable if modules are already built in an IDE.                        #
+###########################################################################
+
+#-Pfastest
+#-T4C
+#-rf
+#appserver/featuresets
+
+################################################################################
+# Building all distribution artifacts, running QA and all maven managed tests. #
+# Excludes Ant, TCK and documentation.                                         #
+# Typical time: 10 minutes.                                                    #
+################################################################################
+
+#-Pqa
+
+################################################################################
+# Building all distribution artifacts, running just unit tests.                #
+# Excludes QA, integration tests, Ant, TCK and documentation.                  #
+# Typical time: 7 minutes.                                                     #
+################################################################################
+
+#-Pfast
+
+############################################################
+# Building all distribution artifacts as fast as possible. #
+# Excludes everything not serving this purpose.            #
+# Typical time: 1.5 minutes.                               #
+############################################################
+
+#-Pfastest
+#-T4C
+
+#################################
+# Configure log level for tests #
+#################################
+
+#-Dtest.logLevel=FINEST

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The Zip distributions can be found on following paths:
 You can use also some maven optimizations, see [Maven documentation](https://maven.apache.org/ref/3.9.5/maven-embedder/cli.html).
 Especially `-am`, `-amd`, `-f`, `-pl`, `-rf` and their combinations are useful.
 
+If you use Maven 3.9+, we recommend that you copy the `.mvn/maven.config.template` file into `.mvn/maven.config` and uncomment one of the options there or customize the options as you need. Then you can just run `mvn clean install` and the options in `maven.config` will be applied automatically. Or with just `mvn`, the default goal will be run with those options. See [Configuring Maven Documentation](https://maven.apache.org/configure.html)
+
 If you want to see more logs you can use the `-Dtest.logLevel=FINEST` option set to an appropriate log level.
 Note that this applies just for tests which are executed by Maven and which use the **GlassFish Java Util Logging Extension (GJULE)**.
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,9 @@
          -->
         <profile>
             <id>fastest</id>
+            <properties>
+                <cyclonedx.skip>true</cyclonedx.skip>
+            </properties>
             <modules>
                 <module>qa</module>
                 <module>nucleus</module>


### PR DESCRIPTION
This adds Maven config templates that can be used in `.mvn/maven.config` (see https://maven.apache.org/configure.html).

The idea is that people can copy and modify these templates in their `.mvn/maven.config` file, which wouldn't be versioned. Then it's easy to speed up the build by selecting the target artifact (uncomment that artifact in the `maven.config` file), as an alternative to #24534.

For example, instead of executing `mvn clean install -Pfastest -pl 'org.glassfish.main.distributions:glassfish' -am -T4C` on command line to build only the GlassFish Server distribution with the fasted profile, it's possible to copy `.mvn/maven.config.template` into `.mvn/maven.config` and uncomment the following:

```
-Pfastest
-T4C
-am
-pl
org.glassfish.main.distributions:glassfish
```

Then just execute `mvn clean install` to clean and build the GlassFish Server distribution. Or just `mvn` to build it without clean.

I think this is simpler and cleaner solution than which I proposed earlier in #24534. If this PR as merged, I'm going to close #24534.

In this PR, I also added the `-Dcyclonedx.skip=true` property to the `fastest` profile. The CycloneDX SBOM check, which is not necessary and slows down the build by a few seconds: https://cyclonedx.org/.