### PR TITLE
Fixed masking passwords in a map used for logging in admingui + added warning to documentation

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -169,7 +169,7 @@ public class RestUtil {
                     neutralizeForLog(GuiUtil.getCommonMessage("LOG_REST_REQUEST_INFO",
                             new Object[] {
                                     endpoint,
-                                    (useData && "post".equals(method)) ? data : attrs, method
+                                    (useData && "post".equals(method)) ? data : maskedAttr, method
                             })));
         }
 

--- a/docs/administration-guide/src/main/asciidoc/logging.adoc
+++ b/docs/administration-guide/src/main/asciidoc/logging.adoc
@@ -38,6 +38,14 @@ we recommend to use the
 or even better it's latest facade
 `https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.Logger.html[System.Logger]`.
 
+[WARNING]
+====
+Logs may contain sensitive information.
+Despite the {productName} in default configuration doesn't log any passwords,
+before you share logs with anyone else you should verify that you don't compromise your
+system by any information contained in logs, especially if you configured more verbose log levels.
+====
+
 [[log-manager]]
 ==== Log Manager
 
@@ -870,6 +878,14 @@ You can view the full syntax and options of the subcommand by typing
 You will probably need to set logger levels most often.
 Let's imagine that you would need to set the most verbose logging of an application
 using the `org.acme` package (and logger names).
+
+[WARNING]
+====
+Logs may contain sensitive information.
+Despite the {productName} in default configuration doesn't log any passwords,
+before you share logs with anyone else you should verify that you don't compromise your
+system by any information contained in logs, especially if you configured more verbose log levels.
+====
 
 Then you can edit the `logging.properties` file directly, what can be quite
 more complicated it you use more than one instance, see the xref:configuring-warning[warning].

--- a/docs/security-guide/src/main/asciidoc/running-in-secure-environment.adoc
+++ b/docs/security-guide/src/main/asciidoc/running-in-secure-environment.adoc
@@ -427,15 +427,24 @@ attempted breaches. Noting repeated failed logon attempts or a
 surprising pattern of security events can prevent serious problems.
 
 |Set logging for security and SSL messages. a|
-Consider setting module log levels for
-table.jakarta.enterprise.system.ssl.security and
-jakarta.enterprise.system.core.security. You can set a level from Severe
-to Finest (the default is Info), but be aware that the finer logging
-levels may produce a large log file.
+Consider setting module log levels for +
+`jakarta.enterprise.system.security.ssl` +
+and +
+`jakarta.enterprise.system.core.security`. +
+You can set a level from `SEVERE` to `FINEST` (the default is `INFO`),
+but be aware that the finer logging levels may produce a large log file
+and may contain sensitive information.
 
-By default, {productName} logging messages are recorded in the server
-log, and you can set the file rotation limit, as described in
+By default, {productName} logging messages are recorded in the `server.log` file,
+and you can set the file rotation limit, as described in
 xref:reference-manual.adoc#rotate-log[`rotate-log`(1)]
+
+|Ensure that you don't share sensitive information in logs.
+|Logs may contain sensitive information.
+Despite the ${productName} in default configuration doesn't log any passwords,
+before you share logs with anyone else you should verify that you don't compromise your
+system by any information contained in logs, especially if you configured
+more verbose log levels.
 
 |Ensure that you have correctly assigned users to the correct groups.
 |Make sure you have assigned the desired set of users to the right


### PR DESCRIPTION
* This was discussed on GitLab - the bug was reported there
* I  added warning about sharing logs into documentation on three appropriate places:
  * To the introduction of the logging documentation
  * To the part about configuring log levels
  * To the list of recommendations in the security guide
* In general passwords are not the only thing which can be misused to compromise some production system. People should be careful when they share logs, especially when they configured more verbose log levels. Internal host names, distinguished names of internal certificates, dumped HTTP communication, TLS negotiations, ....