### PR TITLE
Fix exception if GF Embedded config file is set without schema

### DIFF
--- a/appserver/tests/embedded/basic/config/README.md
+++ b/appserver/tests/embedded/basic/config/README.md
@@ -1,0 +1,1 @@
+Tests starting GlassFish Embedded with configuration options

--- a/appserver/tests/embedded/basic/config/pom.xml
+++ b/appserver/tests/embedded/basic/config/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.tests.embedded</groupId>
+        <artifactId>basic</artifactId>
+        <version>7.0.18-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.tests.embedded.basic</groupId>
+    <artifactId>config</artifactId>
+    <name>Test different config options</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources-to-surefire-workingdir</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${surefire.workdir}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/test/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>run-with-uber-jar</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-all</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>run-with-uber-jar-web</id>
+            <activation>
+                <property>
+                    <name>build</name>
+                    <value>uber-jar-web</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-web</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>run-with-shell-jar</id>
+            <activation>
+                <property>
+                    <name>build</name>
+                    <value>static-shell</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-static-shell</artifactId>
+                    <version>${project.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${env.S1AS_HOME}/lib/embedded/glassfish-embedded-static-shell.jar
+                    </systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/appserver/tests/embedded/basic/config/src/test/java/org/glassfish/tests/embedded/basic/config/ConfigTest.java
+++ b/appserver/tests/embedded/basic/config/src/test/java/org/glassfish/tests/embedded/basic/config/ConfigTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.basic.config;
+
+import com.sun.enterprise.config.serverbeans.Domain;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.glassfish.embeddable.GlassFish;
+import org.glassfish.embeddable.GlassFishException;
+import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Ondro Mihalyi
+ */
+
+public class ConfigTest {
+
+    public static final Logger logger = Logger.getLogger(ConfigTest.class.getName());
+
+    static GlassFishRuntime runtime;
+
+    @BeforeAll
+    static void bootStrap() throws GlassFishException {
+                runtime = GlassFishRuntime.bootstrap();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ConfigFileArgumentsProvider.class)
+    void testConfigFile(String configFile) throws GlassFishException, IOException, URISyntaxException {
+        GlassFishProperties gfp = new GlassFishProperties();
+        gfp.setConfigFileURI(configFile);
+
+        GlassFish instance1 = runtime.newGlassFish(gfp);
+        logger.info(() -> "Instance1 created" + instance1);
+        instance1.start();
+        logger.info("Instance1 started #1");
+
+        final String domainName = instance1.getService(Domain.class).getName();
+        assertTrue("myDomain".equals(domainName), "Domain name is " + domainName);
+
+        instance1.stop();
+        logger.info("Instance1 stopped #1");
+        instance1.dispose();
+        logger.info("Instance1 disposed");
+        checkDisposed();
+    }
+
+    private static class ConfigFileArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext ec) throws Exception {
+            return Stream.of(Arguments.of(fileInClassPath()),
+                    Arguments.of("domain.xml"),
+                    Arguments.of(new File("domain.xml").getAbsolutePath())
+            );
+        }
+
+        private String fileInClassPath() throws URISyntaxException, IOException {
+            return this.getClass().getClassLoader().getResources("domain.xml").nextElement().toURI().toString();
+        }
+
+    }
+    // throws exception if the temp dir is not cleaned out.
+    private void checkDisposed() {
+        String instanceRoot = System.getProperty("com.sun.aas.instanceRoot");
+        logger.info(() -> "Checking whether " + instanceRoot + " is disposed or not");
+        if (new File(instanceRoot).exists()) {
+            throw new RuntimeException("Directory " + instanceRoot +
+                    " is not cleaned up after glassfish.dispose()");
+        }
+    }
+
+}

