### PR TITLE
Remove json-2.0.jar from dependencies

### DIFF
--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -79,11 +79,6 @@
         </dependency>
         <dependency>
             <groupId>com.sun.woodstock.dependlibs</groupId>
-            <artifactId>json</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
             <artifactId>prototype</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -131,7 +126,7 @@
                             <outputDirectory>${dependencies.extra.directory}</outputDirectory>
                             <includeArtifactIds>
                                 commons-io,
-                                dojo-ajax-nodemo,json,prototype,
+                                dojo-ajax-nodemo,prototype,
                                 woodstock-webui-jsf,woodstock-webui-jsf-suntheme
                             </includeArtifactIds>
                             <includeScope>provided</includeScope>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -37,5 +37,5 @@
     </locale-charset-info>
     <class-loader
         delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/json-${woodstock-json.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -168,7 +168,6 @@
         <woodstock.version>6.0.1</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
         <woodstock-dojo-ajax-nodemo.version>1.12.4</woodstock-dojo-ajax-nodemo.version>
-        <woodstock-json.version>2.0</woodstock-json.version>
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <!-- Other -->


### PR DESCRIPTION
Fix for: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/15598

json-2.0.jar contains `org.json` package and json.js, but they are no longer necessary.
- the `org.json` package has been replaced by `jakarta.json`
- json.js implements parse and stringify methods, but JavaScript engine now provide a superior impl itself

Also, while it is difficult to cover all operations, I've confirmed that the admin console basically works without it.

so we can remove it.

json-2.0.jar also needs to be removed from woodstock, and I'll create a pull request as well.
(This fix alone allows GlassFish to run without json-2.0.jar, even without integrating the woodstock that has had json-2.0.jar removed.)