### PR TITLE
Fix target argument in create-jms-resource

### DIFF
--- a/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/CreateJMSResource.java
+++ b/appserver/jms/admin/src/main/java/org/glassfish/jms/admin/cli/CreateJMSResource.java
@@ -263,6 +263,7 @@ public class CreateJMSResource implements AdminCommand {
             aoAttrList.set(DEFAULT_OPERAND,  jndiName);
             aoAttrList.set("restype",  resourceType);
             aoAttrList.set("raname",  DEFAULT_JMS_ADAPTER);
+            aoAttrList.set("target",  target);
             if (enabled != null) {
                 aoAttrList.set("enabled", Boolean.toString(enabled));
             }


### PR DESCRIPTION
The `create-jms-resource` admin command ignores that target argument and always binds the resource to the default `server` target.

This fixes it by adding setting the target attribute in the subsequent `create-admin-object` command.