### PR TITLE
Fixes #25085 - Use HTTPS in Oracle links of the documentation

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/domains.adoc
+++ b/docs/administration-guide/src/main/asciidoc/domains.adoc
@@ -865,17 +865,17 @@ Before You Begin
 To run the `create-service` subcommand, you must have `solaris.smf.*`
 authorization. For information about how to set the authorizations, see
 the
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)]
 man page and the
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
 man page. You must also have write permission in the directory tree:
 `/var/svc/manifest/application/SUNWappserver`. Usually, the superuser
 has both of these permissions. Additionally, Oracle Solaris
 administration commands such as
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`],
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`],
 and
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`]
 must be available in the PATH.
 
 If a particular {productName} domain or instance should not have
@@ -926,19 +926,19 @@ See Also
 For information about administering the service, see the following
 Oracle Solaris documentation:
 
-* "http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1hbrunlevels-25516[Managing
+* "https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1hbrunlevels-25516[Managing
 Services (Overview)]" in System Administration Guide: Basic
 Administration
-* "http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1faauf[Managing
+* "https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1faauf[Managing
 Services (Tasks)]" in System Administration Guide: Basic Administration
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`(1)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvcadm-1m[`svcadm`(1M)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`(1M)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5rbac-5[`rbac`(5)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5smf-security-5[`smf_security`(5)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`(1)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvcadm-1m[`svcadm`(1M)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`(1M)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5rbac-5[`rbac`(5)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5smf-security-5[`smf_security`(5)]
 
 [[to-prevent-service-shutdown-when-a-user-logs-out-on-windows]]
 

--- a/docs/administration-guide/src/main/asciidoc/jms.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jms.adoc
@@ -1376,7 +1376,7 @@ WebLogic JMS]
 WebLogic Server provides several different clients for use by standalone
 applications that run outside of WebLogic Server. These client are
 summarized in
-"http://www.oracle.com/pls/as1111/lookup?id=SACLT117[Overview of
+"https://www.oracle.com/pls/as1111/lookup?id=SACLT117[Overview of
 Stand-alone Clients"] in Programming Stand-alone Clients for Oracle
 WebLogic Server. When connecting from {productName} to WebLogic JMS
 resources you must use the WebLogic Thin T3 client,
@@ -1412,11 +1412,11 @@ The example code snippets in this section refer to a WebLogic JMS
 connection factory named `WLoutboundQueueFactory` and queue destination
 named `WLoutboundQueue`. For conceptual overviews on configuring
 WebLogic JMS resources, refer to
-"http://www.oracle.com/pls/as1111/lookup?id=JMSAD123[Understanding JMS
+"https://www.oracle.com/pls/as1111/lookup?id=JMSAD123[Understanding JMS
 Resource Configuration]" in Configuring and Managing JMS for Oracle
 WebLogic Server. For detailed instructions on configuring WebLogic JMS
 resources, refer to
-"http://www.oracle.com/pls/as1111/lookup?id=WLACH01854[Configure JMS
+"https://www.oracle.com/pls/as1111/lookup?id=WLACH01854[Configure JMS
 system modules and add JMS resources]" in the WebLogic Administration
 Console Online Help.
 
@@ -1610,9 +1610,9 @@ GenericJMSRA Properties for WebLogic JMS]. +
 Make sure to use the appropriate WebLogic administration tools, such as
 the WebLogic Administration Console or the WebLogic Scripting Tool (WLST).
 For more information, see
-"http://www.oracle.com/pls/as1111/lookup?id=WLACH01853[Configure
+"https://www.oracle.com/pls/as1111/lookup?id=WLACH01853[Configure
 Messaging]" in WebLogic Server Administration Console Online Help and
-http://www.oracle.com/pls/as1111/lookup?id=WLSTC112[WebLogic Server WLST
+https://www.oracle.com/pls/as1111/lookup?id=WLSTC112[WebLogic Server WLST
 Online and Offline Command Reference].
 
 [[accessing-connections-and-destinations-directly]]

--- a/docs/ha-administration-guide/src/main/asciidoc/instances.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/instances.adoc
@@ -1649,7 +1649,7 @@ without a change to the `config/domain.xml` file:
 1. Change the last modified time of the `config/domain.xml` file. +
 Exactly how to change the last modified time depends on the operating
 system. For example, on UNIX and Linux systems, you can use the
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1touch-1[`touch`(1)] command.
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1touch-1[`touch`(1)] command.
 
 2. Resynchronize each instance in the domain with the DAS. +
 For instructions, see xref:#to-resynchronize-an-instance-and-the-das-online[To Resynchronize an Instance and the DAS Online].
@@ -1657,7 +1657,7 @@ For instructions, see xref:#to-resynchronize-an-instance-and-the-das-online[To R
 See Also
 
 * xref:#to-resynchronize-an-instance-and-the-das-online[To Resynchronize an Instance and the DAS Online]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1touch-1[`touch`(1)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1touch-1[`touch`(1)]
 
 [[to-resynchronize-additional-configuration-files]]
 

--- a/docs/ha-administration-guide/src/main/asciidoc/ssh-setup.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/ssh-setup.adoc
@@ -985,7 +985,7 @@ online         Jul_06   svc:/network/ssh:default
 
 See Also
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)]
 
 [[GSHAG327]]
 
@@ -1367,7 +1367,7 @@ public key authentication.
 1. Generate an SSH key pair with an encrypted private key file.
 +
 Use the SSH utility
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`]
 for this purpose.
 +
 [source]
@@ -1529,7 +1529,7 @@ See Also
 * xref:reference-manual.adoc#asadmin[`asadmin`(1M)]
 * xref:reference-manual.adoc#create-password-alias[`create-password-alias`(1)]
 * xref:reference-manual.adoc#setup-ssh[`setup-ssh`(1)]
-* http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)]
+* https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)]
 
 You can also view the full syntax and options of the subcommands by
 typing the following commands at the command line:

