### PR TITLE
Fix versions of X-Powered-By field for empty "product.name"

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
@@ -373,10 +373,9 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
 
             serverVersion = serverInfo == null ? Version.getProductId() : serverInfo;
 
-            if (isXPoweredByEnabled) {
-                String serverVersionForXPoweredBy = (serverInfo == null || serverInfo.isEmpty()) ? Version.getProductId() : serverInfo;
+            if (isXPoweredByEnabled && (serverVersion != null && !serverVersion.isEmpty())) {
                 xPoweredBy = "Servlet/6.0 JSP/3.1"
-                        + "(" + serverVersionForXPoweredBy
+                        + "(" + serverVersion
                         + " Java/"
                         + System.getProperty("java.vm.vendor") + "/"
                         + System.getProperty("java.specification.version") + ")";

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
@@ -371,9 +371,10 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
             */
             String serverInfo = System.getProperty("product.name");
 
-            serverVersion = serverInfo == null ? Version.getProductId() : serverInfo;
+            // null means users prefer not to disclose the server info.
+            serverVersion = serverInfo == null ? Version.getProductId() : (serverInfo.isEmpty() ? null : serverInfo);
 
-            if (isXPoweredByEnabled && (serverVersion != null && !serverVersion.isEmpty())) {
+            if (isXPoweredByEnabled && serverVersion != null) {
                 xPoweredBy = "Servlet/6.0 JSP/3.1"
                         + "(" + serverVersion
                         + " Java/"
@@ -396,7 +397,7 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
             final HttpResponsePacket response = request.getResponse();
 
             // Set response "Server" header
-            if (serverVersion != null && !serverVersion.isEmpty()) {
+            if (serverVersion != null) {
                 response.addHeader(Header.Server, serverVersion);
             }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java
@@ -356,7 +356,7 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
 
             /*
             * Set the server info.
-            * By default, the server info is taken from Version#getVersion.
+            * By default, the server info is taken from Version#getProductId.
             * However, customers may override it via the product.name system
             * property.
             * Some customers prefer not to disclose the server info
@@ -374,8 +374,9 @@ public class GlassfishNetworkListener extends GenericGrizzlyListener {
             serverVersion = serverInfo == null ? Version.getProductId() : serverInfo;
 
             if (isXPoweredByEnabled) {
+                String serverVersionForXPoweredBy = (serverInfo == null || serverInfo.isEmpty()) ? Version.getProductId() : serverInfo;
                 xPoweredBy = "Servlet/6.0 JSP/3.1"
-                        + "(" + serverVersion
+                        + "(" + serverVersionForXPoweredBy
                         + " Java/"
                         + System.getProperty("java.vm.vendor") + "/"
                         + System.getProperty("java.specification.version") + ")";


### PR DESCRIPTION
* Follow-up: https://github.com/eclipse-ee4j/glassfish/pull/24322

X-Powered-By response field looks broken as follows by setting "product.name" system property to the empty string [*1]:

```sh
# curl -i http://localhost:8080/
HTTP/1.1 200 OK
X-Powered-By: Servlet/6.0 JSP/3.1( Java/Eclipse Adoptium/17)
```

Expected behavior:

```sh
# curl -i http://localhost:8080/
HTTP/1.1 200 OK
X-Powered-By: Servlet/6.0 JSP/3.1(Eclipse GlassFish 7.0.21 Java/Eclipse Adoptium/17)
```

[*1] This use case is described below:

https://github.com/eclipse-ee4j/glassfish/blob/71df878e14aaca628a8c97ef9bff1894751de26a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/GlassfishNetworkListener.java#L357-L371

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>
