### PR TITLE
Fixed url to file conversion breaking paths with spaces

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -33,6 +33,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
@@ -1031,6 +1032,24 @@ public final class FileUtils {
         }
         return matches;
     }
+
+
+    /**
+     * Convert a URL to an absolute file if it is possible..
+     *
+     * @param resourceUrl
+     * @return absolute path to the file or directory pointed by the URL
+     * @throws IllegalArgumentException if the URL cannot be converted to a File
+     *
+     */
+    public static File toFile(URL resourceUrl) throws IllegalArgumentException {
+        try {
+            return new File(resourceUrl.toURI()).getAbsoluteFile();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot convert URL to File: " + resourceUrl, e);
+        }
+    }
+
 
     /**
      * Represents a unit of work that should be retried, if needed, until it

--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/io/FileUtilsTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/io/FileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,6 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -146,5 +147,15 @@ public class FileUtilsTest {
             assertEquals(testFile.length(), outputFile.length());
             assertEquals(0, inputStream.available(), "available bytes");
         }
+    }
+
+
+    @Test
+    public void testToFile() throws Exception {
+        URL url = new File("test.txt").toURI().toURL();
+        File file = FileUtils.toFile(url);
+        assertTrue(file.isAbsolute(), "isAbsolute");
+        assertThrows(IllegalArgumentException.class,
+            () -> FileUtils.toFile(new URL("http://localhost:8080/test.txt")));
     }
 }

--- a/nucleus/core/kernel/pom.xml
+++ b/nucleus/core/kernel/pom.xml
@@ -32,10 +32,6 @@
 
     <name>Kernel Classes</name>
 
-    <properties>
-        <commonClassLoader.tests.skip>false</commonClassLoader.tests.skip>
-    </properties>
-
     <developers>
         <developer>
             <id>dochez</id>
@@ -273,66 +269,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.7.1</version>
-                <executions>
-                    <execution>
-                        <id>commonClassLoader tests</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <skipAssembly>${commonClassLoader.tests.skip}</skipAssembly>
-                    <inlineDescriptors>
-                        <inlineDescriptor>
-                            <id>domain</id>
-                            <includeBaseDirectory>false</includeBaseDirectory>
-                            <formats>
-                                <format>dir</format>
-                            </formats>
-                            <fileSets>
-                                <fileSet>
-                                    <outputDirectory>lib/classes</outputDirectory>
-                                    <includes>
-                                        <include>**/CommonClassLoaderServiceImplTestDomainClass.class</include>
-                                    </includes>
-                                    <directory>target/test-classes/</directory>
-                                </fileSet>
-                            </fileSets>
-                        </inlineDescriptor>
-                        <inlineDescriptor>
-                            <id>additional-classes</id>
-                            <includeBaseDirectory>false</includeBaseDirectory>
-                            <formats>
-                                <format>dir</format>
-                            </formats>
-                            <fileSets>
-                                <fileSet>
-                                    <outputDirectory>/</outputDirectory>
-                                    <includes>
-                                        <include>**/CommonClassLoaderServiceImplTestAdditionalClass.class</include>
-                                    </includes>
-                                    <directory>target/test-classes/</directory>
-                                </fileSet>
-                            </fileSets>
-                        </inlineDescriptor>
-                    </inlineDescriptors>
-                    <finalName>test</finalName>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>fastest</id>
-            <properties>
-                <commonClassLoader.tests.skip>true</commonClassLoader.tests.skip>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,19 +18,50 @@ package com.sun.enterprise.v3.server;
 import jakarta.inject.Inject;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.System.Logger;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.main.core.kernel.test.KernelJUnitExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
+import static java.lang.System.Logger.Level.INFO;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * Note: The CommonClassLoaderServiceImpl is stateful, so every change affects other tests.
+ *
+ * @author Ondro Mihaliy
+ * @author David Matejcek
+ */
 @ExtendWith(KernelJUnitExtension.class)
