### PR TITLE
Reduced number of builds to keep from 10 to 2 as requested by Jenkins ops

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018-2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -226,7 +226,7 @@ spec:
   }
 
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
+    buildDiscarder(logRotator(numToKeepStr: '2'))
 
     // to allow re-running a test stage
     preserveStashes()


### PR DESCRIPTION
- Currently Eclipse GlassFish projects uses 139 GB of CI disk space.

