### PR TITLE
Fix running of the authentication TCK.

### DIFF
--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -99,6 +99,7 @@
                         <argument>clean</argument>
                         <argument>install</argument>
                         <argument>-Dglassfish.version=${glassfish.version}</argument>
+                        <argument>-Dmaven.multiModuleProjectDirectory=${tck.root}/authentication-tck-3.1.0/tck</argument>
                     </arguments>
                     <environmentVariables>
                         <LC_ALL>C</LC_ALL>


### PR DESCRIPTION
`maven.multiModuleProjectDirectory` propagated from the calling pom, and was therefore setting the wrong value.

