### PR TITLE
Improve error messages on deploying apps over upload size limit in Admin Console

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/DeploymentHandler.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/DeploymentHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -74,7 +75,7 @@ public class DeploymentHandler {
 
         if (GuiUtil.isEmpty(origPath)) {
             GuiUtil.getLogger().info("deploy(): origPath is NULL");
-            String mesg = GuiUtil.getMessage("msg.deploy.nullArchiveError");
+            String mesg = GuiUtil.getMessage("deployment.failure");
             GuiUtil.handleError(handlerCtx, mesg);
             return;
         }


### PR DESCRIPTION
In Admin Console, a pop-up message is incomprehensible when deploying an app larger than the upload size limit [*1] fails.  
[*1] `maxSize` of `UploadFilter` in `install-dir/glassfish/lib/install/applications/__admingui/WEB-INF/web.xml`

![2-error-org](https://github.com/user-attachments/assets/73de2f9f-0230-4e73-a169-1503a0878ccd)

After fixed:  

![3-error-fixed](https://github.com/user-attachments/assets/09813a73-8389-46c7-afa2-901f35b000aa)

BTW, the above message in red seems incorrect ("bytes" would be correct, not "Mb").  
I will make a PR to fix this typo for Woodstock.

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>