### PR TITLE
Added basic develocity setup #25322

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,4 +26,6 @@ jobs:
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
       run: ./apache-maven-3.9.9/bin/mvn -B -e clean install -Pstaging -Pqa '-Dcheckstyle.skip=true'
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ appserver/tests/appserv-tests/temppwd
 
 opendj-*.zip
 /opendj/
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -8,7 +8,6 @@
   <projectId>glassfish</projectId>
   <buildScan>
     <obfuscation>
-      <username>#{'eclipse-' + env['EF_SHORT_NAME'] + '-bot'}</username>
       <ipAddresses>0.0.0.0</ipAddresses>
     </obfuscation>
     <publishing>
@@ -16,7 +15,7 @@
         <![CDATA[authenticated]]>
       </onlyIf>
     </publishing>
-    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+    <backgroundBuildScanUpload>#{isFalse(env['CI']) and isFalse(env['JENKINS_URL'])}</backgroundBuildScanUpload>
   </buildScan>
   <buildCache>
     <local>
@@ -24,7 +23,7 @@
     </local>
     <remote>
       <enabled>false</enabled>
-      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</storeEnabled>
     </remote>
   </buildCache>
 </develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>glassfish</projectId>
+  <buildScan>
+    <obfuscation>
+      <username>#{'eclipse-' + env['EF_SHORT_NAME'] + '-bot'}</username>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.23</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>2.0.1</version>
+  </extension>
+</extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
+def secrets = [
+  [path: 'cbi/glassfish/develocity.eclipse.org', secretValues: [
+    [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
+    ]
+  ]
+]
 
 def dumpSysInfo() {
   sh """
@@ -66,12 +72,14 @@ def generateAntPodTemplate(job) {
           timeout(time: 1, unit: 'HOURS') {
             withAnt(installation: 'apache-ant-latest') {
               dumpSysInfo()
-              sh """
-                mkdir -p ${WORKSPACE}/appserver/tests
-                tar -xzf ${WORKSPACE}/bundles/appserv_tests.tar.gz -C ${WORKSPACE}/appserver/tests
-                export CLASSPATH=${WORKSPACE}/glassfish7/javadb
-                ${WORKSPACE}/appserver/tests/gftest.sh run_test ${job}
-              """
+              withVault([vaultSecrets: secrets]) {
+                  sh """
+                    mkdir -p ${WORKSPACE}/appserver/tests
+                    tar -xzf ${WORKSPACE}/bundles/appserv_tests.tar.gz -C ${WORKSPACE}/appserver/tests
+                    export CLASSPATH=${WORKSPACE}/glassfish7/javadb
+                    ${WORKSPACE}/appserver/tests/gftest.sh run_test ${job}
+                  """
+              }
             }
           }
         } finally {
@@ -186,18 +194,20 @@ spec:
         checkout scm
         container('maven') {
           dumpSysInfo()
-          sh '''
-            # Validate the structure in all submodules (especially version ids)
-            mvn -B -e -fae clean validate -Ptck,set-version-id,staging
-            # Until we fix ANTLR in cmp-support-sqlstore, broken in parallel builds. Just -Pfast after the fix.
-            mvn -B -e install -Pfastest,staging -T4C
-            ./gfbuild.sh archive_bundles
-            ./gfbuild.sh archive_embedded
-            mvn -B -e clean -Pstaging
-            tar -c -C ${WORKSPACE}/appserver/tests common_test.sh gftest.sh appserv-tests quicklook | gzip --fast > ${WORKSPACE}/bundles/appserv_tests.tar.gz
-            ls -la ${WORKSPACE}/bundles
-            ls -la ${WORKSPACE}/embedded
-          '''
+          withVault([vaultSecrets: secrets]) {
+              sh '''
+                # Validate the structure in all submodules (especially version ids)
+                mvn -B -e -fae clean validate -Ptck,set-version-id,staging
+                # Until we fix ANTLR in cmp-support-sqlstore, broken in parallel builds. Just -Pfast after the fix.
+                mvn -B -e install -Pfastest,staging -T4C
+                ./gfbuild.sh archive_bundles
+                ./gfbuild.sh archive_embedded
+                mvn -B -e clean -Pstaging
+                tar -c -C ${WORKSPACE}/appserver/tests common_test.sh gftest.sh appserv-tests quicklook | gzip --fast > ${WORKSPACE}/bundles/appserv_tests.tar.gz
+                ls -la ${WORKSPACE}/bundles
+                ls -la ${WORKSPACE}/embedded
+              '''
+          }
         }
         archiveArtifacts artifacts: 'bundles/*.zip', onlyIfSuccessful: true
         archiveArtifacts artifacts: 'embedded/*', onlyIfSuccessful: true
@@ -210,9 +220,11 @@ spec:
         container('maven') {
           dumpSysInfo()
           timeout(time: 1, unit: 'HOURS') {
-            sh '''
-                mvn -B -e clean install -Pstaging,qa
-            '''
+            withVault([vaultSecrets: secrets]) {
+                sh '''
+                    mvn -B -e clean install -Pstaging,qa
+                '''
+            }
           }
         }
       }
@@ -245,9 +257,11 @@ spec:
         container('maven') {
           dumpSysInfo()
           timeout(time: 1, unit: 'HOURS') {
-            sh '''
-                mvn -B -e clean install -Pstaging -f docs -amd
-            '''
+            withVault([vaultSecrets: secrets]) {
+                sh '''
+                    mvn -B -e clean install -Pstaging -f docs -amd
+                '''
+            }
           }
         }
       }


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the [issue #25322](https://github.com/eclipse-ee4j/glassfish/issues/25322).

### Description
This PR publishes a build scan for every CI build (once CI credentials are created) and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Local and remote caching was left disabled on this PR by design so that the build is not affected by this change.

The build scans of the Eclipse Glassfish project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Glassfish project and all other Eclipse projects.

On this Develocity instance, Eclipse Glassfish will have access not only to all of the published build scans but also to other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. 

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). This is the first part of Develocity integration issue no. #25322. The second part, if you opt for it, would be to enable caching for the project.

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them. If your project is interested in being a part of this initiative, please reach out to Eclipse infra by filling out a [helpdesk ticket](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/new) to get the CI credentials.

Locally, you can authenticate by running `mvn develocity:provision-access-key`. More info available [here](https://docs.gradle.com/develocity/maven-extension/current/#automated_access_key_provisioning)