### PR TITLE
Fix principal in Jakarta SecurityContext when using SSO

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates.
+ * Copyright (c) 2022, 2025 Eclipse Foundation and/or its affiliates.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,22 +27,35 @@ import java.net.PasswordAuthentication;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.security.KeyManagementException;
 import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
 import org.glassfish.admin.rest.client.ClientWrapper;
 import org.glassfish.main.itest.tools.asadmin.Asadmin;
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
 import org.glassfish.main.itest.tools.asadmin.StartServ;
 
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -73,6 +86,7 @@ public class GlassFishTestEnvironment {
 
     private static final int ASADMIN_START_DOMAIN_TIMEOUT = 30_000;
     private static final int ASADMIN_START_DOMAIN_TIMEOUT_FOR_DEBUG = 300_000;
+    private static HttpClient client = null;
 
     static {
         LOG.log(Level.INFO, "Using basedir: {0}", BASEDIR);
@@ -226,6 +240,26 @@ public class GlassFishTestEnvironment {
         connection.setConnectTimeout(100);
         connection.setRequestProperty("X-Requested-By", "JUnit5Test");
         return connection;
+    }
+
+    /**
+     * Creates a {@link HttpURLConnection} for the given port and context.
+     *
+     * @param secured true for https, false for http
+     * @param port
+     * @param context - part of the url behind the <code>http://localhost:[port]</code>
+     * @return a new disconnected {@link HttpURLConnection}.
+     * @throws IOException
+     */
+    public static HttpResponse<String> getHttpResource(final boolean secured, final int port, final String context)
+        throws Exception {
+        final String protocol = secured ? "https" : "http";
+        URI uri = URI.create(protocol + "://localhost:" + port + context);
+        final HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(15))
+                .header("X-Requested-By", "JUnit5Test")
+                .build();
+        return newInsecureHttpClient().send(request, ofString(StandardCharsets.UTF_8));
     }
 
     public static URI webSocketUri(final int port, final String context) throws URISyntaxException {
@@ -415,4 +449,37 @@ public class GlassFishTestEnvironment {
 
         void execute() throws IOException;
     }
+
+    private static HttpClient newInsecureHttpClient() throws KeyManagementException, NoSuchAlgorithmException {
+        if (client == null) {
+            // Java 17 doesn't allow to close http client, so we reuse a global one.
+            // Once we start using Java 21, client should be created for every call and returned instance should be closed
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustAllCerts, new SecureRandom());
+            client = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .connectTimeout(Duration.ofMillis(100))
+                    .build();
+        }
+        return client;
+    }
+
+    private static final TrustManager[] trustAllCerts = new TrustManager[]{
+        new X509TrustManager() {
+            @Override
+            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                return null;
+            }
+
+            @Override
+            public void checkClientTrusted(
+                    java.security.cert.X509Certificate[] certs, String authType) {
+            }
+
+            @Override
+            public void checkServerTrusted(
+                    java.security.cert.X509Certificate[] certs, String authType) {
+            }
+        }
+    };
 }

