### PR TITLE
GJULE - fixed dependency on system default charset

### DIFF
--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/LogFormatDetector.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/LogFormatDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,6 +20,7 @@ package org.glassfish.main.jul.formatter;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.nio.charset.Charset;
 import java.util.logging.Formatter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -76,15 +77,16 @@ public class LogFormatDetector {
 
     /**
      * @param logFile
+     * @param expectedCharset
      * @return full class name of the concrete detected {@link Formatter} or null if the file is
      *         null or could not be read.
      */
-    public String detectFormatter(final File logFile) {
+    public String detectFormatter(final File logFile, final Charset expectedCharset) {
         if (logFile == null || !logFile.canRead()) {
             return null;
         }
         final String firstLine;
-        try (BufferedReader br = new BufferedReader(new FileReader(logFile))) {
+        try (BufferedReader br = new BufferedReader(new FileReader(logFile, expectedCharset))) {
             firstLine = br.readLine();
         } catch (Exception e) {
             GlassFishLoggingTracer.error(getClass(), e.getMessage(), e);

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
@@ -340,7 +340,7 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
 
         final Formatter formatter = configuration.getFormatterConfiguration();
         setFormatter(formatter);
-        if (isRollRequired(configuration.getLogFile(), formatter)) {
+        if (isRollRequired(configuration.getLogFile(), formatter, this.configuration.getEncoding())) {
             logFileManager.roll();
         }
         // Output is disabled after the creation of the LogFileManager.
@@ -467,11 +467,11 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
     }
 
 
-    private static boolean isRollRequired(final File logFile, final Formatter formatter) {
+    private static boolean isRollRequired(final File logFile, final Formatter formatter, final Charset expectedCharset) {
         if (logFile.length() == 0) {
             return false;
         }
-        final String detectedFormatterName = new LogFormatDetector().detectFormatter(logFile);
+        final String detectedFormatterName = new LogFormatDetector().detectFormatter(logFile, expectedCharset);
         return detectedFormatterName == null || !formatter.getClass().getName().equals(detectedFormatterName);
     }
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SimpleLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SimpleLogHandler.java
@@ -17,6 +17,7 @@
 package org.glassfish.main.jul.handler;
 
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -46,11 +47,14 @@ public class SimpleLogHandler extends StreamHandler {
      */
     public SimpleLogHandler() {
         final HandlerConfigurationHelper helper = HandlerConfigurationHelper.forHandlerClass(getClass());
+        final PrintStream outputStream;
         if (helper.getBoolean(SimpleLogHandlerProperty.USE_ERROR_STREAM, true)) {
-            setOutputStream(new UncloseablePrintStream(LoggingSystemEnvironment.getOriginalStdErr()));
+            outputStream = LoggingSystemEnvironment.getOriginalStdErr();
         } else {
-            setOutputStream(new UncloseablePrintStream(LoggingSystemEnvironment.getOriginalStdOut()));
+            outputStream = LoggingSystemEnvironment.getOriginalStdOut();
         }
+        setOutputStream(new UncloseablePrintStream(outputStream,
+            helper.getCharset(SimpleLogHandlerProperty.ENCODING, Charset.defaultCharset())));
         setFormatter(helper.getFormatter(OneLineFormatter.class));
     }
 
@@ -90,8 +94,8 @@ public class SimpleLogHandler extends StreamHandler {
      */
     private static final class UncloseablePrintStream extends PrintStream {
 
-        private UncloseablePrintStream(PrintStream out) {
-            super(out, false);
+        private UncloseablePrintStream(PrintStream out, Charset encoding) {
+            super(out, false, encoding);
         }
 
         @Override

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/formatter/LogFormatDetectorTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/formatter/LogFormatDetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,10 +16,9 @@
 
 package org.glassfish.main.jul.formatter;
 
-import java.io.File;
-
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -89,7 +88,7 @@ public class LogFormatDetectorTest {
 
     @Test
     public void noFile() throws Exception {
-        assertNull(detector.detectFormatter((File) null));
+        assertNull(detector.detectFormatter(null, UTF_8));
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -156,7 +156,7 @@ public class LoggingPrintStreamTest {
         stream.println(89L);
         stream.println(Level.OFF);
         stream.println("It's fine.");
-        stream.write("F".getBytes());
+        stream.write("F".getBytes(UTF_8));
         stream.write(0);
 
         // This should not produce any record.


### PR DESCRIPTION
- server.log check: we cannot check if the charset is same, but at least we can find that it is incompatible.
- stdoout+stderr: the encoding can be set explicitly
- Reported locally by SpotBugs
