### PR TITLE
Fix random 403 responses

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -75,7 +75,7 @@ public class SecurityContext extends AbstractSecurityContext {
     // Did the client log in as or did the server generate the context
     private boolean serverGeneratedSecurityContext;
 
-    private ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
+    private final ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
 
     /*
      * This creates a new SecurityContext object. Note: that the docs for Subject state that the internal sets (eg. the

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -75,7 +75,7 @@ public class SecurityContext extends AbstractSecurityContext {
     // Did the client log in as or did the server generate the context
     private boolean serverGeneratedSecurityContext;
 
-    private Principal sessionPrincipal;
+    private ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
 
     /*
      * This creates a new SecurityContext object. Note: that the docs for Subject state that the internal sets (eg. the
@@ -289,8 +289,7 @@ public class SecurityContext extends AbstractSecurityContext {
     public static SecurityContext getCurrent() {
         SecurityContext securityContext = currentSecurityContext.get();
         if (securityContext == null) {
-            securityContext = generateDefaultSecurityContext();
-            currentSecurityContext.set(securityContext);
+            securityContext = defaultSecurityContext;
         }
 
         return securityContext;
@@ -371,11 +370,15 @@ public class SecurityContext extends AbstractSecurityContext {
     }
 
     public Principal getSessionPrincipal() {
-        return sessionPrincipal;
+        return sessionPrincipal.get();
     }
 
     public void setSessionPrincipal(Principal sessionPrincipal) {
-        this.sessionPrincipal = sessionPrincipal;
+        if (sessionPrincipal != null) {
+            this.sessionPrincipal.set(sessionPrincipal);
+        } else {
+            this.sessionPrincipal.remove();
+        }
     }
 
     public Set<Principal> getPrincipalSet() {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -289,7 +289,8 @@ public class SecurityContext extends AbstractSecurityContext {
     public static SecurityContext getCurrent() {
         SecurityContext securityContext = currentSecurityContext.get();
         if (securityContext == null) {
-            securityContext = defaultSecurityContext;
+            securityContext = generateDefaultSecurityContext();
+            currentSecurityContext.set(securityContext);
         }
 
         return securityContext;


### PR DESCRIPTION
Fixes #25141 and https://github.com/eclipse-ee4j/glassfish/issues/25206.

The securityContext is stateful, cannot be shared among requests. [RealmAdapter](https://github.com/eclipse-ee4j/glassfish/blob/e20777f9194eb85d0ad39a35938f229f1ca5b794/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java#L447) stores the principal from request to it. We need to create  a copy of the default context for each request instead of  using the shared default context.

This is a quick fix but I can imagine a better and nicer fix. For example, keep returning `defaultSecurityContext` and instead let `RealmAdapter` to create a new security context if a user is signed in, and then store the principal to it. This would keep the same `defaultSecurityContext` for anonymous user. 

Another option is to save the `sessionPrincipal` into a ThreadLocal. Although the `SecurityContext` is already stored in a thread local, the default context is shared in multiple thread locals. Storing `sessionPrincipal` in another thread local would keep it only for the current thread even if the security context is shared. However, I don't like adding another thread local.

Maybe @arjantijms , @dmatej , @avpinchuk , @pzygielo, @hs536 you have some idea to improve it? Or it's OK to go with my simple solution?

About tests, I'm not sure if adding tests makes sense. The issue is random. Sometimes doesn't happen even after 1000 requests, especially on a slower machine. So the test would not be reliable and might not fail each time even if the behavior is broken.