### PR TITLE
Fix #25258 No message defined on setting invalid pool name of JDBC resource

### DIFF
--- a/appserver/jdbc/jdbc-config/src/main/resources/org/glassfish/jdbc/config/LocalStrings.properties
+++ b/appserver/jdbc/jdbc-config/src/main/resources/org/glassfish/jdbc/config/LocalStrings.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2024 Contributors to the Eclipse Foundation.
 # Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,3 +16,4 @@
 #
 
 resourcename.isnot.unique=Name is already used by another resource.
+resourceref.invalid.poolname=Invalid pool name! Check whether the pool exists.


### PR DESCRIPTION
* Fixes #25258

After fixed:

```sh
# /opt/glassfish7-fixed/glassfish/bin/asadmin set resources.jdbc-resource.jdbc/__default.pool-name=MissingPool
remote failure: Could not change the attributes: Constraints for this JdbcResource configuration have been violated: on property [ pool-name ] violation reason [ Invalid pool name, check whether the pool exists. ]
Constraints for this JdbcResource configuration have been violated: on property [ pool-name ] violation reason [ Invalid pool name! Check whether the pool exists. ]
Command set failed.

```

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>