--- a/docs/performance-tuning-guide/src/main/asciidoc/overview.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/overview.adoc
@@ -186,9 +186,9 @@ The type of authentication mechanism chosen may require additional
 hardware for the deployment. Typically a directory server executes on a
 separate server, and may also require a backup for replication and high
 availability. Refer to the
-http://www.oracle.com/us/products/middleware/identity-management/oracle-directory-services/index.html[Oracle
+https://www.oracle.com/us/products/middleware/identity-management/oracle-directory-services/index.html[Oracle
 Java System Directory Server]
-(`http://www.oracle.com/us/products/middleware/identity-management/oracle-directory-services/index.html`)
+(`https://www.oracle.com/us/products/middleware/identity-management/oracle-directory-services/index.html`)
 documentation for more information on deployment, sizing, and
 availability guidelines.
 

--- a/docs/reference-manual/src/main/asciidoc/appclient.adoc
+++ b/docs/reference-manual/src/main/asciidoc/appclient.adoc
@@ -187,7 +187,7 @@ executed.
 === Attributes
 
 See
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
 for descriptions of the following attributes:
 
 [width="100%",cols="50%,50%",options="header",]

--- a/docs/reference-manual/src/main/asciidoc/asadmin.adoc
+++ b/docs/reference-manual/src/main/asciidoc/asadmin.adoc
@@ -778,7 +778,7 @@ options as shown in the following table.
 === Attributes
 
 See
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
 for descriptions of the following attributes:
 
 [width="100%",cols="50%,50%",options="header",]
@@ -816,7 +816,7 @@ xref:update-file-user.adoc#update-file-user[`update-file-user`(1)],
 xref:update-node-ssh.adoc#update-node-dcom[`update-node-dcom`(1)],
 xref:update-node-ssh001.adoc#update-node-ssh[`update-node-ssh`(1)]
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
 
 '''''
 

--- a/docs/reference-manual/src/main/asciidoc/create-service.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-service.adoc
@@ -94,9 +94,9 @@ enable, disable, delete, or stop the service. For more information about
 SMF, see the following documentation for the Oracle Solaris operating
 system:
 
-* "http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1hbrunlevels-25516[
+* "https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1hbrunlevels-25516[
 Managing Services (Overview)]" in System Administration Guide: Basic Administration
-* "http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1faauf[
+* "https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1faauf[
 Managing Services (Tasks)]" in System Administration Guide: Basic Administration
 
 On Oracle Solaris systems, this subcommand must be run as the OS-level
@@ -116,9 +116,9 @@ directory by default:
 
 To run this subcommand, you must have `solaris.smf.*` authorization. For
 information about how to grant authorizations to users, see the
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)]
 and
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
 man pages.
 
 To run these commands as non-root user, the system administrator must be
@@ -126,10 +126,10 @@ contacted so that the relevant authorizations are granted. You must also
 ensure that the following conditions are met:
 
 * Oracle Solaris 10 administration commands such as
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`(1M)],
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`(1M)],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)],
 and
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`(1)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`(1)]
 are available through the `PATH` statement, so that these commands can
 be executed. A simple test to do so is to run the command `which svccfg`
 in the shell.
@@ -311,17 +311,17 @@ Command create-service executed successfully.
 
 xref:asadmin.adoc#asadmin[`asadmin`(1M)]
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`(1)],
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1auths-1[`auths`(1)],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1svcs-1[`svcs`(1)]
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`(1M)],
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)],
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msvccfg-1m[`svccfg`(1M)],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Museradd-1m[`useradd`(1M)],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Musermod-1m[`usermod`(1M)]
 
-"http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1hbrunlevels-25516[Managing
+"https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1hbrunlevels-25516[Managing
 Services (Overview)]" in System Administration Guide: Basic
 Administration,
-"http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1faauf[Managing
+"https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=SYSADV1faauf[Managing
 Services (Tasks)]" in System Administration Guide: Basic Administration
 
 Microsoft .NET Framework (`https://dotnet.microsoft.com/`)

--- a/docs/reference-manual/src/main/asciidoc/debug-asadmin.adoc
+++ b/docs/reference-manual/src/main/asciidoc/debug-asadmin.adoc
@@ -40,6 +40,6 @@ debug-asadmin [--host host]
 Use the `debug-asadmin` utility to debug local admin commands and the launching of the {productName}. See the `asadmin` command for full documentation.
 
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
 
 '''''

