### PR TITLE
Remove Jersey-MOXy integration module from GlassFish distributions

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2023 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2024 Contributors to Eclipse Foundation.
     Copyright (c) 2015, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -164,6 +164,9 @@
           </dependency>
 
         <!-- Jersey -->
+        <!-- Since MOXy has been removed from GlassFish,
+             the Jersey-MOXy integration module should not be there.
+             See https://github.com/eclipse-ee4j/glassfish/issues/24749
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-moxy</artifactId>
@@ -174,6 +177,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        -->
         <dependency>
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-cdi1x</artifactId>


### PR DESCRIPTION
Closes #24749, closes #25009
