### PR TITLE
Xbootclasspath removed from templates

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -405,7 +405,6 @@
              <!-- For ORB compatibility with JDK11+ JDKs see https://github.com/eclipse-ee4j/orb-gmbal/issues/22 -->
              <jvm-options>-Dorg.glassfish.gmbal.no.multipleUpperBoundsException=true</jvm-options>
 
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
              <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>

--- a/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
+++ b/appserver/distributions/glassfish/src/main/assembly/glassfish.xml
@@ -327,7 +327,6 @@
             <fileMode>640</fileMode>
             <includes>
                 <include>glassfish-jul-extension.jar</include>
-                <include>grizzly-npn-api.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/lib/bootstrap</outputDirectory>
         </fileSet>
@@ -379,7 +378,6 @@
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
                 <exclude>glassfish-jul-extension.jar</exclude>
-                <exclude>grizzly-npn-api.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>

--- a/appserver/distributions/web/src/main/assembly/web.xml
+++ b/appserver/distributions/web/src/main/assembly/web.xml
@@ -201,7 +201,6 @@
             <fileMode>640</fileMode>
             <includes>
                 <include>glassfish-jul-extension.jar</include>
-                <include>grizzly-npn-api.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/glassfish/lib/bootstrap</outputDirectory>
         </fileSet>
@@ -253,7 +252,6 @@
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>appserver-domain.jar</exclude>
                 <exclude>glassfish-jul-extension.jar</exclude>
-                <exclude>grizzly-npn-api.jar</exclude>
                 <exclude>cli-optional.jar</exclude>
                 <exclude>appserver-cli.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -588,18 +588,6 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-api</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-osgi</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- additional grizzly modules package which includes websockets -->
         <dependency>

--- a/appserver/extras/embedded/nucleus/pom.xml
+++ b/appserver/extras/embedded/nucleus/pom.xml
@@ -147,18 +147,6 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-api</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-osgi</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
         <!-- glassfish-nucleus -->
         <dependency>
             <groupId>org.glassfish.main.admin</groupId>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -36,7 +36,8 @@
         <path.derby>../../../javadb/lib</path.derby>
         <classpath.derby>${path.derby}/derby.jar ${path.derby}/derbyclient.jar ${path.derby}/derbynet.jar ${path.derby}/derbytools.jar ${path.derby}/derbyrun.jar</classpath.derby>
         <path.bootstrap>../bootstrap</path.bootstrap>
-        <classpath.bootstrap>${path.bootstrap}/grizzly-npn-api.jar ${path.bootstrap}/glassfish-jul-extension.jar</classpath.bootstrap>        </properties>
+        <classpath.bootstrap>${path.bootstrap}/glassfish-jul-extension.jar</classpath.bootstrap>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -473,18 +474,6 @@
             <groupId>org.glassfish.main.grizzly</groupId>
             <artifactId>glassfish-grizzly-extra-all</artifactId>
             <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-api</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-osgi</artifactId>
-            <version>${grizzly.npn.version}</version>
             <optional>true</optional>
         </dependency>
         <!-- glassfish-jca -->

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -157,18 +157,6 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-api</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-osgi</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <optional>true</optional>
-        </dependency>
         <!-- additional grizzly modules package which includes websockets -->
         <dependency>
             <groupId>org.glassfish.main.grizzly</groupId>

--- a/appserver/featuresets/debug/pom.xml
+++ b/appserver/featuresets/debug/pom.xml
@@ -90,6 +90,10 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-npn-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
         </dependency>
 

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -328,7 +328,6 @@
              <!-- For ORB compatibility with JDK11+ JDKs see https://github.com/eclipse-ee4j/orb-gmbal/issues/22 -->
              <jvm-options>-Dorg.glassfish.gmbal.no.multipleUpperBoundsException=true</jvm-options>
 
-             <jvm-options>-Xbootclasspath/a:${com.sun.aas.installRoot}/lib/grizzly-npn-api.jar</jvm-options>
              <jvm-options>--add-opens=java.base/java.io=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/cp/GlassfishBootstrapClassLoader.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/cp/GlassfishBootstrapClassLoader.java
