### PR TITLE
Dynamically update classloader after adding a library with the add-library command

### DIFF
--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/connpool/SQLTraceListenerTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/connpool/SQLTraceListenerTest.java
@@ -78,10 +78,7 @@ public class SQLTraceListenerTest {
 
         result = ASADMIN.exec("add-library", lib.getAbsolutePath());
         assertThat(result, asadminOK());
-
-        // add-library requires restart
-        result = ASADMIN.exec("restart-domain");
-        assertThat(result, asadminOK());
+        // add-library shouldn't require a restart anymore
 
         DOMAIN_SETTINGS.backupDerbyPoolSettings();
         DOMAIN_SETTINGS.setDerbyPoolEmbededded();

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/GlassfishUrlClassLoader.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/GlassfishUrlClassLoader.java
@@ -80,6 +80,12 @@ public class GlassfishUrlClassLoader extends URLClassLoader {
         super(urls, parent, factory);
     }
 
+    // turn protected to public
+    @Override
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+
 
     @Override
     protected Class<?> findClass(final String name) throws ClassNotFoundException {

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -260,6 +260,56 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.1</version>
+                <executions>
+                    <execution>
+                        <id>commonClassLoader tests</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <inlineDescriptors>
+                        <inlineDescriptor>
+                            <id>domain</id>
+                            <includeBaseDirectory>false</includeBaseDirectory>
+                            <formats>
+                                <format>dir</format>
+                            </formats>
+                            <fileSets>
+                                <fileSet>
+                                    <outputDirectory>lib/classes</outputDirectory>
+                                    <includes>
+                                        <include>**/CommonClassLoaderServiceImplTestDomainClass.class</include>
+                                    </includes>
+                                    <directory>target/test-classes/</directory>
+                                </fileSet>
+                            </fileSets>
+                        </inlineDescriptor>
+                        <inlineDescriptor>
+                            <id>additional-classes</id>
+                            <includeBaseDirectory>false</includeBaseDirectory>
+                            <formats>
+                                <format>dir</format>
+                            </formats>
+                            <fileSets>
+                                <fileSet>
+                                    <outputDirectory>/</outputDirectory>
+                                    <includes>
+                                        <include>**/CommonClassLoaderServiceImplTestAdditionalClass.class</include>
+                                    </includes>
+                                    <directory>target/test-classes/</directory>
+                                </fileSet>
+                            </fileSets>
+                        </inlineDescriptor>
+                    </inlineDescriptors>
+                    <finalName>test</finalName>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -31,6 +31,10 @@
     <packaging>glassfish-jar</packaging>
 
     <name>Kernel Classes</name>
+    
+    <properties>
+        <commonClassLoader.tests.skip>false</commonClassLoader.tests.skip>
+    </properties>
 
     <developers>
         <developer>
@@ -273,6 +277,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skipAssembly>${commonClassLoader.tests.skip}</skipAssembly>
                     <inlineDescriptors>
                         <inlineDescriptor>
                             <id>domain</id>
@@ -312,4 +317,13 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>fastest</id>
+            <properties>
+                <commonClassLoader.tests.skip>true</commonClassLoader.tests.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
@@ -159,10 +159,10 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
      * @throws UnsupportedOperationException If adding not supported by the classloader
      */
     public void addToClassPath(URL url) {
-        if (commonClassLoader != null) {
-            commonClassLoader.addURL(url);
-        } else {
+        if (commonClassLoader == null) {
             commonClassLoader = new GlassfishUrlClassLoader(new URL[] {url}, APIClassLoader);
+        } else {
+            commonClassLoader.addURL(url);
         }
         commonClassPath = urlsToClassPath(Arrays.stream(commonClassLoader.getURLs()));
     }
@@ -175,7 +175,8 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
         return urls
                 .map(URL::getFile)
                 .filter(Predicate.not(String::isBlank))
-                .map(file -> new File(file).getAbsolutePath())
+                .map(File::new)
+                .map(File::getAbsolutePath)
                 .collect(Collectors.joining(File.pathSeparator));
     }
 

--- a/nucleus/core/kernel/src/test/assembly/assembly-commonClassLoader.xml
+++ b/nucleus/core/kernel/src/test/assembly/assembly-commonClassLoader.xml
@@ -1,0 +1,13 @@
+    <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+      [...]
+      <dependencySets>
+        <dependencySet>
+          <includes>
+            <include>*:war</include>
+          </includes>
+        </dependencySet>
+      </dependencySets>
+      [...]
+    </assembly>

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.v3.server;
+
+import com.sun.enterprise.module.bootstrap.StartupContext;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.api.admin.ServerEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+public class CommonClassLoaderServiceImplTest {
+
+    private int loadClassCalls;
+    private int getResourceCalls;
+
+    CommonClassLoaderServiceImpl commonCLService;
+    MockServerEnvironment serverEnv;
+
+    @BeforeEach
+    public void setUp() {
+        commonCLService = new CommonClassLoaderServiceImpl();
+        commonCLService.acls = new APIClassLoaderServiceImpl() {
+            @Override
+            public ClassLoader getAPIClassLoader() {
+                return new URLClassLoader(new URL[0], null);
+            }
+
+        };
+        serverEnv = new MockServerEnvironment();
+        commonCLService.env = serverEnv;
+    }
+
+    @Test
+    public void testAddingUrlWithNoInitialUrls() throws MalformedURLException, ClassNotFoundException {
+        commonCLService.postConstruct();
+
+        final String classesPath = "target/test-additional-classes/";
+        commonCLService.addToClassPath(new File(classesPath).toURI().toURL());
+
+// we need to retrieve the classloader after adding URLs, otherwise we
+        // would get its parent because of an optimization in the service
+        final ClassLoader commonClassLoader = commonCLService.getCommonClassLoader();
+        commonClassLoader.loadClass(CommonClassLoaderServiceImplTestAdditionalClass.class.getName());
+        assertThat(commonCLService.getCommonClassPath(), containsString(new File(classesPath).getAbsolutePath()));
+    }
+
+    @Test
+    public void testAddingUrlWithInitialUrl() throws MalformedURLException, ClassNotFoundException {
+        final String domainDir = "target/test-domain";
+        serverEnv.setInstanceRoot(new File(domainDir));
+        commonCLService.postConstruct();
+        // the classloader should already be the one we want, initialized with classes in domain/lib/classes
+        final ClassLoader commonClassLoader = commonCLService.getCommonClassLoader();
+
+        final String classesPath = "target/test-additional-classes/";
+        commonCLService.addToClassPath(new File(classesPath).toURI().toURL());
+
+        commonClassLoader.loadClass(CommonClassLoaderServiceImplTestAdditionalClass.class.getName());
+        commonClassLoader.loadClass(CommonClassLoaderServiceImplTestDomainClass.class.getName());
+        assertThat(commonCLService.getCommonClassPath(), containsString(new File(classesPath).getAbsolutePath()));
+        assertThat(commonCLService.getCommonClassPath(), containsString(Path.of(domainDir,"lib","classes").toAbsolutePath().toString()));
+    }
+
+    static class MockServerEnvironment implements ServerEnvironment {
+
+        File instanceRoot;
+
+        @Override
+        public File getInstanceRoot() {
+            return instanceRoot;
+        }
+
+        public void setInstanceRoot(File instanceRoot) {
+            this.instanceRoot = instanceRoot;
+        }
+
+        @Override
+        public StartupContext getStartupContext() {
+            return null;
+        }
+
+        @Override
+        public File getConfigDirPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getLibPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationRepositoryPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationStubPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationCompileJspPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationGeneratedXMLPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationEJBStubPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationPolicyFilePath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getApplicationAltDDPath() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getMasterPasswordFile() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getJKS() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public File getTrustStore() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Status getStatus() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public RuntimeType getRuntimeType() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public String getInstanceName() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean isInstance() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean isDas() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+    }
+}

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTestAdditionalClass.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTestAdditionalClass.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.v3.server;
+
+/**
+ * To be used in CommonClassLoaderServiceImplTest
+ * @author Ondro Mihalyi
+ */
+public class CommonClassLoaderServiceImplTestAdditionalClass {
+
+}

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTestDomainClass.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTestDomainClass.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.v3.server;
+
+/**
+ * To be used in CommonClassLoaderServiceImplTest
+ * @author Ondro Mihalyi
+ */
+public class CommonClassLoaderServiceImplTestDomainClass {
+
+}


### PR DESCRIPTION
Dynamically updates the common classloader if a common library is added. It means that restart is not needed to add the library to the classpath.