### PR TITLE
Integrate Nimbus 9.40

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,7 +99,7 @@
         <soteria.version>3.0.3</soteria.version>
         <exousia.version>2.1.2</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>9.39.1</nimbus.version>
+        <nimbus.version>9.40</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->


### PR DESCRIPTION
Changes: https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt

```
version 9.40 (2024-06-06)
    * New JWTClaimsSet.Builder.serializeNullClaims(boolean) method to control
      the serialisation of claims with null values when
      JWTClaimsSet.toPayload(), JWTClaimsSet.toJSONObject() or
      JWTClaimsSet.toString() is called. The serialisation to claims with null
      values is disabled by default. Note that with serializeNullClaims(true)
      the previous behaviour of JWTClaimsSet.toPayload(),
      JWTClaimsSet.toJSONObject() and JWTClaimsSet.toString() will no longer
      apply and claims will null values will be serialised.
    * Fixes regression, JWTClaimsSet.Builder.build() must not by default
      serialise claims with null values (iss #549).
```