@@ -72,7 +72,6 @@ public class GlassfishBootstrapClassLoader extends URLClassLoader {
         final List<URL> urls = new ArrayList<>();
         final File libDir = glassfishDir.toPath().resolve(Paths.get("lib", "bootstrap")).toFile();
         urls.add(getURL(libDir, "glassfish-jul-extension"));
-        urls.add(getURL(libDir, "grizzly-npn-api"));
         return urls.toArray(new URL[urls.size()]);
     }
 

--- a/nucleus/distributions/atomic/src/main/assembly/atomic.xml
+++ b/nucleus/distributions/atomic/src/main/assembly/atomic.xml
@@ -75,7 +75,6 @@
             <directory>${temp.dir}</directory>
             <includes>
                 <include>glassfish-jul-extension.jar</include>
-                <include>grizzly-npn-api.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/lib/bootstrap</outputDirectory>
         </fileSet>
@@ -142,7 +141,6 @@
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>glassfish-jul-extension.jar</exclude>
-                <exclude>grizzly-npn-api.jar</exclude>
             </excludes>
             <outputDirectory>${install.dir.name}/modules</outputDirectory>
         </fileSet>

--- a/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
+++ b/nucleus/distributions/nucleus/src/main/assembly/nucleus-new.xml
@@ -100,7 +100,6 @@
             <directory>${temp.dir}</directory>
             <includes>
                 <include>glassfish-jul-extension.jar</include>
-                <include>grizzly-npn-api.jar</include>
             </includes>
             <outputDirectory>${install.dir.name}/lib/bootstrap</outputDirectory>
         </fileSet>
@@ -145,7 +144,6 @@
                 <exclude>org.osgi.util.function.jar</exclude>
                 <exclude>org.osgi.util.promise.jar</exclude>
                 <exclude>glassfish-jul-extension.jar</exclude>
-                <exclude>grizzly-npn-api.jar</exclude>
                 <exclude>felix.jar</exclude>
                 <exclude>nucleus-domain.jar</exclude>
                 <exclude>cluster-cli.jar</exclude>

--- a/nucleus/featuresets/atomic/pom.xml
+++ b/nucleus/featuresets/atomic/pom.xml
@@ -419,28 +419,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-api</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-osgi</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <!-- nucleus -->
         <dependency>

--- a/nucleus/grizzly/config/pom.xml
+++ b/nucleus/grizzly/config/pom.xml
@@ -31,6 +31,10 @@
 
     <name>grizzly-config</name>
 
+    <properties>
+        <test.logManager>org.glassfish.main.jul.GlassFishLogManager</test.logManager>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
@@ -56,6 +60,10 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-npn-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-portunif</artifactId>
         </dependency>
         <dependency>
