### PR TITLE
Enhance start-db command - initdb and suspend

### DIFF
--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyControl.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyControl.java
@@ -55,7 +55,7 @@ public final class DerbyControl {
     public static void main(String[] args) {
         if (args.length < 3) {
             System.out.println("paramters not specified.");
-            System.out.println("DerbyControl <derby command> <derby host> <derby port> <redirect> [<derby home> | <derby user> <derby password>");
+            System.out.println("DerbyControl <derby command> <derby host> <derby port> <redirect> [<derby home> | <derby user> <derby password>]");
             System.exit(1);
         }
 

--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyControl.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -55,7 +55,7 @@ public final class DerbyControl {
     public static void main(String[] args) {
         if (args.length < 3) {
             System.out.println("paramters not specified.");
-            System.out.println("DerbyControl <derby command> <derby host> <derby port> <derby home> <redirect output>");
+            System.out.println("DerbyControl <derby command> <derby host> <derby port> <redirect> [<derby home> | <derby user> <derby password>");
             System.exit(1);
         }
 
@@ -63,30 +63,47 @@ public final class DerbyControl {
         if (args.length == 3) {
             derbyControl = new DerbyControl(args[0], args[1], args[2]);
         } else if (args.length == 4) {
-            derbyControl = new DerbyControl(args[0], args[1], args[2], args[3]);
+            // Variant used by sysinfoCmd
+            derbyControl = new DerbyControl(
+                    args[0],   // command
+                    args[1],   // host
+                    args[2],   // port
+                    args[3]);  // redirect
         } else if (args.length == 5) {
-            derbyControl = new DerbyControl(args[0], args[1], args[2], args[3], args[4]);
+            // Variant used by startDatabaseCmd
+            derbyControl = new DerbyControl(
+                    args[0],   // command
+                    args[1],   // host
+                    args[2],   // port
+                    args[3],   // redirect
+                    args[4]);  // home
         } else {
-            derbyControl = new DerbyControl(args[0], args[1], args[2], args[3], args[4], args[5]);
+            derbyControl = new DerbyControl(
+                    args[0],   // command
+                    args[1],   // host
+                    args[2],   // port
+                    args[3],   // redirect
+                    args[4],   // user
+                    args[5]);  // password
         }
 
         derbyControl.invokeNetworkServerControl();
     }
 
-    public DerbyControl(final String dc, final String dht, final String dp, final String redirect, final String dhe, final String duser, final String dpwd) {
-        this.derbyCommand = dc;
-        this.derbyHost = dht;
-        this.derbyPort = dp;
-        this.derbyHome = dhe;
+    public DerbyControl(final String derbyCommand, final String derbyHost, final String derbyPort, final String redirect, final String derbyHome, final String derbyUser, final String derbyPassword) {
+        this.derbyCommand = derbyCommand;
+        this.derbyHost = derbyHost;
+        this.derbyPort = derbyPort;
         this.redirect = Boolean.valueOf(redirect).booleanValue();
-        this.derbyUser = duser;
-        this.derbyPassword = dpwd;
+        this.derbyHome = derbyHome;
+        this.derbyUser = derbyUser;
+        this.derbyPassword = derbyPassword;
 
         if (this.redirect) {
 
             try {
                 String dbLog = "";
-                if (derbyHome == null) {
+                if (this.derbyHome == null) {
                     // If derbyHome is null then redirect the output to a temporary file
                     // which gets deleted after the jvm exists.
                     dbLog = createTempLogFile();
@@ -115,22 +132,22 @@ public final class DerbyControl {
     }
 
     // constructor
-    public DerbyControl(final String dc, final String dht, final String dp) {
-        this(dc, dht, dp, "true", null, null, null);
+    public DerbyControl(final String derbyCommand, final String derbyHost, final String derbyPort) {
+        this(derbyCommand, derbyHost, derbyPort, "true", null, null, null);
     }
 
     // constructor
-    public DerbyControl(final String dc, final String dht, final String dp, final String redirect) {
-        this(dc, dht, dp, redirect, null, null, null);
+    public DerbyControl(final String derbyCommand, final String derbyHost, final String derbyPort, final String redirect) {
+        this(derbyCommand, derbyHost, derbyPort, redirect, null, null, null);
     }
 
     // constructor
-    public DerbyControl(final String dc, final String dht, final String dp, final String redirect, final String dhe) {
-        this(dc, dht, dp, redirect, dhe, null, null);
+    public DerbyControl(final String derbyCommand, final String derbyHost, final String derbyPort, final String redirect, final String derbyHome) {
+        this(derbyCommand, derbyHost, derbyPort, redirect, derbyHome, null, null);
     }
 
-    public DerbyControl(final String dc, final String dht, final String dp, final String redirect, final String duser, final String dpassword) {
-        this(dc, dht, dp, redirect, null, duser, dpassword);
+    public DerbyControl(final String derbyCommand, final String derbyHost, final String derbyPort, final String redirect, final String derbyUser, final String derbyPassword) {
+        this(derbyCommand, derbyHost, derbyPort, redirect, null, derbyUser, derbyPassword);
     }
 
     /**

--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyExecuteSQL.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyExecuteSQL.java
@@ -78,18 +78,20 @@ public class DerbyExecuteSQL {
                 properties.put("password", derbyPassword);
             }
 
-            try (Connection connection = driver.connect("jdbc:derby://" + derbyHost + ":" + derbyPort + "/" + derbyName, new Properties())) {
+            try (Connection connection = driver.connect("jdbc:derby://" + derbyHost + ":" + derbyPort + "/" + derbyName, properties)) {
                 try (Scanner scanner = new Scanner(new File(sqlFileName), "UTF-8")) {
 
                     scanner.useDelimiter(";");
 
                     while (scanner.hasNext()) {
+                        String statement = null;
                         try {
-                            String statement = scanner.next().strip();
+                            statement = scanner.next().strip();
                             if (!statement.isEmpty()) {
                                 connection.prepareStatement(statement).execute();
                             }
                         } catch (SQLException s) {
+                            System.out.println("Exeception executing: " + statement);
                             s.printStackTrace();
                         }
                     }

--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyExecuteSQL.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DerbyExecuteSQL.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.admin.cli.optional;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.Scanner;
+
+import static com.sun.enterprise.util.Utility.isAllEmpty;
+
+/**
+ * This class executes SQL statements from a file against Derby. Its prime purpose is for database initialization
+ * after starting it.
+ *
+ * <p>
+ * The reason for creating this class instead of directly executing SQL from the
+ * StartDatabaseCommand class is so that a separate JVM is launched when starting the database with all the right
+ * drivers in place for the remote Derby.
+ *
+ * @author Arjan Tijms
+ */
+public class DerbyExecuteSQL {
+
+    final private String derbyHost;
+    final private String derbyPort;
+    final private String derbyName;
+    final private String sqlFileName;
+    final private String derbyUser;
+    final private String derbyPassword;
+
+    public static void main(String[] args) {
+        DerbyExecuteSQL sql = new DerbyExecuteSQL(
+                args[0],
+                args[1],
+                args[2],
+                args[3],
+                args.length < 5? null : args[4],
+                args.length < 6? null : args[5]);
+
+        sql.executeCommand();
+    }
+
+    public DerbyExecuteSQL(String derbyHost, String derbyPort, String derbyName, String sqlFileName, String derbyUser, String derbyPassword) {
+        this.derbyHost = derbyHost;
+        this.derbyPort = derbyPort;
+        this.derbyName = derbyName;
+        this.sqlFileName = sqlFileName;
+        this.derbyUser = derbyUser;
+        this.derbyPassword = derbyPassword;
+    }
+
+    private void executeCommand() {
+        try {
+            Driver driver = (Driver)
+                Class.forName("org.apache.derby.jdbc.ClientDriver")
+                     .getDeclaredConstructor()
+                     .newInstance();
+
+            Properties properties = new Properties();
+            if (!isAllEmpty(derbyUser, derbyPassword)) {
+                properties.put("user", derbyUser);
+                properties.put("password", derbyPassword);
+            }
+
+            try (Connection connection = driver.connect("jdbc:derby://" + derbyHost + ":" + derbyPort + "/" + derbyName, new Properties())) {
+                try (Scanner scanner = new Scanner(new File(sqlFileName), "UTF-8")) {
+
+                    scanner.useDelimiter(";");
+
+                    while (scanner.hasNext()) {
+                        try {
+                            String statement = scanner.next().strip();
+                            if (!statement.isEmpty()) {
+                                connection.prepareStatement(statement).execute();
+                            }
+                        } catch (SQLException s) {
+                            s.printStackTrace();
+                        }
+                    }
+                }
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+}
+
+

--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/StartDatabaseCommand.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/StartDatabaseCommand.java
@@ -55,11 +55,17 @@ public final class StartDatabaseCommand extends DatabaseCommand {
     @Param(name = "dbhome", optional = true)
     private String dbHome;
 
-    @Param(optional = true)
-    private String dbname;
+    @Param(name = "dbname", optional = true)
+    private String dbName;
 
     @Param(optional = true)
     private String sqlfilename;
+
+    @Param(name = "dbuser", optional = true)
+    private String dbUser;
+
+    @Param(name = "dbpassword", optional = true, password = true)
+    private String dbPassword;
 
     @Param(name = "jvmoptions", optional = true, separator = ' ')
     private String[] jvmoptions;
@@ -144,8 +150,13 @@ public final class StartDatabaseCommand extends DatabaseCommand {
         cmd.add("com.sun.enterprise.admin.cli.optional.DerbyExecuteSQL");
         cmd.add(dbHost);
         cmd.add(dbPort);
-        cmd.add(dbname);
+        cmd.add(dbName);
         cmd.add(sqlfilename);
+
+        if (!isAnyNull(dbUser, dbPassword)) {
+            cmd.add(dbUser);
+            cmd.add(dbPassword);
+        }
 
         return cmd.toArray(new String[cmd.size()]);
     }
@@ -277,7 +288,7 @@ public final class StartDatabaseCommand extends DatabaseCommand {
                     }
                 }
 
-                if (cpePing.exitValue() == 0 && !isAnyNull(dbname, sqlfilename)) {
+                if (cpePing.exitValue() == 0 && !isAnyNull(dbName, sqlfilename)) {
                     cpeSysInfo.execute("executeSQLCmd", executeSQLCmd(), true);
                     if (cpeSysInfo.exitValue() != 0) {
                         logger.info("Failed to execute SQL to init DB.");

--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/StartDatabaseCommand.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/StartDatabaseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,7 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package com.sun.enterprise.admin.cli.optional;
 
 import com.sun.enterprise.admin.cli.CLIProcessExecutor;
@@ -34,6 +33,7 @@ import org.glassfish.hk2.api.PerLookup;
 import org.jvnet.hk2.annotations.Service;
 
 import static com.sun.enterprise.admin.cli.optional.DerbyControl.DB_LOG_FILENAME;
+import static com.sun.enterprise.util.Utility.isAnyNull;
 import static java.io.File.pathSeparator;
 import static java.io.File.separator;
 import static java.util.Arrays.asList;
@@ -55,8 +55,20 @@ public final class StartDatabaseCommand extends DatabaseCommand {
     @Param(name = "dbhome", optional = true)
     private String dbHome;
 
+    @Param(optional = true)
+    private String dbname;
+
+    @Param(optional = true)
+    private String sqlfilename;
+
     @Param(name = "jvmoptions", optional = true, separator = ' ')
     private String[] jvmoptions;
+
+    /**
+     * Starts the database server in debug mode with suspend on
+     */
+    @Param(optional = true, shortName = "s", defaultValue = "false")
+    private boolean suspend;
 
     /**
      * defines the command to start the derby database Note that when using Darwin (Mac), the property,
@@ -70,6 +82,10 @@ public final class StartDatabaseCommand extends DatabaseCommand {
         if (OS.isDarwin()) {
             cmd.add("-Dderby.storage.fileSyncTransactionLog=True");
         }
+        if (suspend) {
+            cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:9011");
+        }
+
         cmd.add("-cp");
         cmd.add(sClasspath + pathSeparator + sDatabaseClasspath);
         if (jvmoptions != null) {
@@ -111,6 +127,27 @@ public final class StartDatabaseCommand extends DatabaseCommand {
             "sysinfo",
             dbHost, dbPort, "false" };
 
+    }
+
+    public String[] executeSQLCmd() throws Exception {
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add(javaHome + separator + "bin" + separator + "java");
+        cmd.add("-Djava.library.path=" + installRoot + separator + "lib");
+        if (suspend) {
+            cmd.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:9012");
+        }
+
+        cmd.add("-cp");
+        cmd.add(sClasspath + pathSeparator + sDatabaseClasspath);
+
+        cmd.add("com.sun.enterprise.admin.cli.optional.DerbyExecuteSQL");
+        cmd.add(dbHost);
+        cmd.add(dbPort);
+        cmd.add(dbname);
+        cmd.add(sqlfilename);
+
+        return cmd.toArray(new String[cmd.size()]);
     }
 
     /**
@@ -217,7 +254,7 @@ public final class StartDatabaseCommand extends DatabaseCommand {
                 int counter = 0;
 
                 // Give time for the database to be started
-                while (cpePing.exitValue() != 0 && counter < 10) {
+                while (cpePing.exitValue() != 0 && (suspend || counter < 10)) {
                     cpePing.execute("pingDatabaseCmd", pingDatabaseCmd(true), true);
                     Thread.sleep(500);
                     counter++;
@@ -239,6 +276,14 @@ public final class StartDatabaseCommand extends DatabaseCommand {
                         }
                     }
                 }
+
+                if (cpePing.exitValue() == 0 && !isAnyNull(dbname, sqlfilename)) {
+                    cpeSysInfo.execute("executeSQLCmd", executeSQLCmd(), true);
+                    if (cpeSysInfo.exitValue() != 0) {
+                        logger.info("Failed to execute SQL to init DB.");
+                    }
+                }
+
             } catch (Exception e) {
                 throw new CommandException(strings.get("CommandUnSuccessful", name), e);
             }

--- a/docs/reference-manual/src/main/asciidoc/start-database.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-database.adoc
@@ -18,7 +18,7 @@ Starts the Java DB
 [source]
 ----
 asadmin [asadmin-options] start-database [--help]
-[--jvmoptions jvm-options]
+[--jvmoptions jvm-options] [--suspend={true|false}]
 [--dbhost host] [--dbport port-no]
 [--dbhome db-file-path]
 ----
@@ -78,6 +78,22 @@ asadmin-options::
     option-name=value.
   * If the option has only a name, the format is option-name.
     For example, `-Xmx512m`.
+`--suspend`::
+`-s`::
+  Specifies whether the domain is started with
+  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
+  Platform Debugger Architecture (JPDA)]
+  (https://docs.oracle.com/en/java/javase/11/docs/specs/jpda/conninv.html)
+  debugging enabled and suspend the newly started VM before the main class loads.
+  When a debugger connects, it can send a JDWP command to resume the suspended VM.
+  With debugging enabled extra exceptions can be printed.
+  Possible values are as follows:
+
+  `true`;;
+    The instance is started with JPDA debugging enabled and a suspendPolicy of `SUSPEND_ALL`.
+    The port number for JPDA debugging is displayed.
+  `false`;;
+    The instance is started with JPDA debugging disabled (default).
 `--dbhost`::
   The host name or IP address of the Java DB server process. The default
   is the IP address 0.0.0.0, which denotes all network interfaces on the
@@ -97,6 +113,14 @@ asadmin-options::
   current working directory.
   * Otherwise, the `start-database` subcommand creates the files in the
   as-install``/databases`` directory.
+`--dbname`::
+  The name of the database that should be used to initialize when
+  `sqlfilename` is specified.
+`--sqlfilename`::
+  Path to a file containing SQL statements to be executed after starting
+  up the Java DB. Each statement should be separated by a ";". Statements
+  may be put on new lines. The file encoding to be used is UTF-8. 
+  This file is only taken into consideration when `dbname` is specified. 
 
 +
 To create the database files at a particular location, you must set

--- a/docs/reference-manual/src/main/asciidoc/start-database.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-database.adoc
@@ -21,6 +21,8 @@ asadmin [asadmin-options] start-database [--help]
 [--jvmoptions jvm-options] [--suspend={true|false}]
 [--dbhost host] [--dbport port-no]
 [--dbhome db-file-path]
+[--dbname name] [sqlfilename sql-file-path]
+[--dbuser] [--passwordfile password-file-path]
 ----
 
 === Description
@@ -121,6 +123,13 @@ asadmin-options::
   up the Java DB. Each statement should be separated by a ";". Statements
   may be put on new lines. The file encoding to be used is UTF-8. 
   This file is only taken into consideration when `dbname` is specified. 
+`--dbuser`::
+  The user name of the Java DB user that is to execute init SQL statements.
+  This option is used only when `dbname` and `sqlfilename` are specified. 
+  If this option is omitted the DB schema used for the init SQL statements 
+  is owned by the default user. Must be combined with the general `passwordfile` 
+  option of which the file it points to must contain the `AS_ADMIN_DBPASSWORD` 
+  key with as value the password associated with the user.
 
 +
 To create the database files at a particular location, you must set


### PR DESCRIPTION
This adds a feature to the start-database command to initialize the DB using a file with SQL statements. This is roughly equivalent to the feature in Jakarta Persistence to initialize a datasource.

It also adds a feature to suspend the process running Derby, so, if needed, starting the DB and the SQL execution can be debugged.
