### PR TITLE
Update Jakarta Validation TCK to 3.1.1

### DIFF
--- a/appserver/tests/tck/tck-download/jakarta-validation-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-validation-tck/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.main.tests.tck</groupId>
+        <artifactId>tck-download</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta-validation-tck</artifactId>
+    <packaging>pom</packaging>
+    <name>TCK: Install Jakarta validation TCK</name>
+
+    <properties>
+        <tck.test.validation.version>3.1.1</tck.test.validation.version>
+        <tck.test.validation.file>validation-tck-dist-${tck.test.validation.version}.zip</tck.test.validation.file>
+        <tck.test.validation.url>https://download.eclipse.org/jakartaee/bean-validation/3.1/${tck.test.validation.file}</tck.test.validation.url>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-validation-tck</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <url>${tck.test.validation.url}</url>
+                    <unpack>true</unpack>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+            </plugin>
+            
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-parent-pom</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/validation-tck-dist-${tck.test.validation.version}/src/pom.xml</file>
+                            <groupId>jakarta.validation</groupId>
+                            <artifactId>validation-tck-parent</artifactId>
+                            <version>${tck.test.validation.version}</version>
+                            <packaging>pom</packaging>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>install-install-the-tests-jar</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/validation-tck-dist-${tck.test.validation.version}/artifacts/validation-tck-tests-${tck.test.validation.version}.jar</file>
+                            <groupId>jakarta.validation</groupId>
+                            <artifactId>validation-tck-tests</artifactId>
+                            <version>${tck.test.validation.version}</version>
+                            <packaging>jar</packaging>
+                         </configuration>
+                    </execution>
+                    
+                    <execution>
+                        <id>install-test-suite-xml</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.build.directory}/validation-tck-dist-${tck.test.validation.version}/artifacts/tck-tests.xml</file>
+                            <groupId>jakarta.validation</groupId>
+                            <artifactId>validation-tck-tests</artifactId>
+                            <version>${tck.test.validation.version}</version>
+                            <packaging>xml</packaging>
+                            <classifier>suite</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/appserver/tests/tck/validation/pom.xml
+++ b/appserver/tests/tck/validation/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,11 +31,9 @@
     <description>Aggregates dependencies and runs the Jakarta Validation TCK</description>
  
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <validation.tck-4-0.version>3.0.1</validation.tck-4-0.version>
 
         <glassfish.version>${project.version}</glassfish.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
@@ -48,8 +46,8 @@
         <!--  The TCK  -->
         <dependency>
             <groupId>jakarta.validation</groupId>
-            <artifactId>beanvalidation-tck-tests</artifactId>
-            <version>3.0.1</version>
+            <artifactId>validation-tck-tests</artifactId>
+            <version>3.1.1</version>
             <scope>test</scope>
         </dependency>
         
@@ -57,7 +55,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-core-impl</artifactId>
-            <version>4.0.4</version>
+            <version>4.1.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -90,14 +88,14 @@
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.2</version>
+            <version>1.6</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version>
+            <version>7.9.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -107,7 +105,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.7.0.Alpha13</version>
+                <version>1.9.1.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/appserver/tests/tck/validation/suite.xml
+++ b/appserver/tests/tck/validation/suite.xml
@@ -1,25 +1,15 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-
 <!--
 
-    Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Jakarta Validation TCK
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License v. 2.0, which is available at
-    http://www.eclipse.org/legal/epl-2.0.
-
-    This Source Code may also be made available under the following Secondary
-    Licenses when the conditions for such availability set forth in the
-    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
-    version 2 with the GNU Classpath Exception, which is available at
-    https://www.gnu.org/software/classpath/license.html.
-
-    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+    License: Apache License, Version 2.0
+    See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 
 -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="Jakarta-Bean-Validation-TCK" verbose="2" configfailurepolicy="continue">
-    <listeners>
+<suite name="Jakarta-Validation-TCK" verbose="1">
+     <listeners>
         <!-- Required - avoid randomly mixed test method execution -->
         <listener class-name="org.jboss.cdi.tck.impl.testng.SingleTestClassMethodInterceptor" />
         <!-- Optional - intended for debug purpose only -->
@@ -32,21 +22,20 @@
         <listener class-name="org.testng.reporters.TestHTMLReporter" />
     </listeners>
 
-	<test name="Jakarta-Bean-Validation-TCK">
 
-		<method-selectors>
-			<method-selector>
-				<selector-class
-					name="org.hibernate.beanvalidation.tck.util.IntegrationTestsMethodSelector" priority="0" />
-			</method-selector>
-			<method-selector>
-				<selector-class
-					name="org.hibernate.beanvalidation.tck.util.JavaFXTestsMethodSelector" priority="1" />
-			</method-selector>
-		</method-selectors>
+    <test name="Jakarta-Validation-TCK">
 
-		<packages>
-			<package name="org.hibernate.beanvalidation.tck.tests.*" />
-		</packages>
-	</test>
+        <method-selectors>
+            <method-selector>
+                <selector-class name="org.hibernate.beanvalidation.tck.util.IntegrationTestsMethodSelector" priority="1"/>
+            </method-selector>
+            <method-selector>
+                <selector-class name="org.hibernate.beanvalidation.tck.util.JavaFXTestsMethodSelector" priority="2"/>
+            </method-selector>
+        </method-selectors>
+
+        <packages>
+            <package name="org.hibernate.beanvalidation.tck.tests.*"/>
+        </packages>
+    </test>
 </suite>


### PR DESCRIPTION
```
[INFO] Results:
[INFO] 
[INFO] Tests run: 1049, Failures: 0, Errors: 0, Skipped: 0
```
