### PR TITLE
Option to prefer env vars when resolving variables in JVM options 

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/jvm.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jvm.adoc
@@ -55,9 +55,6 @@ xref:reference-manual.adoc#create-jvm-options[`create-jvm-options`] subcommand.
 To create more than one JVM option, use a colon (:) to separate the
 options. If the JVM option itself contains a colon (:), use the
 backslash (\) to offset the colon delimiter.
-+
-Information about properties for the subcommand is included in this help
-page.
 3. To apply your changes, restart {productName}. See
 xref:domains.adoc#to-restart-a-domain[To Restart a Domain].
 
@@ -78,7 +75,7 @@ Command create-jvm-options executed successfully.
 
 See Also
 
-You can also view the full syntax and options of the subcommand by
+You can also view the full syntax and options of the subcommand in the xref:reference-manual.adoc#create-jvm-options[`create-jvm-options`] reference manual, or by
 typing `asadmin help create-jvm-options` at the command line.
 
 [[to-list-jvm-options]]

--- a/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
@@ -61,8 +61,18 @@ are preceded by the dash character (`-`). For example:
 If the subcommand specifies an option that already exists, the command
 does not re-create the option.
 
+Variable references, e.g. `${variable}`, can be used anywhere in JVM options. In that case, they are resolved as follows:
 
-[NOTE]
+1. Profiler properties in Java Config
+2. System properties in JVM options in Java Config
+3. System properties in instance, cluster, or config that match the instance being started
+4. System properties in the JVM of the server launcher (note that they may be different from properties in the JVM of the server if it starts with a different JVM)
+5. `asenv` properties
+6. Environment variables
+
+If a property `org.glassfish.envPreferredToProperties` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source.
+
+[CAUTION]
 ====
 Ensure that any option that you create is valid. The subcommand might
 allow you to create an invalid option, but such an invalid option can

--- a/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
@@ -70,7 +70,7 @@ Variable references, e.g. `${variable}`, can be used anywhere in JVM options. In
 5. `asenv` properties
 6. Environment variables
 
-If a property `org.glassfish.envPreferredToProperties` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source.
+If a property `org.glassfish.envPreferredToProperties` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source. It's also possible to override options and system properties defined in JVM options with an environment variable that either has the same name, or same name if case is ignored and non-alphanumeric characters are replaced with the `_` character. For example, a property `-Dmy.name` can be defined by redefined by environment variables `my.name`, `my_name`, or `MY_NAME`.
 
 [CAUTION]
 ====

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -67,7 +66,6 @@ import static com.sun.enterprise.util.SystemPropertyConstants.INSTALL_ROOT_PROPE
 import static com.sun.enterprise.util.SystemPropertyConstants.INSTANCE_ROOT_PROPERTY;
 import static com.sun.enterprise.util.SystemPropertyConstants.JAVA_ROOT_PROPERTY;
 import static com.sun.enterprise.util.SystemPropertyConstants.PREFER_ENV_VARS_OVER_PROPERTIES;
