### PR TITLE
Bump OpenMQ version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -110,7 +110,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.4.0</openmq.version>
+        <openmq.version>6.5.0</openmq.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>


### PR DESCRIPTION
Messaging TCK 3.1.0 - Summary: https://ci.eclipse.org/openmq/job/2_openmq-run-tck-against-staged-build_6.5.x/2/artifact/messaging-tck/bin/summary.txt