### PR TITLE
Enhancement: Respect scheme from the serverName listener property in redirect URLs

### DIFF
--- a/appserver/admingui/web/src/main/help/en/help/ref-httplisteneredit.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-httplisteneredit.html
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/help/en/help/ref-httplisteneredit.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-httplisteneredit.html
@@ -69,7 +69,7 @@
 <dt>Server Name</dt>
 <dd>
 <p>The host name to be used in the URLs the server sends to the client. This name is the alias name if your server uses an alias. If your server does not use an alias, leave this field blank.</p>
-<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client.</p>
+<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client. If a scheme and <code>://</code> are prepended, the scheme will be used in the URLs.</p>
 </dd>
 </dl>
 <a id="sthref117" name="sthref117"></a>

--- a/appserver/admingui/web/src/main/help/en/help/ref-httplistenernew.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-httplistenernew.html
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/help/en/help/ref-httplistenernew.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-httplistenernew.html
@@ -65,7 +65,7 @@
 <dt>Server Name</dt>
 <dd>
 <p>The host name to be used in the URLs the server sends to the client. This name is the alias name if your server uses an alias. If your server does not use an alias, leave this field blank.</p>
-<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client.</p>
+<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client. If a scheme and <code>://</code> are prepended, the scheme will be used in the URLs.</p>
 </dd>
 </dl>
 <a id="sthref114" name="sthref114"></a>

--- a/appserver/admingui/web/src/main/help/en/help/ref-protocolnew.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-protocolnew.html
@@ -60,7 +60,7 @@
 <dt>Server Name</dt>
 <dd>
 <p>The host name to be used in the URLs the server sends to the client. This name is the alias name if your server uses an alias. If your server does not use an alias, leave this field blank.</p>
-<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client.</p>
+<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client. If a scheme and <code>://</code> are prepended, the scheme will be used in the URLs.</p>
 </dd>
 <dt>Default Virtual Server</dt>
 <dd>

--- a/appserver/admingui/web/src/main/help/en/help/ref-protocolnew.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-protocolnew.html
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/help/en/help/task-httplisteneredit.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-httplisteneredit.html
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/help/en/help/task-httplisteneredit.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-httplisteneredit.html
@@ -67,7 +67,7 @@
 <li>
 <p>In the Server Name field, type the host name to be used in the URLs the server sends to the client.</p>
 <p>This name is the alias name if your server uses an alias. If your server does not use an alias, leave this field blank.</p>
-<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client.</p>
+<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client. If a scheme and <code>://</code> are prepended, the scheme will be used in the URLs.</p>
 </li>
 <li>
 <p>Click Save.</p>

--- a/appserver/admingui/web/src/main/help/en/help/task-httplistenernew.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-httplistenernew.html
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/help/en/help/task-httplistenernew.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-httplistenernew.html
@@ -72,7 +72,7 @@
 <li>
 <p>In the Server Name field, type the host name to be used in the URLs the server sends to the client.</p>
 <p>This name is the alias name if your server uses an alias. If your server does not use an alias, leave this field blank.</p>
-<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client.</p>
+<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client. If a scheme and <code>://</code> are prepended, the scheme will be used in the URLs.</p>
 </li>
 <li>
 <p>Click OK.</p>

--- a/appserver/admingui/web/src/main/help/en/help/task-protocolnew.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-protocolnew.html
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/help/en/help/task-protocolnew.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-protocolnew.html
@@ -64,7 +64,7 @@
 <li>
 <p>In the Server Name field, type the host name to be used in the URLs the server sends to the client.</p>
 <p>This name is the alias name if your server uses an alias. If your server does not use an alias, leave this field blank.</p>
-<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client.</p>
+<p>This value affects URLs the server automatically generates; it does not affect the URLs for directories and files stored in the server. If your server uses an alias, the server-name should be the alias name. If a colon and port number are appended, that port is used in URLs the server sends to the client. If a scheme and <code>://</code> are prepended, the scheme will be used in the URLs.</p>
 </li>
 <li>
 <p>From the Default Virtual Server drop-down list, select the virtual server to be associated with this protocol.</p>