--- a/appserver/tests/embedded/basic/config/src/test/resources/domain.xml
+++ b/appserver/tests/embedded/basic/config/src/test/resources/domain.xml
@@ -1,0 +1,175 @@
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+  <property name="administrative.domain.name" value="myDomain"/>
+  <security-configurations>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/embedded_default" />
+      <property name="connectionAttributes" value=";create=true" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="server" config-ref="server-config">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+    </server>
+  </servers>
+ <configs>
+   <config name="server-config">
+     <http-service>
+        <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
+        <virtual-server id="server" network-listeners="http-listener, https-listener" />
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="3700" id="orb-listener-1" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3820" id="SSL">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3920" id="SSL_MUTUALAUTH">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector enabled="false" auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="8686" name="system" />
+        <das-config autodeploy-enabled="false" dynamic-reload-enabled="true" deploy-xml-validation="full" autodeploy-dir="${com.sun.aas.instanceRoot}/autodeploy" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+      <ejb-container steady-pool-size="0" max-pool-size="32" session-store="${com.sun.aas.instanceRoot}/session-store" pool-resize-quantity="8">
+        <ejb-timer-service />
+      </ejb-container>
+      <mdb-container steady-pool-size="0" max-pool-size="32" pool-resize-quantity="8" >
+      </mdb-container>
+      <jms-service type="EMBEDDED" default-jms-host="default_JMS_host">
+        <jms-host name="default_JMS_host" host="localhost" port="7676" admin-user-name="admin" admin-password="admin" lazy-init="false"/>
+      </jms-service>
+      <log-service file="${com.sun.aas.instanceRoot}/logs/server.log" log-rotation-limit-in-bytes="2000000">
+        <module-log-levels />
+      </log-service>
+      <security-service activate-default-principal-to-role-mapping="true" jacc="simple">
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <monitoring-service>
+        <module-monitoring-levels />
+      </monitoring-service>
+      <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" >
+      </transaction-service>
+      <java-config>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Dorg.glassfish.jms.InitializeOnDemand=true</jvm-options>
+      </java-config>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+          <protocol security-enabled="true" name="https-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="0" protocol="http-listener" transport="tcp" name="http-listener" thread-pool="http-thread-pool" enabled="false" />
+          <network-listener port="0" protocol="https-listener" transport="tcp" name="https-listener" thread-pool="http-thread-pool" enabled="false" />
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+      </thread-pools>
+    </config>
+  </configs>
+</domain>

--- a/appserver/tests/embedded/basic/pom.xml
+++ b/appserver/tests/embedded/basic/pom.xml
@@ -32,5 +32,6 @@
     <name>Basic tests for testing org.glassfish.embeddable APIs</name>
     <modules>
         <module>lifecycle</module>
+        <module>config</module>
     </modules>
 </project>

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -32,6 +32,11 @@
     <artifactId>embedded</artifactId>
     <packaging>pom</packaging>
     <name>GlassFish Embedded Tests</name>
+    
+    <properties>
+        <surefire.workdir>${project.build.directory}/surefire-workdir</surefire.workdir>
+        <failsafe.workdir>${project.build.directory}/failsafe-workdir</failsafe.workdir>
+    </properties>
 
     <modules>
         <module>basic</module>
@@ -66,20 +71,20 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <workingDirectory>${project.build.directory}/surefire-workdir</workingDirectory>
+                        <workingDirectory>${surefire.workdir}</workingDirectory>
                         <systemPropertyVariables>
                             <project.directory>${basedir}</project.directory>
-                            <buildDir>${project.build.directory}/surefire-workdir</buildDir>
+                            <buildDir>${surefire.workdir}</buildDir>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <configuration>
-                        <workingDirectory>${project.build.directory}/failsafe-workdir</workingDirectory>
+                        <workingDirectory>${failsafe.workdir}</workingDirectory>
                         <systemPropertyVariables>
                             <project.directory>${basedir}</project.directory>
-                            <buildDir>${project.build.directory}/failsafe-workdir</buildDir>
+                            <buildDir>${failsafe.workdir}</buildDir>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXml.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/DomainXml.java
@@ -19,6 +19,7 @@ package org.glassfish.config.support;
 
 import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Server;
+import com.sun.enterprise.config.util.ConfigApiLoggerInfo;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.bootstrap.StartupContext;
 import com.sun.enterprise.util.LocalStringManagerImpl;
