### PR TITLE
Upgraded command-security-maven-plugin to 1.0.18

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1110,7 +1110,7 @@
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
                     <artifactId>command-security-maven-plugin</artifactId>
-                    <version>1.0.17</version>
+                    <version>1.0.18</version>
                     <configuration>
                         <isFailureFatal>${command.security.maven.plugin.isFailureFatal}</isFailureFatal>
                     </configuration>


### PR DESCRIPTION
* Fixes building with Java 23
* https://github.com/eclipse-ee4j/glassfish-security-plugin/releases/tag/1.0.18