### PR TITLE
Executable GlassFish Embedded in GlassFish Server installation

### DIFF
--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -35,6 +35,8 @@
     <properties>
         <path.derby>../../../javadb/lib</path.derby>
         <classpath.derby>${path.derby}/derby.jar ${path.derby}/derbyclient.jar ${path.derby}/derbynet.jar ${path.derby}/derbytools.jar ${path.derby}/derbyrun.jar</classpath.derby>
+        <path.bootstrap>../bootstrap</path.bootstrap>
+        <classpath.bootstrap>${path.bootstrap}/grizzly-npn-api.jar ${path.bootstrap}/glassfish-jul-extension.jar</classpath.bootstrap>
     </properties>
 
     <dependencies>
@@ -1383,7 +1385,8 @@
                         </manifest>
                         <manifestEntries>
                             <Bundle-SymbolicName>org.glassfish.embedded.static-shell</Bundle-SymbolicName>
-                            <Class-Path>${classpath.derby}</Class-Path>
+                            <Class-Path>${classpath.derby} ${classpath.bootstrap}</Class-Path>
+                            <Main-Class>com.sun.enterprise.glassfish.bootstrap.UberMain</Main-Class>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
This makes GlassFish Embedded static shell in the GlassFish Server installation, located at `glassfish/lib/embedded/glassfish-embedded-static-shell.jar`, equal to the classical GlassFish Embedded JAR. The UberMain class is the main class of the JAR and the GlassFish bootstrap JARs are added to the classpath.

The GlassFish Embedded static shell JAR can be treated as glassfish-embedded-all.jar - it can be added to the classpath and run GlassFish Embedded apps, or can be started as an executable JAR with `java -jar glassfish/lib/embedded/glassfish-embedded-static-shell.jar`.

This is a preparation for running GlassFish Embedded from the GlassFish Server Docker image. I'm working on adding more features to the executable JAR to allow configuring it and running applications from command line.