@@ -77,7 +78,7 @@ import static java.util.logging.Level.WARNING;
  */
 public abstract class DomainXml implements Populator {
 
-    private static final Logger LOG = Logger.getLogger(DomainXml.class.getName());
+    private static final Logger LOG = ConfigApiLoggerInfo.getLogger();
 
     @Inject
     StartupContext context;

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishProperties.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishProperties.java
@@ -17,6 +17,8 @@
 
 package org.glassfish.embeddable;
 
+import java.io.File;
+import java.net.URI;
 import java.util.Properties;
 
 /**
@@ -135,7 +137,7 @@ public class GlassFishProperties {
      * Unless specified, the configuration file is operated on read only mode.
      * To writeback any changes, call {@link #setConfigFileReadOnly(boolean)} with 'false'.
      *
-     * @param configFileURI Location of configuration file.
+     * @param configFileURI Location of configuration file. File path, or full URI with the schema, e.g. file:
      */
     public void setConfigFileURI(String configFileURI) {
         gfProperties.setProperty(CONFIG_FILE_URI_PROP_NAME, configFileURI);
@@ -148,6 +150,15 @@ public class GlassFishProperties {
      */
     public String getConfigFileURI() {
         return gfProperties.getProperty(CONFIG_FILE_URI_PROP_NAME);
+    }
+
+    /**
+     * Get the absolute URI, with schema, set using {@link #setConfigFileURI(String)}. Internally uses {@link #filePathToAbsoluteURI(java.lang.String)}.
+     *
+     * @return The configurationFileURI set using {@link #setConfigFileURI(String)} converted to URI
+     */
+    public URI getAbsoluteConfigFileURI() {
+        return filePathToAbsoluteURI(getConfigFileURI());
     }
 
     /**
@@ -234,5 +245,23 @@ public class GlassFishProperties {
             }
         }
         return port;
+    }
+
+    /**
+     * Converts to absolute URI with absolute path.
+     * If the filePath doesn't contain schema, it will add file: schema
+     *
+     * @param filePath Path to create the URI
+     * @return absolute URI
+     */
+    public static URI filePathToAbsoluteURI(String filePath) {
+        if (filePath == null) {
+            return null;
+        }
+        URI uri = URI.create(filePath);
+        if (!uri.isAbsolute()) {
+            return new File(filePath).getAbsoluteFile().toURI();
+        }
+        return uri;
     }
 }

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/embedded/EmbeddedGlassFishRuntime.java
@@ -199,9 +199,9 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
             }
 
             // If the user has specified a custom domain.xml then copy it.
-            String configFileURI = gfProps.getConfigFileURI();
+            URI configFileURI = gfProps.getAbsoluteConfigFileURI();
             if(configFileURI != null) {
-                copy(URI.create(configFileURI).toURL(), new File(instanceConfigDir, "domain.xml"), true);
+                copy(configFileURI.toURL(), new File(instanceConfigDir, "domain.xml"), true);
             }
         } catch (Exception ex) {
             LOG.log(SEVERE, "Failed to create instanceRoot", ex);

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/embedded/EmbeddedDomainXml.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/embedded/EmbeddedDomainXml.java
@@ -24,7 +24,6 @@ import jakarta.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URL;
 
 import org.glassfish.embeddable.GlassFishProperties;
@@ -49,7 +48,7 @@ public class EmbeddedDomainXml extends GFDomainXml {
     static URL getDomainXml(StartupContext startupContext) throws IOException {
         String configFileURI = startupContext.getArguments().getProperty(GlassFishProperties.CONFIG_FILE_URI_PROP_NAME);
         if (configFileURI != null) { // user specified domain.xml
-            return URI.create(configFileURI).toURL();
+            return GlassFishProperties.filePathToAbsoluteURI(configFileURI).toURL();
         }
         String instanceRoot = startupContext.getArguments().getProperty(
                 "com.sun.aas.instanceRoot");


### PR DESCRIPTION
GlassFish Embedded expects that the `URI` argument to `glassFishProperties.setConfigFileURI()` is "absolute", which means it should start with schema, e.g. "file:/glassfish/domain.xml". Otherwise it will throw an exception. This is counterintuitive.

This fixes it to accept also a path without the schema,  and retrieves the `URI` from `File`. Then it's enough to pass "/glassfish/domain.xml", or a relative path, "domain.xml", for example.

Also fixes a log message if domain.xml is not valid.