### PR TITLE
GJULE - Easier default configuration

### DIFF
--- a/nucleus/glassfish-jul-extension/pom.xml
+++ b/nucleus/glassfish-jul-extension/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <test.logManager>org.glassfish.main.jul.GlassFishLogManager</test.logManager>
+        <test.enableDefaultLogCfg>false</test.enableDefaultLogCfg>
     </properties>
 
     <dependencies>

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogManagerInitializer.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/GlassFishLogManagerInitializer.java
@@ -20,6 +20,8 @@ import java.util.Properties;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+import org.glassfish.main.jul.cfg.GlassFishLoggingConstants;
+
 import static org.glassfish.main.jul.cfg.GlassFishLoggingConstants.CLASS_LOG_MANAGER_GLASSFISH;
 import static org.glassfish.main.jul.cfg.GlassFishLoggingConstants.JVM_OPT_LOGGING_MANAGER;
 import static org.glassfish.main.jul.tracing.GlassFishLoggingTracer.stacktrace;
@@ -33,15 +35,20 @@ import static org.glassfish.main.jul.tracing.GlassFishLoggingTracer.trace;
  * in the JVM starts the initialization.
  * <p>
  * Simply said - this must be the first thing application must execute.
+ * <p>
+ * As an example, when you enable GC logging, it will be always faster than this class.
+ * That is why is this class deprecated and we recommend to use the
+ * {@link GlassFishLoggingConstants#JVM_OPT_LOGGING_MANAGER} and other related options
+ * which guarantee that the log manager will be set.
  *
  * @author David Matejcek
  */
+@Deprecated
 public final class GlassFishLogManagerInitializer {
 
     private GlassFishLogManagerInitializer() {
         // hidden
     }
-
 
 
     /**

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLoggingConstants.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/cfg/GlassFishLoggingConstants.java
@@ -45,6 +45,13 @@ public class GlassFishLoggingConstants {
      * existence.
      */
     public static final String JVM_OPT_LOGGING_MANAGER = "java.util.logging.manager";
+
+    /**
+     * System property name to ask the starting log manager to block until application finishes
+     * the configuration.
+     */
+    public static final String JVM_OPT_LOGGING_CFG_BLOCK = "java.util.logging.config.block";
+
     /**
      * System property name defining property file which will be automatically loaded on startup.
      * Usually it is named <code>logging.properties</code>
@@ -52,7 +59,7 @@ public class GlassFishLoggingConstants {
     public static final String JVM_OPT_LOGGING_CFG_FILE = "java.util.logging.config.file";
     /**
      * System property telling the GlassFishLogManager to use defaults if there would not be any
-     * logging.properties neither set by {@value #JVM_OPT_LOGGING_CFG_FILE} nor available on classpath.
+     * logging.properties set by {@value #JVM_OPT_LOGGING_CFG_FILE}.
      * <p>
      * Defaults use the SimpleLogHandler and level INFO or level set by
      * {@value #JVM_OPT_LOGGING_CFG_DEFAULT_LEVEL}
@@ -76,6 +83,9 @@ public class GlassFishLoggingConstants {
      * <p>
      * If the property is not set, GJULE makes the decision based on the (<code>*.printSource</code>
      * property) - if any formatter requires this feature, the feature is enabled.
+     * This applies just when the formatter is set from the supplied log manager configuration,
+     * not when you configure formatter from your code.
+     *
      * <p>
      * It is disabled otherwise.
      */

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/OneLineFormatter.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/formatter/OneLineFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,9 @@ package org.glassfish.main.jul.formatter;
 import java.util.Arrays;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
+import org.glassfish.main.jul.cfg.GlassFishLoggingConstants;
 import org.glassfish.main.jul.cfg.LogProperty;
 import org.glassfish.main.jul.record.GlassFishLogRecord;
 
@@ -31,6 +33,12 @@ import static org.glassfish.main.jul.formatter.OneLineFormatter.OneLineFormatter
 /**
  * Fast {@link Formatter} usable in tests or even in production if you need only simple logs with
  * time, level and messages.
+ * <p>
+ * Note that if you configured the formatter from your code (and not a property file),
+ * if you want to source class and method automatically detected, you have to enable
+ * {@link GlassFishLoggingConstants#KEY_CLASS_AND_METHOD_DETECTION_ENABLED}. Without that the output
+ * will contain just class and method fields manually set to the LogRecord or using {@link Logger}
+ * methods which have these parameters to do that.
  *
  * @author David Matejcek
  */

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLogManagerLifeCycleTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLogManagerLifeCycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -98,7 +98,6 @@ public class GlassFishLogManagerLifeCycleTest {
      * {@link BlockingExternallyManagedLogHandler} to block logging system in
      * {@link GlassFishLoggingStatus#CONFIGURING} state, so it is just collecting
      * log records to the StartupQueue.
-     * <p>
      */
     @Test
     @Order(1)

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -186,6 +186,7 @@
         <!-- GlassFishLogManager is a child of this module, so we cannot use it here yet. -->
         <test.logManager>java.util.logging.LogManager</test.logManager>
         <test.logLevel>INFO</test.logLevel>
+        <test.enableDefaultLogCfg>true</test.enableDefaultLogCfg>
     </properties>
 
     <dependencyManagement>
@@ -883,7 +884,7 @@
                         </excludes>
                         <systemPropertyVariables>
                             <java.util.logging.manager>${test.logManager}</java.util.logging.manager>
-                            <java.util.logging.config.useDefaults>true</java.util.logging.config.useDefaults>
+                            <java.util.logging.config.useDefaults>${test.enableDefaultLogCfg}</java.util.logging.config.useDefaults>
                             <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                             <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
                         </systemPropertyVariables>
@@ -906,7 +907,7 @@
                         </includes>
                         <systemPropertyVariables>
                             <java.util.logging.manager>${test.logManager}</java.util.logging.manager>
-                            <java.util.logging.config.useDefaults>true</java.util.logging.config.useDefaults>
+                            <java.util.logging.config.useDefaults>${test.enableDefaultLogCfg}</java.util.logging.config.useDefaults>
                             <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                         </systemPropertyVariables>
                     </configuration>


### PR DESCRIPTION
- No need to use code/properties with the special blocking handler via GlassFishLogManagerInitializer, you can use JVM option instead.
- Changed evaluation of the first logging configuration after JVM startup. 
- This is not a fix for #25133 but it is a first small part of the solution.