### PR TITLE
Add -XX:+EnableDynamicAgentLoading for JEP 451

### DIFF
--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -223,6 +223,7 @@
         
         <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
         <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
+        <jvm-options>-XX:+EnableDynamicAgentLoading</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -419,6 +420,7 @@
 
              <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
              <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
+             <jvm-options>-XX:+EnableDynamicAgentLoading</jvm-options>
          </java-config>
          <availability-service>
              <web-container-availability/>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -182,6 +182,7 @@
         
         <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
         <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
+        <jvm-options>-XX:+EnableDynamicAgentLoading</jvm-options>
       </java-config>
       <network-config>
         <protocols>
@@ -339,6 +340,7 @@
              <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
              <!-- To enable attaching the flashlight agent to the current VM in OpenJDK 9+ -->
              <jvm-options>-Djdk.attach.allowAttachSelf=true</jvm-options>
+             <jvm-options>-XX:+EnableDynamicAgentLoading</jvm-options>
          </java-config>
          <availability-service/>
          <network-config>


### PR DESCRIPTION
* see also: [JEP 451](https://openjdk.org/jeps/451)

Currently, starting GlassFish on JDK 21 and then executing `asadmin enable-monitoring` prints the following message in the server log:

```
[2024-12-02T19:08:59.248054+09:00] [GF 8.0.0-M7] [SEVERE] [] [jakarta.enterprise.logging.stderr] [tid: _ThreadID=90 _ThreadName=Attach Listener] [levelValue: 1000] [[
  WARNING: A Java agent has been loaded dynamically (/opt/glassfish8-org/glassfish/lib/monitor/flashlight-agent.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release]]
```

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>
