### PR TITLE
Fix InaccessibleObjectException from JPMS in ThreadLocal cleaner

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/LogFacade.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/LogFacade.java
@@ -105,6 +105,11 @@ public class LogFacade {
     public static final String CHECK_THREAD_LOCALS_FOR_LEAKS_FAIL = PREFIX + "00011";
 
     @LogMessageInfo(
+            message = "Finding ThreadLocal references for web application [{0}] is not supported by the JVM. Use '--add-opens java.base/java.lang=ALL-UNNAMED' java argument to enable it",
+            level = "FINE")
+    public static final String CHECK_THREAD_LOCALS_FOR_LEAKS_NOT_SUPPORTED = PREFIX + "00012";
+
+    @LogMessageInfo(
             message = "The web application [{0}] created a ThreadLocal with key of [{1}]"
                 + " but failed to remove it when the web application was stopped."
                 + " Threads are going to be renewed over time to try and avoid a probable memory leak.",

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ReferenceCleaner.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/ReferenceCleaner.java
@@ -44,6 +44,8 @@ import static org.glassfish.web.loader.LogFacade.CHECK_THREAD_LOCALS_FOR_LEAKS;
 import static org.glassfish.web.loader.LogFacade.CHECK_THREAD_LOCALS_FOR_LEAKS_KEY;
 import static org.glassfish.web.loader.LogFacade.getString;
 
+import java.lang.reflect.InaccessibleObjectException;
+
 class ReferenceCleaner {
     private static final Logger LOG = LogFacade.getSysLogger(ReferenceCleaner.class);
 
@@ -143,6 +145,9 @@ class ReferenceCleaner {
                     checkThreadLocalMapForLeaks(inheritableMap, tableField);
                 }
             }
+        } catch (InaccessibleObjectException e) {
+            // module java.base does not "opens java.lang"
+            LOG.log(WARNING, getString(LogFacade.CHECK_THREAD_LOCALS_FOR_LEAKS_NOT_SUPPORTED, loader.getName()));
         } catch (Exception e) {
             LOG.log(WARNING, getString(LogFacade.CHECK_THREAD_LOCALS_FOR_LEAKS_FAIL, loader.getName()), e);
         }

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -85,6 +85,8 @@ import static org.glassfish.web.loader.LogFacade.UNABLE_TO_LOAD_CLASS;
 import static org.glassfish.web.loader.LogFacade.UNSUPPORTED_VERSION;
 import static org.glassfish.web.loader.LogFacade.getString;
 
+import org.apache.naming.resources.BaseDirContext;
+
 /**
  * Specialized web application class loader.
  * <p>
@@ -313,6 +315,9 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
             dirCtx = proxyRes.getDirContext();
         } else {
             dirCtx = resources;
+            if (dirCtx instanceof BaseDirContext) {
+                contextName = new File(((BaseDirContext)dirCtx).getDocBase()).getName();
+            }
         }
         if (dirCtx instanceof WebDirContext) {
             ((WebDirContext) dirCtx).setJarFileResourcesProvider(this);


### PR DESCRIPTION
Before it logged a warning and stacktrace if java.lang not open on JDK 17+.  But this situation is expected. If it happens, the thread local checker is just not executed, because it cannot get info about ThreadLocals from the JVM. Logs only a simple warning, with instructions how to open the package and enable the checker.

Also sets the context (appName) of the WebApp CL to the name of the app file as a fallback.

Before, the log message looked like this:

```
org.glassfish.web.loader.ReferenceCleaner checkThreadLocalsForLeaks
WARNING: Failed to check for ThreadLocal references for web application [unknown]
java.lang.reflect.InaccessibleObjectException: Unable to make field java.lang.ThreadLocal$ThreadLocalMap java.lang.Thread.threadLocals accessible: module java.base does not "opens java.lang" to unnamed module @1cc50131
	at java.base/java.lang.reflect.AccessibleObject.throwInaccessibleObjectException(AccessibleObject.java:391)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:367)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:315)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:183)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:177)
	at org.glassfish.web.loader.ReferenceCleaner.setAccessible(ReferenceCleaner.java:348)
	at org.glassfish.web.loader.ReferenceCleaner.checkThreadLocalsForLeaks(ReferenceCleaner.java:115)
```