### PR TITLE
Replace none/only testcompile with full in a profile for JDK 23

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -829,26 +829,6 @@
                                 <proc>only</proc>
                             </configuration>
                         </execution>
-                        <execution>
-                            <id>default-testcompile</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>testCompile</goal>
-                            </goals>
-                            <configuration>
-                                <proc>none</proc>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>testprocess-annotations</id>
-                            <phase>process-classes</phase>
-                            <goals>
-                                <goal>testCompile</goal>
-                            </goals>
-                            <configuration>
-                                <proc>only</proc>
-                            </configuration>
-                        </execution>
                     </executions>
                 </plugin>
                 <plugin>
@@ -1726,6 +1706,23 @@
             <properties>
                 <file.executable.suffix>.bat</file.executable.suffix>
             </properties>
+        </profile>
+        
+        <profile>
+            <id>jdk23-test-annotation-processing</id>
+              <activation>
+              <jdk>[23,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <testCompilerArgument>-proc:full</testCompilerArgument>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Better alternative for https://github.com/eclipse-ee4j/glassfish/pull/25102

none/only doesn't work correct with JMH on JDK 23. proc:full works better for that.