### PR TITLE
Fix TCK failure for EJB32 tests

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -108,7 +108,7 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
-        <eclipselink.version>4.0.4</eclipselink.version>
+        <eclipselink.version>4.0.3</eclipselink.version>
         <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->
@@ -143,7 +143,7 @@
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.0.1</jakarta.cdi-api.version>
-        <weld.version>5.1.2.Final</weld.version>
+        <weld.version>5.1.3.Final</weld.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->

--- a/appserver/tests/tck/platform-tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/platform-tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -183,7 +183,7 @@ public class TckRunner {
     }
 
     private Process startBash(final String command) throws IOException {
-        ProcessBuilder bash = new ProcessBuilder("/bin/zsh", "-c", command).inheritIO().directory(cfg.getTargetDir());
+        ProcessBuilder bash = new ProcessBuilder("/bin/bash", "-c", command).inheritIO().directory(cfg.getTargetDir());
         configureEnvironment(bash.environment());
         return bash.start();
     }

--- a/appserver/tests/tck/platform-tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/platform-tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -183,7 +183,7 @@ public class TckRunner {
     }
 
     private Process startBash(final String command) throws IOException {
-        ProcessBuilder bash = new ProcessBuilder("/bin/bash", "-c", command).inheritIO().directory(cfg.getTargetDir());
+        ProcessBuilder bash = new ProcessBuilder("/bin/zsh", "-c", command).inheritIO().directory(cfg.getTargetDir());
         configureEnvironment(bash.environment());
         return bash.start();
     }
@@ -206,6 +206,7 @@ public class TckRunner {
         env.put("PATH", String.join(":",
             cfg.getJdkDirectory().getAbsolutePath() + "/bin",
             cfg.getAntDirectory().getAbsolutePath() + "/bin",
+            "/opt/homebrew/bin", // For macOs, to override BSD tar with GNU Tar etc
             "/usr/bin",
             "/bin"));
         env.put("CTS_HOME", cfg.getTargetDir().getAbsolutePath());

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -136,8 +136,8 @@
         <!-- 3rd party dependencies -->
 
         <commons-io.version>2.18.0</commons-io.version>
-        <jboss.logging.annotation.version>2.2.1.Final</jboss.logging.annotation.version>
-        <jboss.logging.version>3.5.3.Final</jboss.logging.version>
+        <jboss.logging.annotation.version>3.0.3.Final</jboss.logging.annotation.version>
+        <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.7.1</asm.version>
         <jsch.version>0.2.21</jsch.version>


### PR DESCRIPTION
Use EclipseLink 4.0.3 instead of 4.0.4
Weld back to 5.1.3

