### PR TITLE
Declare back glassfish-jul-extension dependency

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -680,6 +680,14 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <!-- Cannot be in nucleus-parent, because it is built under it -->
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
- Given that as for hamcrest and JUnit, scope is managed already:
https://github.com/eclipse-ee4j/glassfish/blob/a4c576d0deeb41a577ac7ce127ba2758443535e4/nucleus/parent/pom.xml#L194-L200
this effectively reverts #25321 

- Closes #25339 