-import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.lang.System.Logger.Level.INFO;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -719,9 +719,7 @@ public abstract class GFLauncher {
     }
 
     private static Boolean isPreferEnvOverProperties(Map<String, String> properties) {
-        return Optional.ofNullable(properties.get(PREFER_ENV_VARS_OVER_PROPERTIES))
-                .map(Boolean::valueOf)
-                .orElse(FALSE);
+        return Boolean.parseBoolean(properties.get(PREFER_ENV_VARS_OVER_PROPERTIES));
     }
 
     private void fixLogFilename() throws GFLauncherException {

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JvmOptions.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JvmOptions.java
@@ -136,6 +136,7 @@ class JvmOptions {
     Map<String, String> getCombinedMap() {
         // used for resolving tokens
         Map<String, String> all = new HashMap<>(plainProps);
+        all.putAll(longProps);
         all.putAll(xProps);
         all.putAll(xxProps);
         all.putAll(sysProps);

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
@@ -204,6 +204,8 @@ public class SystemPropertyConstants {
     public static final String DEFAULT_ADMIN_TIMEOUT_PROPERTY = "org.glassfish.admin.timeout";
     private static final int DEFAULT_ADMIN_TIMEOUT_VALUE = 5000;
 
+    public static final String PREFER_ENV_VARS_OVER_PROPERTIES = "org.glassfish.envPreferredToProperties";
+
     private static final StringManager sm = StringManager.getManager(SystemPropertyConstants.class);
 
     public static final String OPEN = "${";

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/create-jvm-options.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/create-jvm-options.1
@@ -60,7 +60,12 @@ DESCRIPTION
        If a property `org.glassfish.envPreferredToProperties` is defined as
        `true` (in any source except environment variables), then environment
        variables take precedence over other sources, instead of being the last
-       resolved source.
+       resolved source. It's also possible to override options and system
+       properties defined in JVM options with an environment variable that
+       either has the same name, or same name if case is ignored 
+       and non-alphanumeric characters are replaced with the `_` character.
+       For example, a property `-Dmy.name` can be defined by redefined by 
+       environment variables `my.name`, `my_name`, or `MY_NAME`.
 
            Caution
            +------------------------------------------------+

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/create-jvm-options.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/create-jvm-options.1
@@ -44,15 +44,33 @@ DESCRIPTION
        If the subcommand specifies an option that already exists, the command
        does not re-create the option.
 
-           Note
-           +----------------------------------------+
-           |           Ensure that any option that  |
-           |           you create is valid. The     |
-           |           subcommand might allow you   |
-           |           to create an invalid option, |
-           |           but such an invalid option   |
-           |           can cause startup to fail.   |
-           +----------------------------------------+
+       Variable references, e.g. ${variable}, can be used anywhere in JVM 
+       options. In that case, they are resolved as follows:
+
+       1. Profiler properties in Java Config
+       2. System properties in JVM options in Java Config
+       3. System properties in instance, cluster, or config that match the
+           instance being started
+       4. System properties in the JVM of the server launcher (note that they
+           may be different from properties in the JVM of the server if it
+           starts with a different JVM)
+       5. asenv properties
+       6. Environment variables
+
+       If a property `org.glassfish.envPreferredToProperties` is defined as
+       `true` (in any source except environment variables), then environment
+       variables take precedence over other sources, instead of being the last
+       resolved source.
+
+           Caution
+           +------------------------------------------------+
+           |           Ensure that any option that          |
+           |           you create is valid. The             |
+           |           subcommand might allow you           |
+           |           to create an invalid option,         |
+           |           but such an invalid option           |
+           |           can cause startup to fail.           |
+           +------------------------------------------------+
 
        An option can be verified by examining the server log after GlassFish
        Server starts. Options for the Java application launcher are written to


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/25381.

Adds support for system property `org.glassfish.envPreferredToProperties`. When it's set to `true` (e.g. in server-config or in JVM options), then environment variables take precedence in resolution of variable references in JVM options.

Until now, it was possible to resolve a variable in JVM options using an environment variable, if the variable was not defined in GlassFish configuration. A default value cannot be provided, an environment variable would be then hidden. In Docker, a default value could be provided by a default value of an environment variable.

With this change, it's possible to redefine variables in JVM options via environment variables even if they are already in GlassFish configuration, e.g. in a system property. In Docker, this provides an alternative way to configure default properties and override them with environment variables.

It's also possible to directly override a value of a system property or option that is specified in JVM options. This was not possible before at all.

Examples:

**I want to:**

* allow to define a property "application.name" with environment variable APPNAME
* provide the default value as a system property

This can be done now with:

* create  JVM option:  `asadmin create-jvm-options '-Dapplication.name=${APPNAME}'`
* create a system property for the default value: `create-system-properties APPNAME=application`

The default value of property `application.name` is "application". If GlassFish started with environment variable `APPNAME=myapp`, then the value of `application.name` is `myapp`.

**I want to**

* specify an existing property "app.name" in JVM options with an environment variable

This can be done with:

* create JVM option "application.name": `asadmin create-jvm-options '-Dapplication.name=defaultapp`
* specify the environment variable APPLICATION_NAME=myapp
* start GlassFish - the system property `application.name` will be set to "myapp", the main JVM process will be started with `-Dapplication.name=myapp`