### PR TITLE
BAT file and startlocal vs endlocal, windows path separator

### DIFF
--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
@@ -16,20 +16,20 @@ REM
 REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
-
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 set ARGS=%*
 
 REM Execute CLIBootstrap with the arguments passed to this script

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008 -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" start-domain --verbose %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" stop-domain %*

--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
@@ -16,12 +16,12 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
@@ -34,4 +34,5 @@ set "EL_IMPL=%AS_INSTALL_LIB%\expressly;%AS_INSTALL_LIB%\jakarta.el-api.jar"
 set "JSTL_IMPL=%AS_INSTALL_LIB%\jakarta.servlet.jsp.jstl.jar"
 set "AS_LIB=%~dp0..\lib"
 set "JAKARTAEE_API=%AS_LIB%\jakartaee.jar"
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -cp "%JSP_IMPL%;%JAKARTAEE_API%;%AS_LIB%" org.glassfish.wasp.JspC -sysClasspath "%JSP_IMPL%;%EL_IMPL%;%JSTL_IMPL%;%JAKARTAEE_API%;%AS_LIB%" -schemas "/schemas/" -dtds "/dtds/" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" start-domain --verbose %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv.bat
@@ -17,16 +17,17 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
-setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
+endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
+setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" stop-domain %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/asenv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/asenv.bat
@@ -38,6 +38,7 @@ REM  directory.
 REM
 REM  This file uses UTF-8 character encoding.
 
+endlocal
 set AS_IMQ_LIB=..\..\mq\lib
 set AS_IMQ_BIN=..\..\mq\bin
 set AS_CONFIG=..\config

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/config.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/config.bat
@@ -15,6 +15,8 @@ REM
 REM SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 REM Resolve AS_INSTALL from script location
+
+endlocal
 call :resolveAsInstall "%~dp0.."
 call :loadAsenv
 call :chooseJava

--- a/nucleus/distributions/nucleus-common/src/main/resources/config/config.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/config.bat
@@ -43,7 +43,7 @@ if defined AS_JAVA (
     set "javaSearchType=JAVA_HOME"
     set "javaSearchTarget=%JAVA_HOME%"
 ) else (
-    for %%i in (java.exe) do set "JAVA=%%~$PATH:i"
+    for %%i in (java.exe) do set "JAVA=%%~$PATH;i"
     set "javaSearchType=PATH"
     set "javaSearchTarget=%PATH%"
 )


### PR DESCRIPTION
Observation - with recent changes in #25436 AS_INSTALL was not always set.
This PR is rather defensive as Windows rules are quite confusing.
I noticed also one typo - used Linux path separator on Windows - fixed here.