### PR TITLE
Fixes remote JNDI lookup

### DIFF
--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/RemoteSerialContextProviderImpl.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/RemoteSerialContextProviderImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -65,7 +66,7 @@ public class RemoteSerialContextProviderImpl
         for(Iterator<Map.Entry> it = entrySet.iterator(); it.hasNext();) {
             Object val = it.next().getValue();
             // Issue 17219 skip non-serializable values for remote client.
-            if(!(val instanceof java.io.Serializable) || val instanceof Context) {
+            if(!(val instanceof java.io.Serializable)) {
                 it.remove();
             }
         }


### PR DESCRIPTION
This is a bug fix. Fixes #24522. 

* Fixes `java.io.NonSerializableException` during remote lookup.
* Remote `list()` method now enumerates subcontexts bounded to the current context (this behavior consistent with the local `list()` method).