### PR TITLE
Redesign kernel events dispatching facility

### DIFF
--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -79,6 +79,10 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-osgi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.glassfish.main.admin</groupId>

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/KernelLoggerInfo.java
@@ -287,7 +287,7 @@ public class KernelLoggerInfo {
             level = "SEVERE")
     public static final String cantDetermineLocation = LOGMSG_PREFIX + "-00040";
 
-   @LogMessageInfo(
+    @LogMessageInfo(
             message = "Application deployment failed: {0}",
             cause = "The deployment command for an application failed as indicated in the message.",
             action = "Check the application and redeploy.",
@@ -453,11 +453,11 @@ public class KernelLoggerInfo {
     public static final String exceptionAutodeployment = LOGMSG_PREFIX + "-00067";
 
     @LogMessageInfo(
-            message = "Exception while sending an event.",
-            cause = "An exception occurred while sending an event.",
+            message = "Exception while registering an event listener.",
+            cause = "An exception occurred while registering an event listener.",
             action = "Check the system logs and contact support.",
             level = "SEVERE")
-    public static final String exceptionSendEvent = LOGMSG_PREFIX + "-00068";
+    public static final String exceptionRegisterEventListener = LOGMSG_PREFIX + "-00068";
 
     @LogMessageInfo(
             message = "Exception while dispatching an event",

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsFactory.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/EventsFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.kernel.event;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+
+import org.glassfish.api.event.Events;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ * HK2 factory for the {@link Events} implementations.
+ */
+@Service
+public class EventsFactory implements Factory<Events> {
+
+    private static final String BUNDLE_REFERENCE_CLASS_NAME = "org.osgi.framework.BundleReference";
+
+    @Inject
+    private ServiceLocator serviceLocator;
+
+    @Override
+    @Singleton
+    public Events provide() {
+        if (isOSGiEnv()) {
+            return serviceLocator.createAndInitialize(OSGiAwareEventsImpl.class);
+        }
+        return serviceLocator.createAndInitialize(EventsImpl.class);
+    }
+
+    @Override
+    public void dispose(Events events) {
+        serviceLocator.preDestroy(events);
+    }
+
+    /**
+     * Determine if we are operating in OSGi environment.
+     *
+     * <p>We do this by checking what class loader is used to this class.
+     *
+     * @return {@code true} if we are called in the context of OSGi framework, {@code false} otherwise
+     */
+    private boolean isOSGiEnv() {
+        return isBundleReference(getClass().getClassLoader());
+    }
+
+    /**
+     * Determines if the specified object is OSGi bundle reference.
+     *
+     * @param obj the object to check
+     * @return {@code true} if the {@code obj} is OSGi bundle reference, {@code false} otherwise
+     */
+    private boolean isBundleReference(Object obj) {
+        Queue<Class<?>> interfaces = new ArrayDeque<>();
+        Class<?> c = obj.getClass();
+        while (c != null && c != Object.class) {
+            interfaces.addAll(Arrays.asList(c.getInterfaces()));
+            while (!interfaces.isEmpty()) {
+                Class<?> interfaceClass = interfaces.poll();
+                if (BUNDLE_REFERENCE_CLASS_NAME.equals(interfaceClass.getName())) {
+                    return true;
+                }
+                interfaces.addAll(Arrays.asList(interfaceClass.getInterfaces()));
+            }
+            c = c.getSuperclass();
+        }
+        return false;
+    }
+}

--- a/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/OSGiAwareEventsImpl.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/kernel/event/OSGiAwareEventsImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.kernel.event;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * OSGi-aware implementation of the events dispatching facility.
+ */
+public class OSGiAwareEventsImpl extends EventsImpl implements FrameworkListener {
+
+    @PostConstruct
+    public void addFrameworkListener() {
+        BundleContext bundleContext = getBundleContext();
+        if (bundleContext != null) {
+            bundleContext.addFrameworkListener(this);
+        }
+    }
+
+    @PreDestroy
+    public void removeFrameworkListener() {
+        BundleContext bundleContext = getBundleContext();
+        if (bundleContext != null) {
+            bundleContext.removeFrameworkListener(this);
+        }
+    }
+
+    @Override
+    public void frameworkEvent(FrameworkEvent frameworkEvent) {
+        if (frameworkEvent.getType() == FrameworkEvent.PACKAGES_REFRESHED) {
+            // Get System Bundle context
+            BundleContext bundleContext = frameworkEvent.getBundle().getBundleContext();
+            // Uninstalled bundles has been removed when framework has been refreshed.
+            // Remove listeners registered by this uninstalled bundles.
+            listeners.keySet().removeIf(listener -> {
+                // Get bundle for event listener
+                Bundle bundle = FrameworkUtil.getBundle(listener.unwrap().getClass());
+                if (bundle != null) {
+                    // Even if Bundle has been removed, it must preserve bundle_id.
+                    return bundleContext.getBundle(bundle.getBundleId()) == null;
+                }
+                return true;
+            });
+        }
+    }
+
+    private BundleContext getBundleContext() {
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        return bundle != null ? bundle.getBundleContext() : null;
+    }
+}


### PR DESCRIPTION
Improve kernel events dispatching performance:

* Eliminates a lot of unnecessary reflection during dispatching of the *each* event
* *O(log(n))* event listener unregistering cost
* Excludes multiple registration of the same event listeners