### PR TITLE
Bump weld from 6.0.0.Beta4 to 6.0.0.CR1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -149,7 +149,7 @@
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.1.0</jakarta.cdi-api.version>
-        <weld.version>6.0.0.Beta4</weld.version>
+        <weld.version>6.0.0.CR1</weld.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->


### PR DESCRIPTION
https://github.com/weld/core/compare/6.0.0.Beta4...6.0.0.CR1
https://github.com/weld/api/compare/6.0.Beta4...6.0.CR1

The issue reported for Beta1 (https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/15605) is claimed to be resolved in CR1.

