### PR TITLE
Add Add-Opens and Add-Exports to GlassFish static shell.

### DIFF
--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -1381,6 +1381,8 @@
                             <Bundle-SymbolicName>org.glassfish.embedded.static-shell</Bundle-SymbolicName>
                             <Class-Path>${classpath.derby} ${classpath.bootstrap}</Class-Path>
                             <Main-Class>org.glassfish.runnablejar.UberMain</Main-Class>
+                            <Add-Opens>java.base/java.lang java.base/java.io java.base/java.util java.base/sun.nio.fs java.base/sun.net.www.protocol.jrt java.naming/javax.naming.spi java.rmi/sun.rmi.transport jdk.management/com.sun.management.internal java.base/jdk.internal.vm.annotation</Add-Opens>
+                            <Add-Exports>java.naming/com.sun.jndi.ldap java.base/jdk.internal.vm.annotation</Add-Exports>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
To make it compatible with newer Java versions.
Same as for GlassFish Embedded and in the GF JVM options.

This is applied when running the static shell JAR directly, from withing GlassFish Server installation, e.g.:

```
java -jar glassfish/lib/embedded/java/glassfish-embedded-static-shell.jar
```