### PR TITLE
Spotted bugs in tests

### DIFF
--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/progress/DummyParent.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/progress/DummyParent.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,17 +17,34 @@
 
 package org.glassfish.api.admin.progress;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
- *
  * @author mmares
  */
 public class DummyParent extends ProgressStatusImpl {
 
-    public ProgressStatusEvent lastEvent;
+    private static final long serialVersionUID = 1L;
+    private final AtomicReference<ProgressStatusEvent> lastEvent = new AtomicReference<>();
 
     @Override
     protected void fireEvent(ProgressStatusEvent event) {
-        lastEvent = event;
+        lastEvent.set(event);
     }
 
+
+    /**
+     * @return last event or null
+     */
+    public ProgressStatusEvent getLastProgressStatusEvent() {
+        return lastEvent.get();
+    }
+
+
+    /**
+     * Sets the last event to null.
+     */
+    public void resetLastProgressStatusEvent() {
+        this.lastEvent.set(null);
+    }
 }

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/progress/ProgressStatusImplTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/progress/ProgressStatusImplTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- *
  * @author mmares
  */
 public class ProgressStatusImplTest {
@@ -47,27 +46,27 @@ public class ProgressStatusImplTest {
         ProgressStatusImpl psi = new ProgressStatusImpl("first", parent, null);
         assertThat(psi.getTotalStepCount(), lessThan(0));
         psi.setTotalStepCount(10);
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         assertEquals(10, psi.getTotalStepCount());
         psi = new ProgressStatusImpl("first", 10, parent, null);
         assertEquals(10, psi.getTotalStepCount());
         psi.progress(8);
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         psi.setTotalStepCount(6);
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         assertEquals(6, psi.getTotalStepCount());
         assertEquals(0, psi.getRemainingStepCount());
         psi.setTotalStepCount(10);
         assertEquals(10, psi.getTotalStepCount());
         assertEquals(4, psi.getRemainingStepCount());
         psi.complete();
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         psi.setTotalStepCount(15);
-        assertNull(parent.lastEvent);
+        assertNull(parent.getLastProgressStatusEvent());
         assertEquals(10, psi.getTotalStepCount());
     }
 
@@ -76,8 +75,8 @@ public class ProgressStatusImplTest {
         ProgressStatusImpl psi = new ProgressStatusImpl("first", 10, parent, null);
         assertEquals(10, psi.getRemainingStepCount());
         psi.progress(1);
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         assertEquals(9, psi.getRemainingStepCount());
         psi.progress(2);
         assertEquals(7, psi.getRemainingStepCount());
@@ -90,11 +89,11 @@ public class ProgressStatusImplTest {
         psi.progress(2, null);
         assertEquals(1, psi.getRemainingStepCount());
         psi.progress(1);
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         assertEquals(0, psi.getRemainingStepCount());
         psi.progress(1);
-        assertNull(parent.lastEvent);
+        assertNull(parent.getLastProgressStatusEvent());
         assertEquals(0, psi.getRemainingStepCount());
         psi = new ProgressStatusImpl("second", parent, null);
         assertThat(psi.getRemainingStepCount(), lessThan(0));
@@ -129,8 +128,8 @@ public class ProgressStatusImplTest {
         assertFalse(psi.isComplete());
         psi.complete();
         assertTrue(psi.isComplete());
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         psi = new ProgressStatusImpl("first", parent, null);
         assertFalse(psi.isComplete());
         psi.complete();
@@ -148,9 +147,9 @@ public class ProgressStatusImplTest {
         assertFalse(psi.isComplete());
         psi = new ProgressStatusImpl("first", 10, parent, null);
         psi.complete();
-        parent.lastEvent = null;
+        parent.resetLastProgressStatusEvent();
         psi.complete();
-        assertNull(parent.lastEvent);
+        assertNull(parent.getLastProgressStatusEvent());
     }
 
     @Test
@@ -162,9 +161,9 @@ public class ProgressStatusImplTest {
         ProgressStatus ch3 = psi.createChild("A.3", 10);
         assertEquals(0, psi.getRemainingStepCount());
         assertEquals(15, psi.getTotalStepCount());
-        parent.lastEvent = null;
+        parent.resetLastProgressStatusEvent();
         ch1.progress(1);
-        assertNotNull(parent.lastEvent);
+        assertNotNull(parent.getLastProgressStatusEvent());
         psi.complete();
         assertTrue(psi.isComplete());
         assertTrue(ch1.isComplete());

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/progress/ProgressStatusMirroringImplTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/progress/ProgressStatusMirroringImplTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -74,10 +74,10 @@ public class ProgressStatusMirroringImplTest {
         ProgressStatus ch2 = prog.createChild("A2", 0);
         assertNotNull(ch2);
         assertEquals(0, prog.currentStepCount);
-        parent.lastEvent = null;
+        parent.resetLastProgressStatusEvent();
         ch1.progress(1);
-        assertNotNull(parent.lastEvent);
-        parent.lastEvent = null;
+        assertNotNull(parent.getLastProgressStatusEvent());
+        parent.resetLastProgressStatusEvent();
         assertEquals(1, prog.currentStepCount);
         ch2.progress(2, "Some message");
         assertEquals(3, prog.currentStepCount);

--- a/nucleus/hk2-config-generator/src/test/java/org/jvnet/hk2/config/test/example/SimpleConfigBeanWrapper.java
+++ b/nucleus/hk2-config-generator/src/test/java/org/jvnet/hk2/config/test/example/SimpleConfigBeanWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -70,7 +70,6 @@ public final class SimpleConfigBeanWrapper extends ConfigBean {
 
     @Override
     public <T extends ConfigBeanProxy> T createProxy(Class<T> proxyType) {
-        SimpleConfigViewWrapper.habitat = getHabitat();
         if (defaultView==null) {
             defaultView = new SimpleConfigViewWrapper(this);
         }

--- a/nucleus/hk2-config-generator/src/test/java/org/jvnet/hk2/config/test/example/SimpleConfigViewWrapper.java
+++ b/nucleus/hk2-config-generator/src/test/java/org/jvnet/hk2/config/test/example/SimpleConfigViewWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.regex.Pattern;
 
-import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.config.ConfigBeanProxy;
 import org.jvnet.hk2.config.ConfigView;
 
@@ -74,12 +73,6 @@ public class SimpleConfigViewWrapper implements ConfigView {
     @Override
     public <T extends ConfigBeanProxy> T getProxy(Class<T> proxyType) {
         return proxyType.cast(Proxy.newProxyInstance(proxyType.getClassLoader(), new Class[] {proxyType}, this));
-    }
-
-    static ServiceLocator habitat;
-
-    public static void setHabitat(ServiceLocator h) {
-        habitat = h;
     }
 
    /**


### PR DESCRIPTION
- detected by SpotBugs
  - unused ServiceLocator in hk2 config generator tests
  - known null value - was a bad practice. The field value could be changed in general but was used as if it could not be changed. But if it could not be changed, it is known null and there is no reason to check it with assert. Or if it could be changed, then it should not be public. 

