### PR TITLE
Fix #25220 The number of Logging pump threads grows infinitely

### DIFF
--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
@@ -397,10 +397,21 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
 
     private void initStandardStreamsLogging() {
         trace(GlassFishLogHandler.class, "initStandardStreamsLogging()");
+
+        LoggingPrintStream prevStdoutStream = this.stdoutStream;
+        LoggingPrintStream prevStderrStream = this.stderrStream;
+
         this.stdoutStream = LoggingPrintStream.create(STDOUT_LOGGER, INFO, 5000, configuration.getEncoding());
         this.stderrStream = LoggingPrintStream.create(STDERR_LOGGER, SEVERE, 1000, configuration.getEncoding());
         System.setOut(this.stdoutStream);
         System.setErr(this.stderrStream);
+
+        if (prevStdoutStream != null) {
+            prevStdoutStream.close();
+        }
+        if (prevStderrStream != null) {
+            prevStderrStream.close();
+        }
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java
@@ -137,6 +137,7 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
 
         private final LogRecordBuffer buffer;
         private final Logger logger;
+        private volatile boolean pumpClosed;
 
         private Pump(final Logger logger, final LogRecordBuffer buffer) {
             this.buffer = buffer;
@@ -151,7 +152,7 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
         @Override
         public void run() {
             // the thread will be interrupted by it's owner finally
-            while (true) {
+            while (!pumpClosed) {
                 try {
                     logAllPendingRecordsOrWait();
                 } catch (final Exception e) {
@@ -169,6 +170,7 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
          * The pump can be locked, waiting
          */
         void shutdown() {
+            pumpClosed = true;
             this.interrupt();
             // we interrupted waiting or working thread, now we have to process remaining records.
             logAllPendingRecords();


### PR DESCRIPTION
* Fixes #25220

Fix to destroy old threads through LoggingOutputStream.close() when updating contents of logging.properties.

First, fix LoggingOutputStream.close() to be called when logging.properties is updated.
When logging.properties is updated, GlassFishLogHandler.reconfigure() is called to recreate the LoggingOutputStream based on the updated contents of logging.properties.
https://github.com/eclipse-ee4j/glassfish/blob/c35434465df28b1dd34d1580838170eea6e1e7fd/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java#L191-L217
However, there is no process to stop the existing LoggingOutputStream's Pump Thread during this recreation.

Second, fix processing so that the Pump Thread is destroyed when LoggingOutputStream.close() is called.
When LoggingOutputStream.close() is called, Pump.shutdown() is called, but Pump.shutdown() cannot stop the Pump thread.
https://github.com/eclipse-ee4j/glassfish/blob/c35434465df28b1dd34d1580838170eea6e1e7fd/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java#L171-L175
If Pump.interrupt() is called, the implementation absorbs the InterruptException inside the LogRecordBuffer class.
https://github.com/eclipse-ee4j/glassfish/blob/c35434465df28b1dd34d1580838170eea6e1e7fd/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java#L159-L168
Therefore, the while loop of the Pump thread does not stop when Pump.shutdown() is called.
So, the fix is to add a flag and modify Pump.shutdown() to stop Thread.