### PR TITLE
Fixes Jakarta Servlet API version

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -887,7 +887,7 @@
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
-                            <specVersion>${jakarta.servlet-api.version}</specVersion>
+                            <specVersion>6.0</specVersion>
                             <specImplVersion>${jakarta.servlet-api.version}</specImplVersion>
                             <apiPackage>jakarta.servlet</apiPackage>
                         </spec>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -883,12 +883,12 @@
                             <artifact>
                                 <groupId>jakarta.servlet</groupId>
                                 <artifactId>jakarta.servlet-api</artifactId>
-                                <version>${servlet-api.version}</version>
+                                <version>${jakarta.servlet-api.version}</version>
                             </artifact>
                             <nonFinal>false</nonFinal>
                             <jarType>api</jarType>
-                            <specVersion>3.1</specVersion>
-                            <specImplVersion>${servlet-api.version}</specImplVersion>
+                            <specVersion>${jakarta.servlet-api.version}</specVersion>
+                            <specImplVersion>${jakarta.servlet-api.version}</specImplVersion>
                             <apiPackage>jakarta.servlet</apiPackage>
                         </spec>
                         <spec>

--- a/appserver/tests/cdi/cases/preDestroyScoping/web/pom.xml
+++ b/appserver/tests/cdi/cases/preDestroyScoping/web/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
     Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -51,7 +52,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/hk2/cdi/ear/war1/pom.xml
+++ b/appserver/tests/hk2/cdi/ear/war1/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
     Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -58,7 +59,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/hk2/cdi/ear/war2/pom.xml
+++ b/appserver/tests/hk2/cdi/ear/war2/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
     Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -58,7 +59,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/hk2/isolation/web/iso1/pom.xml
+++ b/appserver/tests/hk2/isolation/web/iso1/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
     Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -45,7 +46,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/hk2/isolation/web/iso2/pom.xml
+++ b/appserver/tests/hk2/isolation/web/iso2/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to Eclipse Foundation.
     Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -45,7 +46,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fixes Jakarta Servlet API version in various POMs.

If we build GlassFish with the empty maven cache:

```sh
mvn clean install -Pstaging
```
the local maven repo contains strange artifact:

![image](https://github.com/eclipse-ee4j/glassfish/assets/57197113/cd5438a7-f7dc-4a21-877c-4e1731055db0)
