### PR TITLE
Part 1,2,3,4 for issue #24900 Document and rename some ResourceHandle fields.

### DIFF
--- a/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/BasicResourceAllocator.java
+++ b/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/BasicResourceAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,12 +42,10 @@ public final class BasicResourceAllocator extends AbstractConnectorAllocator {
     public BasicResourceAllocator() {
     }
 
-
     @Override
     public ResourceHandle createResource() throws PoolingException {
         throw new UnsupportedOperationException();
     }
-
 
     public ResourceHandle createResource(XAResource xaResource) throws PoolingException {
         ResourceHandle resourceHandle = null;
@@ -56,7 +54,7 @@ public final class BasicResourceAllocator extends AbstractConnectorAllocator {
         if (xaResource != null) {
             logger.logp(Level.FINEST, "BasicResourceAllocator", "createResource", "NOT NULL", xaResource);
             try {
-                resourceHandle = new ResourceHandle(null, spec, this, null);
+                resourceHandle = new ResourceHandle(null, spec, this);
                 if (logger.isLoggable(Level.FINEST)) {
                     xaResource = new XAResourceWrapper(xaResource);
                 }
@@ -71,13 +69,11 @@ public final class BasicResourceAllocator extends AbstractConnectorAllocator {
         return resourceHandle;
     }
 
-
     @Override
     public void closeUserConnection(ResourceHandle resourceHandle)
             throws PoolingException {
         throw new UnsupportedOperationException();
     }
-
 
     @Override
     public boolean matchConnection(ResourceHandle resourceHandle) {

--- a/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/ConnectorMessageBeanClient.java
+++ b/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/ConnectorMessageBeanClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -353,7 +353,7 @@ public final class ConnectorMessageBeanClient implements MessageBeanClient, Mess
      */
     @Override
     public MessageEndpoint createEndpoint(XAResource xa) throws UnavailableException {
-        // This is a temporary workaround for blocking the the create enpoint
+        // This is a temporary workaround for blocking the created endpoint
         // until the deployment completes. One thread would wait for maximum a
         // a minute.
         return createEndpoint(xa, WAIT_TIME);

--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ResourceHandle.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ResourceHandle.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,33 +20,85 @@ package com.sun.appserv.connectors.internal.api;
 import javax.transaction.xa.XAResource;
 
 /**
- * ResourceHandle interface to be used by transaction manager components
+ * ResourceHandle interface to be used by transaction manager components.
  *
  * @author Marina Vatkina
  */
 
 public interface ResourceHandle {
 
+    /**
+     * Returns true if the resource is part of a transaction.
+     *
+     * @return true if the resource is part of a transaction.
+     */
     public boolean isTransactional();
 
-    //TODO V3 not needed as of now.
+    /**
+     * To check whether lazy enlistment is suspended or not.<br>
+     * If {@code true}, transaction manager will not do enlist/lazy enlist.
+     *
+     * @return true if enlistment is suspended, otherwise false.
+     */
     public boolean isEnlistmentSuspended();
 
+    /**
+     * Allows a ResourceManager to change the enlistement suspended state of a resource to enlist a resource in a
+     * transaction.
+     *
+     * @param enlistmentSuspended true if enlistment in a transaction is suspended, false if enlistment is not suspended.
+     */
     public void setEnlistmentSuspended(boolean enlistmentSuspended);
 
+    /**
+     * Returns the (optional) XAResource reference for this resource handle.
+     *
+     * @return the XAResource reference for this resource handle or null if no reference is set.
+     */
     public XAResource getXAResource();
 
+    /**
+     * Returns true if the ResourceHandle is supported in an XA transaction.
+     *
+     * @return true if the ResourceHandle is supported in an XA transaction, otherwise false.
+     */
     public boolean supportsXA();
 
+    /**
+     * Returns the component instance holding this resource handle.
+     *
+     * @return the component instance holding this resource handle.
+     */
     public Object getComponentInstance();
 
+    /**
+     * Sets the component instance holding this resource handle.
+     *
+     * @param instance the component instance holding this resource handle.
+     */
     public void setComponentInstance(Object instance);
 
+    /**
+     * Closes the (optional) 'userConnection' / 'connection handle' (used by the application code to refer to the underlying
+     * physical connection). Example: the ManagedConnection represented by this ResourceHandle is closed / cleaned up.
+     *
+     * @throws PoolingException wrapping any 'userConnection' specific exception that might occur during the close call.
+     * @throws UnsupportedOperationException when the method is not implemented.
+     */
     public void closeUserConnection() throws PoolingException;
 
+    /**
+     * Returns true if the resource handle is enlisted in a transaction.
+     *
+     * @return true if the resource handle is enlisted in a transaction.
+     */
     public boolean isEnlisted();
 
+    /**
+     * Returns true if the resource handle is sharable within the component.
+     *
+     * @return true if the resource handle is sharable within the component.
+     */
     public boolean isShareable();
 
-    public void destroyResource();
 }

--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/TransactedPoolManager.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/TransactedPoolManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -29,24 +30,30 @@ import org.jvnet.hk2.annotations.Contract;
 public interface TransactedPoolManager {
 
     /**
-     * Indicate that a resource is enlisted.
+     * Indicate that a resource is enlisted.<br>
+     * Expecting this method is called from the
+     * {@link com.sun.enterprise.resource.ResourceHandle#enlistedInTransaction(Transaction)} method and not directly from a
+     * pool manager.
+     *
      * @param tran Transaction to which the resource is enlisted
-     * @param res Resource that is enlisted
+     * @param resource Resource that is enlisted
      * @throws IllegalStateException when unable to enlist the resource
      */
-    void resourceEnlisted(Transaction tran, ResourceHandle res) throws IllegalStateException;
+    void resourceEnlisted(Transaction tran, ResourceHandle resource) throws IllegalStateException;
 
     /**
-     * registers the provided resource with the component & enlists the resource in the transaction
-     * @param handle resource-handle
+     * Registers the provided resource with the component & enlists the resource in the transaction
+     *
+     * @param resource Resource to be registered.
      * @throws PoolingException when unable to register the resource
      */
-    void registerResource(ResourceHandle handle) throws PoolingException;
+    void registerResource(ResourceHandle resource) throws PoolingException;
 
     /**
-     * unregisters the resource from the component and delists the resource from the transaction
-     * @param resource resource-handle
-     * @param xaresFlag
+     * Unregisters the resource from the component and delists the resource from the transaction
+     *
+     * @param resource Resource to be unregistered.
+     * @param xaresFlag flag indicating transaction success. This can be XAResource.TMSUCCESS or XAResource.TMFAIL
      */
     void unregisterResource(ResourceHandle resource, int xaresFlag);
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -75,7 +75,6 @@ public class ConnectorConnectionPool implements Serializable {
     private String poolWaitQueue;
     private String dataStructureParameters;
     private String resourceGatewayClass;
-    private String resourceSelectionStrategyClass;
     private boolean nonTransactional_;
     private boolean nonComponent_;
 
@@ -772,14 +771,6 @@ public class ConnectorConnectionPool implements Serializable {
 
     public void setResourceGatewayClass(String resourceGatewayClass) {
         this.resourceGatewayClass = resourceGatewayClass;
-    }
-
-    public String getResourceSelectionStrategyClass() {
-        return resourceSelectionStrategyClass;
-    }
-
-    public void setResourceSelectionStrategyClass(String resourceSelectionStrategyClass) {
-        this.resourceSelectionStrategyClass = resourceSelectionStrategyClass;
     }
 
     public boolean isPreferValidateOverRecreate() {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRuntime.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRuntime.java
@@ -234,9 +234,8 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     @Inject
     private Provider<ResourceManager> resourceManagerProvider;
 
-    /* protected for unit test */
     @Inject
-    protected ProcessEnvironment processEnvironment;
+    private ProcessEnvironment processEnvironment;
 
     @Inject
     private DriverLoader driverLoader;

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectionPoolReconfigHelper.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectionPoolReconfigHelper.java
@@ -34,8 +34,17 @@ public final class ConnectionPoolReconfigHelper {
         LogDomains.RSR_LOGGER);
 
     public enum ReconfigAction {
+        /**
+         * Recreate connection pool
+         */
         RECREATE_POOL,
+        /**
+         * Update ManagedConnectionFactory and attributes
+         */
         UPDATE_MCF_AND_ATTRIBUTES,
+        /**
+         * No operation
+         */
         NO_OP
     }
 

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/AssocWithThreadResourceHandle.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/AssocWithThreadResourceHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,6 +19,8 @@ package com.sun.enterprise.resource;
 
 import com.sun.enterprise.resource.allocator.ResourceAllocator;
 
+import jakarta.resource.spi.ManagedConnection;
+
 /**
  * ResourceHandle with state related to assoc-with-thread pool
  *
@@ -30,8 +32,8 @@ public class AssocWithThreadResourceHandle extends ResourceHandle {
     private long threadId_;
     private boolean dirty_;
 
-    public AssocWithThreadResourceHandle(Object resource, ResourceSpec spec, ResourceAllocator alloc, ClientSecurityInfo info) {
-        super(resource, spec, alloc, info);
+    public AssocWithThreadResourceHandle(ManagedConnection resource, ResourceSpec spec, ResourceAllocator alloc) {
+        super(resource, spec, alloc);
     }
 
     public boolean isDirty() {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ConnectorXAResource.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ConnectorXAResource.java
@@ -81,7 +81,7 @@ public class ConnectorXAResource implements XAResource {
     @Override
     public void commit(Xid xid, boolean onePhase) throws XAException {
         try {
-            ManagedConnection managedConnection = (ManagedConnection) getResourceHandle().getResource();
+            ManagedConnection managedConnection = getResourceHandle().getResource();
             managedConnection.getLocalTransaction().commit();
         } catch (Exception ex) {
             handleResourceException(ex);
@@ -96,7 +96,7 @@ public class ConnectorXAResource implements XAResource {
         try {
             ResourceHandle handle = getResourceHandle();
             if (!localHandle_.equals(handle)) {
-                ManagedConnection managedConnection = (ManagedConnection) handle.getResource();
+                ManagedConnection managedConnection = handle.getResource();
                 managedConnection.associateConnection(userHandle);
                 LocalTxConnectionEventListener listener = (LocalTxConnectionEventListener) handle.getListener();
 
@@ -122,7 +122,7 @@ public class ConnectorXAResource implements XAResource {
 
                 ResourceHandle handle = listener.removeAssociation(userHandle);
                 if (handle != null) { // not needed, just to be sure.
-                    ManagedConnection associatedConnection = (ManagedConnection) handle.getResource();
+                    ManagedConnection associatedConnection = handle.getResource();
                     associatedConnection.associateConnection(userHandle);
                     _logger.log(FINE, "connection_sharing_reset_association", userHandle);
                 }
@@ -177,7 +177,7 @@ public class ConnectorXAResource implements XAResource {
     public void rollback(Xid xid) throws XAException {
         try {
             ResourceHandle handle = getResourceHandle();
-            ManagedConnection managedConnection = (ManagedConnection) handle.getResource();
+            ManagedConnection managedConnection = handle.getResource();
             managedConnection.getLocalTransaction().rollback();
         } catch (Exception ex) {
             handleResourceException(ex);
@@ -211,7 +211,7 @@ public class ConnectorXAResource implements XAResource {
             }
 
             if (resourceHandle.getResourceState().isUnenlisted()) {
-                ManagedConnection managedConnection = (ManagedConnection) resourceHandle.getResource();
+                ManagedConnection managedConnection = resourceHandle.getResource();
 
                 // Begin the local transaction if first time
                 // this ManagedConnection is used in this JTA transaction
@@ -236,8 +236,8 @@ public class ConnectorXAResource implements XAResource {
             // Clear the associations and Map all associated handles back to their actual Managed Connection.
             Map<Object, ResourceHandle> associatedHandles = listener.getAssociatedHandlesAndClearMap();
             for (Entry<Object, ResourceHandle> userHandleEntry : associatedHandles.entrySet()) {
-                ResourceHandle associatedHandle = (ResourceHandle) userHandleEntry.getValue();
-                ManagedConnection associatedConnection = (ManagedConnection) associatedHandle.getResource();
+                ResourceHandle associatedHandle = userHandleEntry.getValue();
+                ManagedConnection associatedConnection = associatedHandle.getResource();
                 associatedConnection.associateConnection(userHandleEntry.getKey());
                 _logger.log(FINE, "connection_sharing_reset_association", userHandleEntry.getKey());
             }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceSpec.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceSpec.java
@@ -183,15 +183,16 @@ public class ResourceSpec implements Serializable {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer("ResourceSpec :- ");
-        sb.append("\nconnectionPoolName : ").append(poolInfo);
-        sb.append("\nisXA_ : ").append(isXA_);
-        sb.append("\nresoureId : ").append(resourceId);
-        sb.append("\nresoureIdType : ").append(resourceIdType);
-        sb.append("\npmResource : ").append(pmResource);
-        sb.append("\nnonTxResource : ").append(nonTxResource);
-        sb.append("\nlazyEnlistable : ").append(lazyEnlistable_);
-        sb.append("\nlazyAssociatable : ").append(lazyAssociatable_);
+        StringBuffer sb = new StringBuffer("<ResourceSpec ");
+        sb.append("connectionPoolName : ").append(poolInfo);
+        sb.append(", isXA_ : ").append(isXA_);
+        sb.append(", resoureId : ").append(resourceId);
+        sb.append(", resoureIdType : ").append(resourceIdType);
+        sb.append(", pmResource : ").append(pmResource);
+        sb.append(", nonTxResource : ").append(nonTxResource);
+        sb.append(", lazyEnlistable : ").append(lazyEnlistable_);
+        sb.append(", lazyAssociatable : ").append(lazyAssociatable_);
+        sb.append("/>");
         return sb.toString();
     }
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceState.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,8 +18,27 @@
 package com.sun.enterprise.resource;
 
 public class ResourceState {
+
+    /**
+     * Indicates that a resource has been enlisted in a transaction.
+     *
+     * @see jakarta.transaction.Transaction#enlistResource(XAResource)
+     */
     private boolean enlisted;
+
+    /**
+     * The busy state reflects the moment the resource is taken from the connection pool. It should be set to {@code true}
+     * once it is taken from the pool, and it should be set to {@code false} once it is returned to the pool.
+     * <p>
+     * Setting to {@code true} happens at the moment the resource is taken from the pool (getResourceFromPool).<br>
+     * Setting to {@code false} happens at the moment the connection is returned to the pool (resourceClosed).
+     */
     private boolean busy;
+
+    /**
+     * Timestamp represents the time of resource creation, or the time the resource usage was complete and is handed back to
+     * the pool. The timestamp value is used in the remove idle and invalid resources logic of the resource pool resizer.
+     */
     private long timestamp;
 
     public boolean isEnlisted() {
@@ -58,8 +77,17 @@ public class ResourceState {
         touchTimestamp();
     }
 
+    /**
+     * Resets all fields, representing the constructor call situation.
+     */
+    public void reset() {
+        touchTimestamp();
+        setBusy(false);
+        setEnlisted(false);
+    }
+
     @Override
     public String toString() {
-        return "Enlisted :" + enlisted + " Busy :" + busy;
+        return "<ResourceState enlisted=" + enlisted + ", busy=" + busy + "/>";
     }
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/AbstractConnectorAllocator.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/AbstractConnectorAllocator.java
@@ -93,7 +93,7 @@ public abstract class AbstractConnectorAllocator implements ResourceAllocator {
     @Override
     public boolean isConnectionValid(ResourceHandle h) {
         HashSet<ManagedConnection> conn = new HashSet<>();
-        conn.add((ManagedConnection) h.getResource());
+        conn.add(h.getResource());
         Set<?> invalids = null;
         try {
             invalids = getInvalidConnections(conn);
@@ -135,7 +135,7 @@ public abstract class AbstractConnectorAllocator implements ResourceAllocator {
     @Override
     public void cleanup(ResourceHandle h) throws PoolingException {
         try {
-            ManagedConnection mc = (ManagedConnection) h.getResource();
+            ManagedConnection mc = h.getResource();
             mc.cleanup();
         } catch (Exception ex) {
             _logger.log(Level.WARNING, "managed_con.cleanup-failed", ex);
@@ -146,7 +146,7 @@ public abstract class AbstractConnectorAllocator implements ResourceAllocator {
     @Override
     public boolean matchConnection(ResourceHandle h) {
         Set<ManagedConnection> set = new HashSet<>();
-        set.add((ManagedConnection) h.getResource());
+        set.add(h.getResource());
         try {
             ManagedConnection mc = mcf.matchManagedConnections(set, subject, reqInfo);
             return mc != null;
@@ -157,9 +157,8 @@ public abstract class AbstractConnectorAllocator implements ResourceAllocator {
 
     @Override
     public void closeUserConnection(ResourceHandle resource) throws PoolingException {
-
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
+            ManagedConnection mc = resource.getResource();
             mc.cleanup();
         } catch (ResourceException ex) {
             throw new PoolingException(ex);
@@ -177,8 +176,8 @@ public abstract class AbstractConnectorAllocator implements ResourceAllocator {
         throw new UnsupportedOperationException();
     }
 
-    protected ResourceHandle createResourceHandle(Object resource, ResourceSpec spec,
-                                                  ResourceAllocator alloc, ClientSecurityInfo info) {
+    protected ResourceHandle createResourceHandle(ManagedConnection resource, ResourceSpec spec,
+            ResourceAllocator alloc) {
 
         ConnectorConstants.PoolType pt = ConnectorConstants.PoolType.STANDARD_POOL;
         try {
@@ -187,9 +186,9 @@ public abstract class AbstractConnectorAllocator implements ResourceAllocator {
             _logger.log(Level.WARNING,"unable_to_determine_pool_type", spec.getPoolInfo());
         }
         if (pt == ConnectorConstants.PoolType.ASSOCIATE_WITH_THREAD_POOL) {
-            return new AssocWithThreadResourceHandle(resource, spec, alloc, info);
+            return new AssocWithThreadResourceHandle(resource, spec, alloc);
         } else {
-            return new ResourceHandle(resource, spec, alloc, info);
+            return new ResourceHandle(resource, spec, alloc);
         }
     }
 

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/ConnectorAllocator.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/ConnectorAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,8 +34,12 @@ import jakarta.resource.spi.ManagedConnectionFactory;
 import javax.security.auth.Subject;
 import javax.transaction.xa.XAResource;
 
-
 /**
+ * XATransaction Connector Allocator, used for transaction level:
+ * {@link com.sun.appserv.connectors.internal.api.ConnectorConstants#XA_TRANSACTION_INT}.
+ * <p>
+ * TODO: Rename class to reflect XATransaction
+ *
  * @author Tony Ng
  */
 public class ConnectorAllocator extends AbstractConnectorAllocator {
@@ -143,7 +147,7 @@ public class ConnectorAllocator extends AbstractConnectorAllocator {
     public ResourceHandle createResource() throws PoolingException {
         try {
             ManagedConnection mc = mcf.createManagedConnection(subject, reqInfo);
-            ResourceHandle resource = createResourceHandle(mc, spec, this, info);
+            ResourceHandle resource = createResourceHandle(mc, spec, this);
             ConnectionEventListener l = new ConnectionListenerImpl(resource);
             mc.addConnectionEventListener(l);
             return resource;
@@ -156,7 +160,7 @@ public class ConnectorAllocator extends AbstractConnectorAllocator {
     public void fillInResourceObjects(ResourceHandle resource)
             throws PoolingException {
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
+            ManagedConnection mc = resource.getResource();
             Object con = mc.getConnection(subject, reqInfo);
             resource.incrementCount();
             XAResource xares = mc.getXAResource();
@@ -177,7 +181,7 @@ public class ConnectorAllocator extends AbstractConnectorAllocator {
         }
 
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
+            ManagedConnection mc = resource.getResource();
             mc.destroy();
         } catch (Exception ex) {
             throw new PoolingException(ex);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/LocalTxConnectorAllocator.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/LocalTxConnectorAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -41,6 +41,9 @@ import javax.security.auth.Subject;
 import javax.transaction.xa.XAResource;
 
 /**
+ * LocalTransaction Connector Allocator, used for transaction level:
+ * {@link com.sun.appserv.connectors.internal.api.ConnectorConstants#LOCAL_TRANSACTION_INT}.
+ *
  * @author Tony Ng
  */
 public class LocalTxConnectorAllocator extends AbstractConnectorAllocator {
@@ -70,7 +73,7 @@ public class LocalTxConnectorAllocator extends AbstractConnectorAllocator {
         try {
             ManagedConnection mc = mcf.createManagedConnection(subject, reqInfo);
 
-            ResourceHandle resource = createResourceHandle(mc, spec, this, info);
+            ResourceHandle resource = createResourceHandle(mc, spec, this);
             ConnectionEventListener l = new LocalTxConnectionEventListener(resource);
             mc.addConnectionEventListener(l);
             resource.setListener(l);
@@ -88,10 +91,8 @@ public class LocalTxConnectorAllocator extends AbstractConnectorAllocator {
     public void fillInResourceObjects(ResourceHandle resource)
             throws PoolingException {
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
-
+            ManagedConnection mc = resource.getResource();
             Object con = mc.getConnection(subject, reqInfo);
-
             ConnectorXAResource xares = (ConnectorXAResource) resource.getXAResource();
             xares.setUserHandle(con);
             resource.fillInResourceObjects(con, xares);
@@ -104,7 +105,7 @@ public class LocalTxConnectorAllocator extends AbstractConnectorAllocator {
     public void destroyResource(ResourceHandle resource)
             throws PoolingException {
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
+            ManagedConnection mc = resource.getResource();
             XAResource xares = resource.getXAResource();
             forceTransactionCompletion(xares);
             mc.destroy();

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/NoTxConnectorAllocator.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/NoTxConnectorAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,6 +34,9 @@ import jakarta.resource.spi.ManagedConnectionFactory;
 import javax.security.auth.Subject;
 
 /**
+ * NoTransaction Connector Allocator, used for transaction level:
+ * {@link com.sun.appserv.connectors.internal.api.ConnectorConstants#NO_TRANSACTION_INT}.
+ *
  * @author Tony Ng
  */
 public class NoTxConnectorAllocator extends AbstractConnectorAllocator {
@@ -104,12 +107,11 @@ public class NoTxConnectorAllocator extends AbstractConnectorAllocator {
         super(poolMgr, mcf, spec, subject, reqInfo, info, desc);
     }
 
-
     @Override
     public ResourceHandle createResource() throws PoolingException {
         try {
             ManagedConnection mc = mcf.createManagedConnection(subject, reqInfo);
-            ResourceHandle resource = createResourceHandle(mc, spec, this, info);
+            ResourceHandle resource = createResourceHandle(mc, spec, this);
             ConnectionEventListener l = new ConnectionListenerImpl(resource);
             mc.addConnectionEventListener(l);
             return resource;
@@ -119,10 +121,9 @@ public class NoTxConnectorAllocator extends AbstractConnectorAllocator {
     }
 
     @Override
-    public void fillInResourceObjects(ResourceHandle resource)
-            throws PoolingException {
+    public void fillInResourceObjects(ResourceHandle resource) throws PoolingException {
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
+            ManagedConnection mc = resource.getResource();
             Object con = mc.getConnection(subject, reqInfo);
             resource.fillInResourceObjects(con, null);
         } catch (ResourceException ex) {
@@ -131,11 +132,9 @@ public class NoTxConnectorAllocator extends AbstractConnectorAllocator {
     }
 
     @Override
-    public void destroyResource(ResourceHandle resource)
-            throws PoolingException {
-
+    public void destroyResource(ResourceHandle resource) throws PoolingException {
         try {
-            ManagedConnection mc = (ManagedConnection) resource.getResource();
+            ManagedConnection mc = resource.getResource();
             mc.destroy();
         } catch (Exception ex) {
             throw new PoolingException(ex);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/ResourceAllocator.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/allocator/ResourceAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -38,10 +38,28 @@ public interface ResourceAllocator {
 
     void destroyResource(ResourceHandle resource) throws PoolingException;
 
-    boolean matchConnection(ResourceHandle h);
+    /**
+     * Represents the "match-connections" configuration value of a connection pool.<br>
+     * If true, enables connection matching. You can set to false if connections are homogeneous.
+     * <p>
+     * Jakarta documentation:
+     * {@link jakarta.resource.spi.ManagedConnectionFactory#matchManagedConnections(Set, Subject, ConnectionRequestInfo)}
+     * mentions: "criteria used for matching is specific to a resource adapter and is not prescribed by the Connector
+     * specification."
+     *
+     * @param handle The resource handle to be matched.
+     * @return True if matching applies to this handle, otherwise false
+     */
+    boolean matchConnection(ResourceHandle handle);
 
     boolean isTransactional();
 
+    /**
+     * Forces the cleanup of the ManagedConnection associated to the given resource.
+     *
+     * @param resource the resource referencing a ManagedConnection
+     * @throws PoolingException in case the cleanup failed
+     */
     void cleanup(ResourceHandle resource) throws PoolingException;
 
     boolean shareableWithinComponent();

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListener.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListener.java
@@ -20,17 +20,22 @@ package com.sun.enterprise.resource.listener;
 import com.sun.enterprise.connectors.ConnectorRuntime;
 import com.sun.enterprise.resource.ResourceHandle;
 import com.sun.enterprise.resource.pool.PoolManager;
+import com.sun.logging.LogDomains;
 
 import jakarta.resource.spi.ConnectionEvent;
 import jakarta.resource.spi.ManagedConnection;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Binod P.G
  */
 public class LocalTxConnectionEventListener extends ConnectionEventListener {
+
+    private static final Logger logger = LogDomains.getLogger(ResourceHandle.class, LogDomains.RSR_LOGGER);
 
     /**
      * A shortcut to the singleton PoolManager instance. Field could also be removed.
@@ -56,14 +61,33 @@ public class LocalTxConnectionEventListener extends ConnectionEventListener {
 
     public LocalTxConnectionEventListener(ResourceHandle resource) {
         this.resource = resource;
+
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "LocalTxConnectionEventListener constructor, resource=" + resource + ", this=" + this);
+        }
     }
 
     @Override
     public synchronized void connectionClosed(ConnectionEvent evt) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "LocalTxConnectionEventListener.connectionClosed START, resource=" + resource + ", this=" + this);
+            for (Object key : associatedHandles.keySet()) {
+                ResourceHandle associatedHandle = associatedHandles.get(key);
+                logger.log(Level.FINE,
+                        "LocalTxConnectionEventListener.connectionClosed associatedHandles: key=" + key + ", handle=" + associatedHandle);
+                logger.log(Level.FINE,
+                        "LocalTxConnectionEventListener.connectionClosed associatedHandles: resource=" + associatedHandle.getResource());
+            }
+        }
+
         Object connectionHandle = evt.getConnectionHandle();
         ResourceHandle handle = associatedHandles.getOrDefault(connectionHandle, resource);
         // ManagedConnection instance is still valid and put back in the pool: do not remove the event listener.
         poolManager.resourceClosed(handle);
+
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "LocalTxConnectionEventListener.connectionClosed END, resource=" + resource + ", handle=" + handle + ", this=" + this);
+        }
     }
 
     @Override
@@ -117,6 +141,9 @@ public class LocalTxConnectionEventListener extends ConnectionEventListener {
      * @param resourceHandle the original Handle
      */
     public synchronized void associateHandle(Object userHandle, ResourceHandle resourceHandle) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "LocalTxConnectionEventListener associateHandle, userHandle=" + userHandle + ", resourceHandle=" + resourceHandle + ", this=" + this);
+        }
         associatedHandles.put(userHandle, resourceHandle);
     }
 
@@ -128,6 +155,9 @@ public class LocalTxConnectionEventListener extends ConnectionEventListener {
      * can also indicate that the map previously associated null with userHandle.
      */
     public synchronized ResourceHandle removeAssociation(Object userHandle) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "LocalTxConnectionEventListener removeAssociation, userHandle=" + userHandle + ", this=" + this);
+        }
         return associatedHandles.remove(userHandle);
     }
 
@@ -136,6 +166,8 @@ public class LocalTxConnectionEventListener extends ConnectionEventListener {
      * @return The clone of the associatedHandles map.
      */
     public synchronized Map<Object, ResourceHandle> getAssociatedHandlesAndClearMap() {
+        logger.log(Level.FINE, "LocalTxConnectionEventListener getAssociatedHandlesAndClearMap, this=" + this);
+
         // Clone the associatedHandles, because we will clear the list in this method
         IdentityHashMap<Object, ResourceHandle> result = (IdentityHashMap<Object, ResourceHandle>) associatedHandles.clone();
 

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/AbstractPoolManager.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/AbstractPoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,33 +17,31 @@
 
 package com.sun.enterprise.resource.pool;
 
-import com.sun.enterprise.resource.ResourceSpec;
-
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.glassfish.resourcebase.resources.api.PoolInfo;
-
 /**
  * Abstract Pool manager for unimplemented features. Throws UnsupportedOperationException when invoked.
  */
 public abstract class AbstractPoolManager implements PoolManager {
 
-    @Override
-    public void emptyResourcePool(ResourceSpec spec) {
-        throw new UnsupportedOperationException();
-    }
+// Not used in the code
+//    @Override
+//    public void emptyResourcePool(ResourceSpec spec) {
+//        throw new UnsupportedOperationException();
+//    }
 
-    @Override
-    public void killAllPools() {
-        throw new UnsupportedOperationException();
-    }
+// Not used in the code
+//    @Override
+//    public void killAllPools() {
+//        throw new UnsupportedOperationException();
+//    }
 
-    @Override
-    public void setSelfManaged(PoolInfo poolInfo, boolean flag) {
-        throw new UnsupportedOperationException();
-    }
+// Not used in the code
+//    @Override
+//    public void setSelfManaged(PoolInfo poolInfo, boolean flag) {
+//        throw new UnsupportedOperationException();
+//    }
 
-    public ConcurrentHashMap getMonitoredPoolTable() {
-        throw new UnsupportedOperationException();
-    }
+// Not used in the code
+//    public ConcurrentHashMap getMonitoredPoolTable() {
+//        throw new UnsupportedOperationException();
+//    }
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/AssocWithThreadResourcePool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/AssocWithThreadResourcePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -49,7 +49,7 @@ public class AssocWithThreadResourcePool extends ConnectionPool {
     @Override
     protected void initializePoolDataStructure() throws PoolingException {
         dataStructure = DataStructureFactory.getDataStructure("com.sun.enterprise.resource.pool.datastructure.ListDataStructure",
-                dataStructureParameters, maxPoolSize, this, resourceSelectionStrategyClass);
+                dataStructureParameters, maxPoolSize, this);
     }
 
     /**

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManager.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManager.java
@@ -46,62 +46,142 @@ import org.jvnet.hk2.annotations.Contract;
 public interface PoolManager extends TransactedPoolManager {
 
     // transaction support levels
-    int NO_TRANSACTION = 0;
-    int LOCAL_TRANSACTION = 1;
-    int XA_TRANSACTION = 2;
+    // int NO_TRANSACTION = 0;
+    // int LOCAL_TRANSACTION = 1;
+    // int XA_TRANSACTION = 2;
 
     // Authentication mechanism levels
-    int BASIC_PASSWORD = 0;
-    int KERBV5 = 1;
+    // int BASIC_PASSWORD = 0;
+    // int KERBV5 = 1;
 
     // Credential Interest levels
-    String PASSWORD_CREDENTIAL = "jakarta.resource.spi.security.PasswordCredential";
-    String GENERIC_CREDENTIAL = "jakarta.resource.spi.security.GenericCredential";
+    // String PASSWORD_CREDENTIAL = "jakarta.resource.spi.security.PasswordCredential";
+    // String GENERIC_CREDENTIAL = "jakarta.resource.spi.security.GenericCredential";
 
     /**
      * Flush Connection pool by reinitializing the connections established in the pool.
      *
-     * @param poolInfo
-     * @throws com.sun.appserv.connectors.internal.api.PoolingException
+     * @param poolInfo the pool identifier for which the status needs to be flushed.
+     * @throws com.sun.appserv.connectors.internal.api.PoolingException in case the given pool is not initialized.
      */
     boolean flushConnectionPool(PoolInfo poolInfo) throws PoolingException;
 
     /**
-     * @return connection pool status.
+     * Returns the pool status for the pool identified by the given poolInfo.
+     *
+     * @param poolInfo the pool identifier for which the status needs to be returned.
+     * @return pool status information if the pool is found based on the provided poolInfo, otherwise null is returned.
      */
     PoolStatus getPoolStatus(PoolInfo poolInfo);
 
     ResourceHandle getResourceFromPool(ResourceSpec spec, ResourceAllocator alloc, ClientSecurityInfo info,
-        Transaction transaction) throws PoolingException, RetryableUnavailableException;
+            Transaction transaction) throws PoolingException, RetryableUnavailableException;
 
-    void createEmptyConnectionPool(PoolInfo poolInfo, PoolType pt, Hashtable env) throws PoolingException;
+    /**
+     * Creates an empty connection pool with the given pool info and pool type.
+     *
+     * @param poolInfo the pool identifier of the new pool
+     * @param poolType the type of the connection pool
+     * @param env hashtable used to find the connection pool ConnectorConnectionPool information to set parameters like
+     * maximum number of connections
+     * @throws PoolingException when unable to create/initialize pool
+     */
+    void createEmptyConnectionPool(PoolInfo poolInfo, PoolType poolType, Hashtable env) throws PoolingException;
 
+    /**
+     * Returns the resource back to the pool IF errorOccurred is false. If errorOccurred is true the resource is removed
+     * from the pool.
+     * <p>
+     * Note: The resource object may not be used anymore by the calling code after this call.
+     *
+     * @param resourceHandle the resource handle.
+     * @param errorOccurred true if an error occurred and the resource should not be returned to the pool, otherwise use
+     * false
+     * <p>
+     * TODO The method name is misleading<br>
+     * TODO Why is NoTxConnectorAllocator the only one calling this interface method and the rest of the calls are using
+     * resourceClosed / resourceErrorOccurred and resourceAbortOccurred ? Is the difference between resourceClosed and
+     * putbackResourceToPool that resourceClosed informs the transaction and putbackResourceToPool does not?
+     */
     void putbackResourceToPool(ResourceHandle resourceHandle, boolean errorOccurred);
 
-    void putbackBadResourceToPool(ResourceHandle resourceHandle);
-
+    /**
+     * Notifies the pool the resource is not used by a bean/application anymore.<br>
+     * The resource is returned to the pool and the state of the resource is no longer busy.<br>
+     * The resource is NOT delisted / unenlisted from the current transaction.
+     * <p>
+     * Note: The resource object may not be used anymore by the calling code after this call.
+     *
+     * @param resourceHandle the resource handle
+     * @param poolInfo the pool information of the pool where the resource is expected to be removed from. If the given pool
+     * info is not found no exception is thrown.
+     * <p>
+     * TODO Why is this method public available and only used internal in PoolManagerImpl and externally in
+     * LazyEnlistableResourceManagerImpl. Why can't LazyEnlistableResourceManagerImpl just call resourceClosed? If poolInfo
+     * = resourceHandle.getResourceSpec().getPoolInfo() then LazyEnlistableResourceManagerImpl could just as well call
+     * resourceClosed and then this method can be removed from the interface.
+     */
     void putbackDirectToPool(ResourceHandle resourceHandle, PoolInfo poolInfo);
 
+    /**
+     * Closes the resource handle and returns it back to the connection pool.<br>
+     * The resource is returned to the pool and the state of the resource is no longer busy.<br>
+     * The resource is also delisted / unenlisted from the current transaction.
+     * <p>
+     * Note: The resource object may not be used anymore by the calling code after this call.
+     *
+     * @param resourceHandle the resource handle to be closed and returned to the pool.
+     */
     void resourceClosed(ResourceHandle resourceHandle);
 
+    // TODO Why is this method public available? Why is it not called via resourceErrorOccurred or resourceAbortOccurred?
     void badResourceClosed(ResourceHandle resourceHandle);
 
     void resourceErrorOccurred(ResourceHandle resourceHandle);
 
     void resourceAbortOccurred(ResourceHandle resourceHandle);
 
+    /**
+     * Inform all the connection pools using this transaction that the transaction has completed. This method is called by
+     * the EJB Transaction Manager.<br>
+     * All resource handles associated to the given transaction are delisted.<br>
+     * All resource handles associated to the given transaction handed back to the connection pool.
+     *
+     * @param transaction the transaction that is completed
+     * @param status the status of the transaction
+     */
     void transactionCompleted(Transaction transaction, int status);
 
-    void emptyResourcePool(ResourceSpec spec);
+    // Not used in the code
+    // void emptyResourcePool(ResourceSpec spec);
 
+    /**
+     * Kills the pool for the given PoolInfo.<br>
+     * Note: if the pool is not found the method ends with success.
+     *
+     * @param poolInfo the pool identifier for which the pool needs to be killed.
+     */
     void killPool(PoolInfo poolInfo);
 
+    /**
+     * Reconfigures the connection pool to apply the given properties.<br>
+     * Note: if the pool is not found the method ends with success.
+     *
+     * @param ccp the object containing the new connection pool properties that will be applied to the existing pool
+     * @throws PoolingException if reconfiguration of the pool failed
+     */
     void reconfigPoolProperties(ConnectorConnectionPool ccp) throws PoolingException;
 
+    /**
+     * Switch on matching in the pool.
+     *
+     * @param poolInfo the pool identifier for which the pool matching needs to be switched on.
+     */
     boolean switchOnMatching(PoolInfo poolInfo);
 
     /**
-     * Obtain a transactional resource such as JDBC connection
+     * Obtain a transactional resource such as JDBC connection from the connection pool. The caller is blocked until a
+     * resource is acquired or the max-wait-time of the connection pool expires.
      *
      * @param spec Specification for the resource
      * @param alloc Allocator for the resource
@@ -113,17 +193,39 @@ public interface PoolManager extends TransactedPoolManager {
 
     ResourceReferenceDescriptor getResourceReference(SimpleJndiName jndiName, SimpleJndiName logicalName);
 
-    void killAllPools();
-
+    /**
+     * Kills all free connections in the registered connection pools. The pools are not killed.
+     */
     void killFreeConnectionsInPools();
 
+    /**
+     * Returns the ResourcePool for the given PoolInfo
+     *
+     * @param poolInfo the pool identifier
+     * @return the ResourcePool if found, otherwise null
+     */
     ResourcePool getPool(PoolInfo poolInfo);
 
-    void setSelfManaged(PoolInfo poolInfo, boolean flag);
+    /**
+     * This method gets called by the LazyEnlistableConnectionManagerImpl when a connection needs enlistment, i.e on use of
+     * a Statement etc. Based on the given managagedConneciton the transaction manager is found and used to find the
+     * transaction. If no transaction was found this method returns without an error.
+     *
+     * @param managedConnection the managedConnection that needs to be enlisted in the transaction
+     * @throws ResourceException in case enlistment to the transaction failed.
+     */
+    void lazyEnlist(ManagedConnection managedConnection) throws ResourceException;
 
-    void lazyEnlist(ManagedConnection mc) throws ResourceException;
-
+    /**
+     * Registers a PoolLifeCycle listener in the pool manager. The listener is used to keep track of statistics of the pool
+     * life cycle: pool created and pool destroyed events.
+     *
+     * @param poolListener the listener instance
+     */
     void registerPoolLifeCycleListener(PoolLifeCycle poolListener);
 
+    /**
+     * Unregisters the PoolLifeCycle listener in the pool manager.
+     */
     void unregisterPoolLifeCycleListener();
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolStatus.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolStatus.java
@@ -62,4 +62,9 @@ public class PoolStatus {
     public PoolStatus(PoolInfo poolInfo) {
         this.poolInfo = poolInfo;
     }
+
+    @Override
+    public String toString() {
+        return "PoolStatus [poolInfo=" + poolInfo + ", numConnFree=" + numConnFree + ", numConnUsed=" + numConnUsed + "]";
+    }
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolTxHelper.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolTxHelper.java
@@ -55,7 +55,8 @@ public class PoolTxHelper {
      * Check whether the local resource can be put back to pool If true, unenlist the resource
      *
      * @param h ResourceHandle to be verified
-     * @return boolean
+     * @return true if the resource handle is eligible for reuse, otherwise false. NOTE in case of true, this method alters
+     * the handle state to enlisted=false
      */
     public boolean isLocalResourceEligibleForReuse(ResourceHandle h) {
         boolean result = false;
@@ -70,8 +71,16 @@ public class PoolTxHelper {
                 }
                 return result;
             }
+
             h.getResourceState().setEnlisted(false);
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.log(Level.FINE, "Pool: isLocalResourceEligibleForReuse, eligible=true, enlisted changed to true for handle=" + h);
+            }
             result = true;
+        }
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "Pool: isLocalResourceEligibleForReuse, eligible=false, handle=" + h);
         }
         return result;
     }
@@ -153,7 +162,6 @@ public class PoolTxHelper {
      * @return boolean indicating whether thegiven non-xa resource is in transaction
      */
     private boolean isNonXAResourceInTransaction(JavaEETransaction tran, ResourceHandle resource) {
-
         return resource.equals(tran.getNonXAResource());
     }
 
@@ -175,6 +183,9 @@ public class PoolTxHelper {
      * @param resource Resource to be enlisted in the transaction
      */
     public void resourceEnlisted(Transaction tran, ResourceHandle resource) {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "Pool: resourceEnlisted START, tran=" + tran + ", resource=" + resource + ", poolInfo=" + poolInfo);
+        }
         try {
             JavaEETransaction j2eetran = (JavaEETransaction) tran;
             Set set = j2eetran.getResources(poolInfo);
@@ -192,7 +203,7 @@ public class PoolTxHelper {
         ResourceState state = resource.getResourceState();
         state.setEnlisted(true);
         if (_logger.isLoggable(Level.FINE)) {
-            _logger.log(Level.FINE, "Pool [ " + poolInfo + " ]: resourceEnlisted: " + resource);
+            _logger.log(Level.FINE, "Pool: resourceEnlisted END, tran=" + tran + ", resource=" + resource);
         }
     }
 
@@ -205,6 +216,10 @@ public class PoolTxHelper {
      * @return delisted resources
      */
     public List<ResourceHandle> transactionCompleted(Transaction tran, int status, PoolInfo poolInfo) {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "Pool: transactionCompleted START, tran= " + tran + ", poolInfo=" + poolInfo);
+        }
+
         JavaEETransaction j2eetran;
         List<ResourceHandle> delistedResources = new ArrayList<>();
         try {
@@ -232,6 +247,10 @@ public class PoolTxHelper {
             if (_logger.isLoggable(Level.FINE)) {
                 _logger.log(Level.FINE, "Pool: transactionCompleted: " + resource);
             }
+        }
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "Pool: transactionCompleted END, tran= " + tran);
         }
         return delistedResources;
     }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ResourcePool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ResourcePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -38,31 +38,85 @@ public interface ResourcePool {
     // Modify getResource() to throw PoolingException
     ResourceHandle getResource(ResourceSpec spec, ResourceAllocator alloc, Transaction transaction) throws PoolingException, RetryableUnavailableException;
 
+    /**
+     * Indicate that the resource is not used by a bean/application anymore.
+     *
+     * @param resource The resource that is not used anymore. After the call the resource is also marked as 'not busy' /
+     * 'free'.
+     */
     void resourceClosed(ResourceHandle resource);
 
+    /**
+     * Updates the resource to be marked as not busy / free, remove the resource from the connection pool and inform any
+     * waiting threads that a resource has become available.
+     *
+     * @param resource the resource that will be removed from the connection pool
+     */
     void resourceErrorOccurred(ResourceHandle resource);
 
+    /**
+     * This method is called when a resource is enlisted in a transaction.
+     *
+     * @param tran the Transaction to enlist the resource in
+     * @param resource the ResourceHandle that will be enlisted in the given transaction
+     */
     void resourceEnlisted(Transaction tran, ResourceHandle resource);
 
-    // Get status of pool
+    /**
+     * Get the Pool status by computing the free/used values of the connections in the pool. Computations are based on
+     * whether the pool is initialized or not when this method is invoked.
+     *
+     * @return the PoolStatus object
+     */
     PoolStatus getPoolStatus();
 
+    /**
+     * Called when a transaction is completed.<br>
+     * All resource handles associated to the given transaction are delisted.<br>
+     * All resource handles associated to the given transaction handed back to the connection pool.
+     *
+     * @param tran The transaction
+     * @param status The jakarta.transaction.Status value of the transaction.
+     */
     void transactionCompleted(Transaction tran, int status);
 
+    /**
+     * Resize the pool by removing idle and invalid resources.<br>
+     * Only when forced is true the pool size is scaled down with the pool resize quantity.
+     *
+     * @param forced when force is true, scale down the pool with the pool resize quantity.
+     */
     void resizePool(boolean forced);
 
-    // forcefully destroy all connections in the pool even if
-    // connections have transactions in progress
+    /**
+     * Forcefully destroy all connections in the pool even if connections have transactions in progress
+     */
     void emptyPool();
 
-    // reconfig the pool's properties
+    /**
+     * Reconfigure the Pool's properties. The reconfigConnectorConnectionPool method in the ConnectorRuntime will use this
+     * method (through PoolManager) if it needs to just change pool properties and not recreate the pool
+     *
+     * @param poolResource - the ConnectorConnectionPool JavaBean that holds the new pool properties
+     * @throws PoolingException if the pool resizing fails
+     */
     void reconfigurePool(ConnectorConnectionPool ccp) throws PoolingException;
 
-    // cancel the resizer task in the pool
+    /**
+     * Cancel the resizer task in the pool if it exists.
+     */
     void cancelResizerTask();
 
+    /**
+     * Switch on matching of connections in the pool.
+     */
     void switchOnMatching();
 
+    /**
+     * Get the PoolInfo unique identifier of this pool.
+     *
+     * @return the PoolInfo unique identifier of this pool
+     */
     PoolInfo getPoolInfo();
 
     void emptyFreeConnectionsInPool();
@@ -117,22 +171,23 @@ public interface ResourcePool {
     void setSelfManaged(boolean selfManaged);
 
     /**
-     * set pool life cycle listener
+     * Set the pool life cycle listener
      *
-     * @param listener
+     * @param listener the new PoolLifeCycleListener
      */
     void setPoolLifeCycleListener(PoolLifeCycleListener listener);
 
     /**
-     * remove pool life cycle listener
+     * Remove the pool life cycle listener
      */
     void removePoolLifeCycleListener();
 
     /**
-     * Flush Connection pool by reinitializing the connections established in the pool.
+     * Flush Connection pool by removing all resources established in the connection pool and bring the pool to steady pool
+     * size.
      *
      * @return boolean indicating whether flush operation was successful or not
-     * @throws com.sun.appserv.connectors.internal.api.PoolingException
+     * @throws PoolingException in case the pool was not initialized
      */
     boolean flushConnectionPool() throws PoolingException;
 
@@ -160,7 +215,7 @@ public interface ResourcePool {
     /**
      * returns the reconfig-wait-time
      *
-     * @return long
+     * @return the reconfig-wait-time
      */
     long getReconfigWaitTime();
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/UnpooledResource.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/UnpooledResource.java
@@ -20,7 +20,6 @@ package com.sun.enterprise.resource.pool;
 import com.sun.appserv.connectors.internal.api.PoolingException;
 import com.sun.enterprise.resource.ResourceHandle;
 import com.sun.enterprise.resource.ResourceSpec;
-import com.sun.enterprise.resource.ResourceState;
 import com.sun.enterprise.resource.allocator.ResourceAllocator;
 
 import jakarta.transaction.Transaction;
@@ -81,10 +80,10 @@ public class UnpooledResource extends ConnectionPool {
             this.poolSize.decrement();
             throw ex;
         }
+        handle.getResourceState().reset();
 
-        ResourceState state = new ResourceState();
-        handle.setResourceState(state);
-        state.setEnlisted(false);
+        // TODO: document that all get(Unenlisted)Resource methods must return state busy resource
+        // TODO: rename variables, they currently have 2 or 3 names by default: handle, resource and resourceHandle
         setResourceStateToBusy(handle);
         return handle;
     }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructure.java
@@ -43,11 +43,11 @@ public interface DataStructure {
     void setMaxSize(int maxSize);
 
     /**
-     * creates a new resource and adds to the datastructure.
+     * Create a new resource using the given resource-allocator and add it to the datastructure.
      *
-     * @param allocator ResourceAllocator
-     * @param count Number (units) of resources to create
-     * @return int number of resources added.
+     * @param allocator the resource-allocator to be used
+     * @param count the number (units) of resources to create
+     * @return the number of resources added
      * @throws PoolingException when unable to create a resource
      */
     int addResource(ResourceAllocator allocator, int count) throws PoolingException;
@@ -93,11 +93,11 @@ public interface DataStructure {
     int getResourcesSize();
 
     /**
-     * Get all resources in the datastructure Note : do not use this for normal usages as it can potentially represent all
-     * resources (including the ones in use). This is used under special circumstances where there is a need to process all
-     * resources.
+     * Get all resources in the datastructure<br>
+     * Note: do not use this for normal usages as it can potentially represent all resources (including the ones in use).
+     * This is used under special circumstances where there is a need to process all resources.
      *
-     * @return List<ResourceHandle>
+     * @return the list of resources in the data structure.
      */
     List<ResourceHandle> getAllResources();
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructureFactory.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructureFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -39,33 +39,33 @@ public class DataStructureFactory {
     // TODO synchronize datastructure creation ?
     protected final static Logger _logger = LogDomains.getLogger(DataStructureFactory.class, LogDomains.RSR_LOGGER);
 
-    public static DataStructure getDataStructure(String className, String parameters, int maxPoolSize, ResourceHandler handler, String strategyClass) throws PoolingException {
+    public static DataStructure getDataStructure(String className, String parameters, int maxPoolSize, ResourceHandler handler) throws PoolingException {
         DataStructure dataStructure;
 
         if (className != null) {
             if (className.equals(ListDataStructure.class.getName())) {
-                dataStructure = new ListDataStructure(parameters, maxPoolSize, handler, strategyClass);
+                dataStructure = new ListDataStructure(parameters, maxPoolSize, handler);
             } else if (className.equals(RWLockDataStructure.class.getName())) {
-                dataStructure = new RWLockDataStructure(parameters, maxPoolSize, handler, strategyClass);
+                dataStructure = new RWLockDataStructure(parameters, maxPoolSize, handler);
             } else {
-                dataStructure = initializeCustomDataStructureInPrivilegedMode(className, parameters, maxPoolSize, handler, strategyClass);
+                dataStructure = initializeCustomDataStructureInPrivilegedMode(className, parameters, maxPoolSize, handler);
             }
         } else {
             debug("Initializing RWLock DataStructure");
-            dataStructure = new RWLockDataStructure(parameters, maxPoolSize, handler, strategyClass);
+            dataStructure = new RWLockDataStructure(parameters, maxPoolSize, handler);
         }
 
         return dataStructure;
     }
 
-    private static DataStructure initializeCustomDataStructureInPrivilegedMode(final String className, final String parameters, final int maxPoolSize, final ResourceHandler handler, final String strategyClass) throws PoolingException {
+    private static DataStructure initializeCustomDataStructureInPrivilegedMode(final String className, final String parameters, final int maxPoolSize, final ResourceHandler handler) throws PoolingException {
         Object result = AccessController.doPrivileged(new PrivilegedAction<Object>() {
             @Override
             public Object run() {
 
                 Object result = null;
                 try {
-                    result = initializeDataStructure(className, parameters, maxPoolSize, handler, strategyClass);
+                    result = initializeDataStructure(className, parameters, maxPoolSize, handler);
                 } catch (Exception e) {
                     _logger.log(WARNING, "pool.datastructure.init.failure", className);
                     _logger.log(WARNING, "pool.datastructure.init.failure.exception", e);
@@ -80,12 +80,12 @@ public class DataStructureFactory {
         }
     }
 
-    private static DataStructure initializeDataStructure(String className, String parameters, int maxPoolSize, ResourceHandler handler, String strategyClass) throws Exception {
+    private static DataStructure initializeDataStructure(String className, String parameters, int maxPoolSize, ResourceHandler handler) throws Exception {
         DataStructure ds;
-        Object[] constructorParameters = new Object[] { parameters, maxPoolSize, handler, strategyClass };
+        Object[] constructorParameters = new Object[] { parameters, maxPoolSize, handler };
 
         Class class1 = Thread.currentThread().getContextClassLoader().loadClass(className);
-        Constructor constructor = class1.getConstructor(String.class, int.class, ResourceHandler.class, String.class);
+        Constructor constructor = class1.getConstructor(String.class, int.class, ResourceHandler.class);
         ds = (DataStructure) constructor.newInstance(constructorParameters);
         _logger.log(FINEST, "Using Pool Data Structure : ", className);
 

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/ListDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/ListDataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -44,15 +44,13 @@ public class ListDataStructure implements DataStructure {
     private ResourceHandler handler;
     private ResourceSelectionStrategy strategy;
 
-    public ListDataStructure(String parameters, int maxSize, ResourceHandler handler, String strategyClass) {
+    public ListDataStructure(String parameters, int maxSize, ResourceHandler handler) {
         resources = new ArrayList<>((maxSize > 1000) ? 1000 : maxSize);
         free = new ArrayList<>((maxSize > 1000) ? 1000 : maxSize);
         this.handler = handler;
-        initializeStrategy(strategyClass);
         dynSemaphore = new DynamicSemaphore();
         setMaxSize(maxSize);
     }
-
 
     /**
      * Set maxSize based on the new max pool size set on the connection pool
@@ -84,10 +82,6 @@ public class ListDataStructure implements DataStructure {
             this.dynSemaphore.reducePermits(permits);
         }
         this.maxSize = newMaxSize;
-    }
-
-    private void initializeStrategy(String strategyClass) {
-        //TODO
     }
 
     /**

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/RWLockDataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -54,7 +54,7 @@ public class RWLockDataStructure implements DataStructure {
 
     private volatile int maxSize;
 
-    public RWLockDataStructure(String parameters, int maxSize, ResourceHandler handler, String strategyClass) {
+    public RWLockDataStructure(String parameters, int maxSize, ResourceHandler handler) {
         this.availableResources = new DataStructureSemaphore(maxSize);
         this.useMask = new BitSet(maxSize);
         this.resources = new ResourceHandle[maxSize];
@@ -63,7 +63,6 @@ public class RWLockDataStructure implements DataStructure {
 
         LOG.log(Level.FINEST, "pool.datastructure.rwlockds.init");
     }
-
 
     @Override
     public int addResource(ResourceAllocator allocator, int count) throws PoolingException {
@@ -96,7 +95,7 @@ public class RWLockDataStructure implements DataStructure {
                         newResources = Arrays.copyOf(resources, currentMaxSize);
                     }
 
-                    resource.setIndex(size);
+                    resource.setRwLockDataStructureResourceIndex(size);
 
                     stamp = lock.tryConvertToWriteLock(stamp);
                     if (stamp == 0L) {
@@ -167,7 +166,7 @@ public class RWLockDataStructure implements DataStructure {
                 }
 
                 int currentSize = size;
-                int removeIndex = resource.getIndex();
+                int removeIndex = resource.getRwLockDataStructureResourceIndex();
                 if (!lock.validate(stamp)) {
                     continue;
                 }
@@ -196,7 +195,7 @@ public class RWLockDataStructure implements DataStructure {
                 if (removeIndex < lastIndex) {
                     // Move last resource in place of removed
                     ResourceHandle lastResource = resources[lastIndex];
-                    lastResource.setIndex(removeIndex);
+                    lastResource.setRwLockDataStructureResourceIndex(removeIndex);
                     resources[removeIndex] = lastResource;
                     useMask.set(removeIndex, useMask.get(lastIndex));
                 }
@@ -228,7 +227,7 @@ public class RWLockDataStructure implements DataStructure {
                 }
 
                 int currentSize = size;
-                int returnIndex = resource.getIndex();
+                int returnIndex = resource.getRwLockDataStructureResourceIndex();
                 if (!lock.validate(stamp)) {
                     continue;
                 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/resizer/AssocWithThreadPoolResizer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/resizer/AssocWithThreadPoolResizer.java
@@ -186,7 +186,7 @@ public class AssocWithThreadPoolResizer extends Resizer {
                 for (ResourceHandle handle : freeConnectionsToValidate) {
                     if (handle != null) {
                         Set<ManagedConnection> connectionsToTest = new HashSet<>();
-                        connectionsToTest.add((ManagedConnection) handle.getResource());
+                        connectionsToTest.add(handle.getResource());
                         Set<ManagedConnection> invalidConnections = handler.getInvalidConnections(connectionsToTest);
                         if (invalidConnections != null && !invalidConnections.isEmpty()) {
                             invalidConnectionsCount = validateAndRemoveResource(handle, invalidConnections);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/resizer/Resizer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/resizer/Resizer.java
@@ -83,9 +83,10 @@ public class Resizer extends TimerTask {
     }
 
     /**
-     * Resize the pool
+     * Resize the pool by removing idle and invalid resources.<br>
+     * Only when forced is true the pool size is scaled down with the pool resize quantity.
      *
-     * @param forced when force is true, scale down the pool.
+     * @param forced when force is true, scale down the pool with the pool resize quantity.
      */
     public void resizePool(boolean forced) {
 
@@ -125,13 +126,14 @@ public class Resizer extends TimerTask {
     }
 
     /**
-     * Scale down pool by a <code>size &lt;= pool-resize-quantity</code>
+     * Scale down pool by a <code>size &lt;= pool-resize-quantity</code> but only if forced is true
      *
-     * @param forced scale-down only when forced
-     * @param scaleDownQuantity no. of resources to remove
+     * @param scaleDownQuantity the number of resources to remove
+     * @param forced scale-down only when forced value is true
+     *
+     * TODO: move forced parameter out of this method and move it to the calling code
      */
     protected void scaleDownPool(int scaleDownQuantity, boolean forced) {
-
         if (pool.getResizeQuantity() > 0 && forced) {
 
             scaleDownQuantity = (scaleDownQuantity <= (dataStructure.getResourcesSize() - pool.getSteadyPoolSize())) ? scaleDownQuantity : 0;
@@ -232,7 +234,7 @@ public class Resizer extends TimerTask {
                     // validate if the connection is one in the freeConnectionsToValidate
                     if (freeConnectionsToValidate.contains(handle.toString())) {
                         Set<ManagedConnection> connectionsToTest = new HashSet<>();
-                        connectionsToTest.add((ManagedConnection) handle.getResource());
+                        connectionsToTest.add(handle.getResource());
                         Set<ManagedConnection> invalidConnections = handler.getInvalidConnections(connectionsToTest);
                         if (invalidConnections != null && !invalidConnections.isEmpty()) {
                             invalidConnectionsCount = validateAndRemoveResource(handle, invalidConnections);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/rm/ResourceManager.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/rm/ResourceManager.java
@@ -71,7 +71,7 @@ public interface ResourceManager {
      * Delist the resource from the transaction.
      *
      * @param resource Resource to be delisted.
-     * @param xaresFlag XA Flag
+     * @param xaresFlag flag indicating transaction success. This can be XAResource.TMSUCCESS or XAResource.TMFAIL
      */
     void delistResource(ResourceHandle resource, int xaresFlag);
 
@@ -79,7 +79,7 @@ public interface ResourceManager {
      * Unregister the resource from a transaction's list.
      *
      * @param resource Resource to be unregistered.
-     * @param xaresFlag XA Flag
+     * @param xaresFlag flag indicating transaction success. This can be XAResource.TMSUCCESS or XAResource.TMFAIL
      */
     void unregisterResource(ResourceHandle resource, int xaresFlag);
 }

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListenerTest.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListenerTest.java
@@ -82,6 +82,6 @@ public class LocalTxConnectionEventListenerTest {
     private ResourceHandle createResourceHandle(int i) throws ResourceException {
         ManagedConnection managedConnection = createNiceMock(ManagedConnection.class);
         replay();
-        return new ResourceHandle(managedConnection, new ResourceSpec(new SimpleJndiName("testResource" + i), 0), null, null);
+        return new ResourceHandle(managedConnection, new ResourceSpec(new SimpleJndiName("testResource" + i), 0), null);
     }
 }

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/ConnectionPoolTest.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/ConnectionPoolTest.java
@@ -31,7 +31,6 @@ import com.sun.enterprise.resource.pool.datastructure.DataStructure;
 import com.sun.enterprise.transaction.api.JavaEETransaction;
 import com.sun.logging.LogDomains;
 
-import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ManagedConnection;
 import jakarta.resource.spi.ManagedConnectionFactory;
 import jakarta.resource.spi.RetryableUnavailableException;
@@ -94,7 +93,7 @@ public class ConnectionPoolTest {
     // they can probably also be made as a unit test here / or in a similar unit test
 
     @BeforeEach
-    public void createAndPopulateMocks() throws PoolingException, ResourceException {
+    public void createAndPopulateMocks() throws Exception {
         List<Object> mocks = new ArrayList<>();
 
         // Mock ManagedConnection
@@ -124,18 +123,18 @@ public class ConnectionPoolTest {
 
         // Make sure ConnectorRuntime singleton is initialized
         MyConnectorRuntime connectorRuntime = new MyConnectorRuntime();
-        ProcessEnvironment processEnvironment = new ProcessEnvironment();
-        connectorRuntime.setProcessEnvironment(processEnvironment);
         connectorRuntime.postConstruct();
     }
 
     private void createConnectionPool(int maxPoolSize, int maxWaitTimeInMillis, int poolResizeQuantity) throws PoolingException {
         PoolInfo poolInfo = ConnectionPoolTest.getPoolInfo();
-        MyConnectionPool.myMaxPoolSize = maxPoolSize;
-        MyConnectionPool.maxWaitTimeInMillis = maxWaitTimeInMillis;
-        MyConnectionPool.poolResizeQuantity = poolResizeQuantity;
 
-        connectionPool = new MyConnectionPool(poolInfo);
+        Hashtable<Object, Object> env = new Hashtable<>();
+        env.put("maxPoolSize", Integer.valueOf(maxPoolSize));
+        env.put("maxWaitTimeInMillis", Integer.valueOf(maxWaitTimeInMillis));
+        env.put("poolResizeQuantity", Integer.valueOf(poolResizeQuantity));
+
+        connectionPool = new MyConnectionPool(poolInfo, env);
         assertEquals(0, connectionPool.getSteadyPoolSize());
         assertEquals(maxPoolSize, connectionPool.getMaxPoolSize());
 
@@ -187,7 +186,7 @@ public class ConnectionPoolTest {
 
         // Test issue #24843: make the state of resource1 not busy anymore (it should not happen but it happens in rare cases),
         // resource should still be closed without throwing an exception.
-        resource1.getResourceState().setBusy(false);
+        connectionPool.setResourceStateToFree(resource1);
         connectionPool.resourceClosed(resource1);
         assertResourceIsNotBusy(resource1);
 
@@ -444,16 +443,15 @@ public class ConnectionPoolTest {
         // Clean the pool
         connectionPool.emptyPool();
         assertResourcesSize(0);
+
+        PoolStatus poolStatus = connectionPool.getPoolStatus();
+        assertEquals(0, poolStatus.getNumConnFree());
     }
 
     public static class MyConnectionPool extends ConnectionPool {
 
-        public static int myMaxPoolSize;
-        public static int maxWaitTimeInMillis;
-        public static int poolResizeQuantity;
-
-        public MyConnectionPool(PoolInfo poolInfo) throws PoolingException {
-            super(ConnectionPoolTest.getPoolInfo(), new Hashtable<>());
+        public MyConnectionPool(PoolInfo poolInfo, Hashtable env) throws PoolingException {
+            super(ConnectionPoolTest.getPoolInfo(), env);
         }
 
         @Override
@@ -463,6 +461,13 @@ public class ConnectionPoolTest {
             ConnectorConnectionPool connectorConnectionPool = ConnectionPoolObjectsUtils
                     .createDefaultConnectorPoolObject(poolInfo, null);
 
+            int myMaxPoolSize = (int) env.get("maxPoolSize");
+            int maxWaitTimeInMillis = (int) env.get("maxWaitTimeInMillis");
+            int poolResizeQuantity = (int) env.get("poolResizeQuantity");
+
+            assertTrue(myMaxPoolSize > 0);
+            assertTrue(poolResizeQuantity > 0);
+
             // Override some defaults
             connectorConnectionPool.setSteadyPoolSize("0");
             connectorConnectionPool.setMaxPoolSize("" + myMaxPoolSize);
@@ -471,12 +476,18 @@ public class ConnectionPoolTest {
 
             return connectorConnectionPool;
         }
+
+        protected void scheduleResizerTask() {
+            // Do not schedule any resize tasks
+        }
     }
 
     public class MyConnectorRuntime extends ConnectorRuntime {
+        private ProcessEnvironment processEnvironment = new ProcessEnvironment();
 
-        public void setProcessEnvironment(ProcessEnvironment processEnvironment) {
-            this.processEnvironment = processEnvironment;
+        public MyConnectorRuntime() throws Exception {
+            // Force 'injection' of private field processEnvironment
+            InjectionUtil.injectPrivateField(ConnectorRuntime.class, this, "processEnvironment", processEnvironment);
         }
 
         @Override
@@ -496,7 +507,7 @@ public class ConnectionPoolTest {
         }
     }
 
-    private static PoolInfo getPoolInfo() {
+    public static PoolInfo getPoolInfo() {
         SimpleJndiName jndiName = new SimpleJndiName("myPool");
         return new PoolInfo(jndiName);
     }

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/InjectionUtil.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/InjectionUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.resource.pool;
+
+import java.lang.reflect.Field;
+
+public class InjectionUtil {
+
+    /**
+     * Use injection to fill in private fields in (final) classes. E.g. fields annotated with jakarta.inject.Inject.
+     *
+     * @param clazz the class to be altered
+     * @param clazzInstance the instance of the class that needs to be altered
+     * @param fieldName the name of the field in the class
+     * @param fieldValue the new value for the field
+     * @throws Exception if the injection of the value failed
+     */
+    public static void injectPrivateField(Class<?> clazz, Object clazzInstance, String fieldName, Object fieldValue) throws Exception {
+        Field declaredField = clazz.getDeclaredField(fieldName);
+        declaredField.setAccessible(true);
+        declaredField.set(clazzInstance, fieldValue);
+    }
+}

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/PoolManagerImplTest.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/PoolManagerImplTest.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.resource.pool;
+
+import com.sun.appserv.connectors.internal.api.ConnectorConstants.PoolType;
+import com.sun.appserv.connectors.internal.api.ConnectorRuntimeException;
+import com.sun.appserv.connectors.internal.api.PoolingException;
+import com.sun.enterprise.connectors.ConnectorRuntime;
+import com.sun.enterprise.resource.ClientSecurityInfo;
+import com.sun.enterprise.resource.ResourceHandle;
+import com.sun.enterprise.resource.ResourceSpec;
+import com.sun.enterprise.resource.allocator.ConnectorAllocator;
+import com.sun.enterprise.resource.allocator.LocalTxConnectorAllocator;
+import com.sun.enterprise.resource.allocator.NoTxConnectorAllocator;
+import com.sun.enterprise.resource.allocator.ResourceAllocator;
+import com.sun.enterprise.resource.pool.mock.JavaEETransactionManagerMock;
+import com.sun.enterprise.resource.pool.mock.JavaEETransactionMock;
+import com.sun.enterprise.transaction.api.JavaEETransaction;
+import com.sun.enterprise.transaction.api.JavaEETransactionManager;
+import com.sun.enterprise.transaction.spi.TransactionalResource;
+
+import jakarta.resource.spi.ManagedConnection;
+import jakarta.resource.spi.ManagedConnectionFactory;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.glassfish.api.admin.ProcessEnvironment;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.api.invocation.InvocationManagerImpl;
+import org.glassfish.api.naming.GlassfishNamingManager;
+import org.glassfish.api.naming.SimpleJndiName;
+import org.glassfish.resourcebase.resources.api.PoolInfo;
+import org.glassfish.resourcebase.resources.naming.ResourceNamingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.sun.enterprise.resource.pool.ConnectionPoolTest.getPoolInfo;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.isNull;
+import static org.easymock.EasyMock.notNull;
+import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class PoolManagerImplTest {
+
+    // Mocked instances
+    private GlassfishNamingManager glassfishNamingManager;
+    private ManagedConnection managedConnection;
+    private ManagedConnectionFactory managedConnectionFactory;
+
+    // Regular fields
+    private ClientSecurityInfo clientSecurityInfo = null;
+    private PoolManagerImpl poolManagerImpl = new MyPoolManagerImpl();
+    private PoolInfo poolInfo = getPoolInfo();
+    private JavaEETransaction javaEETransaction = new MyJavaEETransaction();
+    private MyJavaEETransactionManager javaEETransactionManager = new MyJavaEETransactionManager();
+    private PoolType poolType;
+
+    @BeforeEach
+    public void createAndPopulateMocks() throws Exception {
+        List<Object> mocks = new ArrayList<>();
+
+        // Mock GlassfishNamingManager
+        glassfishNamingManager = createNiceMock(GlassfishNamingManager.class);
+        mocks.add(glassfishNamingManager);
+
+        // Mock ManagedConnection
+        managedConnection = createNiceMock(ManagedConnection.class);
+        expect(managedConnection.getConnection(isNull(), isNull()))
+                .andReturn(new MyDatabaseConnection()).anyTimes();
+        mocks.add(managedConnection);
+
+        // Mock ManagedConnectionFactory
+        ManagedConnectionFactory localConnectionFactory = createMock(ManagedConnectionFactory.class);
+        expect(localConnectionFactory.createManagedConnection(isNull(), isNull()))
+                .andReturn(managedConnection)
+                .atLeastOnce();
+        // Must return a not null object in matchManagedConnections to ensure matching in the ConnectionPool is 'true'
+        expect(localConnectionFactory.matchManagedConnections(notNull(), isNull(), isNull()))
+                .andReturn(managedConnection)
+                .atLeastOnce();
+        managedConnectionFactory = localConnectionFactory;
+        mocks.add(managedConnectionFactory);
+
+        replay(mocks.toArray());
+
+        // Make sure ConnectorRuntime singleton is initialized
+        MyConnectorRuntime connectorRuntime = new MyConnectorRuntime();
+        connectorRuntime.postConstruct();
+    }
+
+    /**
+     * Test to show the getResource behavior
+     */
+    @Test
+    void getResourceTest() throws Exception {
+        // Create Standard pool
+        poolType = PoolType.STANDARD_POOL;
+        poolManagerImpl.createEmptyConnectionPool(poolInfo, poolType, new Hashtable<>());
+
+        ResourceSpec resourceSpec = createTestResourceSpec(poolInfo);
+
+        // Test getting a single resource, this will return a 'userConnection' / 'connection handle' object representing the
+        // physical connection, e.g. a database connection.
+
+        // Test using the No transaction allocator
+        ResourceAllocator noTxAllocator = new NoTxConnectorAllocator(null, managedConnectionFactory, resourceSpec, null,
+                null, null, null);
+        Object resource = poolManagerImpl.getResource(resourceSpec, noTxAllocator, clientSecurityInfo);
+        assertTrue(resource instanceof MyDatabaseConnection);
+
+        // Test using the Local transaction allocator
+        ResourceAllocator localTxAllocator = new LocalTxConnectorAllocator(null, managedConnectionFactory, resourceSpec, null,
+                null, null, null, false);
+        resource = poolManagerImpl.getResource(resourceSpec, localTxAllocator, clientSecurityInfo);
+        assertTrue(resource instanceof MyDatabaseConnection);
+
+        // Test using the XA transaction allocator
+        ResourceAllocator xAllocator = new ConnectorAllocator(null, managedConnectionFactory, resourceSpec, null,
+                null, null, null, false);
+        resource = poolManagerImpl.getResource(resourceSpec, xAllocator, clientSecurityInfo);
+        assertTrue(resource instanceof MyDatabaseConnection);
+
+        // Resources from the pool should be occupied
+        assertPoolStatusNumberOfConnectionsUsed(3);
+
+        // Get resource does not return a ResourceHandle, so we cannot return the resources to the pool.
+        // For now just flush all resources from the pool.
+        poolManagerImpl.flushConnectionPool(poolInfo);
+
+        assertPoolStatusNumberOfConnectionsUsed(0);
+
+        // Kill the pool
+        poolManagerImpl.killPool(poolInfo);
+        assertNull(poolManagerImpl.getPoolStatus(poolInfo));
+    }
+
+    /**
+     * Test to show the getResourceFromPool and resourceClosed behavior in relation to the ResourceHandle enlisted and busy
+     * states, while using the LocalTxConnectorAllocator.
+     */
+    @Test
+    public void resourceClosedTest() throws Exception {
+        // Create Standard pool
+        poolType = PoolType.STANDARD_POOL;
+        poolManagerImpl.createEmptyConnectionPool(poolInfo, poolType, new Hashtable<>());
+
+        assertPoolStatusNumberOfConnectionsUsed(0);
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        ResourceSpec resourceSpec = new ResourceSpec(new SimpleJndiName("myResourceSpec"), ResourceSpec.JNDI_NAME);
+        resourceSpec.setPoolInfo(poolInfo);
+
+        // Test using the Local transaction allocator
+        ResourceAllocator localTxAllocator = new LocalTxConnectorAllocator(null, managedConnectionFactory, resourceSpec, null,
+                null, null, null, false);
+        ResourceHandle resource = poolManagerImpl.getResourceFromPool(resourceSpec, localTxAllocator, clientSecurityInfo, javaEETransaction);
+        assertNotNull(resource);
+        assertTrue(resource.getUserConnection() instanceof MyDatabaseConnection);
+
+        // State should be marked busy directly after a getResource call
+        // The resource is not (yet) enlisted in a transaction
+        assertResourceIsBusy(resource);
+        assertResourceIsNotEnlisted(resource);
+
+        // One resource from the pool should be added to the pool and should be occupied
+        assertPoolStatusNumberOfConnectionsUsed(1);
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        // Enlist the resource in the transaction
+        assertResourceIsNotPartOfTransaction(javaEETransaction, resource);
+        resource.enlistedInTransaction(javaEETransaction);
+        assertResourceIsBusy(resource);
+        assertResourceIsEnlisted(resource);
+        assertResourceIsPartOfTransaction(javaEETransaction, resource);
+
+        // Return the resource to the pool
+        poolManagerImpl.resourceClosed(resource);
+        // NOTE: in a multi threaded test the resource cannot be tested after this point!
+
+        // When resource is returned to the pool the state is no longer busy
+        // But the resource is still enlisted in the transaction
+        assertResourceIsNotBusy(resource);
+        assertResourceIsEnlisted(resource);
+        assertResourceHasNoConnectionErrorOccured(resource);
+        assertResourceIsPartOfTransaction(javaEETransaction, resource);
+
+        // Resource is still in use
+        assertPoolStatusNumberOfConnectionsUsed(1);
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        // Stop the transaction to get the resource delisted / unenlisted from the transaction
+        // Mimic com.sun.enterprise.transaction.JavaEETransactionImpl.commit() call
+        poolManagerImpl.transactionCompleted(javaEETransaction, jakarta.transaction.Status.STATUS_COMMITTED);
+
+        // State should remain not busy
+        // And the resource no longer enlisted in the transaction
+        assertResourceIsNotBusy(resource);
+        assertResourceIsNotEnlisted(resource);
+        assertResourceHasNoConnectionErrorOccured(resource);
+        assertResourceIsNotPartOfTransaction(javaEETransaction, resource);
+
+        // Connection should no longer be in use
+        assertPoolStatusNumberOfConnectionsUsed(0);
+        assertPoolStatusNumberOfConnectionsFree(1);
+
+        // Kill the pool
+        poolManagerImpl.killPool(poolInfo);
+        assertNull(poolManagerImpl.getPoolStatus(poolInfo));
+    }
+
+    /**
+     * Test to show the getResourceFromPool and resourceErrorOccurred behavior in relation to the ResourceHandle enlisted
+     * and busy states, while using the LocalTxConnectorAllocator.
+     */
+    @Test
+    public void resourceErrorOccurredTest() throws Exception {
+        resourceErrorOrAbortedOccurredTest(false);
+    }
+
+    /**
+     * Test to show the getResourceFromPool and resourceAbortOccurred behavior in relation to the ResourceHandle enlisted
+     * and busy states, while using the LocalTxConnectorAllocator.
+     */
+    @Test
+    public void resourceAbortOccurredTest() throws Exception {
+        resourceErrorOrAbortedOccurredTest(true);
+    }
+
+    private void resourceErrorOrAbortedOccurredTest(boolean resourceAbortedOccured) throws Exception {
+        // Create Standard pool
+        poolType = PoolType.STANDARD_POOL;
+        poolManagerImpl.createEmptyConnectionPool(poolInfo, poolType, new Hashtable<>());
+
+        assertPoolStatusNumberOfConnectionsUsed(0);
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        ResourceSpec resourceSpec = new ResourceSpec(new SimpleJndiName("myResourceSpec"), ResourceSpec.JNDI_NAME);
+        resourceSpec.setPoolInfo(poolInfo);
+
+        // Test using the Local transaction allocator
+        ResourceAllocator localTxAllocator = new LocalTxConnectorAllocator(null, managedConnectionFactory, resourceSpec, null,
+                null, null, null, false);
+        ResourceHandle resource = poolManagerImpl.getResourceFromPool(resourceSpec, localTxAllocator, clientSecurityInfo, javaEETransaction);
+        assertNotNull(resource);
+        assertTrue(resource.getUserConnection() instanceof MyDatabaseConnection);
+
+        // State should be marked busy directly after a getResource call
+        // The resource is not (yet) enlisted in a transaction
+        assertResourceIsBusy(resource);
+        assertResourceIsNotEnlisted(resource);
+
+        // One resource from the pool should be added to the pool and should be occupied
+        assertPoolStatusNumberOfConnectionsUsed(1);
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        // Enlist the resource in the transaction
+        assertResourceIsNotPartOfTransaction(javaEETransaction, resource);
+        resource.enlistedInTransaction(javaEETransaction);
+        assertResourceIsBusy(resource);
+        assertResourceIsEnlisted(resource);
+        assertResourceIsPartOfTransaction(javaEETransaction, resource);
+
+        if (resourceAbortedOccured) {
+            // Return the resource to the pool using resourceAbortOccurred
+            poolManagerImpl.resourceAbortOccurred(resource);
+            // Related transaction delist should be called for the resource
+            assertTrue(javaEETransactionManager.isDelistIsCalled(resource));
+
+            // TODO: connection error occurred flag on the resource is only set via badConnectionClosed
+            // why isn't it also called for resourceAbortedOccured? Bug?!
+            assertResourceHasNoConnectionErrorOccured(resource);
+        } else {
+            // Return the resource to the pool using resourceErrorOccurred
+            poolManagerImpl.resourceErrorOccurred(resource);
+            // Related transaction delist should be called for the resource, shouldn't it?
+            // resourceErrorOccurred does not seem to remove the resource from the transaction, possible bug?
+            // TODO: should be assertTrue
+            assertFalse(javaEETransactionManager.isDelistIsCalled(resource));
+
+            // TODO: connection error occurred flag on the resource is only set via badConnectionClosed
+            // why isn't it also called for resourceErrorOccurred? Bug?!
+            assertResourceHasNoConnectionErrorOccured(resource);
+        }
+        // NOTE: in a multi threaded test the resource cannot be tested after this point!
+
+        // When resource is returned to the pool the state is no longer busy
+        // But the resource is still enlisted in the transaction
+        assertResourceIsNotBusy(resource);
+        assertResourceIsEnlisted(resource);
+        assertResourceIsPartOfTransaction(javaEETransaction, resource);
+
+        // In case of putbackResourceToPool we would expect: Resource is still in use
+        // assertPoolStatusNumberOfConnectionsUsed(1);
+        // In case of putbackBadResourceToPool the resource is no longer listed as in use
+        assertPoolStatusNumberOfConnectionsUsed(0);
+        // And the bad resource should not have been returned to the free pool
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        // Stop the transaction to get the resource delisted / unenlisted from the transaction
+        // Mimic com.sun.enterprise.transaction.JavaEETransactionImpl.commit() call
+        poolManagerImpl.transactionCompleted(javaEETransaction, jakarta.transaction.Status.STATUS_MARKED_ROLLBACK);
+
+        // State should remain not busy
+        // And the resource no longer enlisted in the transaction
+        assertResourceIsNotBusy(resource);
+        assertResourceIsNotEnlisted(resource);
+        assertResourceIsNotPartOfTransaction(javaEETransaction, resource);
+
+        // Connection should no longer be in use, and number of connections free should remain at 0
+        assertPoolStatusNumberOfConnectionsUsed(0);
+        assertPoolStatusNumberOfConnectionsFree(0);
+
+        // Kill the pool
+        poolManagerImpl.killPool(poolInfo);
+        assertNull(poolManagerImpl.getPoolStatus(poolInfo));
+
+    }
+
+    private void assertResourceIsBusy(ResourceHandle resource) {
+        assertTrue(resource.getResourceState().isBusy());
+    }
+
+    private void assertResourceIsNotBusy(ResourceHandle resource) {
+        assertFalse(resource.getResourceState().isBusy());
+    }
+
+    private void assertResourceIsEnlisted(ResourceHandle resource) {
+        assertTrue(resource.isEnlisted());
+    }
+
+    private void assertResourceIsNotEnlisted(ResourceHandle resource) {
+        assertFalse(resource.isEnlisted());
+    }
+
+    private void assertResourceHasNoConnectionErrorOccured(ResourceHandle resource) {
+        assertFalse(resource.hasConnectionErrorOccurred());
+    }
+
+    private void assertPoolStatusNumberOfConnectionsUsed(int expectedNumber) {
+        PoolStatus poolStatus = poolManagerImpl.getPoolStatus(poolInfo);
+        assertEquals(expectedNumber, poolStatus.getNumConnUsed());
+    }
+
+    private void assertPoolStatusNumberOfConnectionsFree(int expectedNumber) {
+        PoolStatus poolStatus = poolManagerImpl.getPoolStatus(poolInfo);
+        assertEquals(expectedNumber, poolStatus.getNumConnFree());
+    }
+
+    private static ResourceSpec createTestResourceSpec(PoolInfo thePoolInfo) {
+        ResourceSpec resourceSpec = new ResourceSpec(new SimpleJndiName("myResourceSpec"), ResourceSpec.JNDI_NAME);
+        resourceSpec.setPoolInfo(thePoolInfo);
+        return resourceSpec;
+    }
+
+    private void assertResourceIsPartOfTransaction(JavaEETransaction transaction, ResourceHandle expectedResource) {
+        for (Object resource : transaction.getResources(poolInfo)) {
+            if (resource instanceof ResourceHandle) {
+                ResourceHandle foundResource = (ResourceHandle) resource;
+                if (foundResource.equals(expectedResource)) {
+                    return;
+                }
+            }
+        }
+        fail();
+    }
+
+    private void assertResourceIsNotPartOfTransaction(JavaEETransaction transaction, ResourceHandle expectedResource) {
+        Set resources = transaction.getResources(poolInfo);
+        if (resources != null) {
+            for (Object resource : resources) {
+                if (resource instanceof ResourceHandle) {
+                    ResourceHandle foundResource = (ResourceHandle) resource;
+                    if (foundResource.equals(expectedResource)) {
+                        fail();
+                    }
+                }
+            }
+        }
+    }
+
+    private class MyDatabaseConnection {
+    }
+
+    private class MyConnectorRuntime extends ConnectorRuntime {
+        private InvocationManager manager = new InvocationManagerImpl();
+        private ProcessEnvironment processEnvironment = new ProcessEnvironment();
+        private ResourceNamingService resourceNamingService = new ResourceNamingService();
+
+        public MyConnectorRuntime() throws Exception {
+            // Force 'injection', unluckily ResourceNamingService is marked as final
+            // otherwise we could mock it, or subclass it for this unit test.
+            InjectionUtil.injectPrivateField(ResourceNamingService.class, resourceNamingService, "namingManager", glassfishNamingManager);
+
+            // Force 'injection' of private field processEnvironment
+            InjectionUtil.injectPrivateField(ConnectorRuntime.class, this, "processEnvironment", processEnvironment);
+        }
+
+        @Override
+        public JavaEETransactionManager getTransactionManager() {
+            return javaEETransactionManager;
+        }
+
+        @Override
+        public InvocationManager getInvocationManager() {
+            return manager;
+        }
+
+        @Override
+        public ResourceNamingService getResourceNamingService() {
+            return resourceNamingService ;
+        }
+
+        @Override
+        public PoolManager getPoolManager() {
+            return poolManagerImpl;
+        }
+
+        @Override
+        public PoolType getPoolType(PoolInfo poolInfo) throws ConnectorRuntimeException {
+            // Overriden to avoid ResourceNamingService jndi lookup calls in unit test
+            return poolType;
+        }
+    }
+
+    // We cannot depend on the real JavaEETransactionManagerSimplified implementation due to dependency limitations
+    private class MyJavaEETransactionManager extends JavaEETransactionManagerMock {
+
+        Map<TransactionalResource, Boolean> delistIsCalled = new HashMap<>();
+
+        @Override
+        public Transaction getTransaction() throws SystemException {
+            // Assuming only 1 transaction used in each unit test, return it
+            return javaEETransaction;
+        }
+
+        @Override
+        public boolean delistResource(Transaction tran, TransactionalResource resource, int flag) throws IllegalStateException, SystemException {
+            // Store state for unit test validation
+            delistIsCalled.put(resource, Boolean.TRUE);
+
+            // Return delist success
+            return true;
+        }
+
+        public boolean isDelistIsCalled(TransactionalResource resource) {
+            return delistIsCalled.getOrDefault(resource, Boolean.FALSE);
+        }
+    }
+
+    // We cannot depend on the real JavaEETransactionImpl due to dependency limitations
+    private class MyJavaEETransaction extends JavaEETransactionMock {
+
+        private HashMap<Object, Set> resourceTable = new HashMap<>();
+
+        @Override
+        public Set getAllParticipatingPools() {
+            return resourceTable.keySet();
+        }
+
+        @Override
+        public Set getResources(Object poolInfo) {
+            return resourceTable.get(poolInfo);
+        }
+
+        @Override
+        public void setResources(Set resources, Object poolInfo) {
+            resourceTable.put(poolInfo, resources);
+        }
+    }
+
+    private class MyPoolManagerImpl extends PoolManagerImpl {
+
+        // Override createAndInitPool to be able to use our MyConnectionPool implementation to be able to override
+        // getPoolConfigurationFromJndi and scheduleResizerTask in the ConnectionPool class.
+        @Override
+        void createAndInitPool(PoolInfo poolInfo, PoolType poolType, Hashtable env) throws PoolingException {
+            // Abuse env hashTable to get fields into the getPoolConfigurationFromJndi method
+            env.put("maxPoolSize", Integer.valueOf(10));
+            env.put("maxWaitTimeInMillis", Integer.valueOf(500));
+            env.put("poolResizeQuantity", Integer.valueOf(1));
+
+            ConnectionPoolTest.MyConnectionPool pool = new ConnectionPoolTest.MyConnectionPool(poolInfo, env);
+            addPool(pool);
+        }
+    }
+}

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/mock/JavaEETransactionManagerMock.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/mock/JavaEETransactionManagerMock.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.resource.pool.mock;
+
+import com.sun.enterprise.transaction.api.JavaEETransaction;
+import com.sun.enterprise.transaction.api.XAResourceWrapper;
+import com.sun.enterprise.transaction.spi.JavaEETransactionManagerDelegate;
+import com.sun.enterprise.transaction.spi.TransactionalResource;
+
+import jakarta.resource.spi.XATerminator;
+import jakarta.resource.spi.work.WorkException;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.glassfish.api.invocation.ComponentInvocation;
+import org.glassfish.api.invocation.InvocationException;
+import org.glassfish.api.invocation.ResourceHandler;
+
+/**
+ * Mock class without any implementation
+ */
+public class JavaEETransactionManagerMock implements com.sun.enterprise.transaction.api.JavaEETransactionManager {
+
+    @Override
+    public void begin() throws NotSupportedException, SystemException {
+    }
+
+    @Override
+    public void commit()
+            throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
+    }
+
+    @Override
+    public int getStatus() throws SystemException {
+        return 0;
+    }
+
+    @Override
+    public Transaction getTransaction() throws SystemException {
+        return null;
+    }
+
+    @Override
+    public void resume(Transaction tobj) throws InvalidTransactionException, IllegalStateException, SystemException {
+    }
+
+    @Override
+    public void rollback() throws IllegalStateException, SecurityException, SystemException {
+    }
+
+    @Override
+    public void setRollbackOnly() throws IllegalStateException, SystemException {
+    }
+
+    @Override
+    public void setTransactionTimeout(int seconds) throws SystemException {
+    }
+
+    @Override
+    public Transaction suspend() throws SystemException {
+        return null;
+    }
+
+    @Override
+    public void registerSynchronization(Synchronization sync) throws RollbackException, IllegalStateException, SystemException {
+    }
+
+    @Override
+    public boolean enlistResource(Transaction tran, TransactionalResource h) throws RollbackException, IllegalStateException, SystemException {
+        return false;
+    }
+
+    @Override
+    public boolean delistResource(Transaction tran, TransactionalResource h, int flag) throws IllegalStateException, SystemException {
+        return false;
+    }
+
+    @Override
+    public void enlistComponentResources() throws RemoteException {
+    }
+
+    @Override
+    public void delistComponentResources(boolean suspend) throws RemoteException {
+    }
+
+    @Override
+    public void componentDestroyed(Object instance, ComponentInvocation inv) {
+    }
+
+    @Override
+    public void componentDestroyed(Object instance) {
+    }
+
+    @Override
+    public void componentDestroyed(ResourceHandler rh) {
+    }
+
+    @Override
+    public void preInvoke(ComponentInvocation prev) throws InvocationException {
+    }
+
+    @Override
+    public void postInvoke(ComponentInvocation curr, ComponentInvocation prev) throws InvocationException {
+    }
+
+    @Override
+    public void setDefaultTransactionTimeout(int seconds) {
+    }
+
+    @Override
+    public void cleanTxnTimeout() {
+    }
+
+    @Override
+    public List getExistingResourceList(Object instance, ComponentInvocation inv) {
+        return null;
+    }
+
+    @Override
+    public void registerComponentResource(TransactionalResource h) {
+    }
+
+    @Override
+    public void unregisterComponentResource(TransactionalResource h) {
+    }
+
+    @Override
+    public void recover(XAResource[] resourceList) {
+    }
+
+    @Override
+    public void initRecovery(boolean force) {
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public void begin(int timeout) throws NotSupportedException, SystemException {
+    }
+
+    @Override
+    public boolean isNullTransaction() {
+        return false;
+    }
+
+    @Override
+    public void checkTransactionExport(boolean isLocal) {
+    }
+
+    @Override
+    public void checkTransactionImport() {
+    }
+
+    @Override
+    public boolean isTimedOut() {
+        return false;
+    }
+
+    @Override
+    public ArrayList getActiveTransactions() {
+        return null;
+    }
+
+    @Override
+    public void forceRollback(String txnId) throws IllegalStateException, SystemException {
+    }
+
+    @Override
+    public void setMonitoringEnabled(boolean enabled) {
+    }
+
+    @Override
+    public void freeze() {
+    }
+
+    @Override
+    public void unfreeze() {
+    }
+
+    @Override
+    public boolean isFrozen() {
+        return false;
+    }
+
+    @Override
+    public void recreate(Xid xid, long timeout) throws WorkException {
+    }
+
+    @Override
+    public void release(Xid xid) throws WorkException {
+    }
+
+    @Override
+    public XATerminator getXATerminator() {
+        return null;
+    }
+
+    @Override
+    public void setDelegate(JavaEETransactionManagerDelegate delegate) {
+    }
+
+    @Override
+    public JavaEETransaction getCurrentTransaction() {
+        return null;
+    }
+
+    @Override
+    public void setCurrentTransaction(JavaEETransaction tx) {
+    }
+
+    @Override
+    public XAResourceWrapper getXAResourceWrapper(String clName) {
+        return null;
+    }
+
+    @Override
+    public void handlePropertyUpdate(String name, Object value) {
+    }
+
+    @Override
+    public boolean recoverIncompleteTx(boolean delegated, String logPath, XAResource[] xaresArray) throws Exception {
+        return false;
+    }
+
+    @Override
+    public List getResourceList(Object instance, ComponentInvocation inv) {
+        return null;
+    }
+
+    @Override
+    public void clearThreadTx() {
+    }
+
+    @Override
+    public String getTxLogLocation() {
+        return null;
+    }
+
+    @Override
+    public void registerRecoveryResourceHandler(XAResource xaResource) {
+    }
+
+    @Override
+    public int getPurgeCancelledTtransactionsAfter() {
+        return 0;
+    }
+
+    @Override
+    public void setPurgeCancelledTtransactionsAfter(int value) {
+    }
+}

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/mock/JavaEETransactionMock.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/mock/JavaEETransactionMock.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.resource.pool.mock;
+
+import com.sun.enterprise.transaction.api.JavaEETransaction;
+import com.sun.enterprise.transaction.api.SimpleResource;
+import com.sun.enterprise.transaction.spi.TransactionalResource;
+
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+
+import java.util.Set;
+
+import javax.transaction.xa.XAResource;
+
+/**
+ * Mock class without any implementation
+ */
+public class JavaEETransactionMock implements JavaEETransaction {
+
+    @Override
+    public void commit()
+            throws RollbackException, HeuristicMixedException, HeuristicRollbackException, SecurityException, IllegalStateException, SystemException {
+    }
+
+    @Override
+    public boolean delistResource(XAResource xaRes, int flag) throws IllegalStateException, SystemException {
+        return false;
+    }
+
+    @Override
+    public boolean enlistResource(XAResource xaRes) throws RollbackException, IllegalStateException, SystemException {
+        return false;
+    }
+
+    @Override
+    public int getStatus() throws SystemException {
+        return 0;
+    }
+
+    @Override
+    public void registerSynchronization(Synchronization sync) throws RollbackException, IllegalStateException, SystemException {
+    }
+
+    @Override
+    public void rollback() throws IllegalStateException, SystemException {
+    }
+
+    @Override
+    public void setRollbackOnly() throws IllegalStateException, SystemException {
+    }
+
+    @Override
+    public SimpleResource getExtendedEntityManagerResource(EntityManagerFactory factory) {
+        return null;
+    }
+
+    @Override
+    public SimpleResource getTxEntityManagerResource(EntityManagerFactory factory) {
+        return null;
+    }
+
+    @Override
+    public void addTxEntityManagerMapping(EntityManagerFactory factory, SimpleResource em) {
+    }
+
+    @Override
+    public void addExtendedEntityManagerMapping(EntityManagerFactory factory, SimpleResource em) {
+    }
+
+    @Override
+    public void removeExtendedEntityManagerMapping(EntityManagerFactory factory) {
+    }
+
+    @Override
+    public <T> void setContainerData(T data) {
+    }
+
+    @Override
+    public <T> T getContainerData() {
+        return null;
+    }
+
+    @Override
+    public Set getAllParticipatingPools() {
+        return null;
+    }
+
+    @Override
+    public Set getResources(Object poolInfo) {
+        return null;
+    }
+
+    @Override
+    public TransactionalResource getLAOResource() {
+        return null;
+    }
+
+    @Override
+    public void setLAOResource(TransactionalResource h) {
+    }
+
+    @Override
+    public TransactionalResource getNonXAResource() {
+        return null;
+    }
+
+    @Override
+    public void setResources(Set resources, Object poolInfo) {
+    }
+
+    @Override
+    public boolean isLocalTx() {
+        return false;
+    }
+
+    @Override
+    public boolean isTimedOut() {
+        return false;
+    }
+}

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/containers/EJBContainerTransactionManager.java
@@ -136,6 +136,10 @@ public class EJBContainerTransactionManager {
      * Handle transaction requirements, if any, before invoking bean method
      */
     final void preInvokeTx(EjbInvocation inv) throws Exception {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("preInvokeTx START, inv=" + inv);
+        }
+
         // Get existing Tx status: this tells us if the client
         // started a transaction which was propagated on this invocation.
         Integer preInvokeTxStatus = inv.getPreInvokeTxStatus();
@@ -161,6 +165,9 @@ public class EJBContainerTransactionManager {
                 } catch (SystemException ex) {
                     throw new EJBException(ex);
                 }
+            }
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("preInvokeTx END (1), inv=" + inv);
             }
             return;
         }
@@ -275,6 +282,10 @@ public class EJBContainerTransactionManager {
             default:
                 throw new EJBException("Bad transaction attribute");
         }
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("preInvokeTx END (2), inv=" + inv);
+        }
     }
 
     /**
@@ -282,6 +293,9 @@ public class EJBContainerTransactionManager {
      * no-op in those containers that do not need this callback
      */
     private void startNewTx(Transaction prevTx, EjbInvocation inv) throws Exception {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("startNewTx START, inv=" + inv + "\n    prevTx=" + prevTx);
+        }
 
         container.checkUnfinishedTx(prevTx, inv);
 
@@ -313,12 +327,19 @@ public class EJBContainerTransactionManager {
         // a Synchronization object with the TM, the afterCompletion
         // will get called.
         container.afterBegin(context);
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("startNewTx END, inv=" + inv);
+        }
     }
 
     /**
      * Use caller transaction to execute a bean method
      */
     protected void useClientTx(Transaction prevTx, EjbInvocation inv) {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("useClientTx START, inv=" + inv + "\n    prevTx=" + prevTx);
+        }
         Transaction clientTx;
         int status=-1;
         int prevStatus=-1;
@@ -410,12 +431,19 @@ public class EJBContainerTransactionManager {
                 }
             }
         }
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("useClientTx END, inv=" + inv);
+        }
      }
 
     /**
      * Handle transaction requirements, if any, after invoking bean method
      */
     protected void postInvokeTx(EjbInvocation inv) throws Exception {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("postInvokeTx START, inv=" + inv);
+        }
 
         Throwable exception = inv.exception;
 
@@ -436,6 +464,9 @@ public class EJBContainerTransactionManager {
                 inv.exception = ((BaseContainer.PreInvokeException)exception).exception;
             }
 
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("postInvokeTx END (1), inv=" + inv);
+            }
             return;
         }
 
@@ -533,6 +564,10 @@ public class EJBContainerTransactionManager {
 
         // XXX If any of the TM commit/rollback/suspend calls throws an
         // exception, should the transaction be rolled back if not already so ?
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("postInvokeTx END (2), inv=" + inv);
+        }
      }
 
     final UserTransaction getUserTransaction() {
@@ -664,6 +699,10 @@ public class EJBContainerTransactionManager {
 
     // this is the counterpart of startNewTx
     private Throwable completeNewTx(EJBContextImpl context, Throwable exception, int status) throws Exception {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.fine("completeNewTx START, context=" + context + ", status=" + status + ", exception=" + exception);
+        }
+
         Throwable newException = exception;
         if (exception instanceof BaseContainer.PreInvokeException) {
             newException = ((BaseContainer.PreInvokeException) exception).exception;
@@ -672,6 +711,10 @@ public class EJBContainerTransactionManager {
         if (status == Status.STATUS_NO_TRANSACTION) {
             // no tx was started, probably an exception was thrown
             // before tm.begin() was called
+
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("completeNewTx END (1), context=" + context);
+            }
             return newException;
         }
 
@@ -684,6 +727,10 @@ public class EJBContainerTransactionManager {
             // EJB2.0 section 18.3.1, Table 15
             // Rollback the Tx we started
             destroyBeanAndRollback(context, null);
+
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("completeNewTx END (2), context=" + context);
+            }
             return processSystemException(newException);
         }
         try {
@@ -705,15 +752,25 @@ public class EJBContainerTransactionManager {
                     transactionManager.commit();
                 }
             }
+
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("completeNewTx END (3), context=" + context);
+            }
             return newException;
         } catch (RollbackException ex) {
             _logger.log(Level.FINE, "ejb.transaction_abort_exception", ex);
             // EJB2.0 section 18.3.6
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("completeNewTx END (4), context=" + context);
+            }
             return new EJBException("Transaction aborted", ex);
         } catch (Exception ex) {
             _logger.log(Level.FINE, "ejb.cmt_exception", ex);
             // Commit or rollback failed.
             // EJB2.0 section 18.3.6
+            if (_logger.isLoggable(Level.FINE)) {
+                _logger.fine("completeNewTx END (5), context=" + context);
+            }
             return new EJBException("Unable to complete" + " container-managed transaction.", ex);
         }
     }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -714,7 +714,7 @@ public class ManagedConnectionImpl
      * the connection handle and sends a CONNECTION_CLOSED event to all the
      * registered event listeners.
      *
-     * @param e Exception that may have occured while closing the connection handle
+     * @param e Exception that may have occurred while closing the connection handle
      * @param connHolder30Object <code>ConnectionHolder30</code> that has been
      * closed
      * @throws SQLException in case closing the sql connection got out of

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/base/ConnectionHolder.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/base/ConnectionHolder.java
@@ -179,6 +179,10 @@ public abstract class ConnectionHolder implements Connection {
      * @throws SQLException In case of a database error.
      */
     public void close() throws SQLException {
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "ConnectionHolder.close() START managedConnectionImpl=" + managedConnectionImpl);
+        }
+
         if (isClosed) {
             if (_logger.isLoggable(Level.FINE)) {
                 _logger.log(Level.FINE, "jdbc.duplicate_close_connection", this);
@@ -191,6 +195,10 @@ public abstract class ConnectionHolder implements Connection {
             // mc might be null if this is a lazyAssociatable connection
             // and has not been associated yet or has been disassociated
             managedConnectionImpl.connectionClosed(null, this);
+        }
+
+        if (_logger.isLoggable(Level.FINE)) {
+            _logger.log(Level.FINE, "ConnectionHolder.close() END managedConnectionImpl=" + managedConnectionImpl);
         }
     }
 

--- a/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/api/JavaEETransaction.java
+++ b/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/api/JavaEETransaction.java
@@ -29,7 +29,7 @@ import org.jvnet.hk2.annotations.Contract;
 public interface JavaEETransaction
     extends Transaction {
 
-    public  SimpleResource getExtendedEntityManagerResource(EntityManagerFactory factory);
+    public SimpleResource getExtendedEntityManagerResource(EntityManagerFactory factory);
 
     public SimpleResource getTxEntityManagerResource(EntityManagerFactory factory);
 
@@ -45,6 +45,13 @@ public interface JavaEETransaction
 
     public Set getAllParticipatingPools();
 
+    /**
+     * Returns the resources enlisted in this transaction.<br>
+     * Note: this getter is also used to delist / unenlist resources from this transaction instance.
+     *
+     * @param poolInfo the pool identifier for which the resources need to be returned
+     * @return a Set of resources associated to this transaction.
+     */
     public Set getResources(Object poolInfo);
 
     public TransactionalResource getLAOResource();

--- a/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/api/JavaEETransactionManager.java
+++ b/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/api/JavaEETransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -49,7 +49,7 @@ import org.jvnet.hk2.annotations.Contract;
 public interface JavaEETransactionManager extends TransactionManager {
 
     /**
-     * register a synchronization object with the transaction
+     * Register a synchronization object with the transaction
      * associated with the current thread
      *
      * @param sync the synchronization object
@@ -68,12 +68,9 @@ public interface JavaEETransactionManager extends TransactionManager {
     /**
      * Enlist the resource specified with the transaction
      *
-     *
      * @param tran The transaction object
-     *
      * @param h The resource handle object
-     *
-     * @return <i>true</i> if the resource was enlisted successfully; otherwise     *    false.
+     * @return <i>true</i> if the resource was enlisted successfully; otherwise false.
      *
      * @exception RollbackException Thrown to indicate that
      *    the transaction has been marked for rollback only.
@@ -94,10 +91,9 @@ public interface JavaEETransactionManager extends TransactionManager {
      * Delist the resource specified from the transaction
      *
      * @param tran The transaction object
-     *
      * @param h The resource handle object
-     *
      * @param flag One of the values of TMSUCCESS, TMSUSPEND, or TMFAIL.
+     * @return <i>true</i> if the resource was delisted successfully; otherwise false.
      *
      * @exception IllegalStateException Thrown if the transaction in the
      *    target object is inactive.

--- a/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/spi/TransactionalResource.java
+++ b/appserver/transaction/internal-api/src/main/java/com/sun/enterprise/transaction/spi/TransactionalResource.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,44 +22,91 @@ import jakarta.transaction.Transaction;
 import javax.transaction.xa.XAResource;
 
 /**
- * TransactionalResource interface to be implemented by the resource handlers
- * to be able to communicate with used the transaction manager components
+ * TransactionalResource interface to be implemented by the resource handlers to be able to communicate with the
+ * transaction manager components.
  *
  * @author Marina Vatkina
  */
-
 public interface TransactionalResource {
 
+    /**
+     * Returns true if the resource is part of a transaction.
+     *
+     * @return true if the resource is part of a transaction.
+     */
     public boolean isTransactional();
 
-    //TODO V3 not needed as of now.
+    /**
+     * To check whether lazy enlistment is suspended or not.<br>
+     * If {@code true}, transaction manager will not do enlist/lazy enlist.
+     *
+     * @return true if enlistment is suspended, otherwise false.
+     */
     public boolean isEnlistmentSuspended();
 
+    /**
+     * Returns the (optional) XAResource reference for this resource handle.
+     *
+     * @return the XAResource reference for this resource handle or null if no reference is set.
+     */
     public XAResource getXAResource();
 
+    /**
+     * Returns true if the ResourceHandle is supported in an XA transaction.
+     *
+     * @return true if the ResourceHandle is supported in an XA transaction, otherwise false.
+     */
     public boolean supportsXA();
 
+    /**
+     * Returns the component instance holding this resource handle.
+     *
+     * @return the component instance holding this resource handle.
+     */
     public Object getComponentInstance();
 
+    /**
+     * Sets the component instance holding this resource handle.
+     *
+     * @param instance the component instance holding this resource handle.
+     */
     public void setComponentInstance(Object instance);
 
+    /**
+     * Closes the (optional) 'userConnection' / 'connection handle' (used by the application code to refer to the underlying
+     * physical connection). Example: the ManagedConnection represented by this ResourceHandle is closed / cleaned up.
+     *
+     * @throws PoolingException wrapping any 'userConnection' specific exception that might occur during the close call.
+     * @throws UnsupportedOperationException when the method is not implemented.
+     */
     public void closeUserConnection() throws Exception;
 
+    /**
+     * Returns true if the resource handle is enlisted in a transaction.
+     *
+     * @return true if the resource handle is enlisted in a transaction.
+     */
     public boolean isEnlisted();
 
+    /**
+     * Returns true if the resource handle is sharable within the component.
+     *
+     * @return true if the resource handle is sharable within the component.
+     */
     public boolean isShareable();
 
-    public void destroyResource();
-
     /**
-     * @return the String that can identify this resource
+     * Returns the String that can identify this resource.
+     *
+     * @return the String that can identify this resource.
      */
     public String getName();
 
     /**
      * Indicates that a resource has been enlisted in the transaction.
-     * @param tran Transaction to which the resource is enlisted
-     * @throws IllegalStateException when unable to enlist the resource
+     *
+     * @param transaction the Transaction to which the resource is enlisted.
+     * @throws IllegalStateException when unable to enlist the resource.
      */
-    void enlistedInTransaction(Transaction tran) throws IllegalStateException;
+    void enlistedInTransaction(Transaction transaction) throws IllegalStateException;
 }

--- a/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
+++ b/appserver/transaction/jta/src/main/java/com/sun/enterprise/transaction/JavaEETransactionManagerSimplified.java
@@ -1404,13 +1404,6 @@ public class JavaEETransactionManagerSimplified implements JavaEETransactionMana
             } catch (Exception ex2) {
                 // Log.err.println(ex2);
             }
-        } else {
-            // destroy resource. RM Error.
-            try {
-                h.destroyResource();
-            } catch (Exception ex2) {
-                // Log.err.println(ex2);
-            }
         }
     }
 

--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerJTSDelegate.java
@@ -102,6 +102,9 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
 
     private Logger logger;
 
+    /**
+     * use-last-agent-optimization
+     */
     private boolean lao = true;
 
     private volatile TransactionManager transactionManagerImpl;
@@ -140,7 +143,7 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
     @Override
     public void commitDistributedTransaction() throws RollbackException, HeuristicMixedException, HeuristicRollbackException,
             SecurityException, IllegalStateException, SystemException {
-        logger.log(FINE, "TM: commit");
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.commitDistributedTransaction START");
 
         validateTransactionManager();
         TransactionManager transactionManager = transactionManagerLocal.get();
@@ -172,6 +175,7 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
                 javaEETMS.setTransactionCompeting(false);
             }
         }
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.commitDistributedTransaction END");
     }
 
     /**
@@ -179,7 +183,7 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
      */
     @Override
     public void rollbackDistributedTransaction() throws IllegalStateException, SecurityException, SystemException {
-        logger.log(FINE, "TM: rollback");
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.rollbackDistributedTransaction START");
         validateTransactionManager();
 
         TransactionManager transactionManager = transactionManagerLocal.get();
@@ -201,6 +205,7 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
         } finally {
             javaEETMS.monitorTxCompleted(obj, false);
         }
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.rollbackDistributedTransaction END");
     }
 
     @Override
@@ -216,7 +221,8 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
         }
 
         if (logger.isLoggable(FINE)) {
-            logger.log(FINE, "TM: status: " + JavaEETransactionManagerSimplified.getStatusAsString(status));
+            logger.log(FINE, "JavaEETransactionManagerJTSDelegate.getStatus, status="
+                    + JavaEETransactionManagerSimplified.getStatusAsString(status));
         }
 
         return status;
@@ -226,10 +232,15 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
     public Transaction getTransaction() throws SystemException {
         JavaEETransaction javaEETransaction = javaEETransactionManager.getCurrentTransaction();
         if (logger.isLoggable(FINE)) {
-            logger.log(FINE, "TM: getTransaction: tx=" + javaEETransaction + ", tm=" + transactionManagerLocal.get());
+            logger.log(FINE, "JavaEETransactionManagerJTSDelegate.getTransaction START: tx=" + javaEETransaction
+                    + ", tm=" + transactionManagerLocal.get());
         }
 
         if (javaEETransaction != null) {
+            if (logger.isLoggable(FINE)) {
+                logger.log(FINE, "JavaEETransactionManagerJTSDelegate: getTransaction END (1): tx=" + javaEETransaction
+                        + ", tm=" + transactionManagerLocal.get());
+            }
             return javaEETransaction;
         }
 
@@ -241,13 +252,18 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
         }
 
         if (jtsTx == null) {
+            if (logger.isLoggable(FINE)) {
+                logger.log(FINE, "JavaEETransactionManagerJTSDelegate.getTransaction END (2): tx=" + javaEETransaction
+                        + ", tm=" + transactionManagerLocal.get());
+            }
             return null;
         }
 
         // Check if this JTS Transaction was previously active in this JVM (possible for distributed loopbacks).
         javaEETransaction = (JavaEETransaction) globalTransactions.get(jtsTx);
         if (logger.isLoggable(FINE)) {
-            logger.log(FINE, "TM: getTransaction: tx=" + javaEETransaction + ", jtsTx=" + jtsTx);
+            logger.log(FINE, "JavaEETransactionManagerJTSDelegate.getTransaction: tx=" + javaEETransaction + ", jtsTx="
+                    + jtsTx);
         }
 
         if (javaEETransaction == null) {
@@ -256,6 +272,11 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
         }
 
         javaEETransactionManager.setCurrentTransaction(javaEETransaction); // associate tx with thread
+
+        if (logger.isLoggable(FINE)) {
+            logger.log(FINE, "JavaEETransactionManagerJTSDelegate.getTransaction END (3): tx=" + javaEETransaction
+                    + ", tm=" + transactionManagerLocal.get());
+        }
         return javaEETransaction;
     }
 
@@ -313,10 +334,12 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
 
     @Override
     public void setRollbackOnlyDistributedTransaction() throws IllegalStateException, SystemException {
-        logger.log(FINE, "TM: setRollbackOnly");
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.setRollbackOnlyDistributedTransaction START");
 
         validateTransactionManager();
         transactionManagerLocal.get().setRollbackOnly();
+
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.setRollbackOnlyDistributedTransaction END");
     }
 
     @Override
@@ -339,12 +362,14 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
 
     @Override
     public void resume(Transaction tx) throws InvalidTransactionException, IllegalStateException, SystemException {
-        logger.log(FINE, "TM: resume");
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.resume START, tx=" + tx);
 
         if (transactionManagerImpl != null) {
             setTransactionManager();
             transactionManagerLocal.get().resume(tx);
         }
+
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate.resume END, tx=" + tx);
     }
 
     @Override
@@ -420,7 +445,7 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
     }
 
     private Transaction suspendXA() throws SystemException {
-        logger.log(FINE, "TM: suspend");
+        logger.log(FINE, "JavaEETransactionManagerJTSDelegate: suspendXA");
 
         validateTransactionManager();
         return transactionManagerLocal.get().suspend();
@@ -434,7 +459,8 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
 
     private void setTransactionManager() {
         if (logger.isLoggable(FINE)) {
-            logger.log(FINE, "TM: setTransactionManager: tm=" + transactionManagerLocal.get());
+            logger.log(FINE,
+                    "JavaEETransactionManagerJTSDelegate: setTransactionManager: tm=" + transactionManagerLocal.get());
         }
 
         if (transactionManagerImpl == null) {
@@ -498,7 +524,7 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
                 if (value != null && "false".equals(value)) {
                     setUseLAO(false);
                     if (logger.isLoggable(FINE)) {
-                        logger.log(FINE, "TM: LAO is disabled");
+                        logger.log(FINE, "JavaEETransactionManagerJTSDelegate: LAO is disabled");
                     }
                 }
 
@@ -519,7 +545,8 @@ public class JavaEETransactionManagerJTSDelegate implements JavaEETransactionMan
                     if (Boolean.parseBoolean(transactionService.getPropertyValue("delegated-recovery"))) {
                         // Register GMS notification callback
                         if (logger.isLoggable(FINE)) {
-                            logger.log(FINE, "TM: Registering for GMS notification callback");
+                            logger.log(FINE,
+                                    "JavaEETransactionManagerJTSDelegate: Registering for GMS notification callback");
                         }
 
                         int waitTime = 60;

--- a/appserver/transaction/jts/src/test/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerTest.java
+++ b/appserver/transaction/jts/src/test/java/com/sun/enterprise/transaction/jts/JavaEETransactionManagerTest.java
@@ -18,7 +18,6 @@
 package com.sun.enterprise.transaction.jts;
 
 import com.sun.enterprise.config.serverbeans.ServerTags;
-import com.sun.enterprise.resource.ClientSecurityInfo;
 import com.sun.enterprise.resource.ResourceHandle;
 import com.sun.enterprise.resource.ResourceSpec;
 import com.sun.enterprise.resource.allocator.ResourceAllocator;
@@ -30,6 +29,7 @@ import com.sun.enterprise.transaction.TransactionSynchronizationRegistryImpl;
 import com.sun.enterprise.transaction.UserTransactionImpl;
 import com.sun.enterprise.transaction.spi.JavaEETransactionManagerDelegate;
 
+import jakarta.resource.spi.ManagedConnection;
 import jakarta.transaction.HeuristicMixedException;
 import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.InvalidTransactionException;
@@ -1036,12 +1036,12 @@ public class JavaEETransactionManagerTest {
     }
 
     static class TestResourceHandle extends ResourceHandle {
-        private final XAResource resource;
+        private final XAResource xaResource;
         private static PoolManagerImpl poolMgr = new PoolManagerImpl();
 
-        public TestResourceHandle(XAResource resource) {
-            super(null,new ResourceSpec(new SimpleJndiName("testResource"),0) ,null,null);
-            this.resource = resource;
+        public TestResourceHandle(XAResource xaResource) {
+            super(null, new ResourceSpec(new SimpleJndiName("testResource"), 0), null);
+            this.xaResource = xaResource;
         }
 
         @Override
@@ -1065,22 +1065,17 @@ public class JavaEETransactionManagerTest {
         }
 
         @Override
-        public Object getResource() {
-            return resource;
-        }
-
-        @Override
-        public XAResource getXAResource() {
-            return resource;
-        }
-
-        @Override
-        public Object getUserConnection() {
+        public ManagedConnection getResource() {
             return null;
         }
 
         @Override
-        public ClientSecurityInfo getClientSecurityInfo() {
+        public XAResource getXAResource() {
+            return xaResource;
+        }
+
+        @Override
+        public Object getUserConnection() {
             return null;
         }
 


### PR DESCRIPTION
Part 1 for issue #24900 Document and rename some ConnectionPool fields.
Remove some unused methods and constructor parameters. Functional / possible incompatibility changes in DataStructureFactory and in ResourceHandle due to constructor changes.

Part 2 for issue #24900 Start with a new PoolManagertImpl unit test to understand enlisted versus busy states of Resource handles and the wiring inside a transaction to keep track of all used resources.

Part 3 for issue #24900 More documentation and more unit test coverage.

Part 4 for issue #24900 Add more detailed logging to improve log file analysis.