### PR TITLE
Reapply develocity

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,4 +26,6 @@ jobs:
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
       run: ./apache-maven-3.9.9/bin/mvn -B -e clean install -Pstaging -Pqa '-Dcheckstyle.skip=true'
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ appserver/tests/appserv-tests/temppwd
 
 opendj-*.zip
 /opendj/
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>glassfish</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI']) and isFalse(env['JENKINS_URL'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>1.23</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>2.0.1</version>
+  </extension>
+</extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,10 +60,10 @@ def antjobs = [
 ]
 
 def parallelStagesMap = antjobs.collectEntries {
-  ["${it}": generateAntPodTemplate(it)]
+  ["${it}": generateAntPodTemplate(it, secrets)]
 }
 
-def generateAntPodTemplate(job) {
+def generateAntPodTemplate(job, secrets) {
   return {
     node {
       stage("${job}") {


### PR DESCRIPTION
This PR reverts PR https://github.com/eclipse-ee4j/glassfish/pull/25335, which removed the Develocity configuration. It also includes a proposed [fix for ant jobs not starting due to groovy scoping](https://github.com/eclipse-ee4j/glassfish/pull/25342/commits/3169d8dcf1c541c13d51ba62446be609ad70462d). 

*Note*: If possible, please test the ant jobs fix before merging :) 

Relates to issue https://github.com/eclipse-ee4j/glassfish/issues/25322.
