### PR TITLE
Fix #25216 Redirection does not work after session timeout in Admin Console

### DIFF
--- a/appserver/admingui/war/src/main/java/org/glassfish/admingui/common/AdminGuiExceptionHandler.java
+++ b/appserver/admingui/war/src/main/java/org/glassfish/admingui/common/AdminGuiExceptionHandler.java
@@ -19,6 +19,7 @@ import jakarta.faces.FacesException;
 import jakarta.faces.application.ViewExpiredException;
 import jakarta.faces.context.ExceptionHandler;
 import jakarta.faces.context.ExceptionHandlerWrapper;
+import jakarta.faces.context.ExternalContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.ExceptionQueuedEvent;
 import jakarta.faces.event.ExceptionQueuedEventContext;
@@ -43,14 +44,15 @@ public class AdminGuiExceptionHandler extends ExceptionHandlerWrapper {
                     if (facesContext == null) {
                         continue;
                     }
+                    ExternalContext externalContext = facesContext.getExternalContext();
                     if (facesContext.getPartialViewContext().isAjaxRequest()) {
-                        facesContext.getExternalContext().getResponseOutputWriter().write(
+                        externalContext.getResponseOutputWriter().write(
                                 "<script type='text/javascript'>"
-                                        + "window.location.href = '" + facesContext.getExternalContext().getRequestContextPath() + "/';"
+                                        + "window.location.href = '" + externalContext.getRequestContextPath() + "/';"
                                         + "</script>");
                         facesContext.responseComplete();
                     } else {
-                        facesContext.getExternalContext().redirect(facesContext.getExternalContext().getRequestContextPath() + "/");
+                        externalContext.redirect(externalContext.getRequestContextPath() + "/");
                     }
                 } catch (IOException e) {
                     throw new FacesException(e);

--- a/appserver/admingui/war/src/main/java/org/glassfish/admingui/common/AdminGuiExceptionHandler.java
+++ b/appserver/admingui/war/src/main/java/org/glassfish/admingui/common/AdminGuiExceptionHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.admingui.common;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.application.ViewExpiredException;
+import jakarta.faces.context.ExceptionHandler;
+import jakarta.faces.context.ExceptionHandlerWrapper;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.ExceptionQueuedEvent;
+import jakarta.faces.event.ExceptionQueuedEventContext;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+public class AdminGuiExceptionHandler extends ExceptionHandlerWrapper {
+
+    public AdminGuiExceptionHandler(ExceptionHandler wrapped) {
+        super(wrapped);
+    }
+
+    @Override
+    public void handle() throws FacesException {
+        for (Iterator<ExceptionQueuedEvent> i = getUnhandledExceptionQueuedEvents().iterator(); i.hasNext();) {
+            ExceptionQueuedEvent event = i.next();
+            ExceptionQueuedEventContext eventContext = event.getContext();
+            if (eventContext.getException() instanceof ViewExpiredException) {
+                try {
+                    FacesContext facesContext = FacesContext.getCurrentInstance();
+                    if (facesContext == null) {
+                        continue;
+                    }
+                    if (facesContext.getPartialViewContext().isAjaxRequest()) {
+                        facesContext.getExternalContext().getResponseOutputWriter().write(
+                                "<script type='text/javascript'>"
+                                        + "window.location.href = '" + facesContext.getExternalContext().getRequestContextPath() + "/';"
+                                        + "</script>");
+                        facesContext.responseComplete();
+                    } else {
+                        facesContext.getExternalContext().redirect(facesContext.getExternalContext().getRequestContextPath() + "/");
+                    }
+                } catch (IOException e) {
+                    throw new FacesException(e);
+                } finally {
+                    i.remove();
+                }
+            }
+        }
+        getWrapped().handle();
+    }
+}

--- a/appserver/admingui/war/src/main/java/org/glassfish/admingui/common/AdminGuiExceptionHandlerFactory.java
+++ b/appserver/admingui/war/src/main/java/org/glassfish/admingui/common/AdminGuiExceptionHandlerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.admingui.common;
+
+import jakarta.faces.context.ExceptionHandler;
+import jakarta.faces.context.ExceptionHandlerFactory;
+
+public class AdminGuiExceptionHandlerFactory extends ExceptionHandlerFactory {
+
+    public AdminGuiExceptionHandlerFactory(ExceptionHandlerFactory wrapped) {
+        super(wrapped);
+    }
+
+    @Override
+    public ExceptionHandler getExceptionHandler() {
+        return new AdminGuiExceptionHandler(getWrapped().getExceptionHandler());
+    }
+}

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/faces-config.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -43,5 +43,6 @@
     </application>
     <factory>
         <application-factory>org.glassfish.admingui.common.AdminGuiApplicationFactory</application-factory>
+        <exception-handler-factory>org.glassfish.admingui.common.AdminGuiExceptionHandlerFactory</exception-handler-factory>
     </factory>
 </faces-config>


### PR DESCRIPTION
Fixes #25216 .

This fix adds an exception handler for the Admin Console to handle `jakarta.faces.application.ViewExpiredException`.
For Ajax requests, since forwarding/redirection methods of JSF do not work as expected, this fix uses redirection by `windows.location.href` as workaround.