### PR TITLE
Issue #24805 Make ConnectionPool code more strict and do not return Enlisted resources

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceHandle.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/ResourceHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -106,7 +106,7 @@ public class ResourceHandle implements com.sun.appserv.connectors.internal.api.R
      * Other state fields like 'enlistmentSuspended', 'shareCount', 'usageCount', 'lastValidated' and others are directly
      * part of this class as a field.
      */
-    private ResourceState state = new ResourceState();
+    private final ResourceState state = new ResourceState();
 
     /**
      * Used by LocalTxConnectorAllocator to save a listener for the resource handle.
@@ -171,7 +171,7 @@ public class ResourceHandle implements com.sun.appserv.connectors.internal.api.R
 
     /**
      * The connectionErrorOccurred field is set to true when a connection was aborted, or a connection error occurred, or
-     * when a connection being closes is bad.<br>
+     * when a connection being closed is bad.<br>
      * Could also be seen as part of ResourceState.
      */
     private boolean connectionErrorOccurred;

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/AssocWithThreadResourcePool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/AssocWithThreadResourcePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -241,9 +241,8 @@ public class AssocWithThreadResourcePool extends ConnectionPool {
                 if (maxConnectionUsage_ > 0 && h.getUsageCount() >= maxConnectionUsage_) {
                     performMaxConnectionUsageOperation(h);
                 } else {
-
                     if (!((AssocWithThreadResourceHandle) h).isAssociated()) {
-                        dataStructure.returnResource(h);
+                        returnResourceToPool(h);
                     }
                     // update monitoring data
                     if (poolLifeCycleListener != null) {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -725,7 +725,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
      * to see if the connection to the database is still working.
      * <p>
      * If validation is required the resourceHandle last validated time is updated.
-     * 
+     *
      * @param resourceHandle Resource to be validated
      * @param resourceAllocator Allocator to validate the resource
      * @return boolean representing validation result

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -406,7 +406,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
      * @param resourceHandle Resource
      */
     protected void setResourceStateToFree(ResourceHandle resourceHandle) {
-        getResourceState(resourceHandle).setBusy(false);
+        resourceHandle.getResourceState().setBusy(false);
         leakDetector.stopConnectionLeakTracing(resourceHandle, this);
     }
 
@@ -419,7 +419,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
      * @param resourceHandle Resource
      */
     protected void setResourceStateToBusy(ResourceHandle resourceHandle) {
-        getResourceState(resourceHandle).setBusy(true);
+        resourceHandle.getResourceState().setBusy(true);
         leakDetector.startConnectionLeakTracing(resourceHandle, this);
     }
 
@@ -706,19 +706,26 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
     /**
      * To provide an unenlisted, valid, matched resource from pool.
      *
-     * @param resourceSpec the ResourceSpec used to locate the correct resource pool
-     * @param resourceAllocator ResourceAllocator
-     * @param transaction Transaction
+     * @param resourceSpec the ResourceSpec used to locate the correct resource pool, value is ignored
+     * @param resourceAllocator ResourceAllocator the allocator that can create a resource
+     * @param transaction Transaction optional transaction, value is ignored
      * @return ResourceHandle resource from pool
      * @throws PoolingException Exception while getting resource from pool
      */
     protected ResourceHandle getUnenlistedResource(ResourceSpec resourceSpec, ResourceAllocator resourceAllocator, Transaction transaction) throws PoolingException {
-        return getResourceFromPool(resourceAllocator, resourceSpec);
+        return getResourceFromPool(resourceAllocator);
     }
 
     /**
-     * Check whether the connection is valid
-     *
+     * Check whether the connection is valid.
+     * <p>
+     * This is a check that can be enabled in the pool that checks the given resourceHandle:<br>
+     * - "never" based on setting "is-connection-validation-required"<br>
+     * - "every X seconds" based on setting "validate-atmost-once-period-in-seconds"<br>
+     * to see if the connection to the database is still working.
+     * <p>
+     * If validation is required the resourceHandle last validated time is updated.
+     * 
      * @param resourceHandle Resource to be validated
      * @param resourceAllocator Allocator to validate the resource
      * @return boolean representing validation result
@@ -763,19 +770,23 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
      * check whether the connection retrieved from the pool matches with the request.
      *
      * @param resource Resource to be matched
-     * @param alloc ResourceAllocator used to match the connection
+     * @param resourceAllocator ResourceAllocator used to match the connection
      * @return boolean representing the match status of the connection
      */
-    protected boolean matchConnection(ResourceHandle resource, ResourceAllocator alloc) {
+    protected boolean matchConnection(ResourceHandle resource, ResourceAllocator resourceAllocator) {
         // TODO: Explain what matching is in detail.
         // TODO: Explain that if matchConnections is disabled in the connectionpool why 'true' is still returned and not false?!
         // Old documentation mentions: "match-connections / default: true / If true, enables connection matching. You
         // can set to false if connections are homogeneous." Jakarta documentation:
         // jakarta.resource.spi.ManagedConnectionFactory.matchManagedConnections(Set, Subject, ConnectionRequestInfo) mentions:
         // "criteria used for matching is specific to a resource adapter and is not prescribed by the Connector specification."
+        //
+        // com.sun.gjc.spi.ManagedConnectionFactoryImpl.matchManagedConnections(Set, Subject, ConnectionRequestInfo) implementation:
+        // matches on: ManagedConnectionFactory and if password is set also on password.
+        // It does NOT seem to match on the transaction itself.
         boolean matched = true;
         if (matchConnections) {
-            matched = alloc.matchConnection(resource);
+            matched = resourceAllocator.matchConnection(resource);
             if (poolLifeCycleListener != null) {
                 if (matched) {
                     poolLifeCycleListener.connectionMatched();
@@ -789,21 +800,25 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
     }
 
     /**
-     * return resource in free list. If none is found, try to scale up the pool/purge pool and <br>
+     * Return a free resource from the pool. If none is found, try to scale up the pool/purge pool and <br>
      * return a new resource. returns null if the pool new resources cannot be created. <br>
      *
-     * @param resourceAllocator ResourceAllocator
+     * @param resourceAllocator ResourceAllocator the resource allocator to be used for matching and to create the new
+     * resource if required
      * @param resourceSpec the ResourceSpec used to locate the correct resource pool
-     * @return ResourceHandle resource from pool
+     * @return ResourceHandle resource from pool, or null when no resource is available
      * @throws PoolingException if unable to create a new resource
      */
-    protected ResourceHandle getResourceFromPool(ResourceAllocator resourceAllocator, ResourceSpec resourceSpec) throws PoolingException {
+    protected ResourceHandle getResourceFromPool(ResourceAllocator resourceAllocator) throws PoolingException {
 
         // The order of serving a resource request
         // 1. free and enlisted in the same transaction
         // 2. free and unenlisted
         // Do NOT give out a connection that is
         // free and enlisted in a different transaction
+        //
+        // This comments seems to be copied from: getResourceFromTransaction, which performs those checks.
+        // This logic of rule 1 and 2 is not implemented in this method.
         ResourceHandle resourceFromPool = null;
 
         ResourceHandle resourceHandle;
@@ -813,38 +828,80 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
             getResourceFromPoolAndFreeResourceMethodsLock.lock();
             try {
                 while ((resourceHandle = dataStructure.getResource()) != null) {
+                    // Resource from the pool should never be busy before it is returned
+                    makeSureResourceIsNotBusy(resourceHandle);
+
+                    // If somehow the resource is marked as enlisted, skip this one.
+                    // This approach works around issue #24805 where an already enlisted resource is received from the pool.
+                    // Another approach could be to mark this situation as illegal by calling 'removeResource', it could prevent a resource
+                    // leak (where all resources in the pool end up as enlisted and are never returned), but could throw an exception in the
+                    // transaction code that is causing the enlisted resource to be enlisted while the resource is in this pool.
+                    if (resourceHandle.isEnlisted()) {
+                        // Resource is somehow still in use in some transaction. To be returned to the pool.
+                        freeResources.add(resourceHandle);
+                        continue;
+                    }
+
                     if (resourceHandle.hasConnectionErrorOccurred()) {
+                        // No failAllConnections logic here. Possible failAllConnections bug.
                         dataStructure.removeResource(resourceHandle);
                         continue;
                     }
 
+                    // The match implementation matches on: ManagedConnectionFactory and if password is set also on password.
+                    // It does NOT match on the transaction itself.
                     if (matchConnection(resourceHandle, resourceAllocator)) {
 
+                        // Check if the connection is valid. This also does NOT check the transaction.
                         boolean isValid = isConnectionValid(resourceHandle, resourceAllocator);
-                        if (resourceHandle.hasConnectionErrorOccurred() || !isValid) {
+
+                        if (!isValid) {
                             if (failAllConnections) {
-                                resourceFromPool = createSingleResourceAndAdjustPool(resourceAllocator, resourceSpec);
+                                // If a failAllConnections has happened, the pool has been flushed but
+                                // still an inValid resource is received. Get a fresh resource.
+                                resourceFromPool = createSingleResourceAndAdjustPool(resourceAllocator);
                                 // No need to match since the resource is created with the allocator of caller.
                                 break;
                             }
+                            // Ideally this removeResource is called before "if (failAllConnections) break",
+                            // because the createSingleResourceAndAdjustPool will also use dataStructure.getResource and will
+                            // block until one is available, if you remove it first there is less chance of running into
+                            // the pool max, as a small performance enhancement.
                             dataStructure.removeResource(resourceHandle);
                             // Resource is invalid, continue iteration.
                             continue;
                         }
+
+                        // Check if the resource is shareable.
+                        // "resourceHandle.isShareable()" returns "resourceAllocator.shareableWithinComponent()"
+                        // So this if could have been: if (resourceHandle.getResourceAllocator == resourceAllocator).
+                        // It probably should have been: if (resourceHandle.isShareable())
+                        // Possible bug: this equals is not testing 'shareable': it could be "false == false" or "true == true"
                         if (resourceHandle.isShareable() == resourceAllocator.shareableWithinComponent()) {
-                            // Got a matched, valid resource
+                            // Got a matched, "valid" resource, which is shareable.
+                            // Note: Rule "1. free and enlisted in the same transaction" is not tested in this method.
+                            // Note: Rule "2. free and unenlisted" is tested in this method.
                             resourceFromPool = resourceHandle;
                             break;
                         }
+
+                        // Matching, but not shareable. To be returned to the pool.
                         freeResources.add(resourceHandle);
                     } else {
+                        // Not matching. To be returned to the pool.
                         freeResources.add(resourceHandle);
                     }
                 }
             } finally {
                 // Return all unmatched, free resources
                 for (ResourceHandle freeResource : freeResources) {
-                    dataStructure.returnResource(freeResource);
+                    if (freeResource.isEnlisted()) {
+                        // Somehow a resource which is enlisted ended up back in the pool. Return it without validation and assume some
+                        // transaction that still enlists the resource will return the resource correctly to the pool.
+                        dataStructure.returnResource(freeResource);
+                    } else {
+                        returnResourceToPool(freeResource);
+                    }
                 }
                 freeResources.clear();
             }
@@ -856,11 +913,42 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
                 // Set state to Busy via resizePoolAndGetNewResource call
                 resourceFromPool = resizePoolAndGetNewResource(resourceAllocator);
             }
+
+            // Resource from the pool must be marked busy when it is returned from the pool
+            if (resourceHandle != null) {
+                makeSureResourceIsBusy(resourceHandle);
+            }
+
+            // TODO: This method is called getResourceFromPool, but it is only called from getUnenlistedResource
+            // So this method must be renamed to getUnenlistedResourceFromPool, and it MUST FORCE that an unenlisted
+            // resource is returned, like this:
+            if (resourceHandle != null) {
+                // Not expecting an enlisted resource to be returned from the pool
+                makeSureResourceIsNotEnlisted(resourceHandle);
+            }
         } finally {
             getResourceFromPoolAndFreeResourceMethodsLock.unlock();
         }
 
         return resourceFromPool;
+    }
+
+    private void makeSureResourceIsBusy(ResourceHandle resourceHandle) {
+        if (!resourceHandle.getResourceState().isBusy()) {
+            throw new IllegalStateException("Resource must be marked busy! handle: " + resourceHandle);
+        }
+    }
+
+    private void makeSureResourceIsNotBusy(ResourceHandle resourceHandle) {
+        if (resourceHandle.getResourceState().isBusy()) {
+            throw new IllegalStateException("Resource may not be marked busy! handle: " + resourceHandle);
+        }
+    }
+
+    protected void makeSureResourceIsNotEnlisted(ResourceHandle resourceHandle) {
+        if (resourceHandle.getResourceState().isEnlisted()) {
+            throw new IllegalStateException("Resource may not be marked enlisted! handle: " + resourceHandle);
+        }
     }
 
     /**
@@ -869,7 +957,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
      * resources, create new connections and serve the request.<br>
      *
      * @param resourceAllocator ResourceAllocator used to create new resources
-     * @return ResourceHandle newly created resource
+     * @return ResourceHandle newly created resource, or null when no resource is available
      * @throws PoolingException when not able to create resources
      */
     private ResourceHandle resizePoolAndGetNewResource(ResourceAllocator resourceAllocator) throws PoolingException {
@@ -907,6 +995,14 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
             }
         }
 
+        if (newResource != null) {
+            // Just for clarity show that this new resource is busy.
+            makeSureResourceIsBusy(newResource);
+
+            // Just for clarity show that this new resource is not enlisted!
+            makeSureResourceIsNotEnlisted(newResource);
+        }
+
         return newResource;
     }
 
@@ -919,13 +1015,21 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
         try {
             ResourceHandle handle;
             while ((handle = dataStructure.getResource()) != null) {
-                if (matchConnection(handle, alloc)) {
-                    matchedResourceFromPool = handle;
-                    // TODO: ensure the state is not already isBusy here
-                    setResourceStateToBusy(matchedResourceFromPool);
+                // This approach works around issue #24805 where an already enlisted resource is received from the pool.
+                // Another approach could be to mark this situation as illegal by calling 'removeResource', it could prevent a resource
+                // leak (where all resources in the pool end up as enlisted and are never returned), but could throw an exception in the
+                // transaction code that is causing the enlisted resource to be enlisted while the resource is in this pool.
+                if (handle.isEnlisted()) {
+                    // Resource is somehow still in use in some transaction. To be returned to the pool.
+                } else {
+                    if (matchConnection(handle, alloc)) {
+                        matchedResourceFromPool = handle;
+                        // TODO: ensure the state is not already isBusy here
+                        setResourceStateToBusy(matchedResourceFromPool);
 
-                    // Break from the while loop and do not add the handle to the activeResources list.
-                    break;
+                        // Break from the while loop and do not add the handle to the activeResources list.
+                        break;
+                    }
                 }
                 activeResources.add(handle);
             }
@@ -966,25 +1070,39 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
     }
 
     /**
-     * This method will be called from the getUnenlistedResource method if we detect a failAllConnection flag. Here we
-     * simply create a new resource and replace a free resource in the pool by this resource and then give it out. This
-     * replacement is required since the steadypoolsize might equal maxpoolsize and in that case if we were not to remove a
-     * resource from the pool, our resource would be above maxPoolSize
+     * This method will be called from the getResourceFromPool method if failAllConnection flag is set and the current
+     * connection is not valid. Here we simply create a new resource and replace a free resource in the pool by this
+     * resource and then give it out. This replacement is required since the steadypoolsize might equal maxpoolsize and in
+     * that case if we were not to remove a resource from the pool, our resource would be above maxPoolSize
      *
      * @param resourceAllocator the resource allocator to be used to create the new resource
-     * @param resourceSpec the ResourceSpec used to locate the correct resource pool
      * @return newly created resource
      * @throws PoolingException when unable to create a resource
      */
-    protected ResourceHandle createSingleResourceAndAdjustPool(ResourceAllocator resourceAllocator, ResourceSpec resourceSpec) throws PoolingException {
-        // TODO document in getResource when a return value can be null
+    private ResourceHandle createSingleResourceAndAdjustPool(ResourceAllocator resourceAllocator) throws PoolingException {
+        // We are in the 'getResourceFromPool' while loop and already got a lock on an invalid handle.
+        // We are also inside the getResourceFromPoolAndFreeResourceMethodsLock.lock(); so no other thread is expected to
+        // be getting resources from the pool. Get a new handle from the pool, if we can get it, we can remove it.
         ResourceHandle handle = dataStructure.getResource();
+
+        // TODO document in getResource when a return value can be null
         if (handle != null) {
-            // TODO document why it is removed / add unit test to show the behavior described in the javadoc of the method
+            // A handle was received from the pool, remove it.
+
+            // Possible bugs:
+            // TODO: should resourceAllocator.destroyResource not be called?
+            // To stay in sync with the addResource call?
+            // TODO: should deleteResource not be called, that would make the
+            // resourceAllocator.destroyResource call AND update the statistics:
+            // poolLifeCycleListener.decrementConnectionUsed, like addResource(resourceAllocator); does
+            // TODO: write unit test to show if this logic in this method is correct or not.
             dataStructure.removeResource(handle);
         }
 
-        return getNewResource(resourceAllocator);
+        // We are still in the while loop with the inValid handle, and we were able to remove another handle.
+        // Now add a resource in the pool.
+        addResource(resourceAllocator);
+        return dataStructure.getResource();
     }
 
     /**
@@ -1083,7 +1201,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
     public void resourceClosed(ResourceHandle handle) throws IllegalStateException {
         LOG.log(FINE, "Resource was closed, processing handle: {0}", handle);
 
-        ResourceState state = getResourceState(handle);
+        ResourceState state = handle.getResourceState();
         if (state == null) {
             throw new IllegalStateException("State is null");
         }
@@ -1136,8 +1254,10 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
         }
     }
 
-    protected void freeUnenlistedResource(ResourceHandle h) {
-        freeResource(h);
+    protected void freeUnenlistedResource(ResourceHandle resourceHandle) {
+        // TODO: There is no validation here at all that the resourceHandle.state is already set to unenlisted
+        // TODO: If this method is called "free unenlisted resource", why is freeResource not called freeUnenlistedResource?
+        freeResource(resourceHandle);
     }
 
     protected void freeResource(ResourceHandle resourceHandle) {
@@ -1151,7 +1271,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
                     performMaxConnectionUsageOperation(resourceHandle);
                 } else {
                     // Put it back to the free collection.
-                    dataStructure.returnResource(resourceHandle);
+                    returnResourceToPool(resourceHandle);
                     // update the monitoring data
                     if (poolLifeCycleListener != null && !resourceHandle.getDestroyByLeakTimeOut()) {
                         poolLifeCycleListener.decrementConnectionUsed(resourceHandle.getId());
@@ -1165,6 +1285,16 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
         } finally {
             getResourceFromPoolAndFreeResourceMethodsLock.unlock();
         }
+    }
+
+    protected void returnResourceToPool(ResourceHandle resourceHandle) {
+        // Not expecting a busy resource to be returned to the pool
+        makeSureResourceIsNotBusy(resourceHandle);
+
+        // Not expecting an enlisted resource to be returned to the pool
+        makeSureResourceIsNotEnlisted(resourceHandle);
+
+        dataStructure.returnResource(resourceHandle);
     }
 
     /**
@@ -1197,7 +1327,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
             return;
         }
 
-        ResourceState state = getResourceState(resourceHandle);
+        ResourceState state = resourceHandle.getResourceState();
         // Normally a connection error is expected
         // to occur only when the connection is in use by the application.
         // When there is a connection validation involved, the connection
@@ -1349,16 +1479,6 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
         if (poolLifeCycleListener != null) {
             poolLifeCycleListener.connectionValidationFailed(1);
         }
-    }
-
-    // TODO: this method name should be createAndGetNewResource, but it is only used once, to it could be removed
-    private ResourceHandle getNewResource(ResourceAllocator alloc) throws PoolingException {
-        addResource(alloc);
-        return dataStructure.getResource();
-    }
-
-    private ResourceState getResourceState(ResourceHandle h) {
-        return h.getResourceState();
     }
 
     @Override

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructure.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/datastructure/DataStructure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -53,7 +53,9 @@ public interface DataStructure {
     int addResource(ResourceAllocator allocator, int count) throws PoolingException;
 
     /**
-     * get a resource from the datastructure
+     * get a 'free' resource from the datastructure<br>
+     * Note: the 'free' state of the ResourceHandle is not handled by the DataStructure implementation.
+     * Calling code needs to update the ResourceHandle.ResourceState.
      *
      * @return ResourceHandle
      */
@@ -67,7 +69,9 @@ public interface DataStructure {
     void removeResource(ResourceHandle resource);
 
     /**
-     * returns the resource to the datastructure
+     * returns the resource to the datastructure<br>
+     * Note: the 'free' state of the ResourceHandle is not handled by the DataStructure implementation.
+     * Calling code needs to update the ResourceHandle.ResourceState.
      *
      * @param resource ResourceHandle
      */

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/resizer/Resizer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/resizer/Resizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -156,20 +156,19 @@ public class Resizer extends TimerTask {
         int poolSizeBeforeRemoval = dataStructure.getResourcesSize();
         int noOfResourcesRemoved;
         // Find all Connections that are free/not-in-use
-        ResourceState state;
         int size = dataStructure.getFreeListSize();
         // let's cache the current time since precision is not required here.
         long currentTime = System.currentTimeMillis();
         int validConnectionsCounter = 0;
         int idleConnKeptInSteadyCounter = 0;
 
-        // iterate through all thre active resources to find idle-time lapsed ones.
+        // iterate through all the active resources to find idle-time lapsed ones.
         ResourceHandle h;
         Set<ResourceHandle> activeResources = new HashSet<>();
         Set<String> resourcesToValidate = new HashSet<>();
         try {
             while ((h = dataStructure.getResource()) != null) {
-                state = h.getResourceState();
+                ResourceState state = h.getResourceState();
                 if (currentTime - state.getTimestamp() < pool.getIdleTimeout()) {
                     // Should be added for validation.
                     validConnectionsCounter++;

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/PoolManagerImplTest.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/PoolManagerImplTest.java
@@ -27,22 +27,18 @@ import com.sun.enterprise.resource.allocator.ConnectorAllocator;
 import com.sun.enterprise.resource.allocator.LocalTxConnectorAllocator;
 import com.sun.enterprise.resource.allocator.NoTxConnectorAllocator;
 import com.sun.enterprise.resource.allocator.ResourceAllocator;
-import com.sun.enterprise.resource.pool.mock.JavaEETransactionManagerMock;
 import com.sun.enterprise.resource.pool.mock.JavaEETransactionMock;
+import com.sun.enterprise.resource.pool.mock.MyJavaEETransactionManager;
 import com.sun.enterprise.transaction.api.JavaEETransaction;
 import com.sun.enterprise.transaction.api.JavaEETransactionManager;
-import com.sun.enterprise.transaction.spi.TransactionalResource;
 
 import jakarta.resource.spi.ManagedConnection;
 import jakarta.resource.spi.ManagedConnectionFactory;
-import jakarta.transaction.SystemException;
-import jakarta.transaction.Transaction;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.glassfish.api.admin.ProcessEnvironment;
@@ -81,7 +77,7 @@ public class PoolManagerImplTest {
     private PoolManagerImpl poolManagerImpl = new MyPoolManagerImpl();
     private PoolInfo poolInfo = getPoolInfo();
     private JavaEETransaction javaEETransaction = new MyJavaEETransaction();
-    private MyJavaEETransactionManager javaEETransactionManager = new MyJavaEETransactionManager();
+    private MyJavaEETransactionManager javaEETransactionManager = new MyJavaEETransactionManager(javaEETransaction);
     private PoolType poolType;
 
     @BeforeEach
@@ -448,31 +444,6 @@ public class PoolManagerImplTest {
         public PoolType getPoolType(PoolInfo poolInfo) throws ConnectorRuntimeException {
             // Overriden to avoid ResourceNamingService jndi lookup calls in unit test
             return poolType;
-        }
-    }
-
-    // We cannot depend on the real JavaEETransactionManagerSimplified implementation due to dependency limitations
-    private class MyJavaEETransactionManager extends JavaEETransactionManagerMock {
-
-        Map<TransactionalResource, Boolean> delistIsCalled = new HashMap<>();
-
-        @Override
-        public Transaction getTransaction() throws SystemException {
-            // Assuming only 1 transaction used in each unit test, return it
-            return javaEETransaction;
-        }
-
-        @Override
-        public boolean delistResource(Transaction tran, TransactionalResource resource, int flag) throws IllegalStateException, SystemException {
-            // Store state for unit test validation
-            delistIsCalled.put(resource, Boolean.TRUE);
-
-            // Return delist success
-            return true;
-        }
-
-        public boolean isDelistIsCalled(TransactionalResource resource) {
-            return delistIsCalled.getOrDefault(resource, Boolean.FALSE);
         }
     }
 

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/mock/MyJavaEETransactionManager.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/pool/mock/MyJavaEETransactionManager.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.resource.pool.mock;
+
+import com.sun.enterprise.transaction.api.JavaEETransaction;
+import com.sun.enterprise.transaction.spi.TransactionalResource;
+
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * We cannot depend on the real JavaEETransactionManagerSimplified implementation due to dependency limitations
+ */
+public class MyJavaEETransactionManager extends JavaEETransactionManagerMock {
+
+    Map<TransactionalResource, Boolean> delistIsCalled = new HashMap<>();
+    private Transaction javaEETransaction;
+
+    public MyJavaEETransactionManager(JavaEETransaction javaEETransaction) {
+        this.javaEETransaction = javaEETransaction;
+    }
+
+    @Override
+    public Transaction getTransaction() throws SystemException {
+        // Assuming only 1 transaction used in each unit test, return it
+        return javaEETransaction;
+    }
+
+    @Override
+    public boolean delistResource(Transaction tran, TransactionalResource resource, int flag) throws IllegalStateException, SystemException {
+        // Store state for unit test validation
+        delistIsCalled.put(resource, Boolean.TRUE);
+
+        // Return delist success
+        return true;
+    }
+
+    public boolean isDelistIsCalled(TransactionalResource resource) {
+        return delistIsCalled.getOrDefault(resource, Boolean.FALSE);
+    }
+}

--- a/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/README
+++ b/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/README
@@ -95,3 +95,30 @@ Two resources from two different pools (each one with different database, assoc-
 to make sure that connections from appropriate pool is retrieved from the thread-local.
 
 ---
+
+Scenario 9:
+
+Call code that resembles issue 24805 situations: the connection pool might contain
+resources that are marked as enlisted in a transaction, and should not be handed out
+from the pool. If it would be handed out, it could end up in another transaction where
+it would not be enlisted and in the end closing the connection would fail because 
+the closeResouce logic has no transaction associated.
+This test only tests a single thread, to ensure the enlisted state is correct when a 
+resource is returned from the connection pool. 
+
+This tests asks a Singleton utility bean for a database Connection from a @Datasource,
+Then the connection is used and while it is in use another few connections are requested
+from the pool using the same Singleton. The connection pool should not return a 
+ResourceHandle that has the state enlisted.
+
+It could be argued that the Singleton utility class should not return a Connection, but 
+the utility method is marked as Transaction SUPPORTS, and it allows a codebase to only define
+1 location where @Resource is located, plus it allows adding connection statistics and validations
+inside this 1 location. Instead of replicating this all over the codebase in a large system. 
+
+Running this test should not lead to enlisted status validation checks like:
+Caused by: java.lang.IllegalStateException: Resource may not be marked enlisted! handle: 
+<ResourceHandle id=2, state=<ResourceState enlisted=true, busy=true/>/>
+	at com.sun.enterprise.resource.pool.ConnectionPool.getUnenlistedResource(ConnectionPool.java)
+
+---

--- a/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/client/Client.java
+++ b/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/client/Client.java
@@ -85,6 +85,12 @@ public class Client {
         } else {
             stat.addStatus(testSuite + " test8 : ", stat.FAIL);
         }
+        
+        if (simpleSession.test9()) {
+            stat.addStatus(testSuite + " test9 : ", stat.PASS);
+        } else {
+            stat.addStatus(testSuite + " test9 : ", stat.FAIL);
+        }
 
         stat.printSummary();
     }

--- a/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/ejb/DbUtilsBean.java
+++ b/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/ejb/DbUtilsBean.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.s1asdev.jdbc.connsharing.nonxa.ejb;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.SessionBean;
+import jakarta.ejb.SessionContext;
+import jakarta.ejb.Startup;
+import jakarta.ejb.Stateless;
+import jakarta.ejb.TransactionAttribute;
+import jakarta.ejb.TransactionAttributeType;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import java.util.Set;
+import java.util.HashSet;
+
+@Singleton
+public class DbUtilsBean {
+
+    @Resource(mappedName="jdbc/connsharing")
+    private DataSource myworkDatabase;
+
+    @TransactionAttribute(TransactionAttributeType.SUPPORTS)
+    public Connection getConnection() throws SQLException {
+        Connection connection = myworkDatabase.getConnection();
+        // Here additional checks could be added for application usage:
+        // like call statistic counters or thread stack validation.
+        SimpleSessionBean.getPhysicalConnectionAndLog(myworkDatabase, connection);
+        return connection;
+    }
+}

--- a/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/ejb/SimpleSession.java
+++ b/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/ejb/SimpleSession.java
@@ -29,6 +29,7 @@ public interface SimpleSession extends EJBObject {
     public boolean test6() throws RemoteException;
     public boolean test7() throws RemoteException;
     public boolean test8() throws RemoteException;
+    public boolean test9() throws RemoteException;
     
     public boolean query() throws RemoteException;
     public boolean query2() throws RemoteException;

--- a/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/ejb/SimpleSession2.java
+++ b/appserver/tests/appserv-tests/devtests/jdbc/connsharing/nonxa/ejb/SimpleSession2.java
@@ -24,4 +24,5 @@ public interface SimpleSession2 extends EJBObject {
     public boolean test1UpdateWhereId100() throws RemoteException;
     public boolean test2UpdateWhereId200() throws RemoteException;
     public boolean test3GetConnection() throws RemoteException;
+    public boolean test9Issue24085() throws RemoteException;
 }


### PR DESCRIPTION
Make ConnectionPool code more strict and do not return Enlisted resources.

Throw isBusy and enlisted IllegalArgumentExceptions on purpose in the goal to find out why #24805 sometimes occurs. 
This allowed me to see ConnectionPool.internalGetResource skip getResourceFromTransaction logic in some cases, and then calling getUnenlistedResource returned an Enlisted resource.

Therefor adding logic:
Add new isEnlisted logic in the getResourceFromPool method to possibly fix #24805 Remove getMatchedResourceFromPool method. Status is: passes all 209 "./runtests.sh jdbc_all" tests.

Also refactored some old TODO statement: replace getMatchedResourceFromPool implementation with a call to  getResourceFromPool.