### PR TITLE
Disabled automatic rerun of failed TCK tests - should pass on the first attempt.

### DIFF
--- a/appserver/tests/tck/platform-tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
+++ b/appserver/tests/tck/platform-tck-runner/src/main/java/org/glassfish/main/tests/tck/ant/TckRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -219,6 +219,7 @@ public class TckRunner {
         env.put("GF_LOGGING_CFG_VI", cfg.getServerLoggingProperties().getAbsolutePath());
         env.put("DATABASE", "JavaDB");
         env.put("CLIENT_LOGGING_CFG", cfg.getClientLoggingProperties().getAbsolutePath());
+        env.put("ENABLE_RERUN", "false");
 
         LOG.log(Level.DEBUG, "Configured environment: \n{0}", env);
     }


### PR DESCRIPTION
- the env option will be a part of the Platform TCK 10.0.6 but I already use it with the private TCK build
- it helped us to diagnose https://github.com/eclipse-ee4j/glassfish/pull/25256 because several TCK tests failed randomly and the rerun was hiding some failures and caused some confusion which costed us some time.