+@TestMethodOrder(OrderAnnotation.class)
 public class CommonClassLoaderServiceImplTest {
+    private static final Logger LOG = System.getLogger(CommonClassLoaderServiceImplTest.class.getName());
+
+    @TempDir
+    private static File tmpDir;
+    private static Path tmpClassesDir;
 
     @Inject
     private CommonClassLoaderServiceImpl commonCLService;
@@ -38,31 +69,87 @@ public class CommonClassLoaderServiceImplTest {
     @Inject
     private ServerEnvironment env;
 
-    @Test
-    public void testAddingUrlWithNoInitialUrls() throws Exception {
-        final String classesPath = "target/test-additional-classes/";
-        commonCLService.addToClassPath(new File(classesPath).toURI().toURL());
+    private Path libClasses;
 
-        // we need to retrieve the classloader after adding URLs, otherwise we
-        // would get its parent because of an optimization in the service
-        final ClassLoader commonClassLoader = commonCLService.getCommonClassLoader();
-        commonClassLoader.loadClass(CommonClassLoaderServiceImplTestAdditionalClass.class.getName());
-        assertThat(commonCLService.getCommonClassPath(), containsString(new File(classesPath).getAbsolutePath()));
+
+    @BeforeAll
+    static void initAdditionalClassesDir() throws Exception {
+        tmpClassesDir = new File(tmpDir, "additional classes dir").toPath();
+        copyToAdditionalClasses(CommonClassLoaderServiceImplTestAdditionalClass.class, tmpClassesDir);
     }
 
+    @BeforeEach
+    void init() throws Exception {
+        commonCLService.acls = new APIClassLoaderServiceImpl() {
+
+            @Override
+            public ClassLoader getAPIClassLoader() {
+                return new URLClassLoader(new URL[0], null);
+            }
+
+        };
+        libClasses = env.getInstanceRoot().toPath().resolve(Path.of("lib", "classes"));
+    }
+
+
     @Test
-    public void testAddingUrlWithInitialUrl() throws Exception {
-        // the classloader should already be the one we want, initialized with classes in domain/lib/classes
+    @Order(10)
+    void testAddingEmptyPath() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> commonCLService.addToClassPath(new URL("file://")));
+        String classpath = commonCLService.getCommonClassPath();
+        assertThat(classpath, emptyString());
+    }
+
+
+    /**
+     * We need to retrieve the classloader after adding URLs, otherwise we
+     * would get its parent because of an optimization in the service
+     */
+    @Test
+    @Order(20)
+    void testAddingUrlWithNoInitialUrls() throws Exception {
+        commonCLService.postConstruct();
+
+        final ClassLoader origClassLoader = commonCLService.getCommonClassLoader();
+        commonCLService.addToClassPath(tmpClassesDir.toUri().toURL());
+        String classpath = commonCLService.getCommonClassPath();
+        LOG.log(INFO, "classpath: {0}", classpath);
+        assertThat(classpath, containsString(tmpClassesDir.toString()));
+
         final ClassLoader commonClassLoader = commonCLService.getCommonClassLoader();
+        assertNotSame(origClassLoader, commonClassLoader);
+        assertNotNull(commonClassLoader.loadClass(CommonClassLoaderServiceImplTestAdditionalClass.class.getName()));
+    }
 
-        final String classesPath = "target/test-additional-classes/";
-        commonCLService.addToClassPath(new File(classesPath).toURI().toURL());
 
-        commonClassLoader.loadClass(CommonClassLoaderServiceImplTestAdditionalClass.class.getName());
-        commonClassLoader.loadClass(CommonClassLoaderServiceImplTestDomainClass.class.getName());
-        assertThat(commonCLService.getCommonClassPath(),
-            stringContainsInOrder(
-                env.getInstanceRoot().toPath().resolve(Path.of("lib", "classes")).toString(),
-                new File(classesPath).getAbsolutePath()));
+    /**
+     * The classloader should already be the one we want, initialized with classes in
+     * domain/lib/classes
+     */
+    @Test
+    @Order(30)
+    void testAddingUrlWithInitialUrl() throws Exception {
+        copyToAdditionalClasses(CommonClassLoaderServiceImplTestDomainClass.class, libClasses);
+        commonCLService.postConstruct();
+
+        // Don't move this line below commonCLService.addToClassPath()
+        final ClassLoader commonClassLoader = commonCLService.getCommonClassLoader();
+        commonCLService.addToClassPath(tmpClassesDir.toUri().toURL());
+        String[] classpath = commonCLService.getCommonClassPath().split(File.pathSeparator);
+        LOG.log(INFO, "classpath: {0}", Arrays.toString(classpath));
+        assertThat(classpath, arrayContaining(libClasses.toString(), tmpClassesDir.toString()));
+
+        assertNotNull(commonClassLoader.loadClass(CommonClassLoaderServiceImplTestAdditionalClass.class.getName()));
+        assertNotNull(commonClassLoader.loadClass(CommonClassLoaderServiceImplTestDomainClass.class.getName()));
+    }
+
+
+    private static void copyToAdditionalClasses(Class<?> sourceClass, Path targetClasses) throws IOException {
+        String relativePath = sourceClass.getName().replace('.', File.separatorChar) + ".class";
+        try (InputStream in = sourceClass.getClassLoader().getResourceAsStream(relativePath)) {
+            Path targetPath = targetClasses.resolve(relativePath);
+            Files.createDirectories(targetPath.getParent());
+            Files.copy(in, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        }
     }
 }

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/services/impl/GrizzlyProxyTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/services/impl/GrizzlyProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -149,7 +149,7 @@ public class GrizzlyProxyTest {
 
     private static void validateLogContents(String[] messages) throws IOException {
         try (BufferedReader reader = new BufferedReader(new FileReader(TEST_LOG))) {
-            StringBuffer buf = new StringBuffer();
+            StringBuilder buf = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
                 buf.append(line);

--- a/nucleus/core/kernel/src/test/java/org/glassfish/main/core/kernel/test/KernelJUnitExtension.java
+++ b/nucleus/core/kernel/src/test/java/org/glassfish/main/core/kernel/test/KernelJUnitExtension.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,11 +17,15 @@
 package org.glassfish.main.core.kernel.test;
 
 import com.sun.enterprise.admin.util.InstanceStateService;
+import com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys;
+import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.admin.ObjectInputStreamWithServiceLocator;
 
+import java.nio.file.Path;
 import java.util.Set;
 
 import org.glassfish.tests.utils.junit.HK2JUnit5Extension;
+import org.glassfish.tests.utils.junit.JUnitSystem;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 
@@ -32,6 +35,14 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @author David Matejcek
  */
 public class KernelJUnitExtension extends HK2JUnit5Extension {
+
+    static {
+        Path installRoot = JUnitSystem.detectBasedir();
+        Path instanceRoot = installRoot.resolve(Path.of("target", "test-domain"));
+        FileUtils.mkdirsMaybe(instanceRoot.toFile());
+        System.setProperty(BootstrapKeys.INSTALL_ROOT_PROP_NAME, installRoot.toString());
+        System.setProperty(BootstrapKeys.INSTANCE_ROOT_PROP_NAME, instanceRoot.toString());
+    }
 
     @Override
     protected String getDomainXml(final Class<?> testClass) {

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/ExcludeClasses.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/ExcludeClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,5 +43,5 @@ public @interface ExcludeClasses {
      *
      * @return array iof ignored classes
      */
-    public Class<?>[] value();
+    Class<?>[] value();
 }

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2ClasssVisitor.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2ClasssVisitor.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,7 +50,7 @@ class HK2ClasssVisitor extends ClassVisitor {
      * @param locator
      * @param excludedClasses
      */
-    public HK2ClasssVisitor(final ServiceLocator locator, final Set<Class<?>> excludedClasses) {
+    HK2ClasssVisitor(final ServiceLocator locator, final Set<Class<?>> excludedClasses) {
         super(ASM9);
         this.locator = locator;
         this.excludedClasses = excludedClasses.stream().map(Class::getName).collect(Collectors.toSet());

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/JUnitSystem.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/JUnitSystem.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.utils.junit;
+
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Helper class to make possible running tests the same way in Maven as in Eclipse IDE, probably
+ * also other environments.
+ */
+public final class JUnitSystem {
+
+    private JUnitSystem() {
+        // utility class
+    }
+
+    /**
+     * Useful for a heuristic inside Eclipse and other environments.
+     *
+     * @return Absolute path to the glassfish directory.
+     */
+    public static Path detectBasedir() {
+        // Maven would set this property.
+        final String basedir = System.getProperty("basedir");
+        if (basedir != null) {
+            return new File(basedir).toPath().toAbsolutePath();
+        }
+        // Maybe we are standing in the basedir.
+        final File target = new File("target");
+        if (target.exists()) {
+            return target.toPath().toAbsolutePath().getParent();
+        }
+        // Eclipse IDE sometimes uses target as the current dir.
+        return new File(".").toPath().toAbsolutePath().getParent();
+    }
+}


### PR DESCRIPTION
This PR fixes part of issues seen when manually testing another branch on Windows using path with spaces.
Fixes also a validation issue when URL with empty path could pass into the classloader.
I have cherrypicked also another commit refactoring test which I needed here to confirm issues we have noticed in sources.