--- a/docs/reference-manual/src/main/asciidoc/package-appclient.adoc
+++ b/docs/reference-manual/src/main/asciidoc/package-appclient.adoc
@@ -65,7 +65,7 @@ following:
 === Attributes
 
 See
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN5attributes-5[`attributes`(5)]
 for descriptions of the following attributes:
 
 [width="100%",cols="50%,50%",options="header",]

--- a/docs/reference-manual/src/main/asciidoc/setup-ssh.adoc
+++ b/docs/reference-manual/src/main/asciidoc/setup-ssh.adoc
@@ -60,17 +60,17 @@ to log in to remote hosts where SSH is to be set up. Specifically, the
 following prerequisites must be met:
 
 * The
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-1[`ssh`(1)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-1[`ssh`(1)]
 client is installed on the DAS host and is accessible through the DAS
 user's path.
 * The
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msshd-1m[`sshd`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msshd-1m[`sshd`(1M)]
 daemon is installed and running on all hosts where an SSH key is to be
 set up.
 * The user that the `--sshuser` option specifies has an SSH login on all
 hosts where an SSH key is to be set up.
 * The
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)]
 utility is installed on the DAS host either at the default location or
 in a location that is defined in the DAS user's path.
 * On Windows systems, the SSH package for http://www.cygwin.com/[Cygwin]
@@ -87,7 +87,7 @@ behavior of the subcommand is to prompt the user to generate an SSH key
 pair. The SSH key pair is generated without an encryption passphrase. If
 a passphrase-protected key pair is required, the key pair must be
 generated manually by using the SSH
-command http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)].
+command https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)].
 * Distributing the public key. The subcommand appends the content of the
 public key file to the user-home``/.ssh/authorized_keys`` file on each
 remote host. By default, the subcommand locates the public key file in
@@ -238,10 +238,10 @@ Command setup-ssh executed successfully.
 
 xref:asadmin.adoc#asadmin[`asadmin`(1M)]
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-1[`ssh`(1)],
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-1[`ssh`(1)],
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1ssh-keygen-1[`ssh-keygen`(1)]
 
-http://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msshd-1m[`sshd`(1M)]
+https://www.oracle.com/pls/topic/lookup?ctx=E18752&id=REFMAN1Msshd-1m[`sshd`(1M)]
 
 Cygwin Information and Installation (`http://www.cygwin.com/`), MKS
 Software (`http://www.mkssoftware.com/`)

--- a/docs/security-guide/src/main/asciidoc/running-in-secure-environment.adoc
+++ b/docs/security-guide/src/main/asciidoc/running-in-secure-environment.adoc
@@ -75,7 +75,7 @@ might cause great damage to companies or individual clients that use the
 Web site. Understanding the security ramifications of each resource will
 help you protect it properly.
 
-See Also: `http://www.oracle.com/us/products/ondemand/index.html`[[gksce]][[read-security-publications]]
+See Also: `https://www.oracle.com/us/products/ondemand/index.html`[[gksce]][[read-security-publications]]
 
 ==== Read Security Publications
 


### PR DESCRIPTION
Updated links from HTTP to HTTPS in the adoc files.

Links of the `jms.adoc` are not working, regardless of HTTP or HTTPS

Closes #25085 