### PR TITLE
Fix styling of the command logger button in Admin Console in Chrome

### DIFF
--- a/appserver/admingui/commandrecorder/src/main/resources/META-INF/resources/commandrecorder/plugin/mastheadStatusArea.jsf
+++ b/appserver/admingui/commandrecorder/src/main/resources/META-INF/resources/commandrecorder/plugin/mastheadStatusArea.jsf
@@ -15,6 +15,6 @@
 -->
 
 <f:verbatim>
-    <iframe src="/commandrecorder/menu.xhtml" style="overflow:auto; width:600px; height:18px; border:0px;">
+    <iframe src="/commandrecorder/menu.xhtml" style="overflow:auto; width:600px; height:20px; border:0px;">
     </iframe>
 </f:verbatim>


### PR DESCRIPTION
Before this, Chrome displayed scroll arrows next to the button, like this:

![image](https://github.com/user-attachments/assets/40bf27e7-4216-4eab-bd95-ae3ad7a028a4)

This increases the size of the iframe so that the contents of the iframe completely fit into it, and then Chrome doesn't display scrolling arrows.