### PR TITLE
Fix the startserv script if server is already running

### DIFF
--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
@@ -39,29 +39,29 @@ start_as_main_process () {
     # If command fails, the last item in the array will be "FAILED"
     local DRY_RUN_OUTPUT=()
     local SKIP_LINES_UNTIL_DUMP=y
+    local DRY_RUN_OUTPUT_BEFORE_DUMP=
     while read COM; do
       if [[ "$SKIP_LINES_UNTIL_DUMP" == y ]]; then
         if [[ "$COM" == Dump* ]]; then
           SKIP_LINES_UNTIL_DUMP=n
+        elif [[ "$COM" != "FAILED" ]]; then
+          DRY_RUN_OUTPUT_BEFORE_DUMP+="$COM\n";
         fi
       else
         DRY_RUN_OUTPUT+=("$COM");
       fi
-    done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" 2> /dev/null || echo "FAILED" )
-    local OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
-    local LAST_LINE=${DRY_RUN_OUTPUT[${OUTPUT_LENGTH}-1]}
-
-    # If asadmin command failed (last line is FAILED), we execute it again to show
-    #   the output to the user and exit
-    if [[ "$LAST_LINE" == FAILED ]]
+    done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" || echo "FAILED" )
+    if [[ x"$DRY_RUN_OUTPUT" == x ]]
       then
-        exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --dry-run "$@"
-      else
-        # If all OK, execute the command to start GlassFish.
-        # Remove the last line as they aren't part of the command.
-        local FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:0:${OUTPUT_LENGTH}-2})
-        exec "${FINAL_COMMAND[@]}"
+        echo -n -e "${DRY_RUN_OUTPUT_BEFORE_DUMP}" >&2
+        exit 1
     fi
+    local OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
+
+    # If all OK, execute the command to start GlassFish.
+    # Remove the last line as it's not part of the command.
+    local FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:0:${OUTPUT_LENGTH}-2})
+    exec "${FINAL_COMMAND[@]}"
 
 }
 

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -41,6 +41,7 @@ import java.util.logging.Logger;
 import org.glassfish.admin.rest.client.ClientWrapper;
 import org.glassfish.main.itest.tools.asadmin.Asadmin;
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.glassfish.main.itest.tools.asadmin.StartServ;
 
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -63,6 +64,7 @@ public class GlassFishTestEnvironment {
     private static final String ADMIN_PASSWORD = "admintest";
 
     private static final File ASADMIN = findAsadmin();
+    private static final File STARTSERV = findStartServ();
     private static final File KEYTOOL = findKeyTool();
     private static final File PASSWORD_FILE_FOR_UPDATE = findPasswordFile("password_update.txt");
     private static final File PASSWORD_FILE = findPasswordFile("password.txt");
@@ -82,7 +84,7 @@ public class GlassFishTestEnvironment {
             // AS_START_TIMEOUT for the detection that "the server is running!"
             // START_DOMAIN_TIMEOUT for us waiting for the end of the asadmin start-domain process.
             asadmin.withEnv("AS_START_TIMEOUT", Integer.toString(ASADMIN_START_DOMAIN_TIMEOUT - 5000));
-        }
+    }
         // This is the absolutely first start - if it fails, all other starts will fail too.
         assertThat(asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "start-domain",
                 getConfigBoolean("glassfish.suspend") ? "--suspend" : "--debug"), asadminOK());
