### PR TITLE
Fixes CVE-2024-9329: Setting local Name and Port for /managment/* URI

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestManagementAdapter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestManagementAdapter.java
@@ -32,4 +32,11 @@ public class RestManagementAdapter extends RestAdapter {
     public RestManagementAdapter() {
         super(new RestManagementResourceProvider());
     }
+
+    @Override
+    public void service(Request req, Response res) {
+        req.setServerName(req.getLocalName());
+        req.setServerPort(req.getLocalPort());
+        super.service(req, res);
+    }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestManagementAdapter.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/adapter/RestManagementAdapter.java
@@ -18,6 +18,8 @@
 package org.glassfish.admin.rest.adapter;
 
 import org.glassfish.admin.restconnector.Constants;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
 import org.jvnet.hk2.annotations.Service;
 
 /**


### PR DESCRIPTION
## Description
It is possible to trick the Glassfish’s management REST interface by “injecting” a malicious URL via the Host header of a sample request to let the HTML page that is generated by the REST interface when the /management/domain endpoint is targeted.

Fixes [CVE-2024-9329](https://nvd.nist.gov/vuln/detail/CVE-2024-9329)

## Important Info
### Blockers
None

## Testing
### New tests
None

### Testing Performed
Steps:
1. run Glassfish
2. on Powershell run: 
>   Invoke-RestMethod -Method Get `
>   -Uri http://local:4848/management/domain `
>   -Headers @{
>       'Accept' = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
>       'Accept-Encoding' = 'gzip, deflate, br'
>       'Accept-Language' = 'en-US,en;q=0.5'
>       'Host' = 'google.com'
>   } > result.html
3. Open file result.html
4. Check that google.com is not in the URLs

### Testing Environment
Zulu JDK 17 Windows 11 with Maven 3.9.0

## Documentation
None

## Notes for Reviewers
