### PR TITLE
Fixed CDI TCK signature test

### DIFF
--- a/appserver/tests/tck/cdi/cdi-signature/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-signature/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>glassfish-external-tck-cdi-signature</artifactId>
 
-    <name>CDI TCK Signature runner 4.0 for Weld (GlassFish)</name>
+    <name>CDI TCK Signature runner for Weld (GlassFish)</name>
     <description>Aggregates dependencies and runs the CDI Signature TCK on GlassFish</description>
 
     <build>
@@ -50,7 +50,7 @@
                                     <artifactId>cdi-tck-core-impl</artifactId>
                                     <version>${cdi.tck-4-1.version}</version>
                                     <type>sig</type>
-                                    <classifier>sigtest-jdk11</classifier>
+                                    <classifier>sigtest-jdk17</classifier>
                                     <outputDirectory>${project.build.directory}/sigtest</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
@@ -122,7 +122,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <sigfile>target/sigtest/cdi-tck-core-impl-sigtest-jdk11.sig</sigfile>
+                    <sigfile>target/sigtest/cdi-tck-core-impl-sigtest-jdk17.sig</sigfile>
                     <packages>jakarta.decorator,jakarta.enterprise,jakarta.interceptor</packages>
                     <classes>target/cdi-sigtest-classes</classes>
                     <report>target/cdi-sig-report.txt</report>


### PR DESCRIPTION
The jdk11 is not available at https://jakarta.oss.sonatype.org/content/repositories/staging/jakarta/enterprise/cdi-tck-core-impl/4.1.0/
