### PR TITLE
Using CORBA+ORB+PFL to be compatible with JDK11 - 23

### DIFF
--- a/appserver/connectors/connectors-runtime/pom.xml
+++ b/appserver/connectors/connectors-runtime/pom.xml
@@ -151,7 +151,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.interceptor</groupId>

--- a/appserver/connectors/work-management/pom.xml
+++ b/appserver/connectors/work-management/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>
@@ -97,7 +97,7 @@
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
-        
+
         <dependency>
             <groupId>org.glassfish.epicyro</groupId>
             <artifactId>epicyro</artifactId>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -904,6 +904,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal-api-only</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/extras/embedded/nucleus/pom.xml
+++ b/appserver/extras/embedded/nucleus/pom.xml
@@ -202,6 +202,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal-api-only</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -806,6 +806,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal-api-only</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -219,6 +219,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal-api-only</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/pom.xml
@@ -55,9 +55,9 @@
       </dependency>
       <dependency>
           <groupId>org.glassfish.gmbal</groupId>
-          <artifactId>gmbal</artifactId>
+          <artifactId>gmbal-api-only</artifactId>
       </dependency>
-      
+
       <dependency>
           <groupId>org.junit.jupiter</groupId>
           <artifactId>junit-jupiter-engine</artifactId>

--- a/appserver/orb/orb-connector/pom.xml
+++ b/appserver/orb/orb-connector/pom.xml
@@ -112,7 +112,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>

--- a/appserver/security/core-ee/pom.xml
+++ b/appserver/security/core-ee/pom.xml
@@ -153,7 +153,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
 
         <dependency>

--- a/appserver/security/webintegration/pom.xml
+++ b/appserver/security/webintegration/pom.xml
@@ -116,7 +116,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.epicyro</groupId>

--- a/appserver/transaction/jta/pom.xml
+++ b/appserver/transaction/jta/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
 
         <dependency>

--- a/appserver/web/admin/pom.xml
+++ b/appserver/web/admin/pom.xml
@@ -117,7 +117,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/nucleus/admin/monitor/pom.xml
+++ b/nucleus/admin/monitor/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.annotations</groupId>

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -157,7 +157,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.annotations</groupId>

--- a/nucleus/deployment/common/pom.xml
+++ b/nucleus/deployment/common/pom.xml
@@ -88,7 +88,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/nucleus/featuresets/atomic/pom.xml
+++ b/nucleus/featuresets/atomic/pom.xml
@@ -574,6 +574,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.gmbal</groupId>
+            <artifactId>gmbal-api-only</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>internal-api</artifactId>
             <version>${project.version}</version>

--- a/nucleus/grizzly/nucleus-grizzly-all/pom.xml
+++ b/nucleus/grizzly/nucleus-grizzly-all/pom.xml
@@ -75,11 +75,6 @@
             <artifactId>grizzly-config</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -121,12 +121,14 @@
 
         <!-- GlassFish Components -->
 
-        <glassfish-corba.version>4.2.5</glassfish-corba.version>
         <grizzly.version>4.0.2</grizzly.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
-        <glassfish-management-api.version>3.2.3</glassfish-management-api.version>
-        <pfl.version>4.1.2</pfl.version>
-        <gmbal.version>4.0.3</gmbal.version>
+
+        <glassfish-corba.version>5.0.0</glassfish-corba.version>
+        <glassfish-management-api.version>3.3.0</glassfish-management-api.version>
+        <gmbal.version>4.1.0</gmbal.version>
+        <pfl.version>5.1.0</pfl.version>
+
         <shoal.version>3.1.0</shoal.version>
         <ha-api.version>3.1.13</ha-api.version>
         <logging-annotation-processor.version>1.10</logging-annotation-processor.version>
@@ -446,6 +448,11 @@
             <dependency>
                 <groupId>org.glassfish.gmbal</groupId>
                 <artifactId>gmbal</artifactId>
+                <version>${gmbal.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.gmbal</groupId>
+                <artifactId>gmbal-api-only</artifactId>
                 <version>${gmbal.version}</version>
             </dependency>
             <dependency>

--- a/nucleus/security/core/pom.xml
+++ b/nucleus/security/core/pom.xml
@@ -92,7 +92,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.gmbal</groupId>
-            <artifactId>gmbal</artifactId>
+            <artifactId>gmbal-api-only</artifactId>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>


### PR DESCRIPTION
### Basic problem

* Usage of Unsafe methods which don't exist in later Java versions.
* With the absence of JPMS behavior of proxies changes with every Java version
* JPMS enforces clean API without overlapping packages, so I had to fix some issues in dependencies.

### Prerequisities

* https://github.com/eclipse-ee4j/orb-gmbal-commons
  * https://github.com/eclipse-ee4j/orb-gmbal-commons/pull/45
* https://github.com/eclipse-ee4j/orb-gmbal-pfl
  * https://github.com/eclipse-ee4j/orb-gmbal-pfl/pull/61
  * https://github.com/eclipse-ee4j/orb-gmbal-pfl/pull
* https://github.com/eclipse-ee4j/orb-gmbal
  * https://github.com/eclipse-ee4j/orb-gmbal/pull/33
  * https://github.com/eclipse-ee4j/orb-gmbal/pull/34
* https://github.com/eclipse-ee4j/orb
  * https://github.com/eclipse-ee4j/orb/issues/188
  * https://github.com/eclipse-ee4j/orb/pull/198

* Released dependencies:
  * https://github.com/eclipse-ee4j/orb-gmbal-commons/pull/61
  * https://github.com/eclipse-ee4j/orb-gmbal-pfl/pull/92
  * https://github.com/eclipse-ee4j/orb-gmbal/pull/54
  * https://github.com/eclipse-ee4j/orb/pull/221

### Notes

* Testing passed 2025-02-09 (all GF tests + all TCK 10 tests with jdk17, some also with 21 and 11), now we have to review+merge those PRs and release all dependencies.
* Originally intended for GlassFish8 (see #25110 ), however when we discussed that with @arjantijms we came to a conclusion that it should be possible to create such PR directly for GlassFish7.
* TCK passed with JDK11: https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/10.0.x/