--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021, 2024 Contributors to the Eclipse Foundation.
+ * Copyright 2021, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
+++ b/appserver/security/webintegration/src/main/java/com/sun/web/security/RealmAdapter.java
@@ -440,14 +440,15 @@ public final class RealmAdapter extends RealmBase implements RealmInitializer, P
         LoginConfig config = context.getLoginConfig();
 
         if (isJakartaAuthenticationEnabled()) {
+            final SecurityContext securityContext = SecurityContext.getCurrent();
             // Jakarta Authentication is enabled for this application
             try {
                 context.fireContainerEvent(BEFORE_AUTHENTICATION, null);
                 RequestFacade requestFacade = (RequestFacade) request.getRequest();
-                SecurityContext.getCurrent().setSessionPrincipal(requestFacade.getRequestPrincipal());
+                securityContext.setSessionPrincipal(requestFacade.getRequestPrincipal());
                 return validate(request, response, config, authenticator, calledFromAuthenticate);
             } finally {
-                SecurityContext.getCurrent().setSessionPrincipal(null);
+                securityContext.setSessionPrincipal(null);
                 context.fireContainerEvent(AFTER_AUTHENTICATION, null);
             }
         }

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -109,6 +109,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <scope>provided</scope>
@@ -156,6 +161,12 @@
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>common-util</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.security</groupId>
+            <artifactId>security</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/CustomPrincipal.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/CustomPrincipal.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.security.jakartasecurity;
+
+import java.io.Serializable;
+import java.security.Principal;
+
+public class CustomPrincipal implements Principal, Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final String name;
+
+    public CustomPrincipal(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/CustomPrincipalServlet.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/CustomPrincipalServlet.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.security.jakartasecurity;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import static jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
+
+/**
+ * Test Servlet that authenticates the request and returns
+ * the class name of the caller principal
+ */
+@DeclareRoles("admin")
+@WebServlet("/customPrincipal")
+public class CustomPrincipalServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SecurityContext securityContext;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        securityContext.authenticate(request, response, withParams());
+
+        response.setContentType("text/plain");
+
+        final Principal callerPrincipal = securityContext.getCallerPrincipal();
+
+        response.getWriter().write(callerPrincipal.getClass().getName() + ",");
+        Principal applicationPrincipal = securityContext.getPrincipalsByType(CustomPrincipal.class)
+                .toArray(new CustomPrincipal[0])[0];
+
+        response.getWriter().write(applicationPrincipal.getClass().getName() + ": " + applicationPrincipal.getName());
+    }
+
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/SerializableCoreSecurityContextServlet.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/SerializableCoreSecurityContextServlet.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.security.jakartasecurity;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import static jakarta.security.enterprise.authentication.mechanism.http.AuthenticationParameters.withParams;
+
+/**
+ * Test Servlet that authenticates that authenticates the request and verifies that GlassFish SecurityContext can be serialized
+ */
+@DeclareRoles("admin")
+@WebServlet("/serializableCoreSecurityContext")
+public class SerializableCoreSecurityContextServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SecurityContext securityContext;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        securityContext.authenticate(request, response, withParams());
+
+        response.setContentType("text/plain");
+
+        final ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream());
+
+        try {
+        // verify internal core security context is serializable so that it can be used in SSO
+        oos.writeObject(com.sun.enterprise.security.SecurityContext.getCurrent());
+        } catch (Exception e) {
+            response.setStatus(500);
+            response.getWriter().write("Exception " + e);
+            return;
+        }
+
+        response.getWriter().write("OK");
+    }
+
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/TestAuthenticationMechanism.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/security/jakartasecurity/TestAuthenticationMechanism.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.security.jakartasecurity;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.AutoApplySession;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import static java.util.Collections.singleton;
+
+@ApplicationScoped
+@AutoApplySession
+public class TestAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthenticationException {
+
+        httpMessageContext.notifyContainerAboutLogin(
+            new CustomPrincipal("admin" + System.currentTimeMillis()),
+            singleton("admin"));
+
+        return AuthenticationStatus.SUCCESS;
+    }
+
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jakartasecurity/JakartaSecurityTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/jakartasecurity/JakartaSecurityTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.security.jakartasecurity;
+
+
+import java.io.File;
+import java.lang.System.Logger;
+import java.net.http.HttpResponse;
+
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.TestUtilities;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getHttpResource;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class JakartaSecurityTest {
+
+    private static final Logger LOG = System.getLogger(JakartaSecurityTest.class.getName());
+
+    private static final String APP_NAME = "jakarta-security";
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @TempDir
+    private static File tempDir;
+    private static File warFile;
+
+    @BeforeAll
+    public static void prepareDeployment() throws Exception {
+        final WebArchive webArchive = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+            .addPackage(CustomPrincipal.class.getPackage());
+        LOG.log(INFO, webArchive.toString(true));
+
+        warFile = new File(tempDir, APP_NAME + ".war");
+        webArchive.as(ZipExporter.class).exportTo(warFile, true);
+        assertThat(ASADMIN.exec("deploy", "--target", "server", warFile.getAbsolutePath()), asadminOK());
+    }
+
+    @AfterAll
+    public static void cleanup() throws Exception {
+        ASADMIN.exec("undeploy", APP_NAME);
+        TestUtilities.delete(warFile);
+    }
+
+    @Test
+    void testCustomPrincipal() throws Exception {
+        final HttpResponse<String> rootResponse = getHttpResource(false, 8080, "/" + APP_NAME + "/customPrincipal");
+        assertEquals(200, rootResponse.statusCode(), "Response status code");
+        assertTrue(rootResponse.body().contains(CustomPrincipal.class.getName()), "Response body: " + rootResponse.body());
+    }
+
+    @Test
+    void testSerializableCoreSecurityContext() throws Exception {
+        final HttpResponse<String> rootResponse = getHttpResource(false, 8080, "/" + APP_NAME + "/serializableCoreSecurityContext");
+        assertAll(
+            () -> assertEquals(200, rootResponse.statusCode(), "Response status code"),
+            () -> assertTrue(rootResponse.body().contains("OK"), "Response body: " + rootResponse.body())
+        );
+    }
+
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/simplemultirolemapping/SimpleMultiRoleMappingTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/security/simplemultirolemapping/SimpleMultiRoleMappingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023,2025 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,7 +64,6 @@ public class SimpleMultiRoleMappingTest {
     private static File tempDir;
     private static File earFile;
 
-
     @BeforeAll
     public static void prepareDeployment() throws Exception {
         createFileUser(FILE_REALM_NAME, USER_WEBUSER_NAME, USER_WEBUSER_PASSWORD, "webusers");
@@ -91,7 +90,6 @@ public class SimpleMultiRoleMappingTest {
         assertThat(ASADMIN.exec("deploy", "--target", "server", earFile.getAbsolutePath()), asadminOK());
     }
 
-
     @AfterAll
     public static void cleanup() throws Exception {
         ASADMIN.exec("undeploy", APP_NAME);
@@ -100,20 +98,17 @@ public class SimpleMultiRoleMappingTest {
         TestUtilities.delete(earFile);
     }
 
-
     @Test
     void ejb() throws Exception {
         String bobby = getContent("ejb", USER_BOBBY_NAME, USER_BOBBY_PASSWORD);
         assertThat(bobby, stringContainsInOrder("Servlet EjbTest", "Hello from ejb"));
     }
 
-
     @Test
     void web() throws Exception {
         String webtest = getContent("web", USER_WEBUSER_NAME, USER_WEBUSER_PASSWORD);
         assertThat(webtest, stringContainsInOrder("Servlet WebTest", "<h2>Ok</h2>"));
     }
-
 
     private String getContent(String relativePath, String user, String password) throws IOException {
         HttpURLConnection connection = prepareConnection(relativePath, user, password);
@@ -124,7 +119,6 @@ public class SimpleMultiRoleMappingTest {
             connection.disconnect();
         }
     }
-
 
     private HttpURLConnection prepareConnection(String relativePath, String user, String password) throws IOException {
         HttpURLConnection connection = openConnection(8080, "/" + APP_NAME + "/" + relativePath);

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -66,14 +66,14 @@ public class SecurityContext extends AbstractSecurityContext {
 
     private static final long serialVersionUID = 1L;
     private static final Logger _logger = SecurityLoggerInfo.getLogger();
+    // sessionPrincipal is static because it's a thread local, which isn't serializable,
+    // and we need at most one instance per thread
+    private static final ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
 
     private static InheritableThreadLocal<SecurityContext> currentSecurityContext = new InheritableThreadLocal<>();
     private static SecurityContext defaultSecurityContext = generateDefaultSecurityContext();
 
     private static AuthPermission doAsPrivilegedPerm = new AuthPermission("doAsPrivileged");
-
-    // this is static because it's a thread local, which isn't serializable
-    private static ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
 
     // Did the client log in as or did the server generate the context
     private boolean serverGeneratedSecurityContext;

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityContext.java
@@ -72,10 +72,11 @@ public class SecurityContext extends AbstractSecurityContext {
 
     private static AuthPermission doAsPrivilegedPerm = new AuthPermission("doAsPrivileged");
 
+    // this is static because it's a thread local, which isn't serializable
+    private static ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
+
     // Did the client log in as or did the server generate the context
     private boolean serverGeneratedSecurityContext;
-
-    private final ThreadLocal<Principal> sessionPrincipal = new ThreadLocal<>();
 
     /*
      * This creates a new SecurityContext object. Note: that the docs for Subject state that the internal sets (eg. the


### PR DESCRIPTION
WebPrincipal was not serializable because of this fix: https://github.com/eclipse-ee4j/glassfish/pull/25290, which caused exceptions in SSO mechanism, like this:

```
java.lang.IllegalStateException: java.io.NotSerializableException: java.lang.ThreadLocal
	at org.glassfish.web.ha.authenticator.HASingleSignOnEntry.convertToByteArray(HASingleSignOnEntry.java:167)
...
Caused by: java.io.NotSerializableException: java.lang.ThreadLocal
...
	at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:358)
	at org.glassfish.web.ha.authenticator.HASingleSignOnEntry.convertToByteArray(HASingleSignOnEntry.java:163)
	... 33 more
```

This PR moves the thread local variable to the static context so that it's not serialized together with securityContext instance. The value is only relevant within a scope of a specific request, and thus within a specific thread, so it doesn't have to be attached to a specific security context instance.