### PR TITLE
Added the volume mount to the custom Jenkins definition. #25322

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,6 +127,9 @@ spec:
       readOnly: true
     - name: maven-repo-local-storage
       mountPath: "/home/jenkins/.m2/repository/org/glassfish/main"
+    - mountPath: "/home/jenkins/.m2/.develocity"
+      name: "develocity-storage"
+      readOnly: false
     resources:
       limits:
         memory: "8Gi"
@@ -154,6 +157,9 @@ spec:
         path: settings-security.xml
   - name: maven-repo-local-storage
     emptyDir: {}
+  - emptyDir:
+      medium: ""
+    name: "develocity-storage"
 """
     }
   }


### PR DESCRIPTION
Added the volume mount to the custom Jenkins definition as described [here](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5546#note_2955955). This should fix the Jenkins runs where access was denied.

Related to issue #25322.