### PR TITLE
Fixed RarHandler - non-absolute URL to File conversion

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/module/RarHandler.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/module/RarHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -150,7 +150,7 @@ public class RarHandler extends AbstractArchiveHandler {
     public List<URI> getClassPathURIs(ReadableArchive archive) {
         List<URI> uris = super.getClassPathURIs(archive);
         try {
-            File archiveFile = new File(archive.getURI());
+            File archiveFile = new File(archive.getURI().getSchemeSpecificPart());
             if (archiveFile.exists() && archiveFile.isDirectory()) {
                 // add top level jars
                 uris.addAll(ASClassLoaderUtil.getLibDirectoryJarURIs(archiveFile));


### PR DESCRIPTION
- As the Archive#getURI says, the method can return nearly anything and there no guarantee that the URI can be converted to a File.
- Sometimes it is an absolute file, sometimes relative path, sometimes URI pointing to a file inside jar inside ear.
- This minimal fix avoids an exception, and it is similar to conversion used on other places.
