### PR TITLE
Improve the connection pool lookup messages

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorResourceAdminServiceImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorResourceAdminServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -66,15 +66,15 @@ public class ConnectorResourceAdminServiceImpl extends ConnectorService {
         try {
             ccp = (ConnectorConnectionPool) namingService.lookup(poolInfo, jndiNameForPool);
         } catch (NamingException ne) {
-            _logger.log(Level.WARNING,
+            _logger.log(Level.INFO,
                 "Probably the pool {0} is not yet initialized (lazy-loading), trying to check ...", poolInfo);
             try {
                 checkAndLoadPool(poolInfo);
                 ccp = (ConnectorConnectionPool) namingService.lookup(poolInfo, jndiNameForPool);
             } catch (NamingException e) {
-                _logger.log(Level.SEVERE, "Second lookup failed for {0}: {1}", new Object[] {poolInfo, e});
+                _logger.log(Level.SEVERE, "Lookup failed for {0}: {1}", new Object[] {poolInfo, e});
                 throw new ConnectorRuntimeException(
-                    "Second lookup failed again for pool name " + jndiNameForPool + " or " + poolInfo, ne);
+                    "Failed to lookup pool name " + jndiNameForPool + " or " + poolInfo, ne);
             }
         }
 

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorResourceAdminServiceImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/service/ConnectorResourceAdminServiceImpl.java
@@ -72,7 +72,6 @@ public class ConnectorResourceAdminServiceImpl extends ConnectorService {
                 checkAndLoadPool(poolInfo);
                 ccp = (ConnectorConnectionPool) namingService.lookup(poolInfo, jndiNameForPool);
             } catch (NamingException e) {
-                _logger.log(Level.SEVERE, "Lookup failed for {0}: {1}", new Object[] {poolInfo, e});
                 throw new ConnectorRuntimeException(
                     "Failed to lookup pool name " + jndiNameForPool + " or " + poolInfo, ne);
             }


### PR DESCRIPTION
I would like to change the log level of the following message from WARNING to INFO because this warning is printed in the server log even though the lazy-loading works as expected.

```
[2024-12-05T12:26:39.599471+09:00] [GF 7.0.20] [WARNING] [] [jakarta.enterprise.resource.resourceadapter.com.sun.enterprise.connectors.service] [tid: _ThreadID=104 _ThreadName=pool-18-thread-1] [levelValue: 900] [[
  Probably the pool org.glassfish.resourcebase.resources.api.PoolInfo@fdae7f48[jndiName=MyPool1, applicationName=null, moduleName=null] is not yet initialized (lazy-loading), trying to check ...]]
```

I would also like to make the messages a little better when the lookup ultimately fails, so it's easier for those unfamiliar with the internal work (two lookups, accounting for lazy-loading) to understand.

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>
