### PR TITLE
Revisited scripts around asenv

### DIFF
--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/CLIBootstrap.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -83,7 +83,7 @@ public class CLIBootstrap {
     private final static String SECURITY_AUTH_LOGIN_CONFIG_PROPERTY_EXPR = "-Djava.security.auth.login.config=";
     private final static String SYSTEM_CLASS_LOADER_PROPERTY_EXPR = "-Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader";
 
-    private final static String[] ENV_VARS = { "_AS_INSTALL", "APPCPATH", "VMARGS" };
+    private final static String[] ENV_VARS = { "AS_INSTALL", "APPCPATH", "VMARGS" };
 
     private JavaInfo java = new JavaInfo();
     private GlassFishInfo gfInfo = new GlassFishInfo();
@@ -867,7 +867,7 @@ public class CLIBootstrap {
     /**
      * Encapsulates information about the GlassFish installation, mostly useful directories within the installation.
      * <p>
-     * Note that we use the property acc._AS_INSTALL to find the installation.
+     * Note that we use the property acc. AS_INSTALL to find the installation.
      */
     static class GlassFishInfo {
 
@@ -878,9 +878,9 @@ public class CLIBootstrap {
         private static final String ACC_CONFIG_PREFIX = "domains/domain1/config";
 
         GlassFishInfo() {
-            String asInstallPath = System.getProperty(ENV_VAR_PROP_PREFIX + "_AS_INSTALL");
+            String asInstallPath = System.getProperty(ENV_VAR_PROP_PREFIX + "AS_INSTALL");
             if (asInstallPath == null || asInstallPath.length() == 0) {
-                throw new IllegalArgumentException("_AS_INSTALL == null");
+                throw new IllegalArgumentException("AS_INSTALL == null");
             }
             this.home = new File(asInstallPath);
             modules = new File(home, "modules");
@@ -953,11 +953,11 @@ public class CLIBootstrap {
         private final static String SHELL_PROP_NAME = "org.glassfish.appclient.shell";
 
         /*
-         * The appclient and appclient.bat scripts set ACCJava. Properties would be nicer instead of env vars, but the Windows
+         * The appclient and appclient.bat scripts set JAVA. Properties would be nicer instead of env vars, but the Windows
          * script handling of command line args in the for statement treats the = in -Dprop=value as an argument separator and
          * breaks the property assignment apart into two arguments.
          */
-        private final static String ACCJava_ENV_VAR_NAME = "ACCJava";
+        private final static String ACCJava_ENV_VAR_NAME = "JAVA";
 
         private final boolean useWindowsSyntax = File.separatorChar == '\\' && (System.getProperty(SHELL_PROP_NAME) == null);
 

--- a/appserver/appclient/client/acc/src/test/java/org/glassfish/appclient/client/CLIBootstrapTest.java
+++ b/appserver/appclient/client/acc/src/test/java/org/glassfish/appclient/client/CLIBootstrapTest.java
@@ -43,7 +43,7 @@ public class CLIBootstrapTest {
         System.setProperty(CLIBootstrap.ENV_VAR_PROP_PREFIX + "AS_JAVA", "");
         System.setProperty(CLIBootstrap.ENV_VAR_PROP_PREFIX + "JAVA_HOME", "");
         System.setProperty(CLIBootstrap.ENV_VAR_PROP_PREFIX + "PATH", System.getenv("PATH"));
-        System.setProperty(CLIBootstrap.ENV_VAR_PROP_PREFIX + "_AS_INSTALL",
+        System.setProperty(CLIBootstrap.ENV_VAR_PROP_PREFIX + "AS_INSTALL",
             "/Users/Tim/asgroup/v3/H/publish/glassfish7/glassfish");
     }
 

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,64 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-# 
-
-# set -x
-
-chooseJava() {
-#
-# Looks for Java at AS_JAVA, JAVA_HOME or in the path.
-# Sets javaSearchType to tell which was used to look for java,
-# javaSearchTarget to the location (or path), and
-# JAVA to the found java executable.
-#
-# If the user specifies AS_JAVA or JAVA_HOME record that setting
-# to be passed as a property to the bootstrap program.
-#
-    # Depends upon Java from ../config/asenv.conf
-    if [ "${AS_JAVA}" != "" ]; then
-        javaSearchType=AS_JAVA
-        javaSearchTarget="$AS_JAVA"
-        JAVA="${AS_JAVA}/bin/java"
-    elif [ "${JAVA_HOME}" != "" ]; then
-        javaSearchType=JAVA_HOME
-        javaSearchTarget="$JAVA_HOME"
-        JAVA="${JAVA_HOME}/bin/java"
-    else
-        # Look in the PATH.
-        seekJavaOnPath
-        javaSearchType=PATH
-        javaSearchTarget=$PATH
-    fi
-#
-# Make sure java really exists where we were told to look.  If not
-# display how we tried to find it and then try to run it, letting the shell
-# issue the error so we don't have to do i18n of our own message from the script.
-
-    if [ ! -x "${JAVA}" ]; then
-        echo
-        echo $javaSearchType=$javaSearchTarget
-        echo
-        ${JAVA}
-        exit
-    fi
-ACCJava="${JAVA}"
-export ACCJava
-}
-
-seekJavaOnPath() {
-        JAVA=`which java`
-}
-
-
-_AS_INSTALL=`dirname "$0"`/..
-export _AS_INSTALL
-case "`uname`" in
-  CYGWIN*) _AS_INSTALL=`cygpath --windows $_AS_INSTALL`
-           cygwinProp=-Dorg.glassfish.isCygwin=true
-esac
-. "${_AS_INSTALL}/config/asenv.conf"
-
-chooseJava
-
-eval "`"${ACCJava}" -Dorg.glassfish.appclient.shell $cygwinProp -classpath "${_AS_INSTALL}/lib/gf-client.jar" org.glassfish.appclient.client.CLIBootstrap "$@"`"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+eval "`"${JAVA}" -Dorg.glassfish.appclient.shell $cygwinProp -classpath "${AS_INSTALL}/lib/gf-client.jar" org.glassfish.appclient.client.CLIBootstrap "$@"`"

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -16,67 +17,25 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 
-setlocal
-goto :main
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
 
-:seekJavaOnPath
-for /f %%J in ("java.exe") do set JAVA=%%~$PATH:J
-goto :EOF
+:ok
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+set ARGS=%*
 
-:chooseJava
-rem
-rem Looks for Java at AS_JAVA, JAVA_HOME or in the path.
-rem Sets javaSearchType to tell which was used to look for java,
-rem javaSearchTarget to the location (or path), and
-rem JAVA to the found java executable.
-
-    if "%AS_JAVA%x" == "x" goto :checkJAVA_HOME
-       set javaSearchType=AS_JAVA
-       set javaSearchTarget="%AS_JAVA%"
-       set JAVA=%AS_JAVA%\bin\java.exe
-       for %%a in ("%AS_JAVA%") do set ACCJavaHome=%%~sa
-       goto :verifyJava
-
-:checkJAVA_HOME
-    if "%JAVA_HOME%x" == "x" goto :checkPATH
-       set javaSearchType=JAVA_HOME
-       set javaSearchTarget="%JAVA_HOME%"
-       set JAVA=%JAVA_HOME%\bin\java.exe
-       for %%a in ("%JAVA_HOME%") do set ACCJavaHome=%%~sa
-       goto :verifyJava
-
-:checkPATH
-    set JAVA=java
-    call :seekJavaOnPath
-    set javaSearchType=PATH
-    set javaSearchTarget="%PATH%"
-
-:verifyJava
-rem
-rem Make sure java really exists where we were told to look.  If not
-rem display how we tried to find it and then try to run it, letting the shell
-rem issue the error so we don't have to do i18n of our own message from the script.
-    if EXIST "%JAVA%" goto :EOF
-    echo
-    echo %javaSearchType%=%javaSearchTarget%
-    echo
-    "%JAVA%"
-    exit/b %ERRORLEVEL%
-goto :EOF
-
-:main
-set _AS_INSTALL=%~dp0..
-call "%_AS_INSTALL%\config\asenv.bat"
-call :chooseJava
-
-set inputArgs=%*
-rem
-rem Convert the java.exe path and the classpath path to
-rem Windows "short" versions - with no spaces - so the
-rem for /F statement below will work correctly.  Spaces cause
-rem it great troubles.
-rem
-for %%a in ("%JAVA%") do set ACCJava=%%~sa%
-for %%a in ("%_AS_INSTALL%/lib/gf-client.jar") do set XCLASSPATH=%%~sa
-for /F "usebackq tokens=*" %%a in (`%ACCJava% -classpath %XCLASSPATH% org.glassfish.appclient.client.CLIBootstrap`) do set javaCmd=%%a
-%javaCmd%
+REM Execute CLIBootstrap with the arguments passed to this script
+REM to retrieve the command to execute.
+REM FOR /F - processes command output line by line
+REM "delims=" - treats each line as a whole (no delimiter)
+REM %%i - loop variable for batch files, would be %i on command line
+FOR /F "delims=" %%i IN ("%JAVA%" -classpath "%AS_INSTALL%\lib\gf-client.jar" org.glassfish.appclient.client.CLIBootstrap %*) DO set CMD=%%i
+%CMD% %ARGS%

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.js
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.js
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,7 +22,7 @@ var envVars = wshShell.Environment("PROCESS");
 
 var pathSep = ";";
 
-var prelim_AS_INSTALL = new String(envVars("_AS_INSTALL"));
+var prelim_AS_INSTALL = new String(envVars("AS_INSTALL"));
 var javaProgram = new String(quoteStringIfNeeded(envVars("JAVA")));
 var driveLetter = prelim_AS_INSTALL.substring(0,1).toUpperCase();
 var AS_INSTALL = driveLetter + prelim_AS_INSTALL.substring(1);
@@ -32,7 +33,7 @@ var builtinEndorsedDirSetting = quoteMultiStringIfNeeded(
     AS_INSTALL +
     "\\lib\\endorsed" +
     pathSep +
-    AS_INSTALL_MOD + 
+    AS_INSTALL_MOD +
     "\\endorsed", pathSep);
 
 var mainClassIdentRequired = 1;
@@ -123,13 +124,13 @@ function processArgs() {
     var accNonvaluedOptions = ["-textauth", "-noappinvoke", "-usage", "-help"];
     //var re = new RegExp("\"([^\"]+)\"|[^\"\\s]+)","g");
     var re = /"([^"]+)"|([^"\s]+)/g;
-    
+
     // var tokens = inputArgs.split(" ");
     // var tokens = re.exec(inputArgs);
     var tokens = inputArgs.match(re);
     for (tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
         var token = tokens[tokenIndex];
-        
+
         var matched=null;
         matched = matchToWithType(token, jvmValuedOptions, "JVM");
         if (matched == null) {
@@ -152,7 +153,7 @@ function processArgs() {
                 expecting = null;
             }
         }
-        
+
         if (matched == null) {
             if (expecting != null) {
                 recordArg(expectingArgType, expecting, token);

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/package-appclient
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/package-appclient
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2025 Contributors to the Eclipse Foundation.
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,21 +16,8 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-
-# set -x
-_AS_INSTALL=`dirname "$0"`/..
-#
-# Run with the user-specified Java, if any.
-#
-case "`uname`" in
-  CYGWIN*) _AS_INSTALL=`cygpath --windows $_AS_INSTALL`
-esac
-. "${_AS_INSTALL}/config/asenv.conf"
-JAVA=java
-# Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-_AS_INSTALL_LIB=$_AS_INSTALL/lib
-$JAVA -classpath "$_AS_INSTALL_LIB/gf-client.jar" org.glassfish.appclient.client.packageappclient.PackageAppClient "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+AS_INSTALL_LIB=$AS_INSTALL/lib
+"${JAVA}" -classpath "$AS_INSTALL_LIB/gf-client.jar" org.glassfish.appclient.client.packageappclient.PackageAppClient "$@"

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/package-appclient.bat
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/package-appclient.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,17 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-setlocal
-set _AS_INSTALL=%~dp0..
-call "%_AS_INSTALL%\config\asenv.bat"
-REM
-REM  Run with the user-specified Java, if any.
-REM
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-:UsePath
-set JAVA=java
-:run
-set _AS_INSTALL_LIB=%_AS_INSTALL%\lib
-%JAVA% -classpath "%_AS_INSTALL_LIB%\gf-client.jar" org.glassfish.appclient.client.packageappclient.PackageAppClient %*
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
+
+:ok
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -classpath "%AS_INSTALL%\lib\gf-client.jar" org.glassfish.appclient.client.packageappclient.PackageAppClient %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,17 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/../glassfish
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-AS_INSTALL_LIB="$AS_INSTALL/lib"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-exec "$JAVA" -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" "$@"
-
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../glassfish/config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+exec "$JAVA" -jar "$AS_INSTALL/lib/client/appserver-cli.jar" "$@"

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,20 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
-REM  Always use JDK 1.6 or higher
-REM  Depends on Java from ..\glassfish\config\asenv.bat
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
+
 :ok
-call "%~dp0..\glassfish\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-:UsePath
-set JAVA=java
-:run
-%JAVA% -jar "%~dp0..\glassfish\lib\client\appserver-cli.jar" %*
+set "AS_CONFIG=%~dp0..\glassfish\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,15 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-# Always use JDK 1.6 or higher
-AS_INSTALL=`dirname "$0"`/../glassfish
-AS_INSTALL_LIB="$AS_INSTALL/lib"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-exec "$JAVA" -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008 -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" "$@"
-
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../glassfish/config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+exec "$JAVA" -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008 -jar "$AS_INSTALL/lib/client/appserver-cli.jar" "$@"

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,20 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
-REM  Always use JDK 1.6 or higher
-REM  Depends on Java from ..\glassfish\config\asenv.bat
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
+
 :ok
-call "%~dp0..\glassfish\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-:UsePath
-set JAVA=java
-:run
-%JAVA% -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008 -jar "%~dp0..\glassfish\lib\client\appserver-cli.jar" %*
+set "AS_CONFIG=%~dp0..\glassfish\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008 -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -16,21 +16,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/../glassfish
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-start_as_main_process () {
+startAsMainProcess() {
     if [[ "$@" == "--help" ]] || [[ "$@" == "--help=true" ]] || [[ "$@" == "-?" ]]; then
-      exec java -jar "$ASADMIN_JAR" start-domain --help
+      exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --help
     fi
 
     # Execute start-domain --dry-run and store the output line by line into an array.
@@ -50,7 +38,7 @@ start_as_main_process () {
       else
         DRY_RUN_OUTPUT+=("$COM");
       fi
-    done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" || echo "FAILED" )
+    done < <("$JAVA" -jar "$ASADMIN_JAR" start-domain --dry-run "$@" || echo "FAILED" )
     if [[ x"$DRY_RUN_OUTPUT" == x ]]
       then
         echo -n -e "${DRY_RUN_OUTPUT_BEFORE_DUMP}" >&2
@@ -65,8 +53,12 @@ start_as_main_process () {
 
 }
 
-ASADMIN_JAR="$AS_INSTALL_LIB/admin-cli.jar"
-start_as_main_process "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../glassfish/config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+
+ASADMIN_JAR="$AS_INSTALL/modules/admin-cli.jar"
+startAsMainProcess "$@"
 
 # Alternatively, run the following:
 # exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --verbose "$@"

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,5 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
 
-java -jar "%~dp0..\glassfish\modules\admin-cli.jar" start-domain --verbose %*
+:ok
+set "AS_CONFIG=%~dp0..\glassfish\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" start-domain --verbose %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,7 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/../glassfish
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-
-exec java -jar "$AS_INSTALL_LIB/admin-cli.jar" stop-domain "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../glassfish/config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+"$JAVA" -jar "$AS_INSTALL/modules/admin-cli.jar" stop-domain "$@"

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,5 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
 
-java -jar "%~dp0..\glassfish\modules\admin-cli.jar" stop-domain %*
+:ok
+set "AS_CONFIG=%~dp0..\glassfish\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" stop-domain %*

--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,15 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-AS_INSTALL_LIB="$AS_INSTALL/lib"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-exec "$JAVA" -jar "$AS_INSTALL_LIB/client/appserver-cli.jar" "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+exec "$JAVA" -jar "$AS_INSTALL/lib/client/appserver-cli.jar" "$@"

--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,20 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
-REM  Always use JDK 1.6 or higher
-REM  Depends on Java from ..\config\asenv.bat
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
+
 :ok
-call "%~dp0..\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-:UsePath
-set JAVA=java
-:run
-%JAVA% -jar "%~dp0..\lib\client\appserver-cli.jar" %*
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Eclipse Foundation and/or its affiliates.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,6 +39,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -108,6 +109,15 @@ public class GlassFishTestEnvironment {
         // Note: --suspend implicitly enables --debug
         assertThat(asadmin.exec(timeout,"start-domain",
                 isStartDomainSuspendEnabled() ? "--suspend" : "--debug"), asadminOK());
+    }
+
+
+    /**
+     * @return the installation directory, usually referred as AS_INSTALL and named
+     *         <code>glassfish</code> (without version number).
+     */
+    public static File getGlassFishDirectory() {
+        return GF_ROOT;
     }
 
 
@@ -464,21 +474,22 @@ public class GlassFishTestEnvironment {
         return client;
     }
 
+    // FIXME: add loading of the right certificate from keystore.
     private static final TrustManager[] trustAllCerts = new TrustManager[]{
         new X509TrustManager() {
             @Override
-            public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+            public X509Certificate[] getAcceptedIssuers() {
                 return null;
             }
 
-            @Override
-            public void checkClientTrusted(
-                    java.security.cert.X509Certificate[] certs, String authType) {
-            }
 
             @Override
-            public void checkServerTrusted(
-                    java.security.cert.X509Certificate[] certs, String authType) {
+            public void checkClientTrusted(X509Certificate[] certs, String authType) {
+            }
+
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] certs, String authType) {
             }
         }
     };

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -153,11 +153,11 @@ public class Asadmin {
                 .collect(Collectors.toList());
     }
 
+
     /**
-     * Executes the command with arguments asynchronously with
-     * {@value #DEFAULT_TIMEOUT_MSEC} ms timeout. The command can be attached by
-     * the attach command. You should find the job id in the
-     * {@link AsadminResult#getStdOut()} as <code>Job ID: [0-9]+</code>
+     * Executes the command with arguments asynchronously with {@value #DEFAULT_TIMEOUT_MSEC} ms
+     * timeout. The command can be attached by the attach command. You should find the job id in
+     * the {@link AsadminResult#getStdOut()} as <code>Job ID: [0-9]+</code>
      *
      * @param args
      * @return {@link AsadminResult} never null.
@@ -166,9 +166,10 @@ public class Asadmin {
         return (DetachedTerseAsadminResult) exec(DEFAULT_TIMEOUT_MSEC, true, args);
     }
 
+
     /**
-     * Executes the command with arguments synchronously with
-     * {@value #DEFAULT_TIMEOUT_MSEC} ms timeout.
+     * Executes the command with arguments synchronously with {@value #DEFAULT_TIMEOUT_MSEC} ms
+     * timeout.
      *
      * @param args
      * @return {@link AsadminResult} never null.
@@ -178,8 +179,7 @@ public class Asadmin {
     }
 
     /**
-     * Executes the command with arguments synchronously with given timeout in
-     * millis.
+     * Executes the command with arguments synchronously with given timeout in millis.
      *
      * @param timeout timeout in millis
      * @param args command and arguments.
@@ -190,21 +190,20 @@ public class Asadmin {
     }
 
     private File getPasswordFile() {
-        try {
-            if (!additionalPasswords.isEmpty()) {
+        if (!additionalPasswords.isEmpty()) {
+            Objects.requireNonNull(adminPasswordFile, "The admin password file is not set.");
+            try {
                 final Path tempPasswordFile = Files.createTempFile("pwd", "txt");
                 Files.copy(adminPasswordFile.toPath(), tempPasswordFile, StandardCopyOption.REPLACE_EXISTING);
                 String additionalContent = additionalPasswords.entrySet().stream()
-                        .map(entry -> entry.getKey() + "=" + entry.getValue())
-                        .collect(Collectors.joining("\n"));
+                    .map(entry -> entry.getKey() + "=" + entry.getValue()).collect(Collectors.joining("\n"));
                 Files.writeString(tempPasswordFile, "\n" + additionalContent, StandardOpenOption.APPEND);
                 return tempPasswordFile.toFile();
+            } catch (IOException e) {
+                throw new IllegalStateException("Could not create the temporary password file.", e);
             }
-            return adminPasswordFile;
-        } catch (IOException e) {
-            throw new IllegalStateException("Could not create the temporary password file.", e);
         }
-
+        return adminPasswordFile;
     }
 
     /**
@@ -224,8 +223,10 @@ public class Asadmin {
         command.add(asadmin.getAbsolutePath());
         command.add("--user");
         command.add(adminUser);
-        command.add("--passwordfile");
-        command.add(getPasswordFile().getAbsolutePath());
+        if (getPasswordFile() != null) {
+            command.add("--passwordfile");
+            command.add(getPasswordFile().getAbsolutePath());
+        }
         if (detachedAndTerse) {
             command.add("--terse=true");
             command.add("--detach");

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/PathWithSpacesITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/PathWithSpacesITest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test;
+
+import com.sun.enterprise.util.io.FileUtils;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PathWithSpacesITest {
+
+    private static Asadmin asadmin;
+
+    @BeforeAll
+    static void copyGlassFish() throws Exception {
+        File originalGF =  GlassFishTestEnvironment.getGlassFishDirectory().getParentFile();
+        File gfRootWithSpaces = new File(originalGF.getParentFile(), "GlassFish With Spaces");
+        FileUtils.copy(originalGF, gfRootWithSpaces);
+        assertTrue(FileUtils.deleteFile(new File(gfRootWithSpaces, "domains")), "Deletion of domains directory failed");
+        String asadminFileName = SystemUtils.IS_OS_WINDOWS ? "asadmin.bat" : "asadmin";
+        Path asadminPath = gfRootWithSpaces.toPath().resolve(Path.of("bin", asadminFileName));
+        asadmin = new Asadmin(asadminPath.toFile(), "admin", null);
+        assertThat(asadmin.exec("create-domain", "--nopassword", "--portbase", "14800", "spaces"), asadminOK());
+    }
+
+
+    @AfterAll
+    static void stopGlassFish() throws Exception {
+        assertThat(asadmin.exec("stop-domain", "--kill", "spaces"), asadminOK());
+    }
+
+
+    @Test
+    void start() throws Exception {
+        assertThat(asadmin.exec("start-domain", "spaces"), asadminOK());
+    }
+}

--- a/appserver/tests/appserv-tests/config/jws-appclient
+++ b/appserver/tests/appserv-tests/config/jws-appclient
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,83 +16,18 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
+AS_CONFIG="${S1AS_HOME}/config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
 
-# 
-
-# set -x
-
-chooseJava() {
-#
-# Looks for Java at AS_JAVA, JAVA_HOME or in the path.
-# Sets javaSearchType to tell which was used to look for java,
-# javaSearchTarget to the location (or path), and
-# JAVA to the found java executable.
-#
-# If the user specifies AS_JAVA or JAVA_HOME record that setting
-# to be passed as a property to the bootstrap program.
-#
-    # Depends upon Java from ../config/asenv.conf
-    if [ "${AS_JAVA}" != "" ]; then
-        javaSearchType=AS_JAVA
-        javaSearchTarget="$AS_JAVA"
-        JAVA="${AS_JAVA}/bin/java"
-    elif [ "${JAVA_HOME}" != "" ]; then
-        javaSearchType=JAVA_HOME
-        javaSearchTarget="$JAVA_HOME"
-        JAVA="${JAVA_HOME}/bin/java"
-    else
-        # Look in the PATH.
-        seekJavaOnPath
-        javaSearchType=PATH
-        javaSearchTarget=$PATH
-    fi
-#
-# Make sure java really exists where we were told to look.  If not
-# display how we tried to find it and then try to run it, letting the shell
-# issue the error so we don't have to do i18n of our own message from the script.
-
-    if [ ! -x "${JAVA}" ]; then
-        echo
-        echo $javaSearchType=$javaSearchTarget
-        echo
-        ${JAVA}
-        exit
-    fi
-ACCJava="${JAVA}"
-export ACCJava
-}
-
-seekJavaOnPath() {
-        JAVA=`which java`
-}
-
-
-_AS_INSTALL=$S1AS_HOME
-echo "_AS_INSTALL now defined as $_AS_INSTALL"
-export _AS_INSTALL
-case "`uname`" in
-  CYGWIN*) _AS_INSTALL=`cygpath --windows $_AS_INSTALL`
-           cygwinProp=-Dorg.glassfish.isCygwin=true
-esac
-. "${_AS_INSTALL}/config/asenv.conf"
-
-chooseJava
-
-#
 # Submits an app client for execution using Java Web Start
 #
 # Accepts the same command options as the appclient script so the test
 # files can continue to invoke the appclient using the ${APPCLIENT}
 # property substitution.
 #
-# Requirements:
-#   env vars set
-#     JAVA_HOME
-#     APS_HOME
-#
-#
 # This script runs a Java program to compute the URL to invoke the app client using
-# Java Web Start.  The program then returns a javaws command which launches the
+# Java Web Start. The program then returns a javaws command which launches the
 # app client.
-#
-eval `"${ACCJava}" -classpath "${APS_HOME}/lib/javaws-util.jar" util.LaunchJavaWS "$@"`
+
+eval `"${JAVA}" -classpath "${APS_HOME}/lib/javaws-util.jar" util.LaunchJavaWS "$@"`

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,19 +16,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-exec "$JAVA" -cp "$AS_INSTALL_LIB/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/angus-activation.jar" com.sun.tools.jxc.SchemaGeneratorFacade "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+AS_MODULES="$AS_INSTALL/modules"
+WS_CLASSPATH="$AS_MODULES/webservices-api-osgi.jar:$AS_MODULES/webservices-osgi.jar:$AS_MODULES/jakarta.xml.bind-api.jar:$AS_MODULES/jaxb-osgi.jar:$AS_MODULES/jakarta.activation-api.jar:$AS_MODULES/angus-activation.jar"
+exec "$JAVA" -cp "$WS_CLASSPATH" com.sun.tools.jxc.SchemaGeneratorFacade "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/schemagen.bat
@@ -1,6 +1,6 @@
 @echo off
-
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -16,21 +16,19 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-call "%~dp0..\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-
-:UsePath
-set JAVA=java
-
-:run
-%JAVA% -cp "%~dp0..\modules\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.bind-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\angus-activation.jar" com.sun.tools.jxc.SchemaGeneratorFacade %*
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+set "AS_MODULES=%AS_INSTALL%\modules"
+set "WS_CLASSPATH=%AS_MODULES%\webservices-api-osgi.jar;%AS_MODULES%\webservices-osgi.jar:%AS_MODULES%\jakarta.xml.bind-api.jar:%AS_MODULES%\jaxb-osgi.jar:%AS_MODULES%\jakarta.activation-api.jar:%AS_MODULES%\angus-activation.jar"
+"%JAVA%" -cp "%WS_CLASSPATH%" com.sun.tools.jxc.SchemaGeneratorFacade %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,19 +16,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-exec "$JAVA" $WSGEN_OPTS -cp "$AS_INSTALL_LIB/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/angus-activation.jar" com.sun.tools.ws.WsGen "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+AS_MODULES="$AS_INSTALL/modules"
+WS_CLASSPATH="$AS_MODULES/webservices-api-osgi.jar:$AS_MODULES/webservices-osgi.jar:$AS_MODULES/jakarta.xml.bind-api.jar:$AS_MODULES/jaxb-osgi.jar:$AS_MODULES/jakarta.activation-api.jar:$AS_MODULES/angus-activation.jar"
+exec "$JAVA" $WSGEN_OPTS -cp "$WS_CLASSPATH" com.sun.tools.ws.WsGen "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsgen.bat
@@ -1,6 +1,6 @@
 @echo off
-
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -16,21 +16,19 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-call "%~dp0..\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-
-:UsePath
-set JAVA=java
-
-:run
-%JAVA% %WSGEN_OPTS% -cp "%~dp0..\modules\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.bind-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\angus-activation.jar" com.sun.tools.ws.WsGen %*
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+set "AS_MODULES=%AS_INSTALL%\modules"
+set "WS_CLASSPATH=%AS_MODULES%\webservices-api-osgi.jar;%AS_MODULES%\webservices-osgi.jar:%AS_MODULES%\jakarta.xml.bind-api.jar:%AS_MODULES%\jaxb-osgi.jar:%AS_MODULES%\jakarta.activation-api.jar:%AS_MODULES%\angus-activation.jar"
+"%JAVA%" %WSGEN_OPTS% -cp "%WS_CLASSPATH%" com.sun.tools.ws.WsGen %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,19 +16,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-exec "$JAVA" $WSIMPORT_OPTS -cp "$AS_INSTALL_LIB/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/angus-activation.jar" com.sun.tools.ws.WsImport "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+AS_MODULES="$AS_INSTALL/modules"
+WS_CLASSPATH="$AS_MODULES/webservices-api-osgi.jar:$AS_MODULES/webservices-osgi.jar:$AS_MODULES/jakarta.xml.bind-api.jar:$AS_MODULES/jaxb-osgi.jar:$AS_MODULES/jakarta.activation-api.jar:$AS_MODULES/angus-activation.jar"
+exec "$JAVA" $WSIMPORT_OPTS -cp "$WS_CLASSPATH" com.sun.tools.ws.WsImport "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/wsimport.bat
@@ -1,6 +1,6 @@
 @echo off
-
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -16,21 +16,19 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-call "%~dp0..\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-
-:UsePath
-set JAVA=java
-
-:run
-%JAVA% %WSIMPORT_OPTS% -cp "%~dp0..\modules\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.bind-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\angus-activation.jar" com.sun.tools.ws.WsImport %*
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+set "AS_MODULES=%AS_INSTALL%\modules"
+set "WS_CLASSPATH=%AS_MODULES%\webservices-api-osgi.jar;%AS_MODULES%\webservices-osgi.jar:%AS_MODULES%\jakarta.xml.bind-api.jar:%AS_MODULES%\jaxb-osgi.jar:%AS_MODULES%\jakarta.activation-api.jar:%AS_MODULES%\angus-activation.jar"
+"%JAVA%" %WSIMPORT_OPTS% -cp "%WS_CLASSPATH%" com.sun.tools.ws.WsImport %*

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,19 +16,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-exec "$JAVA" -cp "$AS_INSTALL_LIB/webservices-api-osgi.jar:$AS_INSTALL_LIB/webservices-osgi.jar:$AS_INSTALL_LIB/jakarta.xml.bind-api.jar:$AS_INSTALL_LIB/jaxb-osgi.jar:$AS_INSTALL_LIB/jakarta.activation-api.jar:$AS_INSTALL_LIB/angus-activation.jar" com.sun.tools.xjc.Driver "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+AS_MODULES="$AS_INSTALL/modules"
+WS_CLASSPATH="$AS_MODULES/webservices-api-osgi.jar:$AS_MODULES/webservices-osgi.jar:$AS_MODULES/jakarta.xml.bind-api.jar:$AS_MODULES/jaxb-osgi.jar:$AS_MODULES/jakarta.activation-api.jar:$AS_MODULES/angus-activation.jar"
+exec "$JAVA" -cp "$WS_CLASSPATH" com.sun.tools.xjc.Driver "$@"

--- a/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
+++ b/appserver/webservices/webservices-scripts/src/main/resources/glassfish/bin/xjc.bat
@@ -1,6 +1,6 @@
 @echo off
-
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018, 2021 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -16,21 +16,19 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-call "%~dp0..\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-
-:UsePath
-set JAVA=java
-
-:run
-%JAVA% -cp "%~dp0..\modules\webservices-api-osgi.jar;%~dp0..\modules\webservices-osgi.jar;%~dp0..\modules\jakarta.xml.bind-api.jar;%~dp0..\modules\jaxb-osgi.jar;%~dp0..\modules\jakarta.activation-api.jar;%~dp0..\modules\angus-activation.jar" com.sun.tools.xjc.Driver %*
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+set "AS_MODULES=%AS_INSTALL%\modules"
+set "WS_CLASSPATH=%AS_MODULES%\webservices-api-osgi.jar;%AS_MODULES%\webservices-osgi.jar:%AS_MODULES%\jakarta.xml.bind-api.jar:%AS_MODULES%\jaxb-osgi.jar:%AS_MODULES%\jakarta.activation-api.jar:%AS_MODULES%\angus-activation.jar"
+"%JAVA%" -cp "%WS_CLASSPATH%" com.sun.tools.xjc.Driver %*

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -1114,6 +1114,7 @@ public abstract class GFLauncher {
             psFile = configDir.resolve("gfstart.ps1");
             StringBuilder batContent = new StringBuilder(8192);
             batContent.append("@echo off\n");
+            batContent.append("set CMD=");
             ListIterator<String> itemsOfCommand = command.listIterator();
             while (itemsOfCommand.hasNext()) {
                 String line = itemsOfCommand.next();
@@ -1126,6 +1127,7 @@ public abstract class GFLauncher {
                 }
                 batContent.append('\n');
             }
+            batContent.append("call %CMD% ");
             if (stdinPreloaded) {
                 batContent.append("< %1\n");
             }

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -90,8 +90,8 @@ public class GFLauncherTest {
         launcher.launch();
         CommandLine cmdline = launcher.getCommandLine();
         // 0 --> java, 1 --> "-cp" 2 --> the classpath, 3 -->first arg
-        assertThat(cmdline,
-            hasItems(matchesPattern(".*java(.exe)?"), is("-cp"), is("-XX:+UnlockDiagnosticVMOptions"), is("-verbose")));
+        assertThat(cmdline, hasItems(matchesPattern(".*java(.exe)?(\")?"), is("-cp"),
+            is("-XX:+UnlockDiagnosticVMOptions"), is("-verbose")));
     }
 
     /**
@@ -102,8 +102,8 @@ public class GFLauncherTest {
         info.setDomainName("domain2");
         launcher.launch();
         CommandLine cmdline = launcher.getCommandLine();
-        assertThat(cmdline,
-            hasItems(matchesPattern(".*java(.exe)?"), is("-cp"), not(is("-XX:+UnlockDiagnosticVMOptions")), is("-verbose")));
+        assertThat(cmdline, hasItems(matchesPattern(".*java(.exe)?(\")?"), is("-cp"),
+            not(is("-XX:+UnlockDiagnosticVMOptions")), is("-verbose")));
     }
 
 

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,7 +16,10 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname $0`/..
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+
 AS_INSTALL_LIB=$AS_INSTALL/modules
 JSP_IMPL=$AS_INSTALL_LIB/wasp.jar
 EL_IMPL=$AS_INSTALL_LIB/expressly:$AS_INSTALL_LIB/jakarta.el-api.jar
@@ -23,4 +27,4 @@ JSTL_IMPL=$AS_INSTALL_LIB/jakarta.servlet.jsp.jstl.jar
 AS_LIB=$AS_INSTALL/lib
 JAKARTAEE_API=$AS_LIB/jakartaee.jar
 
-java -cp "$JSP_IMPL:$JAKARTAEE_API:$AS_LIB" org.glassfish.wasp.JspC -sysClasspath "$JSP_IMPL:$EL_IMPL:$JSTL_IMPL:$JAKARTAEE_API:$AS_LIB" -schemas "/schemas/" -dtds "/dtds/" "$@"
+"${JAVA}" -cp "$JSP_IMPL:$JAKARTAEE_API:$AS_LIB" org.glassfish.wasp.JspC -sysClasspath "$JSP_IMPL:$EL_IMPL:$JSTL_IMPL:$JAKARTAEE_API:$AS_LIB" -schemas "/schemas/" -dtds "/dtds/" "$@"

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
@@ -15,13 +15,23 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
 
-
-set AS_INSTALL_LIB=%~dp0..\modules
-set JSP_IMPL=%AS_INSTALL_LIB%\wasp.jar
-set EL_IMPL=%AS_INSTALL_LIB%\expressly;%AS_INSTALL_LIB%\jakarta.el-api.jar
-set JSTL_IMPL=%AS_INSTALL_LIB%\jakarta.servlet.jsp.jstl.jar
-set AS_LIB=%~dp0..\lib
-set JAKARTAEE_API=%AS_LIB%\jakartaee.jar
-
-java -cp "%JSP_IMPL%;%JAKARTAEE_API%;%AS_LIB%" org.glassfish.wasp.JspC -sysClasspath "%JSP_IMPL%;%EL_IMPL%;%JSTL_IMPL%;%JAKARTAEE_API%;%AS_LIB%" -schemas "/schemas/" -dtds "/dtds/" %*
+:ok
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+set "AS_INSTALL_LIB=%~dp0..\modules"
+set "JSP_IMPL=%AS_INSTALL_LIB%\wasp.jar"
+set "EL_IMPL=%AS_INSTALL_LIB%\expressly;%AS_INSTALL_LIB%\jakarta.el-api.jar"
+set "JSTL_IMPL=%AS_INSTALL_LIB%\jakarta.servlet.jsp.jstl.jar"
+set "AS_LIB=%~dp0..\lib"
+set "JAKARTAEE_API=%AS_LIB%\jakartaee.jar"
+"%JAVA%" -cp "%JSP_IMPL%;%JAKARTAEE_API%;%AS_LIB%" org.glassfish.wasp.JspC -sysClasspath "%JSP_IMPL%;%EL_IMPL%;%JSTL_IMPL%;%JAKARTAEE_API%;%AS_LIB%" -schemas "/schemas/" -dtds "/dtds/" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,15 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-exec "$JAVA" -jar "$AS_INSTALL_LIB/admin-cli.jar" "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+exec "$JAVA" -jar "$AS_INSTALL/modules/admin-cli.jar" "$@"

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,20 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
-REM  Always use JDK 1.6 or higher
-REM  Depends on Java from ..\config\asenv.bat
 VERIFY OTHER 2>nul
-setlocal ENABLEEXTENSIONS
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
+
 :ok
-call "%~dp0..\config\asenv.bat"
-if "%AS_JAVA%x" == "x" goto UsePath
-set JAVA="%AS_JAVA%\bin\java"
-goto run
-:UsePath
-set JAVA=java
-:run
-%JAVA% -jar "%~dp0..\modules\admin-cli.jar" %*
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -16,21 +16,9 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-case "`uname`" in
-  CYGWIN*) AS_INSTALL=`cygpath --windows $AS_INSTALL`
-esac
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-. "${AS_INSTALL}/config/asenv.conf"
-JAVA=java
-#Depends upon Java from ../config/asenv.conf
-if [ ${AS_JAVA} ]; then
-    JAVA=${AS_JAVA}/bin/java
-fi
-
-start_as_main_process () {
+startAsMainProcess () {
     if [[ "$@" == "--help" ]] || [[ "$@" == "--help=true" ]] || [[ "$@" == "-?" ]]; then
-      exec java -jar "$ASADMIN_JAR" start-domain --help
+      exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --help
     fi
 
     # Execute start-domain --dry-run and store the output line by line into an array.
@@ -50,7 +38,7 @@ start_as_main_process () {
       else
         DRY_RUN_OUTPUT+=("$COM");
       fi
-    done < <(java -jar "$ASADMIN_JAR" start-domain --dry-run "$@" || echo "FAILED" )
+    done < <("$JAVA" -jar "$ASADMIN_JAR" start-domain --dry-run "$@" || echo "FAILED" )
     if [[ x"$DRY_RUN_OUTPUT" == x ]]
       then
         echo -n -e "${DRY_RUN_OUTPUT_BEFORE_DUMP}" >&2
@@ -65,8 +53,12 @@ start_as_main_process () {
 
 }
 
-ASADMIN_JAR="$AS_INSTALL_LIB/admin-cli.jar"
-start_as_main_process "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+
+ASADMIN_JAR="$AS_INSTALL/modules/admin-cli.jar"
+startAsMainProcess "$@"
 
 # Alternatively, run the following:
 # exec "$JAVA" -jar "$ASADMIN_JAR" start-domain --verbose "$@"

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,5 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
 
-java -jar "%~dp0..\modules\admin-cli.jar" start-domain --verbose %*
+:ok
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" start-domain --verbose %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 #
+# Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -15,7 +16,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-AS_INSTALL=`dirname "$0"`/..
-AS_INSTALL_LIB="$AS_INSTALL/modules"
-
-exec java -jar "$AS_INSTALL_LIB/admin-cli.jar" stop-domain "$@"
+AS_CONFIG="$(dirname "$(realpath -s "$0")")/../config"
+AS_CONFIG_SH="${AS_CONFIG}/config.sh"
+source "${AS_CONFIG_SH}" "$AS_CONFIG" || { echo "${AS_CONFIG_SH} not found" >&2; exit 1; }
+exec "${JAVA} -jar "$AS_INSTALL/modules/admin-cli.jar" stop-domain "$@"

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv.bat
@@ -1,5 +1,6 @@
 @echo off
 REM
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -15,5 +16,17 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
+VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
+if ERRORLEVEL 0 goto ok
+echo "Unable to enable extensions"
+exit /B 1
 
-java -jar "%~dp0..\modules\admin-cli.jar" stop-domain %*
+:ok
+set "AS_CONFIG=%~dp0..\config"
+set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
+call "%AS_CONFIG_BAT%" || (
+    echo Error: Cannot load config file
+    exit /B 1
+)
+"%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" stop-domain %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/asenv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/asenv.bat
@@ -1,5 +1,5 @@
 REM
-REM  Copyright (c) 2024 Contributors to the Eclipse Foundation.
+REM  Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
 REM  Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
 REM
 REM  This program and the accompanying materials are made available under the
@@ -41,7 +41,6 @@ REM  This file uses UTF-8 character encoding.
 set AS_IMQ_LIB=..\..\mq\lib
 set AS_IMQ_BIN=..\..\mq\bin
 set AS_CONFIG=..\config
-set AS_INSTALL=..
 set AS_DEF_DOMAINS_PATH=..\domains
 set AS_DEF_NODES_PATH=..\nodes
 set AS_DERBY_INSTALL=..\..\javadb

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/asenv.conf
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/asenv.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Contributors to the Eclipse Foundation.
+# Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
 # Copyright (c) 2004, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -40,7 +40,6 @@
 AS_IMQ_LIB="../../mq/lib"
 AS_IMQ_BIN="../../mq/bin"
 AS_CONFIG="../config"
-AS_INSTALL=".."
 AS_DEF_DOMAINS_PATH="../domains"
 AS_DEF_NODES_PATH="../nodes"
 AS_DERBY_INSTALL="../../javadb"

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/config.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/config.bat
@@ -1,0 +1,57 @@
+@echo off
+REM
+REM Copyright (c) 2025 Contributors to the Eclipse Foundation
+REM
+REM This program and the accompanying materials are made available under the
+REM terms of the Eclipse Public License v. 2.0, which is available at
+REM http://www.eclipse.org/legal/epl-2.0.
+REM
+REM This Source Code may also be made available under the following Secondary
+REM Licenses when the conditions for such availability set forth in the
+REM Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+REM version 2 with the GNU Classpath Exception, which is available at
+REM https://www.gnu.org/software/classpath/license.html.
+REM
+REM SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+REM Resolve AS_INSTALL from script location
+call :resolveAsInstall "%~dp0.."
+call :loadAsenv
+call :chooseJava
+exit /b 0
+
+:resolveAsInstall
+set "AS_INSTALL=%~f1"
+exit /b 0
+
+:loadAsenv
+if exist "%AS_INSTALL%\config\asenv.bat" (
+    call "%AS_INSTALL%\config\asenv.bat"
+) else (
+    echo Error: asenv.bat not found in %AS_INSTALL%\config
+    exit /b 1
+)
+exit /b 0
+
+:chooseJava
+if defined AS_JAVA (
+    set "JAVA=%AS_JAVA%\bin\java.exe"
+    set "javaSearchType=AS_JAVA"
+    set "javaSearchTarget=%AS_JAVA%"
+) else if defined JAVA_HOME (
+    set "JAVA=%JAVA_HOME%\bin\java.exe"
+    set "javaSearchType=JAVA_HOME"
+    set "javaSearchTarget=%JAVA_HOME%"
+) else (
+    for %%i in (java.exe) do set "JAVA=%%~$PATH:i"
+    set "javaSearchType=PATH"
+    set "javaSearchTarget=%PATH%"
+)
+
+if not exist "%JAVA%" (
+    echo.
+    echo The java command "%JAVA%" is not executable.
+    echo It was configured as %javaSearchType%="%javaSearchTarget%"
+    exit /b 1
+)
+exit /b 0

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/config.sh
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/config.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+# Based on the current path of this script resolves absolute path
+# of the server installation (the glassfish directory).
+# Then sets it as AS_INSTALL environment variable.
+resolveAsInstall() {
+    AS_INSTALL="$(realpath -s "$1/..")"
+    case "`uname`" in
+      CYGWIN*) AS_INSTALL=`cygpath --windows "$AS_INSTALL"`
+               cygwinProp=-Dorg.glassfish.isCygwin=true
+    esac
+    export AS_INSTALL
+}
+
+# Loads the asenv.conf file.
+loadAsenv() {
+    . "${AS_INSTALL}/config/asenv.conf"
+}
+
+# Looks for Java at AS_JAVA, JAVA_HOME or in the path.
+# If successful and the executable was found, it is exported
+# as JAVA environment variable.
+chooseJava() {
+    if [ "${AS_JAVA}" != "" ]; then
+        javaSearchType=AS_JAVA
+        javaSearchTarget="$AS_JAVA"
+        JAVA="${AS_JAVA}/bin/java"
+    elif [ "${JAVA_HOME}" != "" ]; then
+        javaSearchType=JAVA_HOME
+        javaSearchTarget="$JAVA_HOME"
+        JAVA="${JAVA_HOME}/bin/java"
+    else
+        JAVA=`which java`
+        javaSearchType=PATH
+        javaSearchTarget=$PATH
+    fi
+
+    if [ ! -x "${JAVA}" ]; then
+        echo
+        echo "The java command \"${JAVA}\" is not executable."
+        echo "It was configured as ${javaSearchType}=\"${javaSearchTarget}\""
+        exit 1
+    fi
+    export JAVA
+}
+
+resolveAsInstall "$1"
+loadAsenv
+chooseJava


### PR DESCRIPTION
### Changes
- Backported "in advance" from future 7.1 branch and rewritten to reduce duplication and to fix all related issues.
- All linux scripts use bash now
- All scripts use the same way of AS_INSTALL resolution
- Removed mentions about Java 1.6
- Fixed %t resolving on Windows (ie JDK log formatting option) which has to be  escaped.
- Added config.sh script sourced by all bash scripts
  - Loads asenv.conf
  - Sets AS_INSTALL
- AS_INSTALL removed from asenv.conf
   - it doesn't make sense here
   - it overrides values set in scripts
   - it was just a relative path
 - Added test to cover GF starts on Linux and Windows (depending on CI operating system)

### Original state
- GlassFish could not start when on path with spaces, both Linux and Windows
- Inconsistent scripts, some were patched in the past, some respected JAVA_HOME, some did not.
- Missing test for paths with spaces