--- a/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
+++ b/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2024 Contributors to the Eclipse Foundation.
 # Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the

--- a/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
+++ b/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
@@ -210,7 +210,7 @@ grizzly.httpPageTitle=HTTP
 grizzly.httpPageTitleHelp=Modify HTTP settings for the protocol.
 
 http.serverNameLabel=Server Name:
-http.serverNameHelp=Alias name if server uses an alias. If a colon and port number are appended, that port will be used in URLs the server sends to the client.
+http.serverNameHelp=Alias name if server uses an alias. A colon and port number can be appended. Scheme and :// can be prepended. They will be used in URLs the server sends to the client.
 http.Adapter=Adapter:
 http.AdapterHelp=Class name of the static resources adapter
 http.defVirtualServerLabel=Default Virtual Server:

--- a/appserver/tests/admin/tests/pom.xml
+++ b/appserver/tests/admin/tests/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -101,6 +102,10 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/ConnectionUtils.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/ConnectionUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.admin.test;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class ConnectionUtils {
+    /**
+     * This method opens a connection to the given URL and returns the string that is returned from that URL. This is
+     * useful for simple servlet retrieval
+     *
+     * @param urlstr The URL to connect to
+     * @return The string returned from that URL, or empty string if there was a problem contacting the URL
+     */
+    public static String getURL(String urlstr) {
+        URLConnection urlc = openConnection(urlstr);
+        return getContent(urlc);
+    }
+
+    /**
+     * This method retrieves the content of the connection response as plain String
+     *
+     * @param connection
+     * @return The string returned from that connection, or empty string if there was a problem contacting the URL
+     */
+    public static String getContent(URLConnection connection) {
+        try (
+                BufferedReader ir = new BufferedReader(new InputStreamReader(connection.getInputStream(), ISO_8859_1)); StringWriter ow = new StringWriter()) {
+            String line;
+            while ((line = ir.readLine()) != null) {
+                ow.write(line);
+                ow.write("\n");
+            }
+            return ow.getBuffer().toString();
+        } catch (IOException ex) {
+            return fail(ex);
+        }
+    }
+
+    public static URLConnection openConnection(String url) {
+        try {
+            return new URL(url).openConnection();
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+
+}

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/TestResources.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/TestResources.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.admin.test;
+
+import java.io.File;
+import java.io.IOException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class TestResources {
+
+    public static final String SIMPLE_HTML_PAGE
+            = "<html>\n"
+            + "    <head>\n"
+            + "        <title>Simple test app</title>\n"
+            + "        <meta charset=\"UTF-8\">\n"
+            + "    </head>\n"
+            + "    <body>\n"
+            + "        <div>Simple test app</div>\n"
+            + "    </body>\n"
+            + "</html>";
+
+    public static File createSimpleWarDeployment(String appName) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class)
+                .addAsWebResource(
+                        new StringAsset(SIMPLE_HTML_PAGE),
+                        "index.html");
+        try {
+            File tempFile = File.createTempFile(appName, ".war");
+            war.as(ZipExporter.class).exportTo(tempFile, true);
+            return tempFile;
+        } catch (IOException e) {
+            throw new IllegalStateException("WAR file creation failed for app " + appName, e);
+        }
+    }
+
+}

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/webapp/HttpServerNameITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/webapp/HttpServerNameITest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.admin.test.webapp;
+
+import static org.glassfish.main.admin.test.ConnectionUtils.getContent;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.glassfish.main.admin.test.TestResources;
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class HttpServerNameITest {
+
+    private static final String TEST_APP_NAME = HttpServerNameITest.class.getSimpleName();
+    private static final int HTTP_PORT = 8080;
+    private static final String SERVER_NAME_PROPERTY = "configs.config.server-config.network-config.protocols.protocol.http-listener-1.http.server-name";
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    private static final AtomicBoolean APP_DEPLOYED = new AtomicBoolean();
+
+    @ParameterizedTest(name = "[{index}] testServerName: {0}")
+    @CsvSource({
+        "'Plain host name', hostname1, http://hostname1:8080/",
+        "'Plain domain name', my.domain.com, http://my.domain.com:8080/",
+        "'Domain name and port', my.domain.com:123, http://my.domain.com:123/",
+        "'Domain name and standard port', my.domain.com:80, http://my.domain.com/",
+        "'Secure domain name', https://my.domain.com, https://my.domain.com:8080/",
+        "'Secure domain name and port', https://my.domain.com:123, https://my.domain.com:123/",
+        "'Secure domain name and standard port', https://my.domain.com:443, https://my.domain.com/"
+    })
+    public void testHostName(String description, String serverName, String expectedUrlPrefix) throws IOException, InterruptedException {
+        assertThat(ASADMIN.exec("set", SERVER_NAME_PROPERTY + "=" + serverName), asadminOK());
+
+        final HttpURLConnection conn = GlassFishTestEnvironment.openConnection(HTTP_PORT, "/" + TEST_APP_NAME);
+        conn.setInstanceFollowRedirects(false);
+
+        assertThat(conn.getHeaderField("Location"), stringContainsInOrder(expectedUrlPrefix));
+        assertThat(getContent(conn), stringContainsInOrder("This document has moved <a href=\"" + expectedUrlPrefix));
+    }
+
+    @BeforeAll
+    static void deploy() {
+        String warFile = TestResources.createSimpleWarDeployment(TEST_APP_NAME).getAbsolutePath();
+        assertThat(ASADMIN.exec("deploy", "--name", TEST_APP_NAME, "--contextroot", TEST_APP_NAME,
+                warFile), asadminOK());
+        APP_DEPLOYED.set(true);
+    }
+
+    @AfterAll
+    static void undeploy() {
+        Assumptions.assumeTrue(APP_DEPLOYED.get());
+        assertThat(ASADMIN.exec("undeploy", TEST_APP_NAME), asadminOK());
+    }
+
+    @AfterEach
+    void cleanup() {
+        ASADMIN.exec("set", SERVER_NAME_PROPERTY + "=");
+    }
+
+}

