### PR TITLE
Integrate WaSP 4.0.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -140,7 +140,7 @@
         <!-- Jakarta Pages and Jakarta Standard Tag Library -->
         <jakarta.pages-api.version>4.0.0</jakarta.pages-api.version>
         <jstl-api.version>3.0.2</jstl-api.version>
-        <wasp.version>4.0.0-M2</wasp.version>
+        <wasp.version>4.0.0</wasp.version>
 
         <!-- Used for Jakarta SOAP (XML Web Services) -->
         <xmlsec.version>4.0.2</xmlsec.version>

--- a/appserver/tests/tck/tck-download/jakarta-pages-tags-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-pages-tags-tck/pom.xml
@@ -33,7 +33,7 @@
 
 
     <properties>
-        <tck.test.pages.file>jakarta-tags-tck-3.0.0.zip</tck.test.pages.file>
+        <tck.test.pages.file>jakarta-tags-tck-3.0.1.zip</tck.test.pages.file>
         <tck.test.pages.url>https://download.eclipse.org/jakartaee/tags/3.0/${tck.test.pages.file}</tck.test.pages.url>
     </properties>
 


### PR DESCRIPTION
No changes vs M2, simply promoted M2 to final.

Updated old Jakarta Tags TCK, but has to be replaced by new TCK (maven / junit based) to pass everything.
