### PR TITLE
Fix #25292 Ephemeral ports are exhausted if stopping the DAS takes a long time

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
@@ -204,7 +204,8 @@ public class StopDomainCommand extends LocalDomainCommand {
         final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final Supplier<Boolean> deathSign;
         if (isLocal()) {
-            deathSign = () -> !ProcessUtils.isListening(addr) && !ProcessUtils.isAlive(watchedPid);
+            // watch process id first to reduce the number of opened ephemeral ports
+            deathSign = () -> !ProcessUtils.isAlive(watchedPid) && !ProcessUtils.isListening(addr);
         } else {
             deathSign = () -> !ProcessUtils.isListening(addr);
         }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -39,6 +39,7 @@ import static com.sun.enterprise.util.StringUtils.ok;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
@@ -233,7 +234,8 @@ public final class ProcessUtils {
                 try {
                     Thread.sleep(100L);
                 } catch (InterruptedException e) {
-                    LOG.log(TRACE, "Interrupted while waiting", e);
+                    LOG.log(WARNING, "Interrupted while waiting", e);
+                    break;
                 }
             }
             return false;

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -230,7 +230,11 @@ public final class ProcessUtils {
                         System.out.flush();
                     }
                 }
-                Thread.yield();
+                try {
+                    Thread.sleep(100L);
+                } catch (InterruptedException e) {
+                    LOG.log(TRACE, "Interrupted while waiting", e);
+                }
             }
             return false;
         } finally {


### PR DESCRIPTION
Fixes #25292.

- Criterion for process aliveness: 
  To reduce the number of ports consumed, use `ProcessUtils.isAlive()` over `ProcessUtils.isListening()` if possible.
- Time interval for testing criterion: 
  To limit the number of ports consumed per a certain period, test the criterion once in a certain amount of time (as in [StopDomainCommand#waitForDeath()](https://github.com/eclipse-ee4j/glassfish/blob/7.0.0-M10/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java#L178) of GlassFish 7.0.0-M10 or earlier).