### PR TITLE
Fix for a ClassCastException when a filter over a WebSocket endpoint wraps the request

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -149,8 +149,7 @@ public class GlassFishTestEnvironment {
 
 
     public static int getPort(HttpListenerType listenerType) {
-        return Integer.parseInt(System.getenv()
-                .getOrDefault(listenerType.getVariableName(), String.valueOf(listenerType.getDefaultPort())));
+        return listenerType.getPort();
     }
     /**
      * Creates a {@link Client} instance for the domain administrator.

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -24,6 +24,8 @@ import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -204,6 +206,14 @@ public class GlassFishTestEnvironment {
         return connection;
     }
 
+    public static URI webSocketUri(final int port, final String context) throws URISyntaxException {
+        return webSocketUri(false, port, context);
+    }
+
+    public static URI webSocketUri(final boolean secured, final int port, final String context) throws URISyntaxException {
+        final String protocol = secured ? "wss" : "ws";
+        return new URI(protocol + "://localhost:" + port + context);
+    }
 
     /**
      * Creates the unencrypted password file on the local file system and uses it to create the user

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -148,6 +148,10 @@ public class GlassFishTestEnvironment {
     }
 
 
+    public static int getPort(HttpListenerType listenerType) {
+        return Integer.parseInt(System.getenv()
+                .getOrDefault(listenerType.getVariableName(), String.valueOf(listenerType.getDefaultPort())));
+    }
     /**
      * Creates a {@link Client} instance for the domain administrator.
      * Caller is responsible for closing.

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/HttpListenerType.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/HttpListenerType.java
@@ -37,4 +37,10 @@ public enum HttpListenerType {
         return defaultPort;
     }
 
+    public int getPort() {
+        return Integer.parseInt(System.getenv()
+                .getOrDefault(getVariableName(), String.valueOf(getDefaultPort()))
+        );
+    }
+
 }

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/HttpListenerType.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/HttpListenerType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.itest.tools;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public enum HttpListenerType {
+    ADMIN("AS_ADMIN_PORT", 4848), HTTP("AS_HTTP_PORT", 8080), HTTPS("AS_HTTPS_PORT", 8181);
+    protected String variableName;
+    protected int defaultPort;
+
+    private HttpListenerType(String variableName, int defaultPort) {
+        this.variableName = variableName;
+        this.defaultPort = defaultPort;
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+
+    public int getDefaultPort() {
+        return defaultPort;
+    }
+
+}

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -16,7 +16,9 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -107,6 +109,22 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.jws</groupId>
             <artifactId>jakarta.jws-api</artifactId>
             <version>3.0.0</version>
@@ -115,12 +133,7 @@
         <dependency>
             <groupId>jakarta.xml.soap</groupId>
             <artifactId>jakarta.xml.soap-api</artifactId>
-            <scope>provided</scope>
             <version>3.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -139,6 +152,17 @@
             <artifactId>glassfish-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.tyrus</groupId>
+            <artifactId>tyrus-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.tyrus</groupId>
+            <artifactId>tyrus-container-grizzly-client</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/websocket/CustomRequestResponseServletFilter.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/websocket/CustomRequestResponseServletFilter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.websocket;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.SEVERE;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@WebFilter("/hello")
+public class CustomRequestResponseServletFilter implements Filter {
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        ServletRequest wrappedRequest = new HttpServletRequestWrapper((HttpServletRequest) request) {
+        };
+        ServletResponse wrappedResponse = new HttpServletResponseWrapper((HttpServletResponse) response) {
+        };
+        try {
+            chain.doFilter(wrappedRequest, wrappedResponse);
+        } catch (Exception e) {
+            Logger.getLogger(this.getClass().getName()).log(SEVERE, e.getMessage(), e);
+        }
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/websocket/HelloWebSocketEndpoint.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/websocket/HelloWebSocketEndpoint.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.websocket;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+
+import java.io.IOException;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@ServerEndpoint("/hello")
+@ApplicationScoped
+public class HelloWebSocketEndpoint {
+
+    @OnMessage
+    public void processGreeting(String message, Session session) throws IOException {
+        session.getBasicRemote().sendText("World");
+    }
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/websocket/WebSocketClient.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/websocket/WebSocketClient.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.websocket;
+
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.DeploymentException;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.function.Consumer;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@ClientEndpoint
+public class WebSocketClient {
+
+    Session userSession = null;
+    private Consumer<String> messageHandler;
+
+    public WebSocketClient(URI endpointURI) {
+        try {
+            WebSocketContainer container = ContainerProvider
+                    .getWebSocketContainer();
+            container.connectToServer(this, endpointURI);
+        } catch (DeploymentException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @OnOpen
+    public void onOpen(Session userSession) {
+        this.userSession = userSession;
+    }
+
+    @OnClose
+    public void onClose(Session userSession, CloseReason reason) {
+        this.userSession = null;
+    }
+
+    @OnMessage
+    public void onMessage(String message) {
+        if (this.messageHandler != null)
+            this.messageHandler.accept(message);
+    }
+
+    public void addMessageHandler(Consumer<String> msgHandler) {
+        this.messageHandler = msgHandler;
+    }
+
+    public void sendMessage(String message) {
+        this.userSession.getAsyncRemote().sendText(message);
+    }
+
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/websocket/WebSocketOnDefaultWebModuleTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/websocket/WebSocketOnDefaultWebModuleTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.HttpListenerType.HTTP;
 import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.webSocketUri;
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -44,6 +45,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 public class WebSocketOnDefaultWebModuleTest {
 
     private static final System.Logger LOG = System.getLogger(WebSocketOnDefaultWebModuleTest.class.getName());
+
+    private static final int HTTP_PORT = GlassFishTestEnvironment.getPort(HTTP);
 
     private static final String WEBAPP_FILE_NAME = "webapp.war";
 
@@ -81,7 +84,7 @@ public class WebSocketOnDefaultWebModuleTest {
     @Test
     public void testWebSocketOnDefaultWebModule() throws IOException, URISyntaxException, InterruptedException, ExecutionException, TimeoutException {
 
-        final WebSocketClient webSocketClient = new WebSocketClient(webSocketUri(8080, "/hello"));
+        final WebSocketClient webSocketClient = new WebSocketClient(webSocketUri(HTTP_PORT, "/hello"));
         webSocketClient.sendMessage("Hello");
         CompletableFuture<String> waitForMessage = new CompletableFuture<>();
         webSocketClient.addMessageHandler(msg -> waitForMessage.complete(msg));
@@ -94,7 +97,7 @@ public class WebSocketOnDefaultWebModuleTest {
     @Test
     public void testWebSocketOnAppContextRoot() throws IOException, URISyntaxException, InterruptedException, ExecutionException, TimeoutException {
 
-        final WebSocketClient webSocketClient = new WebSocketClient(webSocketUri(8080, "/" + WEBAPP_NAME + "/hello"));
+        final WebSocketClient webSocketClient = new WebSocketClient(webSocketUri(HTTP_PORT, "/" + WEBAPP_NAME + "/hello"));
         webSocketClient.sendMessage("Hello");
         CompletableFuture<String> waitForMessage = new CompletableFuture<>();
         webSocketClient.addMessageHandler(msg -> waitForMessage.complete(msg));

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/websocket/WebSocketOnDefaultWebModuleTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/websocket/WebSocketOnDefaultWebModuleTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.websocket;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.webSocketUri;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class WebSocketOnDefaultWebModuleTest {
+
+    private static final System.Logger LOG = System.getLogger(WebSocketOnDefaultWebModuleTest.class.getName());
+
+    private static final String WEBAPP_FILE_NAME = "webapp.war";
+
+    private static final String WEBAPP_NAME = "webapp1";
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @TempDir
+    private static File webAppDir;
+
+    @BeforeAll
+    public static void deployAll() throws IOException {
+        File webApp = createWebApp();
+
+        AsadminResult result = ASADMIN.exec("deploy",
+                "--contextroot", "/" + WEBAPP_NAME,
+                "--name", WEBAPP_NAME,
+                webApp.getAbsolutePath());
+        assertThat(result, asadminOK());
+
+        result = ASADMIN.exec("set",
+                "server-config.http-service.virtual-server.server.default-web-module=" + WEBAPP_NAME);
+        assertThat(result, asadminOK());
+    }
+
+    @AfterAll
+    public static void undeployAll() {
+        assertAll(
+                () -> assertThat(ASADMIN.exec("set",
+                        "server-config.http-service.virtual-server.server.default-web-module="), asadminOK()),
+                () -> assertThat(ASADMIN.exec("undeploy", WEBAPP_NAME), asadminOK())
+        );
+    }
+
+    @Test
+    public void testWebSocketOnDefaultWebModule() throws IOException, URISyntaxException, InterruptedException, ExecutionException, TimeoutException {
+
+        final WebSocketClient webSocketClient = new WebSocketClient(webSocketUri(8080, "/hello"));
+        webSocketClient.sendMessage("Hello");
+        CompletableFuture<String> waitForMessage = new CompletableFuture<>();
+        webSocketClient.addMessageHandler(msg -> waitForMessage.complete(msg));
+
+        final String message = waitForMessage.get(10, TimeUnit.SECONDS);
+
+        assertThat(message, equalTo("World"));
+    }
+
+    @Test
+    public void testWebSocketOnAppContextRoot() throws IOException, URISyntaxException, InterruptedException, ExecutionException, TimeoutException {
+
+        final WebSocketClient webSocketClient = new WebSocketClient(webSocketUri(8080, "/" + WEBAPP_NAME + "/hello"));
+        webSocketClient.sendMessage("Hello");
+        CompletableFuture<String> waitForMessage = new CompletableFuture<>();
+        webSocketClient.addMessageHandler(msg -> waitForMessage.complete(msg));
+
+        final String message = waitForMessage.get(10, TimeUnit.SECONDS);
+
+        assertThat(message, equalTo("World"));
+    }
+
+    private static File createWebApp() throws IOException {
+        WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
+                .addClass(HelloWebSocketEndpoint.class);
+
+        LOG.log(INFO, webArchive.toString(true));
+
+        File webApp = new File(webAppDir, WEBAPP_FILE_NAME);
+        webArchive.as(ZipExporter.class).exportTo(webApp, true);
+        return webApp;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/24712.

Makes the cast to RequestFacade more robust - only if cast is allowed, searches through the chain of wrapped requests.

Added tests for the case fixed in #24691 and also for the case described in #24712.