### PR TITLE
Fixed insecure XML processing - all XSDs and DTD have to be local

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -118,7 +118,10 @@ public class DomainBuilder {
             if (je == null) {
                 throw new DomainException(format("Missing mandatory file {0}.", TEMPLATE_INFO_XML));
             }
-            TemplateInfoHolder templateInfoHolder = new TemplateInfoHolder(_templateJar.getInputStream(je), templateJarPath);
+            final TemplateInfoHolder templateInfoHolder;
+            try (InputStream is = _templateJar.getInputStream(je)) {
+                templateInfoHolder = new TemplateInfoHolder(is, templateJarPath);
+            }
             _extractedEntries.add(TEMPLATE_INFO_XML);
 
             // Loads string substitution XML.

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/stringsubs/impl/StringSubstitutionParser.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/stringsubs/impl/StringSubstitutionParser.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2018-2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -68,6 +69,9 @@ public class StringSubstitutionParser {
             JAXBContext context = JAXBContext.newInstance(StringsubsDefinition.class.getPackage().getName());
             Unmarshaller unmarshaller = context.createUnmarshaller();
             SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file");
+            schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             Schema schema = schemaFactory.newSchema(schemaUrl);
             unmarshaller.setSchema(schema);
             InputSource is = new InputSource(configStream);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/template/TemplateInfoHolder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/template/TemplateInfoHolder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,7 +25,6 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.Unmarshaller;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
@@ -41,7 +41,7 @@ public class TemplateInfoHolder {
     //Path where schema resides.
     private final static String TEMPLATE_INFO_SCHEMA_PATH = "xsd/schema/template-info.xsd";
     private TemplateInfo _templateInfo;
-    private String _location;
+    private final String _location;
 
     public TemplateInfoHolder(InputStream inputSteam, String location) throws DomainException {
         try {
@@ -67,29 +67,22 @@ public class TemplateInfoHolder {
      * @return Parsed Object.
      * @throws Exception If any error occurs in parsing.
      */
-    @SuppressWarnings("rawtypes")
-    private TemplateInfo parse(InputStream configStream) throws Exception {
+    private static TemplateInfo parse(InputStream configStream) throws Exception {
         if (configStream == null) {
-            throw new DomainException("Invalid stream");
+            throw new DomainException("Invalid stream: null");
         }
-        try {
-            URL schemaUrl = getClass().getClassLoader().getResource(TEMPLATE_INFO_SCHEMA_PATH);
-            JAXBContext context = JAXBContext.newInstance(TemplateInfo.class.getPackage().getName());
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            Schema schema = schemaFactory.newSchema(schemaUrl);
-            unmarshaller.setSchema(schema);
-            InputSource is = new InputSource(configStream);
-            SAXSource source = new SAXSource(is);
-            Object obj = unmarshaller.unmarshal(source);
-            return obj instanceof JAXBElement ? (TemplateInfo) (((JAXBElement) obj).getValue()) : (TemplateInfo) obj;
-        } finally {
-            try {
-                configStream.close();
-                configStream = null;
-            } catch (IOException e) {
-                /** Ignore */
-            }
-        }
+        URL schemaUrl = TemplateInfoHolder.class.getClassLoader().getResource(TEMPLATE_INFO_SCHEMA_PATH);
+        JAXBContext context = JAXBContext.newInstance(TemplateInfo.class.getPackage().getName());
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        Schema schema = schemaFactory.newSchema(schemaUrl);
+        unmarshaller.setSchema(schema);
+        InputSource is = new InputSource(configStream);
+        SAXSource source = new SAXSource(is);
+        Object obj = unmarshaller.unmarshal(source);
+        return obj instanceof JAXBElement ? (TemplateInfo) (((JAXBElement) obj).getValue()) : (TemplateInfo) obj;
     }
 }


### PR DESCRIPTION
* See also
  *  https://find-sec-bugs.github.io/bugs.htm#XXE_DTD_TRANSFORM_FACTORY
  * https://docs.stackhawk.com/vulnerabilities/90023/
  * https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
* We use just local XSD and DTD files here 

Additional changes:
* It is better to close the stream where it was open, symmetrically (try-with)