### PR TITLE
Fixed heavy need of garbage collector in GlassFishLogHandlerTest

### DIFF
--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -211,8 +211,14 @@ public class GlassFishLogHandlerTest {
 
     private static void waitForSize(File file, long minLineCount) throws IOException {
         long start = System.currentTimeMillis();
+        long lastLength = 0;
         do {
             Thread.onSpinWait();
+            long newLength = file.length();
+            if (newLength == lastLength) {
+                continue;
+            }
+            lastLength = newLength;
             final long lineCount;
             try (Stream<String> stream = Files.lines(file.toPath(), StandardCharsets.UTF_8)) {
                 lineCount = stream.count();
@@ -220,7 +226,7 @@ public class GlassFishLogHandlerTest {
             if (lineCount >= minLineCount) {
                 return;
             }
-        } while (System.currentTimeMillis() - start < 5000L);
+        } while (System.currentTimeMillis() - start < 2000L);
         fail("Timeout waiting until the file " + file + " grows to " + minLineCount + " lines. File content: \n"
             + Files.readString(file.toPath(), handler.getConfiguration().getEncoding()));
     }


### PR DESCRIPTION
- Every request to count lines causes creation of 8K buffer.
- Thread.onSpinWait() is usually fast
- Instead of sleeping we first call lighther method guarding the more expensive read of the file content.
