### PR TITLE
Add EclipseLink version 5.0.0-B07 with more Version Annotation support to address https://github.com/jakartaee/platform-tck/issues/2112

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -114,7 +114,7 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-        <eclipselink.version>5.0.0-B06</eclipselink.version>
+        <eclipselink.version>5.0.0-B07</eclipselink.version>
         <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->


### PR DESCRIPTION
Address Jakarta EE 11 Platform TCK test failures that depend on @Version fields as per https://github.com/jakartaee/platform-tck/issues/2112

The https://github.com/eclipse-ee4j/eclipselink/issues/2343 changes in 5.0.0-B07  may help pass Jakarta EE 11 Platform TCK (Persistence) tests that expect @Version fields to be set by the Persistence Provider (as per https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2#a2059).  

