### PR TITLE
Fix for #24805: Do not unenlist XA transactions if related to the current Tx

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolTxHelper.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolTxHelper.java
@@ -116,15 +116,15 @@ public class PoolTxHelper {
     /**
      * Check whether the local resource in question is the one participating in transaction.
      *
-     * @param h ResourceHandle
+     * @param handle ResourceHandle
      * @return true if the resource is participating in the transaction
      */
-    public boolean isLocalResourceInTransaction(ResourceHandle h) {
+    private boolean isLocalResourceInTransaction(ResourceHandle handle) {
         boolean result = true;
         try {
             JavaEETransaction txn = (JavaEETransaction) ConnectorRuntime.getRuntime().getTransaction();
             if (txn != null) {
-                result = isNonXAResourceInTransaction(txn, h);
+                result = isNonXAResourceInTransaction(txn, handle) && txn.getResources(poolInfo).contains(handle);
             }
         } catch (SystemException e) {
             if (_logger.isLoggable(Level.FINE)) {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolTxHelper.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolTxHelper.java
@@ -124,7 +124,7 @@ public class PoolTxHelper {
         try {
             JavaEETransaction txn = (JavaEETransaction) ConnectorRuntime.getRuntime().getTransaction();
             if (txn != null) {
-                result = isNonXAResourceInTransaction(txn, handle) && txn.getResources(poolInfo).contains(handle);
+                result = isNonXAResourceInTransaction(txn, handle) || txn.getResources(poolInfo).contains(handle);
             }
         } catch (SystemException e) {
             if (_logger.isLoggable(Level.FINE)) {


### PR DESCRIPTION
Hopefully fixes #24805.

I think the problem with #24805 is:

* Multiple resources (e.g. DB connections) are enlisted in a transaction
* As resources are delisted, they are removed from the transaction but not delisted
* As transaction commits, resources are delisted
* As resources are closed (released to the pool), they are delisted if they are not the non-XA resource in the current transaction

I suspect that sometimes XA resources are closed, which unenlists them, and they are reused by another transaction before the previous transaction completes and delists the resources. Therefore a new transaction uses a resources, which is already marked as enlisted and doesn't attempt to enlist it again. This also means that the new transaction doesn't call the enlistResource method, and doesn't set the non-XA resource and keeps it null. This leads to a NullPtr later.

The NullPtr happens very rarely, I think only if a new transaction asks for the resource between the time when it's closed and previous Tx is completed, and only if the new transaction contains this single resource. Then no other resource calls the enlistResource method and the non-XA resource remains null, which leads to an exception when delisting the single resource in the new transaction.

This PR should keep all XA resources with the transaction if they are still associated with the transaction, and then delist all the resources at the end of the transaction. Otherwise resources are prematurely removed from Tx before Tx commits and delists them.

@escay, can you please try this?