### PR TITLE
Faster autodeploy at startup - do not wait before first autodeployment scan

### DIFF
--- a/nucleus/deployment/autodeploy/src/main/java/org/glassfish/deployment/autodeploy/AutoDeployService.java
+++ b/nucleus/deployment/autodeploy/src/main/java/org/glassfish/deployment/autodeploy/AutoDeployService.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -211,7 +212,7 @@ public class AutoDeployService implements PostConstruct, PreDestroy, ConfigListe
                         }
                     }
                 },
-                pollingInterval,
+                0,
                 pollingInterval);
         logConfig(
                 "Started",


### PR DESCRIPTION
Fixes #25078.

Before, delay time was the same as the poll interval time.  Now there's no delay. Autodeployment is started immediately and then in polling intervals.