### PR TITLE
Disable TLS 1.0 and TLS 1.1 by default

### DIFF
--- a/appserver/admingui/web/src/main/help/en/help/ref-protocolssledit.html
+++ b/appserver/admingui/web/src/main/help/en/help/ref-protocolssledit.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation
+    Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -31,11 +31,11 @@
 </dd>
 <dt>TLS1.0</dt>
 <dd>
-<p>If this checkbox is selected, the TLS1.0 protocol is enabled for the protocol. This option is enabled by default.</p>
+<p>If this checkbox is selected, the TLS1.0 protocol is enabled for the protocol. This option is not enabled by default.</p>
 </dd>
 <dt>TLS1.1</dt>
 <dd>
-<p>If this checkbox is selected, the TLS1.1 protocol is enabled for the protocol. This option is enabled by default.</p>
+<p>If this checkbox is selected, the TLS1.1 protocol is enabled for the protocol. This option is not enabled by default.</p>
 </dd>
 <dt>TLS1.2</dt>
 <dd>

--- a/appserver/admingui/web/src/main/help/en/help/task-protocolssledit.html
+++ b/appserver/admingui/web/src/main/help/en/help/task-protocolssledit.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation
+    Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
     Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -44,11 +44,11 @@
 </li>
 <li>
 <p>Select the TLS1.0 Enabled checkbox to enable Transport Layer Security 1.0(TLS1.0).</p>
-<p>This option is enabled by default.</p>
+<p>This option is not enabled by default.</p>
 </li>
 <li>
 <p>Select the TLS1.1 Enabled checkbox to enable Transport Layer Security 1.1(TLS1.1).</p>
-<p>This option is enabled by default.</p>
+<p>This option is not enabled by default.</p>
 </li>
 <li>
 <p>Select the TLS1.2 Enabled checkbox to enable Transport Layer Security 1.2(TLS1.2).</p>

--- a/nucleus/admin/config-api/src/test/java/com/sun/enterprise/configapi/tests/Ssl2EnabledTest.java
+++ b/nucleus/admin/config-api/src/test/java/com/sun/enterprise/configapi/tests/Ssl2EnabledTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -69,7 +69,10 @@ public class Ssl2EnabledTest {
                 assertNotNull(ssl);
                 assertFalse(Boolean.parseBoolean(ssl.getSsl2Enabled()));
                 assertFalse(Boolean.parseBoolean(ssl.getSsl3Enabled()));
-                assertTrue(Boolean.parseBoolean(ssl.getTlsEnabled()));
+                assertFalse(Boolean.parseBoolean(ssl.getTlsEnabled()));
+                assertFalse(Boolean.parseBoolean(ssl.getTls11Enabled()));
+                assertTrue(Boolean.parseBoolean(ssl.getTls12Enabled()));
+                assertTrue(Boolean.parseBoolean(ssl.getTls13Enabled()));
             },
             () -> {
                 NetworkListener listener = listeners.get(2);

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/dom/Ssl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -38,9 +38,9 @@ public interface Ssl extends ConfigBeanProxy, PropertyBag {
 
     boolean SSL3_ENABLED = false;
 
-    boolean TLS_ENABLED = true;
+    boolean TLS_ENABLED = false;
 
-    boolean TLS11_ENABLED = true;
+    boolean TLS11_ENABLED = false;
 
     boolean TLS12_ENABLED = true;
 


### PR DESCRIPTION
As specified in the RFC 8996, TLS 1.0 and TLS 1.1 are deprecated.
https://datatracker.ietf.org/doc/html/rfc8996