--- a/appserver/web/admin/src/main/manpages/org/glassfish/web/admin/cli/create-http-listener.1
+++ b/appserver/web/admin/src/main/manpages/org/glassfish/web/admin/cli/create-http-listener.1
@@ -69,7 +69,7 @@ OPTIONS
            generates; it doesn't affect the URLs for directories and files
            stored in the server. This name should be the alias name if your
            server uses an alias. If a colon and port number are appended, that
-           port will be used in URLs that the server sends to the client.
+           port will be used in URLs that the server sends to the client. If a scheme and :// are prepended, the scheme will be used in the URLs.
 
        --acceptorthreads
            The number of acceptor threads for the listener socket. The

--- a/appserver/web/admin/src/main/manpages/org/glassfish/web/admin/cli/create-http.1
+++ b/appserver/web/admin/src/main/manpages/org/glassfish/web/admin/cli/create-http.1
@@ -53,7 +53,7 @@ OPTIONS
            generates; it doesn't affect the URLs for directories and files
            stored in the server. This name should be the alias name if your
            server uses an alias. If a colon and port number are appended, that
-           port will be used in URLs that the server sends to the client.
+           port will be used in URLs that the server sends to the client. If a scheme and :// are prepended, the scheme will be used in the URLs.
 
        --target
            Creates the set of HTTP parameters only on the specified target.

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Connector.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Connector.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/Connector.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/Connector.java
@@ -335,4 +335,12 @@ public interface Connector {
      * during authentication.
      */
     int getMaxSavePostSize();
+
+    /**
+     * Return the proxy scheme for this Connector
+     * @return The scheme or null if not set
+     */
+    default String getProxyScheme() {
+        return null;
+    }
 }

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Connector.java
@@ -197,17 +197,23 @@ public class Connector implements org.apache.catalina.Connector, Lifecycle {
 
     /**
      * The server name to which we should pretend requests to this Connector were directed. This is useful when operating
-     * Tomcat behind a proxy server, so that redirects get constructed accurately. If not specified, the server name
+     * GlassFish behind a proxy server, so that redirects get constructed accurately. If not specified, the server name
      * included in the <code>Host</code> header is used.
      */
     private String proxyName;
 
     /**
      * The server port to which we should pretend requests to this Connector were directed. This is useful when operating
-     * Tomcat behind a proxy server, so that redirects get constructed accurately. If not specified, the port number
+     * GlassFish behind a proxy server, so that redirects get constructed accurately. If not specified, the port number
      * specified by the <code>port</code> property is used.
      */
     private int proxyPort = 0;
+
+    /**
+     * The HTTP scheme to which we should pretend requests to this Connector were directed. This is useful when operating
+     * GlassFish behind a proxy server, so that redirects get constructed accurately.
+     */
+    private String proxyScheme = null;
 
     /**
      * The redirect port for non-SSL to SSL redirects.
@@ -822,6 +828,24 @@ public class Connector implements org.apache.catalina.Connector, Lifecycle {
     public void setProxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
         setProperty("proxyPort", String.valueOf(proxyPort));
+    }
+
+    /**
+     * Return the proxy scheme for this Connector
+     * @return The scheme or null if not set
+     */
+    public String getProxyScheme() {
+        return proxyScheme;
+    }
+
+    /**
+     * Set the proxy scheme for this Connector.
+     *
+     * @param proxyPort The new proxy scheme or null to unset
+     */
+    public void setProxyScheme(String scheme) {
+        this.proxyScheme = scheme;
+        setProperty("proxyScheme", String.valueOf(scheme));
     }
 
     /**

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Connector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Response.java
@@ -1539,10 +1539,15 @@ public class Response implements HttpResponse, HttpServletResponse {
     private String getRedirectScheme() {
         String scheme = connectorRequest.getScheme();
 
-        if (getConnector() != null && getConnector().getAuthPassthroughEnabled()) {
-            ProxyHandler proxyHandler = getConnector().getProxyHandler();
-            if (proxyHandler != null && proxyHandler.getSSLKeysize(connectorRequest) > 0) {
-                scheme = "https";
+        if (getConnector() != null) {
+            if (getConnector().getProxyScheme() != null) {
+                scheme = getConnector().getProxyScheme();
+            }
+            if (getConnector().getAuthPassthroughEnabled()) {
+                ProxyHandler proxyHandler = getConnector().getProxyHandler();
+                if (proxyHandler != null && proxyHandler.getSSLKeysize(connectorRequest) > 0) {
+                    scheme = "https";
+                }
             }
         }
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/connector/coyote/PECoyoteConnector.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/docs/reference-manual/src/main/asciidoc/create-http-listener.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-http-listener.adoc
@@ -79,7 +79,7 @@ asadmin-options::
   generates; it doesn't affect the URLs for directories and files stored
   in the server. This name should be the alias name if your server uses
   an alias. If a colon and port number are appended, that port will be
-  used in URLs that the server sends to the client.
+  used in URLs that the server sends to the client. If a scheme and :// are prepended, the scheme will be used in the URLs.
 `--acceptorthreads`::
   The number of acceptor threads for the listener socket. The
   recommended value is the number of processors in the machine. The

--- a/docs/reference-manual/src/main/asciidoc/create-http.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-http.adoc
@@ -66,7 +66,7 @@ asadmin-options::
   generates; it doesn't affect the URLs for directories and files stored
   in the server. This name should be the alias name if your server uses
   an alias. If a colon and port number are appended, that port will be
-  used in URLs that the server sends to the client.
+  used in URLs that the server sends to the client. If a scheme and :// are prepended, the scheme will be used in the URLs.
 `--target`::
   Creates the set of HTTP parameters only on the specified target. Valid
   values are as follows:


### PR DESCRIPTION
ServerName property on the HTTP listener can contain scheme prefix (e.g. https://), which will be respected in redirects created by GlassFish.

For example, if GlassFish is behind a proxy server, connections to the proxy server go through HTTPS but connections from proxy server to GlassFish go through HTTP. If the proxy server is exposed at https://my.domain.com, then it's possible to set the serverName to https://my.domain.com:443 to use https://my.domain.com/ in redirects. This URL doesn't have to be translated by the proxy server because it's the correct URL where the proxy server listens to incoming requests.

This resolves #24918.