### PR TITLE
Updated TestContainers, fixed imports in some of TCK modules

### DIFF
--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/ArquillianBase.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/ArquillianBase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/ArquillianBase.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/ArquillianBase.java
@@ -16,11 +16,8 @@
 
 package org.glassfish.jaccApi.common;
 
-import static java.lang.Boolean.getBoolean;
-import static java.util.logging.Level.SEVERE;
-import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
-import static org.jsoup.Jsoup.parse;
-import static org.jsoup.parser.Parser.xmlParser;
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.WebClient;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,17 +26,20 @@ import java.util.logging.Logger;
 
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.WebClient;
+import static java.lang.Boolean.getBoolean;
+import static java.util.logging.Level.SEVERE;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.jsoup.Jsoup.parse;
+import static org.jsoup.parser.Parser.xmlParser;
 
 public class ArquillianBase {
 

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestAuthConfigProvider.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestAuthConfigProvider.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,9 +17,6 @@
 
 package org.glassfish.jaccApi.common;
 
-import java.util.Map;
-
-import javax.security.auth.callback.CallbackHandler;
 import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.config.AuthConfigFactory;
 import jakarta.security.auth.message.config.AuthConfigProvider;
@@ -26,6 +24,10 @@ import jakarta.security.auth.message.config.ClientAuthConfig;
 import jakarta.security.auth.message.config.ServerAuthConfig;
 import jakarta.security.auth.message.config.ServerAuthContext;
 import jakarta.security.auth.message.module.ServerAuthModule;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
 
 /**
  * This class functions as a kind of factory-factory for {@link ServerAuthConfig} instances, which are by themselves factories

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestServerAuthConfig.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestServerAuthConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,15 +17,16 @@
 
 package org.glassfish.jaccApi.common;
 
-import java.util.Map;
-
-import javax.security.auth.Subject;
-import javax.security.auth.callback.CallbackHandler;
 import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.MessageInfo;
 import jakarta.security.auth.message.config.ServerAuthConfig;
 import jakarta.security.auth.message.config.ServerAuthContext;
 import jakarta.security.auth.message.module.ServerAuthModule;
+
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
 
 /**
  * This class functions as a kind of factory for {@link ServerAuthContext} instances, which are delegates for the actual

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestServerAuthContext.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestServerAuthContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,16 +17,17 @@
 
 package org.glassfish.jaccApi.common;
 
-import java.util.Collections;
-
-import javax.security.auth.Subject;
-import javax.security.auth.callback.CallbackHandler;
 import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.AuthStatus;
 import jakarta.security.auth.message.MessageInfo;
 import jakarta.security.auth.message.ServerAuth;
 import jakarta.security.auth.message.config.ServerAuthContext;
 import jakarta.security.auth.message.module.ServerAuthModule;
+
+import java.util.Collections;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
 
 /**
  * The Server Authentication Context is an extra (required) indirection between the Application Server and the actual Server

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -39,13 +39,13 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
-                <version>1.20.3</version>
+                <version>1.20.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>1.20.3</version>
+                <version>1.20.4</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/lib/harness/EETest.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/lib/harness/EETest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +17,7 @@
 
 package com.sun.ts.lib.harness;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.util.TestUtil;
 
 import java.io.File;

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/lib/harness/ServiceEETest.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/lib/harness/ServiceEETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,6 +17,7 @@
 
 package com.sun.ts.lib.harness;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.common.vehicle.VehicleRunnable;
 import com.sun.ts.tests.common.vehicle.VehicleRunnerFactory;

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/EmptyVehicleRunner.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/EmptyVehicleRunner.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,6 +21,7 @@
 
 package com.sun.ts.tests.common.vehicle;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.harness.ServiceEETest;
 import com.sun.ts.lib.util.TestUtil;
 

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/VehicleRunnable.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/VehicleRunnable.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,6 +20,8 @@
  */
 
 package com.sun.ts.tests.common.vehicle;
+
+import com.sun.javatest.Status;
 
 import java.util.Properties;
 

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/ejbembed/EJBEmbedRunner.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/ejbembed/EJBEmbedRunner.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,6 +21,7 @@
 
 package com.sun.ts.tests.common.vehicle.ejbembed;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.common.vehicle.VehicleRunnable;
 import com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF;

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/ejbliteshare/EJBLiteSecuredWebVehicleRunner.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/ejbliteshare/EJBLiteSecuredWebVehicleRunner.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +17,7 @@
 
 package com.sun.ts.tests.common.vehicle.ejbliteshare;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.porting.TSURL;
 import com.sun.ts.lib.util.BASE64Encoder;
 import com.sun.ts.lib.util.TestUtil;

--- a/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/ejbliteshare/EJBLiteWebVehicleRunner.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/ejb_lite_basic/src/main/java/com/sun/ts/tests/common/vehicle/ejbliteshare/EJBLiteWebVehicleRunner.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,8 +18,10 @@
 /*
  * $Id$
  */
+
 package com.sun.ts.tests.common.vehicle.ejbliteshare;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.porting.TSURL;
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.common.vehicle.VehicleRunnable;

--- a/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,6 +15,7 @@
  */
 package com.sun.ts.run;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.harness.ExecTSTestCmd;
 
 import java.io.IOException;

--- a/appserver/tests/tck/expression_language/src/test/java/com/sun/ts/run/StandaloneRunnerITest.java
+++ b/appserver/tests/tck/expression_language/src/test/java/com/sun/ts/run/StandaloneRunnerITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,8 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+
 package com.sun.ts.run;
 
+import com.sun.javatest.Status;
 import com.sun.ts.lib.harness.ExecTSTestCmd;
 
 import java.io.IOException;

--- a/appserver/tests/tck/platform-tck-runner/pom.xml
+++ b/appserver/tests/tck/platform-tck-runner/pom.xml
@@ -76,6 +76,10 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>
@@ -87,6 +91,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* Imports were broken since https://github.com/eclipse-ee4j/glassfish/pull/25083 , concretely 27bf35bb2e3c1a9392156d419cdd3734723055f8
* Note: TCK doesn't run on my new machine for GlassFish versions 7.0.20 and older - issues with restarts.
