### PR TITLE
Property management used just by embedded pushed down

### DIFF
--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishProperties.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -20,6 +20,7 @@ package org.glassfish.embeddable;
 import java.io.File;
 import java.net.URI;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Encapsulates the set of properties required to create a new GlassFish instance.
@@ -87,6 +88,24 @@ public class GlassFishProperties {
     public Properties getProperties() {
         return gfProperties;
     }
+
+
+    /**
+     * @return set of configured property names
+     */
+    public Set<String> getPropertyNames() {
+        return gfProperties.stringPropertyNames();
+    }
+
+
+    /**
+     * @param name
+     * @return value for the given property or null if not set
+     */
+    public String getProperty(String name) {
+        return gfProperties.getProperty(name);
+    }
+
 
     /**
      * Set any custom glassfish property. May be required for the plugged in

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntime.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/osgi/EmbeddedOSGiGlassFishRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -244,7 +244,7 @@ public class EmbeddedOSGiGlassFishRuntime extends GlassFishRuntime {
 
     private GlassFish createGlassFish(ModuleStartup gfKernel, ServiceLocator locator, Properties gfProps)
         throws GlassFishException {
-        GlassFish gf = new GlassFishImpl(gfKernel, locator, gfProps);
+        GlassFish gf = new GlassFishImpl(gfKernel, locator);
         return new EmbeddedOSGiGlassFishImpl(gf, context);
     }
 


### PR DESCRIPTION
The code was executed on standard server too. 
I noticed that on 7.1 branch where is bit more strict classloading and the CommandRunner is not possible in this phase of startup. We agreed with @OndroMih that I will push the code down where it belongs. 
Original code before changes done in #25422 had if-continue condition for properties except embedded, see https://github.com/eclipse-ee4j/glassfish/pull/25422/files#diff-7faecc510b053d297a3bfc2c3fe025687d4304d5688384265d43af66e1f9ae64
