### PR TITLE
Fixed the wrong project id in Jenkinsfile. #25322

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
  */
 
 def secrets = [
-  [path: 'cbi/glassfish/develocity.eclipse.org', secretValues: [
+  [path: 'cbi/ee4j.glassfish/develocity.eclipse.org', secretValues: [
     [envVar: 'DEVELOCITY_ACCESS_KEY', vaultKey: 'api-token']
     ]
   ]


### PR DESCRIPTION
This fixed the wrong project id path when getting the secrets vault for Develocity API key. The correct project id is `ee4j.glassfish`. 

Additionally, to get scans publishing on CI (both Jenkins and GitHub Actions), a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [parent issue](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).