### PR TITLE
Fix a typo of the WebappClassLoader delegation settings

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -137,7 +137,7 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader implements 
         "sun",                                       // Sun classes (JRE internals)
         "org.xml.sax",                               // SAX 1 & 2 (JRE, jrt-fs.jar)
         "org.w3c.dom",                               // DOM 1 & 2 (JRE, jrt-fs.jar)
-        "org.glassfish.wasp.standard",               // wasp.jar
+        "org.glassfish.wasp.taglibs.standard",       // wasp.jar
         "com.sun.faces"                              // jakarta.faces.jar
     );
     private static final Set<String> DELEGATED_RESOURCE_PATHS = DELEGATED_PACKAGES.stream()


### PR DESCRIPTION
* Follow-up: #24292

`WebappClassLoader.DELEGATE_PACKAGES` has been changed to "org.glassfish.wasp.standard", but "org.glassfish.wasp.taglibs.standard" would be correct.

JSTL implementation has been moved from [Jakarta Tags](https://github.com/jakartaee/tags) to [Eclipse WaSP](https://github.com/eclipse-ee4j/wasp/) since GlassFish 8.

*   https://github.com/jakartaee/tags/pull/244
*   https://github.com/eclipse-ee4j/wasp/pull/54

Then, JSTL namespace has been also changed as follows:

* Jakarta EE 10: [org.apache.taglibs.standard](https://github.com/jakartaee/tags/tree/2.0.0-RELEASE/impl/src/main/java/org/apache/taglibs/standard)
* Jakarta EE 11: [org.glassfish.wasp.taglibs.standard](https://github.com/eclipse-ee4j/wasp/tree/3.2.0/src/main/java/org/glassfish/wasp/taglibs/standard)

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>
