### PR TITLE
Removed security tests depending on SecurityManager

### DIFF
--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/build.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/build.xml
@@ -68,22 +68,11 @@
     <target name="run-pcftests" depends="init-common">
         <property name="ISPCF" value="-Djakarta.security.jacc.PolicyConfigurationFactory.provider=com.sun.s1asdev.security.jaccapi.DummyPolicyConfigurationFactory"/>
         <property name="NOTPCF" value="-Djakarta.security.jacc.PolicyConfigurationFactory.provider=jakarta.security.jacc.PolicyContextException"/>
-        <property name="PFL" value="-Djava.security.policy=${basedir}/config/java.policy"/>
-        <property name="PFL2" value="-Djava.security.policy=${basedir}/config/java.policy2"/>
-
-        <java classname="jakarta.security.jacc.TestPCF" fork="yes"
-            classpath="${s1astest.classpath}">
-            <jvmarg value="-DAPS_HOME=${env.APS_HOME}"/>
-            <jvmarg value="${PFL2}"/>
-            <arg value="true"/>
-            <arg value="java.lang.ClassNotFoundException"/>
-        </java>
 
         <java classname="jakarta.security.jacc.TestPCF" fork="yes"
             classpath="${s1astest.classpath}">
             <jvmarg value="-DAPS_HOME=${env.APS_HOME}"/>
             <jvmarg value="${NOTPCF}"/>
-            <jvmarg value="${PFL2}"/>
             <arg value="true"/>
             <arg value="java.lang.ClassCastException"/>
         </java>
@@ -92,25 +81,6 @@
             classpath="${s1astest.classpath}">
             <jvmarg value="-DAPS_HOME=${env.APS_HOME}"/>
             <jvmarg value="${ISPCF}"/>
-            <jvmarg value="${PFL2}"/>
-            <arg value="true"/>
-            <arg value="jakarta.security.jacc.PolicyContextException"/>
-        </java>
-
-        <java classname="jakarta.security.jacc.TestPCF" fork="yes"
-            classpath="${s1astest.classpath}">
-            <jvmarg value="-DAPS_HOME=${env.APS_HOME}"/>
-            <jvmarg value="${NOTPCF}"/>
-            <jvmarg value="${PFL}"/>
-            <arg value="false"/>
-            <arg value="java.lang.ClassCastException"/>
-        </java>
-
-        <java classname="jakarta.security.jacc.TestPCF" fork="yes"
-            classpath="${s1astest.classpath}">
-            <jvmarg value="-DAPS_HOME=${env.APS_HOME}"/>
-            <jvmarg value="${ISPCF}"/>
-            <jvmarg value="${PFL}"/>
             <arg value="false"/>
         </java>
     </target>

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/src/TestPCF.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/src/TestPCF.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -39,8 +40,7 @@ public class TestPCF {
         System.out.println("expect AccessControlException: " + expectACException);
         System.out.println("expected Exception: " + expectedException);
 
-        description = testSuite + "-" + expectACException + "-" +
-            expectedException + " without SecurityManager";
+        description = testSuite + "-" + expectACException + "-" + expectedException;
         try {
             PolicyConfigurationFactory f =
                 PolicyConfigurationFactory.getPolicyConfigurationFactory();
@@ -49,33 +49,6 @@ public class TestPCF {
             //It should be one of the following:
             //    java.lang.ClassNotFoundException
             //    java.lang.ClassCastException
-            //    jakarta.security.jacc.PolicyContextException
-            if (ex.getClass().getName().equals(expectedException)) {
-                stat.addStatus(description, stat.PASS);
-            } else {
-                ex.printStackTrace();
-                stat.addStatus(description, stat.FAIL);
-            }
-        }
-
-        System.out.println( "--START SECURITY MANAGER -->>");
-        System.setSecurityManager(new SecurityManager());
-
-        description = testSuite + "-" + expectACException + "-" +
-            expectedException + " with SecurityManager";
-        try {
-            PolicyConfigurationFactory f =
-                PolicyConfigurationFactory.getPolicyConfigurationFactory();
-            stat.addStatus(description, stat.PASS);
-        } catch(AccessControlException ace) {
-            if (!expectACException) {
-                ace.printStackTrace();
-            }
-            stat.addStatus(description,
-                (expectACException) ? stat.PASS : stat.FAIL);
-        } catch(Exception ex) {
-            //It should be one of the following:
-            //    java.lang.ClassNotFoundException
             //    jakarta.security.jacc.PolicyContextException
             if (ex.getClass().getName().equals(expectedException)) {
                 stat.addStatus(description, stat.PASS);


### PR DESCRIPTION
* Jenkins: these tests were failing on JDK21 so much that results were ignored in CI, but you can find them in logs under `run-pcftests`
* On JDK17 they fail "less", because they are able to enable the SecurityManager, but that is not supported by Jakarta EE 11 code any more.