@@ -75,12 +83,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-npn-api</artifactId>
-            <version>${grizzly.npn.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
@@ -92,6 +94,11 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -134,7 +134,7 @@ public class GrizzlyConfigTest {
             assertEquals("heap", bufferType);
             GenericGrizzlyListener genericGrizzlyListener =
                     (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-1");
-            MemoryManager mm = genericGrizzlyListener.getTransport().getMemoryManager();
+            MemoryManager<?> mm = genericGrizzlyListener.getTransport().getMemoryManager();
             assertEquals(HeapMemoryManager.class.getName(), mm.getClass().getName());
         } finally {
             if (grizzlyConfig != null) {
@@ -175,7 +175,7 @@ public class GrizzlyConfigTest {
             assertEquals("direct", bufferType);
             GenericGrizzlyListener genericGrizzlyListener =
                                            (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-1");
-            MemoryManager mm = genericGrizzlyListener.getTransport().getMemoryManager();
+            MemoryManager<?> mm = genericGrizzlyListener.getTransport().getMemoryManager();
             assertEquals(ByteBufferManager.class.getName(), mm.getClass().getName());
             assertTrue(((ByteBufferManager) mm).isDirect());
         } finally {
@@ -193,27 +193,24 @@ public class GrizzlyConfigTest {
             configure();
             grizzlyConfig = new GrizzlyConfig("grizzly-config-socket.xml");
             grizzlyConfig.setupNetwork();
-            GenericGrizzlyListener genericGrizzlyListener =
-                    (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-1");
+            GenericGrizzlyListener genericGrizzlyListener = (GenericGrizzlyListener) getListener(grizzlyConfig,
+                "http-listener-1");
             Transport t = genericGrizzlyListener.getTransport();
 
             assertEquals(-1, t.getReadBufferSize());
             assertEquals(-1, t.getWriteBufferSize());
 
-            genericGrizzlyListener =
-                    (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-2");
+            genericGrizzlyListener = (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-2");
             t = genericGrizzlyListener.getTransport();
             assertEquals(8192, t.getReadBufferSize());
             assertEquals(-1, t.getWriteBufferSize());
 
-            genericGrizzlyListener =
-                    (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-3");
+            genericGrizzlyListener = (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-3");
             t = genericGrizzlyListener.getTransport();
             assertEquals(-1, t.getReadBufferSize());
             assertEquals(8000, t.getWriteBufferSize());
 
-            genericGrizzlyListener =
-                    (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-4");
+            genericGrizzlyListener = (GenericGrizzlyListener) getListener(grizzlyConfig, "http-listener-4");
             t = genericGrizzlyListener.getTransport();
             assertEquals(6000, t.getReadBufferSize());
             assertEquals(5000, t.getWriteBufferSize());

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/PUGrizzlyConfigTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/PUGrizzlyConfigTest.java
@@ -66,7 +66,7 @@ public class PUGrizzlyConfigTest {
     }
 
     @Test
-    public void puHttpHttpsSamePortConfig() throws IOException, InstantiationException {
+    public void puHttpHttpsSamePortConfig() throws Exception {
         GrizzlyConfig grizzlyConfig = null;
         try {
             grizzlyConfig = new GrizzlyConfig("grizzly-config-pu-http-https-same-port.xml");
@@ -80,9 +80,6 @@ public class PUGrizzlyConfigTest {
             HttpsURLConnection.setDefaultSSLSocketFactory(helper.getSSLSocketFactory());
             final String httpContent2 = helper.getContent(new URL("https://localhost:38082").openConnection());
             assertEquals("<html><body>You've found the server on port 38082</body></html>", httpContent2);
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException(e.getMessage());
         } finally {
             if (grizzlyConfig != null) {
                 grizzlyConfig.shutdownNetwork();

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -61,6 +61,11 @@
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http2</artifactId>
         </dependency>
+        <!-- To provide AlpnServerNegotiator interface for grizzly-http2 -->
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-npn-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -401,6 +401,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish.grizzly</groupId>
+                <artifactId>grizzly-npn-api</artifactId>
+                <!-- To provide AlpnServerNegotiator interface for grizzly-http2 -->
+                <version>${grizzly.npn.version}</version>
+            </dependency>
 
             <!-- GlassFish Management API -->
             <dependency>


### PR DESCRIPTION
- It was to allow older GF versions with JDK8 to use ALPN and NPN (which was never standardized).
- Even later JDK8 versions have the support backported from JDK9.

Notes:
- NPN is now deprecated and GlassFish7 uses Java 11+, see https://www.cve.org/CVERecord?id=CVE-2024-5535:
    - > NPN is older, was never standardised and is deprecated in favour of ALPN
- The npn impl is here: https://github.com/eclipse-ee4j/grizzly-npn

I created an issue for the library too, however it can stay there for years: https://github.com/eclipse-ee4j/grizzly-npn/issues/21

Reproducer, which was failing when the change was not complete (just first commit + removed npn and npn-osgi dependencies):
```
mvn clean install -pl :grizzly-config -Dtest.logLevel=FINEST
```
