### PR TITLE
Ensure order of logged messages, fix a few flaky tests

### DIFF
--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLogManagerLifeCycleTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/GlassFishLogManagerLifeCycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,8 @@ package org.glassfish.main.jul;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -71,6 +73,7 @@ public class GlassFishLogManagerLifeCycleTest {
     private static GlassFishLogManagerConfiguration originalCfg;
     private static boolean originalLevelResolution;
     private static CompletableFuture<Void> process;
+    private ExecutorService sequentialExecutor = Executors.newSingleThreadExecutor();
 
     @BeforeAll
     public static void backupConfiguration() {
@@ -133,6 +136,7 @@ public class GlassFishLogManagerLifeCycleTest {
             () -> assertEquals(GlassFishLoggingStatus.CONFIGURING, MANAGER.getLoggingStatus()),
             () -> assertNull(COLLECTOR.pop(), "COLLECTOR should be empty after reconfiguration started"));
         doLog(Level.INFO, "Log after reconfiguration started", 0);
+        Thread.sleep(10L);
         assertNull(COLLECTOR.pop(), "COLLECTOR should be empty after reconfiguration started even if we log again");
     }
 
@@ -269,7 +273,7 @@ public class GlassFishLogManagerLifeCycleTest {
      * @throws Exception
      */
     private void doLog(final Level level, final String message, final int sleepMillis) throws Exception {
-        new Thread(() -> LOG.log(level, message)).start();
+        sequentialExecutor.submit(() -> LOG.log(level, message));
         if (sleepMillis > 0) {
             Thread.sleep(sleepMillis);
         }

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@ package org.glassfish.main.jul.handler;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -134,12 +135,14 @@ public class GlassFishLogHandlerTest {
     public void roll() throws Exception {
         assertTrue(handler.isReady(), "handler.ready");
         handler.publish(new GlassFishLogRecord(Level.SEVERE, "File one, record one", false));
+        final File logFile = handler.getConfiguration().getLogFile();
         // pump is now to play
         Thread.sleep(MILLIS_FOR_PUMP);
+        final List<String> fileLines1 = Files.readAllLines(logFile.toPath());
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
-            () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file one exists"),
-            () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
+            () -> assertTrue(logFile.exists(), "file one exists"),
+            () -> assertThat("file content, filename=" + logFile + ", content=" + fileLines1 , fileLines1,
                 contains(
                     stringContainsInOrder("INFO", "main", "Tommy, can you hear me?"),
                     stringContainsInOrder("INFO", "main", "Some info message"),
@@ -152,10 +155,11 @@ public class GlassFishLogHandlerTest {
         handler.roll();
         // There will be an asynchronous thread.
         Thread.sleep(10L);
+        final List<String> fileLines2 = Files.readAllLines(logFile.toPath());
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
-            () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
-            () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
+            () -> assertTrue(logFile.exists(), "file exists"),
+            () -> assertThat("file content, filename=" + logFile + ", content=" + fileLines2 , fileLines2,
                 contains(
                     stringContainsInOrder("INFO", "Rolling the file ", ".log", "output was originally enabled: true"),
                     stringContainsInOrder("INFO", "Archiving file ", ".log", " to ", ".log_")
@@ -164,10 +168,11 @@ public class GlassFishLogHandlerTest {
         );
         handler.publish(new GlassFishLogRecord(Level.SEVERE, "File two, line two", false));
         Thread.sleep(MILLIS_FOR_PUMP);
+        final List<String> fileLines3 = Files.readAllLines(logFile.toPath());
         assertAll(
             () -> assertTrue(handler.isReady(), "handler.ready"),
-            () -> assertTrue(handler.getConfiguration().getLogFile().exists(), "file exists"),
-            () -> assertThat("file content", Files.readAllLines(handler.getConfiguration().getLogFile().toPath()),
+            () -> assertTrue(logFile.exists(), "file exists"),
+            () -> assertThat("file content, filename=" + logFile + ", content=" + fileLines3 , fileLines3,
                 contains(
                     stringContainsInOrder("INFO", "Rolling the file ", ".log", "output was originally enabled: true"),
                     stringContainsInOrder("INFO", "Archiving file ", ".log", " to ", ".log_"),
@@ -176,7 +181,6 @@ public class GlassFishLogHandlerTest {
             )
         );
     }
-
 
     @Test
     @Order(50)


### PR DESCRIPTION
Fixes #25349 
Fixes an issue that caused the `GlassFishLogHandlerTest.roll` test to fail sometimes - the messages produced when rolling log files could be logged in reversed order.

Fixes flaky `GlassFishLogManagerLifeCycleTest.reconfigureWithoutResolvingLevelsWithincompleteconfiguration` test, which produced log messages in undeterministic order but expected them in order. The fix is similar, but this time in the test, not in production code.