### PR TITLE
Suppress internal processing output on executing asadmin create-local-instance

### DIFF
--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/PayloadFilesManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -457,7 +457,7 @@ public abstract class PayloadFilesManager {
                 dirTimestamps.put(extractedFile, lastModified);
             }
             postExtract(extractedFile);
-            logger.log(Level.CONFIG, "Extracted transferred entry {0} of size {1} B to {2}",
+            logger.log(Level.FINER, "Extracted transferred entry {0} of size {1} B to {2}",
                 new Object[] {part.getName(), extractedFile.length(), extractedFile});
             reportExtractionSuccess();
             return extractedFile;


### PR DESCRIPTION
Internal processing message "Extracted transferred entry ..." [*1] is output on executing asadmin create-local-instance.

```sh
# /opt/glassfish7-org/glassfish/bin/asadmin create-local-instance --cluster cluster1 cluster1-1
Rendezvoused with DAS on localhost:4848.
Port Assignments for server instance cluster1-1: 
OSGI_SHELL_TELNET_PORT=26666
JAVA_DEBUGGER_PORT=29009
JMS_PROVIDER_PORT=27676
HTTP_LISTENER_PORT=28080
IIOP_SSL_LISTENER_PORT=23820
ASADMIN_LISTENER_PORT=24848
IIOP_SSL_MUTUALAUTH_PORT=23920
JMX_SYSTEM_CONNECTOR_PORT=28686
HTTP_SSL_LISTENER_PORT=28181
IIOP_LISTENER_PORT=23700
Extracted transferred entry config/keystore.jks of size 6,221 B to /opt/glassfish7-org/glassfish/nodes/localhost-domain1/cluster1-1/config/keystore.jks [*1]
Extracted transferred entry config/cacerts.jks of size 2,495 B to /opt/glassfish7-org/glassfish/nodes/localhost-domain1/cluster1-1/config/cacerts.jks [*1]
Command create-local-instance executed successfully.
```

FYI, we can still view the internal processing with environment variables (`AS_TRACE` / `AS_DEBUG`).

```sh
# export AS_TRACE=true
# /opt/glassfish7-org/glassfish/bin/asadmin create-local-instance --cluster cluster1 cluster1-1
...
---- END PAYLOAD ----
Copyied 6,221 bytes to /opt/glassfish7-org/glassfish/nodes/localhost-domain1/cluster1-1/config/keystore.jks
Extracted transferred entry config/keystore.jks of size 6,221 B to /opt/glassfish7-org/glassfish/nodes/localhost-domain1/cluster1-1/config/keystore.jks [*1]
Copyied 2,495 bytes to /opt/glassfish7-org/glassfish/nodes/localhost-domain1/cluster1-1/config/cacerts.jks
Extracted transferred entry config/cacerts.jks of size 2,495 B to /opt/glassfish7-org/glassfish/nodes/localhost-domain1/cluster1-1/config/cacerts.jks [*1]
doHttpCommand succeeds
loadClass(name=com.sun.enterprise.admin.util.CommandModelData$ParamData, resolve=false)
Command create-local-instance executed successfully.
```

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>
