### PR TITLE
Reduced number of builds to keep from 10 to 2 as requested by Jenkins ops

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -161,7 +161,7 @@ spec:
   }
 
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '2'))
 
     // to allow re-running a test stage
     preserveStashes()


### PR DESCRIPTION
- Currently Eclipse GlassFish projects uses 139 GB of CI disk space.
- There is a plan for migration to new infrastructure: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5072
