### PR TITLE
Mask secrets in CommandInvokedEvent and Command logger

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/RestUtil.java
@@ -41,7 +41,6 @@ import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,6 +70,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import static com.sun.logging.LogCleanerUtil.neutralizeForLog;
+import static org.glassfish.common.util.Constants.PASSWORD_ATTRIBUTE_NAMES;
 
 /**
  *
@@ -286,7 +286,7 @@ public class RestUtil {
 
         for (Map.Entry<String, Object> e : attrs.entrySet()) {
             String key = e.getKey().toLowerCase(GuiUtil.guiLocale);
-            if (pswdAttrList.contains(key)) {
+            if (PASSWORD_ATTRIBUTE_NAMES.contains(key)) {
                 masked.put(e.getKey(), "*******");
             } else {
                 masked.put(e.getKey(), e.getValue());
@@ -967,17 +967,4 @@ public class RestUtil {
         }
     }
 
-    /*
-     * This is a list of attribute name of password for different command. We need to mask its value during logging.
-     */
-    private static final List<String> pswdAttrList = Arrays.asList(
-            "sshpassword", /* create-node-ssh , setup-ssh , update-node, update-node-ssh */
-            "dbpassword", /* jms-availability-service */
-            "jmsdbpassword", /* configure-jms-cluster */
-            "password", /* change-admin-password */
-            "newpassword", /* change-admin-password */
-            "jmsdbpassword", /* configure-jms-cluster */
-            "mappedpassword", /* create-connector-security-map, update-connector-security-map */
-            "userpassword", /* create-file-user , update-file-user */
-            "aliaspassword" /* create-password-alias , update-password-alias */);
 }

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -256,7 +256,6 @@ public class GlassFishTestEnvironment {
         }
     }
 
-
     /**
      * This will delete the jobs.xml file
      */

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -71,6 +71,7 @@ public class GlassFishTestEnvironment {
     private static final File PASSWORD_FILE = findPasswordFile("password.txt");
 
     private static final int ASADMIN_START_DOMAIN_TIMEOUT = 30_000;
+    private static final int ASADMIN_START_DOMAIN_TIMEOUT_FOR_DEBUG = 300_000;
 
     static {
         LOG.log(Level.INFO, "Using basedir: {0}", BASEDIR);
@@ -86,9 +87,11 @@ public class GlassFishTestEnvironment {
             // START_DOMAIN_TIMEOUT for us waiting for the end of the asadmin start-domain process.
             asadmin.withEnv("AS_START_TIMEOUT", Integer.toString(ASADMIN_START_DOMAIN_TIMEOUT - 5000));
         }
+        final int timeout = isStartDomainSuspendEnabled()
+                ? ASADMIN_START_DOMAIN_TIMEOUT_FOR_DEBUG : ASADMIN_START_DOMAIN_TIMEOUT;
         // This is the absolutely first start - if it fails, all other starts will fail too.
         // Note: --suspend implicitly enables --debug
-        assertThat(asadmin.exec(ASADMIN_START_DOMAIN_TIMEOUT, "start-domain",
+        assertThat(asadmin.exec(timeout,"start-domain",
                 isStartDomainSuspendEnabled() ? "--suspend" : "--debug"), asadminOK());
     }
 

--- a/nucleus/common/common-util/src/main/java/org/glassfish/common/util/Constants.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/common/util/Constants.java
@@ -16,6 +16,8 @@
 
 package org.glassfish.common.util;
 
+import java.util.Set;
+
 /**
  * These are constants that can be used throughout the server
  *
@@ -37,4 +39,17 @@ public class Constants {
      */
     public final static int IMPORTANT_RUN_LEVEL_SERVICE = 50;
 
+    /*
+     * This is a list of attribute names that hold passwords for various admin commands. We need to mask their value during logging.
+     */
+    public final static Set<String> PASSWORD_ATTRIBUTE_NAMES = Set.of(
+            "sshpassword", /* create-node-ssh , setup-ssh , update-node, update-node-ssh */
+            "dbpassword", /* jms-availability-service */
+            "password", /* change-admin-password */
+            "newpassword", /* change-admin-password */
+            "jmsdbpassword", /* configure-jms-cluster */
+            "mappedpassword", /* create-connector-security-map, update-connector-security-map */
+            "userpassword", /* create-file-user , update-file-user */
+            "aliaspassword" /* create-password-alias , update-password-alias */
+    );
 }

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -88,6 +88,10 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/ParameterMap.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/ParameterMap.java
@@ -16,6 +16,9 @@
 
 package org.glassfish.api.admin;
 
+import java.util.List;
+import java.util.Set;
+
 import org.jvnet.hk2.component.MultiMap;
 
 /**
@@ -51,4 +54,22 @@ public class ParameterMap extends MultiMap<String, String> {
         add(k, v);
         return this;
     }
+
+    /**
+     * Get a copy of this map with values of secret parameters changed into *******" to hide their values.
+     * Parameters which are not secret, remain without any change.
+     *
+     * @param secretParameters A set of parameter names which are considered secret. Not null.
+     * @return A copy of this map with masked values
+     */
+    public ParameterMap getMaskedMap(Set<String> secretParameters) {
+        final ParameterMap maskedParameters = new ParameterMap(this);
+        maskedParameters.entrySet().forEach(entry -> {
+            if (secretParameters.contains(entry.getKey())) {
+                entry.setValue(List.of("*******"));
+            }
+        });
+        return maskedParameters;
+    }
+
 }

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/ParameterMapTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/ParameterMapTest.java
@@ -82,6 +82,6 @@ public class ParameterMapTest {
     }
 
     static boolean valueIsMasked(Map.Entry<String, List<String>> entry) {
-        return entry.getValue().size() == 1 && entry.getValue().getFirst().startsWith("*");
+        return entry.getValue().size() == 1 && entry.getValue().get(0).startsWith("*");
     }
 }

