### PR TITLE
The XFS file system doesn't return size of the directory content

### DIFF
--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/io/FileUtilsTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/io/FileUtilsTest.java
@@ -88,7 +88,7 @@ public class FileUtilsTest {
         File outputDir = new File(tempDir, "outputDir");
         File testDir = new File(FileUtilsTest.class.getResource("/process").toURI());
         FileUtils.copy(testDir, outputDir);
-        assertEquals(testDir.length(), outputDir.length());
+        assertEquals(FileUtils.getSize(testDir), FileUtils.getSize(outputDir));
     }
 
 


### PR DESCRIPTION
* Fixes #25089 
* The Javadoc of File.length says: "The return value is unspecified if this pathname denotes a directory." - while that worked well on EXT4 and probably on most file systems (returned sum of file sizes under the tree), it doesn't work with XFS.