@@ -94,6 +96,21 @@ public class GlassFishTestEnvironment {
      */
     public static Asadmin getAsadmin() {
         return new Asadmin(ASADMIN, ADMIN_USER, PASSWORD_FILE);
+    }
+
+
+    /**
+     * @return {@link Asadmin} command api for tests.
+     */
+    public static StartServ getStartServ() {
+        return new StartServ(STARTSERV);
+    }
+
+    /**
+     * @return {@link Asadmin} command api for tests.
+     */
+    public static StartServ getStartServInTopLevelBin() {
+        return new StartServ(findStartServ("../"));
     }
 
 
@@ -260,6 +277,10 @@ public class GlassFishTestEnvironment {
         return new File(GF_ROOT, isWindows() ? "bin/asadmin.bat" : "bin/asadmin");
     }
 
+    private static File findStartServ(String... optionalPrefix) {
+        String prefix = optionalPrefix.length > 0 ? optionalPrefix[0] : "";
+        return new File(GF_ROOT, isWindows() ? prefix + "bin/startserv.bat" : prefix + "bin/startserv");
+    }
 
     private static File findKeyTool() {
         return new File(System.getProperty("java.home"), isWindows() ? "bin/keytool.exe" : "bin/keytool");

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/StartServ.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/StartServ.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.itest.tools.asadmin;
+
+import com.sun.enterprise.universal.process.ProcessManager;
+import com.sun.enterprise.universal.process.ProcessManagerException;
+import com.sun.enterprise.universal.process.ProcessManagerTimeoutException;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Tool for executing startserv command.
+ * The tool is stateless.
+ *
+ * @author Ondro Mihalyi
+ */
+public class StartServ {
+    private static final Logger LOG = Logger.getLogger(StartServ.class.getName());
+
+    private static final int DEFAULT_TIMEOUT_MSEC = 30 * 1000;
+
+    private final File startServ;
+    private final Map<String, String> environment = new HashMap<>();
+    private String textToWaitFor;
+
+    /**
+     * Creates a stateless instance of the tool.
+     *
+     * @param startServ - executable file
+     */
+    public StartServ(final File startServ) {
+        this.startServ = startServ;
+    }
+
+
+    /**
+     * Adds environment property set for the asadmin execution.
+     *
+     * @param name
+     * @param value
+     * @return this
+     */
+    public StartServ withEnv(final String name, final String value) {
+        this.environment.put(name, value);
+        return this;
+    }
+
+    /**
+     * Wait for this text in stdout or stderr and exit if found, or until timeout. Don't wait for the process to stop
+     *
+     * @param textToWaitFor
+     * @return this
+     */
+    public StartServ withTextToWaitFor(final String textToWaitFor) {
+        this.textToWaitFor = textToWaitFor;
+        return this;
+    }
+
+    /**
+     * Do not wait for any text in stdout or stderr, wait for the process to stop or until timeout
+     *
+     * @return this
+     */
+    public StartServ withNoTextToWaitFor() {
+        this.textToWaitFor = null;
+        return this;
+    }
+
+    /**
+     * @return asadmin command file name
+     */
+    public String getCommandName() {
+        return startServ.getName();
+    }
+
+    /**
+     * Executes the command with arguments, waits until its standard output contains given text.
+     * Doesn't terminate the command, the command should either stop later or should be killed later.
+     *
+     * @param args command and arguments.
+     * @return {@link AsadminResult} never null. OK if text found in output, error if not found and command terminates or timeout reached.
+     */
+    public AsadminResult exec(final String... args) {
+        return StartServ.this.exec(DEFAULT_TIMEOUT_MSEC, args);
+    }
+
+    /**
+     * Executes the command with arguments.
+     *
+     * @param timeout timeout in millis
+     * @param args command and arguments.
+     * @return {@link AsadminResult} never null.
+     */
+    public AsadminResult exec(final int timeout, final String... args) {
+        final List<String> parameters = Arrays.asList(args);
+        LOG.log(Level.INFO, "exec(script={0}, timeout={1}, args={2})",
+            new Object[] {startServ.getName(), timeout, parameters});
+        final List<String> command = new ArrayList<>();
+        command.add(startServ.getAbsolutePath());
+        command.addAll(parameters);
+
+        final ProcessManager processManager = new ProcessManager(command);
+        processManager.setTimeoutMsec(timeout);
+        processManager.setEcho(false);
+        processManager.setTextToWaitFor(textToWaitFor);
+        for (Entry<String, String> env : this.environment.entrySet()) {
+            processManager.setEnvironment(env.getKey(), env.getValue());
+        }
+        if (System.getenv("AS_TRACE") == null && LOG.isLoggable(Level.FINEST)) {
+            processManager.setEnvironment("AS_TRACE", "true");
+        }
+        // override any env property to what is used by tests
+        processManager.setEnvironment("JAVA_HOME", System.getProperty("java.home"));
+        processManager.setEnvironment("AS_JAVA", System.getProperty("java.home"));
+
+        int exitCode;
+        String asadminErrorMessage = "";
+        try {
+            exitCode = processManager.execute();
+        } catch (final ProcessManagerTimeoutException e) {
+            asadminErrorMessage = e.getMessage();
+            exitCode = 1;
+        } catch (final ProcessManagerException e) {
+            LOG.log(Level.SEVERE, "The execution failed.", e);
+            asadminErrorMessage = e.getMessage();
+            exitCode = 1;
+        }
+
+        final String stdErr = processManager.getStderr() + '\n' + asadminErrorMessage;
+        final AsadminResult result;
+        result = new AsadminResult(this.getCommandName(), exitCode, processManager.getStdout(), stdErr);
+        if (!result.getStdOut().isEmpty()) {
+            System.out.println(result.getStdOut());
+        }
+        if (!result.getStdErr().isEmpty()) {
+            System.err.println(result.getStdErr());
+        }
+        return result;
+    }
+
+}

--- a/appserver/tests/admin/tests/pom.xml
+++ b/appserver/tests/admin/tests/pom.xml
@@ -103,6 +103,10 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/StartServITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/StartServITest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.admin.test;
+
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.stream.Stream;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.itest.tools.asadmin.StartServ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+/**
+ * @author Ondro Mihalyi
+ */
+public class StartServITest {
+
+    private static final StartServ STARTSERV = GlassFishTestEnvironment.getStartServ();
+    private static final StartServ STARTSERV_IN_TOPLEVEL_BIN = GlassFishTestEnvironment.getStartServInTopLevelBin();
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+    private static final String STARTSERV_DOMAIN_NAME = "startserv-domain";
+    private static final String NOT_EXISTING_DOMAIN_NAME = "not-existing-domain";
+
+    @BeforeAll
+    static void setupDomain() {
+        AsadminResult result = ASADMIN.exec("list-domains");
+        if (!result.getOutput().contains(STARTSERV_DOMAIN_NAME)) {
+            ASADMIN.exec("create-domain", "--nopassword", STARTSERV_DOMAIN_NAME);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(StartServArgumentsProvider.class)
+    public void startServerInForeground(StartServ startServ) {
+        try {
+            AsadminResult result = startServ.withTextToWaitFor("Total startup time including CLI").exec(STARTSERV_DOMAIN_NAME);
+            assertThat(result, asadminOK());
+        } finally {
+            ASADMIN.exec("stop-domain", STARTSERV_DOMAIN_NAME);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(StartServArgumentsProvider.class)
+    public void reportCorrectErrorIfAlreadyRunning(StartServ startServ) {
+        try {
+            AsadminResult result = startServ.withTextToWaitFor("Total startup time including CLI").exec(STARTSERV_DOMAIN_NAME);
+            assertThat(result, asadminOK());
+            result = startServ.withNoTextToWaitFor().exec(STARTSERV_DOMAIN_NAME);
+            assertThat(result.getStdErr(), containsString("There is a process already using the admin port"));
+        } finally {
+            ASADMIN.exec("stop-domain", STARTSERV_DOMAIN_NAME);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(StartServArgumentsProvider.class)
+    public void reportCorrectErrorIfInvalidCommand(StartServ startServ) {
+        AsadminResult result = startServ.withNoTextToWaitFor().exec(NOT_EXISTING_DOMAIN_NAME);
+        assertThat(result.getStdErr(), containsString("There is no such domain directory"));
+    }
+
+    @AfterAll
+    static void deleteDomain() {
+        AsadminResult result = ASADMIN.exec("list-domains");
+        if (result.getOutput().contains(STARTSERV_DOMAIN_NAME)) {
+            ASADMIN.exec("delete-domain", STARTSERV_DOMAIN_NAME);
+        }
+    }
+
+    static class StartServArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of(STARTSERV),
+                    Arguments.of(STARTSERV_IN_TOPLEVEL_BIN)
+            );
+        }
+    }
+}

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
@@ -17,7 +17,6 @@
 
 package com.sun.enterprise.universal.process;
 
-import static java.time.Duration.ofSeconds;
 
 import com.sun.enterprise.util.OS;
 
@@ -132,11 +131,12 @@ public class ProcessManagerTest {
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
     void testDetectTextInStdOutIfProcessStops() throws InterruptedException {
+        int sleepTimeSeconds = 1;
         ProcessManager pm = new ProcessManager("sh", "-c", "echo \"start\nhello\ncontinue\"");
         pm.setEcho(false);
         pm.setTextToWaitFor("hello");
         int exitCode = assertDoesNotThrow(pm::execute);
-        Thread.sleep(ofSeconds(1));
+        Thread.sleep(sleepTimeSeconds * 1000);
         assertAll(
                 () -> assertEquals(0, exitCode),
                 () -> assertEquals("start\nhello\ncontinue\n", pm.getStdout())

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
@@ -39,29 +39,29 @@ start_as_main_process () {
     # If command fails, the last item in the array will be "FAILED"
     local DRY_RUN_OUTPUT=()
     local SKIP_LINES_UNTIL_DUMP=y
+    local DRY_RUN_OUTPUT_BEFORE_DUMP=
     while read COM; do
       if [[ "$SKIP_LINES_UNTIL_DUMP" == y ]]; then
         if [[ "$COM" == Dump* ]]; then
           SKIP_LINES_UNTIL_DUMP=n
+        elif [[ "$COM" != "FAILED" ]]; then
+          DRY_RUN_OUTPUT_BEFORE_DUMP+="$COM\n";
         fi
       else
         DRY_RUN_OUTPUT+=("$COM");
       fi
-    done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" 2> /dev/null || echo "FAILED" )
-    local OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
-    local LAST_LINE=${DRY_RUN_OUTPUT[${OUTPUT_LENGTH}-1]}
-
-    # If asadmin command failed (last line is FAILED), we execute it again to show
-    #   the output to the user and exit
-    if [[ "$LAST_LINE" == FAILED ]]
+    done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" || echo "FAILED" )
+    if [[ x"$DRY_RUN_OUTPUT" == x ]]
       then
-        exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --dry-run "$@"
-      else
-        # If all OK, execute the command to start GlassFish.
-        # Remove the last line as they aren't part of the command.
-        local FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:0:${OUTPUT_LENGTH}-2})
-        exec "${FINAL_COMMAND[@]}"
+        echo -n -e "${DRY_RUN_OUTPUT_BEFORE_DUMP}" >&2
+        exit 1
     fi
+    local OUTPUT_LENGTH=${#DRY_RUN_OUTPUT[@]}
+
+    # If all OK, execute the command to start GlassFish.
+    # Remove the last line as it's not part of the command.
+    local FINAL_COMMAND=(${DRY_RUN_OUTPUT[@]:0:${OUTPUT_LENGTH}-2})
+    exec "${FINAL_COMMAND[@]}"
 
 }
 


### PR DESCRIPTION
Also report the error immediately, don't run the command again

Adds tests for the startserv script. For that, improves the process manager to allow waiting until a text it output instead of waiting for the process to complete.