### PR TITLE
Remove unknown plugin parameter

### DIFF
--- a/appserver/distributions/pom.xml
+++ b/appserver/distributions/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -89,7 +90,6 @@
                                 <excludes>META-INF/maven/**</excludes>
                                 <copyTypes>jar,war</copyTypes>
                                 <unpackTypes>zip,rar,war</unpackTypes>
-                                <silent>true</silent>
                                 <copyExcludes>war</copyExcludes>
                                 <mappings>
                                     <mapping>


### PR DESCRIPTION
Fix:
```
[WARNING] Parameter 'silent' is unknown for plugin 'glassfishbuild-maven-plugin:4.0.1:featuresets-dependencies (default-featuresets-dependencies)'
```