--- a/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/ParameterMapTest.java
+++ b/nucleus/common/glassfish-api/src/test/java/org/glassfish/api/admin/ParameterMapTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.api.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class ParameterMapTest {
+
+    @ParameterizedTest
+    @MethodSource("valuesForMaskValues")
+    void maskValues(final Map<String, String> mapWithSecrets, final Set<String> secretKeys) {
+        ParameterMap parameterMap = new ParameterMap();
+        mapWithSecrets.forEach(parameterMap::add);
+        final ParameterMap maskedMap = parameterMap.getMaskedMap(secretKeys);
+
+        assertIterableEquals(mapWithSecrets.keySet(), maskedMap.keySet(), "Masked map should contian the same keys");
+        maskedMap.entrySet().forEach(entry -> {
+            assertTrue(!keyIsSecret(entry, secretKeys) || valueIsMasked(entry),
+                    () -> "Entry is either not secret or should contain masked value. Value is: " + entry.getValue());
+        });
+    }
+
+    private static Stream<Arguments> valuesForMaskValues() {
+        return Stream.of(
+                Arguments.of(
+                        Map.of("secretKey", "secret"),
+                        Set.of("secretKey")
+                ),
+                Arguments.of(
+                        Map.of(),
+                        Set.of("secretKey")
+                ),
+                Arguments.of(
+                        Map.of("secretKey", "secret",
+                                "notSecretKey", "hello"),
+                        Set.of("secretKey")
+                ),
+                Arguments.of(
+                        Map.of("anotherNotSecretKey", "hello",
+                                "secretKey", "secret",
+                                "anotherSecretKey", "secret",
+                                "notSecretKey", "hello"),
+                        Set.of("secretKey", "anotherSecretKey")
+                ),
+                Arguments.of(
+                        Map.of("anotherNotSecretKey", "hello",
+                                "notSecretKey", "hello"),
+                        Set.of("")
+                )
+        );
+    }
+
+    static boolean keyIsSecret(Map.Entry<String, List<String>> entry, Set<String> secretKeys) {
+        return secretKeys.contains(entry.getKey());
+    }
+
+    static boolean valueIsMasked(Map.Entry<String, List<String>> entry) {
+        return entry.getValue().size() == 1 && entry.getValue().getFirst().startsWith("*");
+    }
+}

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/events/CommandInvokedEvent.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/events/CommandInvokedEvent.java
@@ -69,7 +69,11 @@ public class CommandInvokedEvent {
 
     public CommandInvokedEvent(String commandName, ParameterMap parameters, Subject subject) {
         this.commandName = commandName;
-        this.parameters = parameters;
+        if (parameters != null) {
+            this.parameters = parameters;
+        } else {
+            this.parameters = new ParameterMap();
+        }
         this.subject = subject;
     }
 
@@ -77,10 +81,16 @@ public class CommandInvokedEvent {
     private final ParameterMap parameters;
     private final Subject subject;
 
+    /**
+     * @return Name of the executed command
+     */
     public String getCommandName() {
         return commandName;
     }
 
+    /**
+     * @return Parameters used with the command. If not parameters, the result is an empty map. Never null.
+     */
     public ParameterMap getParameters() {
         return parameters;
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
@@ -536,7 +536,7 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
                 inv.parameters(parameters).inbound(inboundPayload).outbound(outboundPayload).execute();
                 try {
                     // note it has become extraordinarily difficult to change the reporter!
-                    CommandRunnerImpl.ExecutionContext inv2 = (CommandRunnerImpl.ExecutionContext) inv;
+                    CommandRunnerExecutionContext inv2 = (CommandRunnerExecutionContext) inv;
                     report = inv2.report();
                 }
                 catch(Exception e) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerExecutionContext.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerExecutionContext.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.enterprise.v3.admin;
+
+import com.sun.enterprise.admin.event.AdminCommandEventBrokerImpl;
+import com.sun.enterprise.util.AnnotationUtil;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.security.auth.Subject;
+
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.admin.AdminCommand;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.AdminCommandEventBroker;
+import org.glassfish.api.admin.AdminCommandState;
+import org.glassfish.api.admin.CommandParameters;
+import org.glassfish.api.admin.CommandRunner;
+import org.glassfish.api.admin.CommandSupport;
+import org.glassfish.api.admin.Job;
+import org.glassfish.api.admin.JobCreator;
+import org.glassfish.api.admin.JobManager;
+import org.glassfish.api.admin.ManagedJob;
+import org.glassfish.api.admin.ParameterMap;
+import org.glassfish.api.admin.Payload;
+import org.glassfish.api.admin.ProgressStatus;
+
+/*
+ * Some private classes used in the implementation of CommandRunner.
+ */
+/**
+ * ExecutionContext is a CommandInvocation, which
+ * defines a command excecution context like the requested
+ * name of the command to execute, the parameters of the command, etc.
+ */
+class CommandRunnerExecutionContext implements CommandRunner.CommandInvocation {
+
+    private final CommandRunnerImpl commandRunner;
+    private static final Logger LOGGER = Logger.getLogger(CommandRunnerExecutionContext.class.getName());
+
+    CommandRunnerExecutionContext(String scope, String name, ActionReport report, Subject subject, boolean isNotify, final CommandRunnerImpl commandRunner) {
+        this.commandRunner = commandRunner;
+        this.scope = scope;
+        this.name = name;
+        this.report = report;
+        this.subject = subject;
+        this.isNotify = isNotify;
+    }
+
+    private class NameListerPair {
+
+        private final String nameRegexp;
+        private final AdminCommandEventBroker.AdminCommandListener listener;
+
+        public NameListerPair(String nameRegexp, AdminCommandEventBroker.AdminCommandListener listener) {
+            this.nameRegexp = nameRegexp;
+            this.listener = listener;
+        }
+    }
+    protected String scope;
+    protected String name;
+    protected ActionReport report;
+    protected ParameterMap params;
+    protected CommandParameters paramObject;
+    protected Payload.Inbound inbound;
+    protected Payload.Outbound outbound;
+    protected Subject subject;
+    protected ProgressStatus progressStatusChild;
+    protected boolean isManagedJob;
+    protected boolean isNotify;
+    private final List<NameListerPair> nameListerPairs = new ArrayList<>();
+
+    @Override
+    public CommandRunner.CommandInvocation parameters(CommandParameters paramObject) {
+        this.paramObject = paramObject;
+        return this;
+    }
+
+    @Override
+    public CommandRunner.CommandInvocation parameters(ParameterMap params) {
+        this.params = params;
+        return this;
+    }
+
+    @Override
+    public CommandRunner.CommandInvocation inbound(Payload.Inbound inbound) {
+        this.inbound = inbound;
+        return this;
+    }
+
+    @Override
+    public CommandRunner.CommandInvocation outbound(Payload.Outbound outbound) {
+        this.outbound = outbound;
+        return this;
+    }
+
+    @Override
+    public CommandRunner.CommandInvocation listener(String nameRegexp, AdminCommandEventBroker.AdminCommandListener listener) {
+        nameListerPairs.add(new NameListerPair(nameRegexp, listener));
+        return this;
+    }
+
+    @Override
+    public CommandRunner.CommandInvocation progressStatusChild(ProgressStatus ps) {
+        this.progressStatusChild = ps;
+        return this;
+    }
+
+    @Override
+    public CommandRunner.CommandInvocation managedJob() {
+        this.isManagedJob = true;
+        return this;
+    }
+
+    @Override
+    public void execute() {
+        execute(null);
+    }
+
+    ParameterMap parameters() {
+        return params;
+    }
+
+    CommandParameters typedParams() {
+        return paramObject;
+    }
+
+    String name() {
+        return name;
+    }
+
+    private String scope() {
+        return scope;
+    }
+
+    @Override
+    public ActionReport report() {
+        return report;
+    }
+
+    void setReport(ActionReport ar) {
+        report = ar;
+    }
+
+    Payload.Inbound inboundPayload() {
+        return inbound;
+    }
+
+    Payload.Outbound outboundPayload() {
+        return outbound;
+    }
+
+    void executeFromCheckpoint(JobManager.Checkpoint checkpoint, boolean revert, AdminCommandEventBroker eventBroker) {
+        Job job = checkpoint.getJob();
+        if (subject == null) {
+            subject = checkpoint.getContext().getSubject();
+        }
+        parameters(job.getParameters());
+        AdminCommandContext context = checkpoint.getContext();
+        this.report = context.getActionReport();
+        this.inbound = context.getInboundPayload();
+        this.outbound = context.getOutboundPayload();
+        this.scope = job.getScope();
+        this.name = job.getName();
+        if (eventBroker == null) {
+            eventBroker = job.getEventBroker() == null ? new AdminCommandEventBrokerImpl() : job.getEventBroker();
+        }
+        ((AdminCommandInstanceImpl) job).setEventBroker(eventBroker);
+        ((AdminCommandInstanceImpl) job).setState(revert ? AdminCommandState.State.REVERTING : AdminCommandState.State.RUNNING_RETRYABLE);
+        JobManager jobManager = commandRunner.serviceLocator.getService(JobManagerService.class);
+        jobManager.registerJob(job);
+        //command
+        AdminCommand command = checkpoint.getCommand();
+        if (command == null) {
+            command = commandRunner.getCommand(job.getScope(), job.getName(), report(), LOGGER);
+            if (command == null) {
+                return;
+            }
+        }
+        //execute
+        commandRunner.doCommand(this, command, subject, job);
+        job.complete(report(), outboundPayload());
+        if (progressStatusChild != null) {
+            progressStatusChild.complete();
+        }
+        CommandSupport.done(commandRunner.serviceLocator, command, job);
+    }
+
+    @Override
+    public void execute(AdminCommand command) {
+        if (command == null) {
+            command = commandRunner.getCommand(scope(), name(), report(), LOGGER);
+            if (command == null) {
+                return;
+            }
+        }
+        /*
+         * The caller should have set the subject explicitly.  In case
+         * it didn't, try setting it from the current access controller context
+         * since the command framework will have set that before invoking
+         * the original command's execute method.
+         */
+        if (subject == null) {
+            subject = AccessController.doPrivileged(new PrivilegedAction<Subject>() {
+                @Override
+                public Subject run() {
+                    return Subject.getSubject(AccessController.getContext());
+                }
+            });
+        }
+        if (!isManagedJob) {
+            isManagedJob = AnnotationUtil.presentTransitive(ManagedJob.class, command.getClass());
+        }
+        JobCreator jobCreator = null;
+        JobManager jobManager = null;
+        jobCreator = commandRunner.serviceLocator.getService(JobCreator.class, scope + "job-creator");
+        jobManager = commandRunner.serviceLocator.getService(JobManagerService.class);
+        if (jobCreator == null) {
+            jobCreator = commandRunner.serviceLocator.getService(JobCreatorService.class);
+        }
+        Job job = null;
+        if (isManagedJob) {
+            job = jobCreator.createJob(jobManager.getNewId(), scope(), name(), subject, isManagedJob, parameters());
+        } else {
+            job = jobCreator.createJob(null, scope(), name(), subject, isManagedJob, parameters());
+        }
+        //Register the brokers  else the detach functionality will not work
+        for (NameListerPair nameListerPair : nameListerPairs) {
+            job.getEventBroker().registerListener(nameListerPair.nameRegexp, nameListerPair.listener);
+        }
+        if (isManagedJob) {
+            jobManager.registerJob(job);
+        }
+        commandRunner.doCommand(this, command, subject, job);
+        job.complete(report(), outboundPayload());
+        if (progressStatusChild != null) {
+            progressStatusChild.complete();
+        }
+        CommandSupport.done(commandRunner.serviceLocator, command, job, isNotify);
+    }
+
+}

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
@@ -17,7 +17,6 @@
 
 package com.sun.enterprise.v3.admin;
 
-import com.sun.enterprise.admin.event.AdminCommandEventBrokerImpl;
 import com.sun.enterprise.admin.util.CachedCommandModel;
 import com.sun.enterprise.admin.util.ClusterOperationUtil;
 import com.sun.enterprise.admin.util.CommandSecurityChecker;
@@ -26,7 +25,6 @@ import com.sun.enterprise.config.serverbeans.Cluster;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.universal.collections.ManifestUtils;
 import com.sun.enterprise.universal.glassfish.AdminCommandResponse;
-import com.sun.enterprise.util.AnnotationUtil;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.StringUtils;
 import com.sun.enterprise.v3.common.XMLContentActionReporter;
@@ -63,6 +61,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -78,7 +77,6 @@ import org.glassfish.api.admin.AdminCommand;
 import org.glassfish.api.admin.AdminCommandContext;
 import org.glassfish.api.admin.AdminCommandContextImpl;
 import org.glassfish.api.admin.AdminCommandEventBroker;
-import org.glassfish.api.admin.AdminCommandEventBroker.AdminCommandListener;
 import org.glassfish.api.admin.AdminCommandLock;
 import org.glassfish.api.admin.AdminCommandLockException;
 import org.glassfish.api.admin.AdminCommandLockTimeoutException;
@@ -91,13 +89,10 @@ import org.glassfish.api.admin.CommandRunner;
 import org.glassfish.api.admin.CommandSupport;
 import org.glassfish.api.admin.FailurePolicy;
 import org.glassfish.api.admin.Job;
-import org.glassfish.api.admin.JobCreator;
 import org.glassfish.api.admin.JobManager;
-import org.glassfish.api.admin.ManagedJob;
 import org.glassfish.api.admin.ParameterMap;
 import org.glassfish.api.admin.Payload;
 import org.glassfish.api.admin.ProcessEnvironment;
-import org.glassfish.api.admin.ProgressStatus;
 import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.api.admin.Supplemental;
@@ -154,7 +149,7 @@ public class CommandRunnerImpl implements CommandRunner {
     private static final InjectionManager injectionMgr = new InjectionManager();
 
     @Inject
-    private ServiceLocator serviceLocator;
+    ServiceLocator serviceLocator;
 
     @Inject
     private ServerContext serverContext;
@@ -393,7 +388,7 @@ public class CommandRunnerImpl implements CommandRunner {
     @Override
     public CommandInvocation getCommandInvocation(String scope, String name, ActionReport report, Subject subject,
         boolean isNotify) {
-        return new ExecutionContext(scope, name, report, subject, isNotify);
+        return new CommandRunnerExecutionContext(scope, name, report, subject, isNotify, this);
     }
 
 
@@ -1132,7 +1127,7 @@ public class CommandRunnerImpl implements CommandRunner {
     /**
      * Called from ExecutionContext.execute.
      */
-    private void doCommand(ExecutionContext inv, AdminCommand command,
+    void doCommand(CommandRunnerExecutionContext inv, AdminCommand command,
             final Subject subject, final Job job) {
 
         publishCommandInvokedEvent(inv, subject);
@@ -1636,248 +1631,20 @@ public class CommandRunnerImpl implements CommandRunner {
     }
 
     public void executeFromCheckpoint(JobManager.Checkpoint checkpoint, boolean revert, AdminCommandEventBroker eventBroker) {
-        ExecutionContext ec = new ExecutionContext(null, null, null, null,false);
+        CommandRunnerExecutionContext ec = new CommandRunnerExecutionContext(null, null, null, null,false, this);
         ec.executeFromCheckpoint(checkpoint, revert, eventBroker);
     }
 
-    private void publishCommandInvokedEvent(ExecutionContext invocation, Subject subject) {
+    private void publishCommandInvokedEvent(CommandRunnerExecutionContext invocation, Subject subject) {
+        final ParameterMap parameters = Objects.requireNonNullElseGet(invocation.parameters(), ParameterMap::new);
+        final ParameterMap maskedMap = parameters.getMaskedMap(PASSWORD_ATTRIBUTE_NAMES);
         final CommandInvokedEvent event = new CommandInvokedEvent(
-                invocation.name(),
-                maskSecretParameters(invocation.parameters()),
+                invocation.name(), maskedMap,
                 subject);
         eventService.getCommandInvokedTopic()
                 .publish(event);
     }
 
-    private ParameterMap maskSecretParameters(ParameterMap parameters) {
-        final ParameterMap maskedParameters = new ParameterMap(parameters);
-        maskedParameters.entrySet().forEach(entry -> {
-            if (PASSWORD_ATTRIBUTE_NAMES.contains(entry.getKey())) {
-                entry.setValue(List.of("*******"));
-            }
-        });
-        return maskedParameters;
-    }
-
-    /*
-     * Some private classes used in the implementation of CommandRunner.
-     */
-    /**
-     * ExecutionContext is a CommandInvocation, which
-     * defines a command excecution context like the requested
-     * name of the command to execute, the parameters of the command, etc.
-     */
-    class ExecutionContext implements CommandInvocation {
-
-        private class NameListerPair {
-
-            private final String nameRegexp;
-            private final AdminCommandEventBroker.AdminCommandListener listener;
-
-            public NameListerPair(String nameRegexp, AdminCommandListener listener) {
-                this.nameRegexp = nameRegexp;
-                this.listener = listener;
-            }
-
-        }
-
-        protected String scope;
-        protected String name;
-        protected ActionReport report;
-        protected ParameterMap params;
-        protected CommandParameters paramObject;
-        protected Payload.Inbound inbound;
-        protected Payload.Outbound outbound;
-        protected Subject subject;
-        protected ProgressStatus progressStatusChild;
-        protected boolean isManagedJob;
-        protected boolean isNotify;
-        private final   List<NameListerPair> nameListerPairs = new ArrayList<>();
-
-        private ExecutionContext(String scope, String name, ActionReport report, Subject subject, boolean isNotify) {
-            this.scope = scope;
-            this.name = name;
-            this.report = report;
-            this.subject = subject;
-            this.isNotify = isNotify;
-        }
-
-        @Override
-        public CommandInvocation parameters(CommandParameters paramObject) {
-            this.paramObject = paramObject;
-            return this;
-        }
-
-        @Override
-        public CommandInvocation parameters(ParameterMap params) {
-            this.params = params;
-            return this;
-        }
-
-        @Override
-        public CommandInvocation inbound(Payload.Inbound inbound) {
-            this.inbound = inbound;
-            return this;
-        }
-
-        @Override
-        public CommandInvocation outbound(Payload.Outbound outbound) {
-            this.outbound = outbound;
-            return this;
-        }
-
-        @Override
-        public CommandInvocation listener(String nameRegexp, AdminCommandEventBroker.AdminCommandListener listener) {
-            nameListerPairs.add(new NameListerPair(nameRegexp, listener));
-            return this;
-        }
-
-        @Override
-        public CommandInvocation progressStatusChild(ProgressStatus ps) {
-            this.progressStatusChild = ps;
-            return this;
-        }
-
-        @Override
-        public CommandInvocation managedJob() {
-            this.isManagedJob = true;
-            return this;
-        }
-
-        @Override
-        public void execute() {
-            execute(null);
-        }
-
-        private ParameterMap parameters() {
-            return params;
-        }
-
-        private CommandParameters typedParams() {
-            return paramObject;
-        }
-
-        private String name() {
-            return name;
-        }
-
-        private String scope() {
-            return scope;
-        }
-
-        @Override
-        public ActionReport report() {
-            return report;
-        }
-
-        private void setReport(ActionReport ar) {
-            report = ar;
-        }
-
-        private Payload.Inbound inboundPayload() {
-            return inbound;
-        }
-
-        private Payload.Outbound outboundPayload() {
-            return outbound;
-        }
-
-        private void executeFromCheckpoint(JobManager.Checkpoint checkpoint, boolean revert, AdminCommandEventBroker eventBroker) {
-            Job job = checkpoint.getJob();
-            if (subject == null) {
-                subject = checkpoint.getContext().getSubject();
-            }
-            parameters(job.getParameters());
-            AdminCommandContext context = checkpoint.getContext();
-            this.report = context.getActionReport();
-            this.inbound = context.getInboundPayload();
-            this.outbound = context.getOutboundPayload();
-            this.scope = job.getScope();
-            this.name = job.getName();
-            if (eventBroker == null) {
-                eventBroker = job.getEventBroker() == null ? new AdminCommandEventBrokerImpl() : job.getEventBroker();
-            }
-            ((AdminCommandInstanceImpl) job).setEventBroker(eventBroker);
-            ((AdminCommandInstanceImpl) job).setState(revert ? AdminCommandState.State.REVERTING : AdminCommandState.State.RUNNING_RETRYABLE);
-            JobManager jobManager = serviceLocator.getService(JobManagerService.class);
-            jobManager.registerJob(job);
-            //command
-            AdminCommand command = checkpoint.getCommand();
-            if (command == null) {
-                command = getCommand(job.getScope(), job.getName(), report(), logger);
-                if (command == null) {
-                    return;
-                }
-            }
-            //execute
-            CommandRunnerImpl.this.doCommand(this, command, subject, job);
-            job.complete(report(), outboundPayload());
-            if (progressStatusChild != null) {
-                progressStatusChild.complete();
-            }
-            CommandSupport.done(serviceLocator, command, job);
-        }
-
-        @Override
-        public void execute(AdminCommand command) {
-            if (command == null) {
-                command = getCommand(scope(), name(), report(), logger);
-                if (command == null) {
-                    return;
-                }
-            }
-            /*
-             * The caller should have set the subject explicitly.  In case
-             * it didn't, try setting it from the current access controller context
-             * since the command framework will have set that before invoking
-             * the original command's execute method.
-             */
-            if (subject == null) {
-                subject = AccessController.doPrivileged(new PrivilegedAction<Subject>() {
-                    @Override
-                    public Subject run() {
-                        return Subject.getSubject(AccessController.getContext());
-                    }
-                });
-            }
-
-            if(!isManagedJob) {
-                isManagedJob = AnnotationUtil.presentTransitive(ManagedJob.class, command.getClass());
-            }
-            JobCreator jobCreator = null;
-            JobManager jobManager = null;
-
-            jobCreator = serviceLocator.getService(JobCreator.class,scope+"job-creator");
-            jobManager = serviceLocator.getService(JobManagerService.class);
-
-            if (jobCreator == null ) {
-                jobCreator = serviceLocator.getService(JobCreatorService.class);
-
-            }
-
-            Job job = null;
-            if (isManagedJob) {
-                job = jobCreator.createJob(jobManager.getNewId(), scope(), name(), subject, isManagedJob, parameters());
-            }  else {
-                job = jobCreator.createJob(null, scope(), name(), subject, isManagedJob, parameters());
-            }
-
-            //Register the brokers  else the detach functionality will not work
-            for (NameListerPair nameListerPair : nameListerPairs) {
-                job.getEventBroker().registerListener(nameListerPair.nameRegexp, nameListerPair.listener);
-            }
-
-            if (isManagedJob)  {
-                jobManager.registerJob(job);
-            }
-            CommandRunnerImpl.this.doCommand(this, command, subject, job);
-            job.complete(report(), outboundPayload());
-            if (progressStatusChild != null) {
-                progressStatusChild.complete();
-            }
-            CommandSupport.done(serviceLocator, command, job, isNotify);
-        }
-    }
 
     /**
      * An InjectionResolver that uses an Object as the source of

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/CommandRunnerImpl.java
@@ -129,6 +129,7 @@ import org.jvnet.hk2.config.UnsatisfiedDependencyException;
 
 import static com.sun.enterprise.util.Utility.isEmpty;
 import static java.util.logging.Level.SEVERE;
+import static org.glassfish.common.util.Constants.PASSWORD_ATTRIBUTE_NAMES;
 
 /**
  * Encapsulates the logic needed to execute a server-side command (for example,
@@ -1642,10 +1643,20 @@ public class CommandRunnerImpl implements CommandRunner {
     private void publishCommandInvokedEvent(ExecutionContext invocation, Subject subject) {
         final CommandInvokedEvent event = new CommandInvokedEvent(
                 invocation.name(),
-                invocation.parameters(),
+                maskSecretParameters(invocation.parameters()),
                 subject);
         eventService.getCommandInvokedTopic()
                 .publish(event);
+    }
+
+    private ParameterMap maskSecretParameters(ParameterMap parameters) {
+        final ParameterMap maskedParameters = new ParameterMap(parameters);
+        maskedParameters.entrySet().forEach(entry -> {
+            if (PASSWORD_ATTRIBUTE_NAMES.contains(entry.getKey())) {
+                entry.setValue(List.of("*******"));
+            }
+        });
+        return maskedParameters;
     }
 
     /*


### PR DESCRIPTION
This fixes a security issue in the Command Logger feature, which allowed to expose passwords used in some admin commands. This fix replaces passwords in the logged messages by "******".