### PR TITLE
Hide "Trying to get this manpage" messages for asadmin --help

### DIFF
--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/admin/ManPageFinder.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/admin/ManPageFinder.java
@@ -118,7 +118,7 @@ public class ManPageFinder {
                         j = 0;
                     }
                 }
-                logger.log(Level.FINE, "Trying to get this manpage: {0}", result);
+                logger.log(Level.FINER, "Trying to get this manpage: {0}", result);
                 return result;
             }
 


### PR DESCRIPTION
Asadmin sets log level to FINE by default, unless --terse option is used. The "Trying to get this manpage" messages are useless for users, and there are many of them logged for by each asadmin command with --help option. Running asadmin with AS_DEBUG=true environment variable enables these messages if needed.

Current behavior:

The output of command `asadmin --help` prints the following at the beginning:

```
Trying to get this manpage: com/sun/enterprise/admin/cli/en/asadmin.9
Trying to get this manpage: com/sun/enterprise/admin/cli/en/asadmin.9m
Trying to get this manpage: com/sun/enterprise/admin/cli/en/asadmin.5asc
Trying to get this manpage: com/sun/enterprise/admin/cli/asadmin.1
Trying to get this manpage: com/sun/enterprise/admin/cli/asadmin.1m
asadmin(1M)                    Utility Commands                    asadmin(1M)

NAME
       asadmin - utility for performing administrative tasks for Oracle
       GlassFish Server
```

Only with the `--terse` option (`asadmin --help --terse`), the output doesn't contain the "Trying to get this manpage..." lines.


With the fix in this PR, the output of `asadmin --help` doesn't contain the "Trying to get this manpage..." lines. Same as the current behavior of `asadmin --help --terse`:

```
asadmin(1M)                    Utility Commands                    asadmin(1M)

NAME
       asadmin - utility for performing administrative tasks for Oracle
       GlassFish Server
```

If needed, the "Trying to get this manpage..." lines can be displayed by setting the `AS_DEBUG` or `AS_TRACE` env variables to `true`, for example:

```
AS_DEBUG=true asadmin --help
```