### PR TITLE
Fixes service creation on Solaris operating system

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/services/SMFService.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/services/SMFService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -422,15 +422,17 @@ public final class SMFService extends ServiceAdapter {
     private boolean serviceNameExists(final String sn) {
         boolean exists = false;
         try {
-            final String[] cmd = new String[] { "/usr/bin/svcs", sn };
+            final String[] cmd = new String[] {"/usr/bin/svcs", sn};
             ProcessManager pm = new ProcessManager(cmd);
             pm.setTimeoutMsec(DEFAULT_SERVICE_TIMEOUT);
-            pm.execute();
-            exists = true;
+            int exitCode = pm.execute();
+            if (exitCode == 0) {
+                exists = true;
+            }
         } catch (final Exception e) {
-            //returns a non-zero status -- the service does not exist, status is already set
+            // Do nothing, status is already set.
         }
-        return (exists);
+        return exists;
     }
 
     private void validateManifest(final String manifestPath) throws Exception {


### PR DESCRIPTION
The `create-service` command failed on Solaris:

![solaris1](https://github.com/user-attachments/assets/ed3c51ea-2cf1-4d27-ba94-11dd2d5ae7ec)

With this patch:

![solaris2](https://github.com/user-attachments/assets/cb7ddcf8-8771-4951-bdf8-054c8627f07f)
