### PR TITLE
More robust pid file read

### DIFF
--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -296,7 +296,11 @@ public final class ProcessUtils {
             return null;
         }
         try {
-            return Long.valueOf(FileUtils.readSmallFile(pidFile, ISO_8859_1).trim());
+            // Usually the process is concurrent to the process writing to the file.
+            // Reproduced by tests at least once that the file can be created but empty
+            // while we are already reading it.
+            final String fileContent = FileUtils.readSmallFile(pidFile, ISO_8859_1).trim();
+            return fileContent.isEmpty() ? null : Long.valueOf(fileContent);
         } catch (NumberFormatException | IOException e) {
             throw new IllegalArgumentException("Could not parse the PID file: " + pidFile, e);
         }


### PR DESCRIPTION
Rare but possible - sometimes the file is created but the pid number is not written yet, so another process sees just the empty file.
