### PR TITLE
Admin Logger: Invoke event from a single central point

### DIFF
--- a/appserver/tests/extras/command-logger/src/test/java/org/glassfish/main/test/extras/commandlogger/CommandLoggerITest.java
+++ b/appserver/tests/extras/command-logger/src/test/java/org/glassfish/main/test/extras/commandlogger/CommandLoggerITest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.params.provider.CsvSource;
  *
  * @author Ondro Mihalyi
  */
-public class CommandLoggerTest {
+public class CommandLoggerITest {
 
     private static final Asadmin ASADMIN = getAsadmin();
 

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/admin/CommandResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/admin/CommandResource.java
@@ -44,8 +44,6 @@ import org.glassfish.api.ActionReport;
 import org.glassfish.api.admin.*;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.Globals;
-import org.glassfish.internal.api.events.CommandInvokedEvent;
-import org.glassfish.internal.api.events.InvokeEventService;
 import org.glassfish.jersey.internal.util.collection.Ref;
 import org.glassfish.jersey.media.sse.SseFeature;
 
@@ -358,9 +356,6 @@ public class CommandResource {
         if (inbound != null) {
             commandInvocation.inbound(inbound);
         }
-        InvokeEventService.get()
-                .getCommandInvokedTopic()
-                .publish(new CommandInvokedEvent(commandName.getName(), params, getSubject(), this.getClass().getSimpleName()));
         commandInvocation.outbound(outbound).parameters(params).execute();
         ar = (ActionReporter) commandInvocation.report();
         fixActionReporterSpecialCases(ar);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/ResourceUtil.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/ResourceUtil.java
@@ -92,8 +92,6 @@ import static org.glassfish.admin.rest.utils.Util.eleminateHypen;
 import static org.glassfish.admin.rest.utils.Util.getHtml;
 import static org.glassfish.admin.rest.utils.Util.methodNameFromDtdName;
 
-import org.glassfish.internal.api.events.CommandInvokedEvent;
-import org.glassfish.internal.api.events.InvokeEventService;
 
 
 
@@ -225,10 +223,6 @@ public class ResourceUtil {
      * @return
      */
     public static RestActionReporter runCommand(String commandName, ParameterMap parameters, Subject subject, boolean managedJob) {
-
-        InvokeEventService.get()
-                .getCommandInvokedTopic()
-                .publish(new CommandInvokedEvent(commandName, parameters, subject, ResourceUtil.class.getSimpleName()));
 
         CommandRunner cr = Globals.getDefaultHabitat().getService(CommandRunner.class);
         RestActionReporter ar = new RestActionReporter();

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/events/CommandInvokedEvent.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/events/CommandInvokedEvent.java
@@ -15,9 +15,11 @@
  */
 package org.glassfish.internal.api.events;
 
+import java.util.Optional;
 import javax.security.auth.Subject;
 import org.glassfish.api.admin.ParameterMap;
 import org.glassfish.hk2.api.messaging.MessageReceiver;
+import org.glassfish.security.common.UserPrincipal;
 
 /**
  * <p>
@@ -62,17 +64,15 @@ public class CommandSubscriber {
  */
 public class CommandInvokedEvent {
 
-    public CommandInvokedEvent(String commandName, ParameterMap parameters, Subject subject, String source) {
+    public CommandInvokedEvent(String commandName, ParameterMap parameters, Subject subject) {
         this.commandName = commandName;
         this.parameters = parameters;
         this.subject = subject;
-        this.source = source;
     }
 
     private final String commandName;
     private final ParameterMap parameters;
     private final Subject subject;
-    private final String source;
 
     public String getCommandName() {
         return commandName;
@@ -86,8 +86,11 @@ public class CommandInvokedEvent {
         return subject;
     }
 
-    public String getSource() {
-        return source;
+    public Optional<UserPrincipal> getUserPrincipal() {
+        return subject.getPrincipals().stream()
+                .filter(principal -> principal instanceof UserPrincipal)
+                .map(UserPrincipal.class::cast)
+                .findAny();
     }
 
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
@@ -179,6 +179,9 @@ public class CommandRunnerImpl implements CommandRunner {
     @Inject
     private CommandSecurityChecker commandSecurityChecker;
 
+    @Inject
+    private InvokeEventService eventService;
+
     /**
      * Returns an initialized ActionReport instance for the passed type or
      * null if it cannot be found.
@@ -1641,8 +1644,7 @@ public class CommandRunnerImpl implements CommandRunner {
                 invocation.name(),
                 invocation.parameters(),
                 subject);
-        InvokeEventService.get()
-                .getCommandInvokedTopic()
+        eventService.getCommandInvokedTopic()
                 .publish(event);
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
@@ -1640,8 +1640,7 @@ public class CommandRunnerImpl implements CommandRunner {
         final CommandInvokedEvent event = new CommandInvokedEvent(
                 invocation.name(),
                 invocation.parameters(),
-                subject,
-                CommandRunner.class.getSimpleName());
+                subject);
         InvokeEventService.get()
                 .getCommandInvokedTopic()
                 .publish(event);

--- a/nucleus/extras/command-logger/src/main/java/org/glassfish/extras/commandlogger/AdminCommandLogger.java
+++ b/nucleus/extras/command-logger/src/main/java/org/glassfish/extras/commandlogger/AdminCommandLogger.java
@@ -56,7 +56,7 @@ public class AdminCommandLogger {
             logger.log(INFO, () -> {
                 return userPrincipalMaybe.map(user -> "User " + user.getName())
                         .orElse("Unknown user")
-                        + " executed command in the Admin Console: " + commandLine;
+                        + " executed admin command: " + commandLine;
             });
         }
 

--- a/nucleus/extras/command-logger/src/main/java/org/glassfish/extras/commandlogger/AdminCommandLogger.java
+++ b/nucleus/extras/command-logger/src/main/java/org/glassfish/extras/commandlogger/AdminCommandLogger.java
@@ -48,14 +48,13 @@ public class AdminCommandLogger {
                 event.getParameters(),
                 event.getUserPrincipal()
                         .map(UserPrincipal::getName)
-                        .orElse(null));
+                        .orElse("Unknown user"));
     }
 
     public void logCommand(String commandName, ParameterMap parameters, String userName) {
         if (shouldLogCommand(commandName)) {
             String commandLine = constructCommandLine(commandName, parameters);
-            logger.log(INFO, () -> userName != null ? "User " + userName : "Unknown user"
-                        + " executed admin command: " + commandLine
+            logger.log(INFO, () -> "User " + userName + " executed admin command: " + commandLine
             );
         }
     }

--- a/nucleus/extras/command-logger/src/main/java/org/glassfish/extras/commandlogger/AdminCommandLogger.java
+++ b/nucleus/extras/command-logger/src/main/java/org/glassfish/extras/commandlogger/AdminCommandLogger.java
@@ -21,9 +21,7 @@ import static java.util.stream.Collectors.joining;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
-import javax.security.auth.Subject;
 import org.glassfish.api.StartupRunLevel;
 import org.glassfish.api.admin.ParameterMap;
 import org.glassfish.config.support.TranslatedConfigView;
@@ -46,20 +44,20 @@ public class AdminCommandLogger {
     private static final System.Logger logger = System.getLogger(AdminCommandLogger.class.getName());
 
     public void receiveCommandInvokedEvent(@SubscribeTo CommandInvokedEvent event) {
-        logCommand(event.getCommandName(), event.getParameters(), event.getSubject());
+        logCommand(event.getCommandName(),
+                event.getParameters(),
+                event.getUserPrincipal()
+                        .map(UserPrincipal::getName)
+                        .orElse(null));
     }
 
-    public void logCommand(String commandName, ParameterMap parameters, Subject subject) {
+    public void logCommand(String commandName, ParameterMap parameters, String userName) {
         if (shouldLogCommand(commandName)) {
             String commandLine = constructCommandLine(commandName, parameters);
-            Optional<UserPrincipal> userPrincipalMaybe = getUserPrincipal(subject);
-            logger.log(INFO, () -> {
-                return userPrincipalMaybe.map(user -> "User " + user.getName())
-                        .orElse("Unknown user")
-                        + " executed admin command: " + commandLine;
-            });
+            logger.log(INFO, () -> userName != null ? "User " + userName : "Unknown user"
+                        + " executed admin command: " + commandLine
+            );
         }
-
     }
 
     private String constructCommandLine(String commandName, ParameterMap parameters) {
@@ -129,13 +127,6 @@ public class AdminCommandLogger {
 
     private boolean isInternalCommand(String commandName) {
         return commandName.matches("_(.*)");
-    }
-
-    private Optional<UserPrincipal> getUserPrincipal(Subject subject) {
-        return subject.getPrincipals().stream()
-                .filter(principal -> principal instanceof UserPrincipal)
-                .map(UserPrincipal.class::cast)
-                .findAny();
     }
 
 }

--- a/nucleus/test-utils/pom.xml
+++ b/nucleus/test-utils/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- Used in Hk2 junit extension to initialize the HK2 Topic service -->
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-extras</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2JUnit5Extension.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2JUnit5Extension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -72,6 +72,7 @@ import static org.glassfish.hk2.utilities.ServiceLocatorUtilities.addOneDescript
 import static org.glassfish.hk2.utilities.ServiceLocatorUtilities.createAndPopulateServiceLocator;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.glassfish.hk2.extras.ExtrasUtilities;
 
 /**
  * This JUnit5 extension allows to use HK2 services in tests.
@@ -145,6 +146,8 @@ public class HK2JUnit5Extension
             ServiceLocatorUtilities.dumpAllDescriptors(locator, System.err);
             throw e;
         }
+
+        ExtrasUtilities.enableTopicDistribution(getLocator());
     }
 
 


### PR DESCRIPTION
Refactoring to simplify the code - trigger the invoke command event from a single core place, just before an admin command is executed. No need to trigger it in 2 places, and also covers the case, when the command is executed directly via GlassFish API, not just via the REST interface. 