### PR TITLE
Speed up deployments - optimization in finding files in deployment packages

### DIFF
--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -583,6 +583,10 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             if (deploymentContext != null) {
                 deploymentContext.postDeployClean(true);
             }
+
+            // Clear FileArchive cache that has been filled during deployment. Clear it exactly one time after deployment.
+            // Cannot use postDeployClean implementation, it is called multiple times (even with value true) during deployment.
+            com.sun.enterprise.deploy.shared.FileArchive.clearCache();
         }
     }
 

--- a/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
+++ b/nucleus/deployment/admin/src/main/java/org/glassfish/deployment/admin/DeployCommand.java
@@ -583,10 +583,6 @@ public class DeployCommand extends DeployCommandParameters implements AdminComma
             if (deploymentContext != null) {
                 deploymentContext.postDeployClean(true);
             }
-
-            // Clear FileArchive cache that has been filled during deployment. Clear it exactly one time after deployment.
-            // Cannot use postDeployClean implementation, it is called multiple times (even with value true) during deployment.
-            com.sun.enterprise.deploy.shared.FileArchive.clearCache();
         }
     }
 

--- a/nucleus/deployment/common/src/main/java/com/sun/enterprise/deploy/shared/FileArchive.java
+++ b/nucleus/deployment/common/src/main/java/com/sun/enterprise/deploy/shared/FileArchive.java
@@ -44,9 +44,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
@@ -118,6 +120,14 @@ public class FileArchive extends AbstractReadableArchive implements WritableArch
      * the staleFileManager field has been set.
      */
     private boolean isOpenedOrCreated;
+
+    /**
+     * File to File entries cache. Cache exists to avoid expensive duplicate calls to {@link getListOfFiles} which results
+     * in disk IO. Use a static variable because for example during deployment many FileArchive instances are created.
+     * Ideally this cache would be part of DeployCommand deploymentContext, so it would not be shared with all FileArchive
+     * usages and would only be used during deployment.
+     */
+    private static final Map<File, List<String>> fileToEntriesCache = new HashMap<>();
 
     public FileArchive() {
     }
@@ -213,6 +223,14 @@ public class FileArchive extends AbstractReadableArchive implements WritableArch
         }
     }
 
+    /**
+     * Empty the cache of file entries. Call this method after deployment code completed to clean up memory and enable fresh
+     * new deployments.
+     */
+    public static void clearCache() {
+        fileToEntriesCache.clear();
+    }
+
     @Override
     public boolean isDirectory(String name) {
         final File candidate = new File(this.archive, name);
@@ -258,9 +276,13 @@ public class FileArchive extends AbstractReadableArchive implements WritableArch
         prefix = prefix.replace('/', File.separatorChar);
         File file = new File(archive, prefix);
 
-        // Here we could cache "File -> found entries"
-        List<String> namesList = getListOfFiles(file, deplLogger);
-        return Collections.enumeration(namesList);
+        if (fileToEntriesCache.containsKey(file)) {
+            return Collections.enumeration(fileToEntriesCache.get(file));
+        } else {
+            List<String> namesList = getListOfFiles(file, deplLogger);
+            fileToEntriesCache.put(file, namesList);
+            return Collections.enumeration(namesList);
+        }
     }
 
     /**

--- a/nucleus/deployment/common/src/test/java/com/sun/enterprise/deploy/shared/FileArchiveTest.java
+++ b/nucleus/deployment/common/src/test/java/com/sun/enterprise/deploy/shared/FileArchiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,13 +24,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Vector;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
@@ -212,8 +210,7 @@ public class FileArchiveTest {
 
 
     private void getListOfFiles(final FileArchive instance, final Set<String> expectedEntryNames, final Logger logger) {
-        final List<String> foundEntryNames = new ArrayList<>();
-        instance.getListOfFiles(archiveDir, foundEntryNames, null, logger);
+        final List<String> foundEntryNames = instance.getListOfFiles(archiveDir, logger);
         assertEquals(expectedEntryNames, new HashSet<>(foundEntryNames), "Missing or unexpected entry names reported");
     }
 
@@ -424,10 +421,9 @@ public class FileArchiveTest {
         assertTrue(lower.setReadable(false, false));
 
         // Try to list the files.  This should fail with our logger getting one record.
-        final Vector<String> fileList = new Vector<>();
         handler.reset();
         assertThat(deplLogger.getHandlers(), arrayContainingInAnyOrder(handler));
-        archive.getListOfFiles(lower, fileList, null /* embeddedArchives */, deplLogger);
+        archive.getListOfFiles(lower, deplLogger);
 
         List<GlassFishLogRecord> logRecords = handler.getAll();
         assertThat("FileArchive logged no message about being unable to list files; expected " + EXPECTED_LOG_KEY,
@@ -440,7 +436,7 @@ public class FileArchiveTest {
         lower.setReadable(true, false);
         handler.reset();
 
-        archive.getListOfFiles(lower, fileList, null, deplLogger);
+        archive.getListOfFiles(lower, deplLogger);
         assertNull(handler.pop(), "FileArchive was incorrectly unable to list files; error key in log record");
     }
 }


### PR DESCRIPTION
Issue #25397 use java.nio:
- Files.walkFileTree instead of recursively finding files.
- Use Path instead of URI. 

and use try with resources.

This change makes deployment times improve on my Windows 11 pc from 110 seconds to 100 seconds.
Not yet adding caching logic, which would improve deployment times for the same ear file around 92 seconds.

Yourkit result after this change:
- 10+ seconds less time spent in java.io.FileSystem.hasBooleanAttributes(File, int)
- (Was 49 seconds, now 30 seconds, but Yourkit is running, without Yourkit about 10 second improvement)

![image](https://github.com/user-attachments/assets/d54097b0-bd40-427f-9d0b-839ed8ea7af9)
![image](https://github.com/user-attachments/assets/fae1f4b8-b029-4d57-bf33-08d1604d966d)



