### PR TITLE
Fix #25214 Services are not initialized in a concurrent way at GlassFish startup

### DIFF
--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/GlassFishMain.java
@@ -77,8 +77,12 @@ public class GlassFishMain {
             checkJdkVersion();
 
             final Properties argsAsProps = argsToMap(args);
-            final OsgiPlatform platform = OsgiPlatform.valueOf(whichPlatform());
+            final String platformName = whichPlatform();
+            final OsgiPlatform platform = OsgiPlatform.valueOf(platformName);
             STDOUT.println("Launching GlassFish on " + platform + " platform");
+
+            // Set the system property to allow downstream code to know the platform on which GlassFish runs.
+            System.setProperty(PLATFORM_PROPERTY_KEY, platformName);
 
             final Path instanceRoot = findInstanceRoot(installRoot, argsAsProps);
             final ServerFiles files = new ServerFiles(installRoot.toPath(), instanceRoot);


### PR DESCRIPTION
Fixes #25214.

Restores the system property `GlassFish_Platform` (`Constants.PLATFORM_PROPERTY_KEY`) setting in `GlassFishMain`, which has been deleted in the commit https://github.com/eclipse-ee4j/glassfish/commit/1d6cdb2bbc94b63b85800b7b8fb60dbf39a7772e

The property `GlassFish_Platform` is used in the `AppServerStartup` class.
Setting the property avoids the threading policy from being set to `USE_NO_THREADS` in `AppServerStartup#postConstruct()`:

https://github.com/eclipse-ee4j/glassfish/blob/c35434465df28b1dd34d1580838170eea6e1e7fd/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java#L145

https://github.com/eclipse-ee4j/glassfish/blob/c35434465df28b1dd34d1580838170eea6e1e7fd/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java#L179-L181
