### PR TITLE
Fallback to basic file attributes if sun.nio.fs cannot be used

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppLibClassLoaderServiceImpl.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.System.Logger;
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Method;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
@@ -422,7 +423,11 @@ public class AppLibClassLoaderServiceImpl implements EventListener {
                 }
                 method.setAccessible(true);
                 field.setAccessible(true);
-            } catch (ReflectiveOperationException e) {
+            } catch (ReflectiveOperationException | InaccessibleObjectException e) {
+                method = null;
+                field = null;
+            } catch (Exception e) {
+                LOG.log(WARNING, () -> "Could not initialize sun.nio.fs. We will fallback to basic file attributes. Error: " + e.getMessage(), e);
                 method = null;
                 field = null;
             }


### PR DESCRIPTION
setAccessible throws InaccessibleObjectException if not allowed.  The generic catch block is just in case - no other exception should be thrown. if it is thrown, we should revert to fallback rather than blow up.

[//]: # "Please remove these comments"

[//]: For general information, please read <"https://github.com/eclipse-ee4j/glassfish/blob/master/CONTRIBUTING.md">.

[//]: DO NOT create a PR for the gh-pages branch. Instead, please read the docs directory README file <"https://github.com/eclipse-ee4j/glassfish/blob/master/docs/README.md"> and create a PR for the appropriate docs subdirectory in the master branch.
