### PR TITLE
Fixed PowerShell script on Windows and removed bat file

### DIFF
--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
@@ -17,19 +17,18 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 set ARGS=%*
 
 REM Execute CLIBootstrap with the arguments passed to this script

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/debug-asadmin.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=9008 -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/startserv.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" start-domain --verbose %*

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/stopserv.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\glassfish\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" stop-domain %*

--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.bat
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\lib\client\appserver-cli.jar" %*

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/CommandLine.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/CommandLine.java
@@ -64,7 +64,7 @@ public final class CommandLine implements Iterable<String> {
      * @param paths
      */
     public void appendClassPath(File... paths) {
-        String value = Stream.of(paths).map(File::toPath).map(CommandLine::toJavaPath)
+        String value = Stream.of(paths).map(File::toPath).map(CommandLine::toAbsoluteStringPath)
             .collect(Collectors.joining(File.pathSeparator));
         command.add("-cp");
         command.add(toQuotedIfNeeded(value));
@@ -78,7 +78,7 @@ public final class CommandLine implements Iterable<String> {
      * @param paths
      */
     public void appendNativeLibraryPath(File... paths) {
-        String value = Stream.of(paths).map(File::toPath).map(CommandLine::toJavaPath)
+        String value = Stream.of(paths).map(File::toPath).map(CommandLine::toAbsoluteStringPath)
             .collect(Collectors.joining(File.pathSeparator));
         command.add("-D" + GFLauncherConstants.JAVA_NATIVE_SYSPROP_NAME + '=' + toQuotedIfNeeded(value));
     }
@@ -90,7 +90,7 @@ public final class CommandLine implements Iterable<String> {
      * @param path
      */
     public void append(Path path) {
-        command.add(toQuotedIfNeeded(toJavaPath(path)));
+        command.add(toQuotedIfNeeded(toAbsoluteStringPath(path)));
     }
 
 
@@ -111,7 +111,7 @@ public final class CommandLine implements Iterable<String> {
      * @param path
      */
     public void appendJavaOption(String itemKey, Path path) {
-        command.add(itemKey + '=' + toQuotedIfNeeded(toJavaPath(path)));
+        command.add(itemKey + '=' + toQuotedIfNeeded(toAbsoluteStringPath(path)));
     }
 
 
@@ -171,8 +171,6 @@ public final class CommandLine implements Iterable<String> {
 
 
     private String toQuotedIfNeeded(String value) {
-        // BAT files have issues when then string doesn't contain a space
-        // and we would use quotation marks.
         if (format == CommandFormat.Script) {
             if (value.indexOf(' ') >= 0) {
                 return toQuoted(value);
@@ -189,13 +187,7 @@ public final class CommandLine implements Iterable<String> {
     }
 
 
-    private static String toJavaPath(Path path) {
-        // Even windows can work with /, however it has some rules.
-        // ProcessBuilder escapes what is needed automatically - but that is not a case of
-        // a bat file content.
-        // Paths with backslash can be used without quotation marks - not in bat,
-        // because space is a separator.
-        // Strings with backspaces quoted are taken as strings -> backslash means escaping.
+    private static String toAbsoluteStringPath(Path path) {
         return path.normalize().toAbsolutePath().toString();
     }
 
@@ -206,8 +198,8 @@ public final class CommandLine implements Iterable<String> {
          */
         ProcessBuilder,
         /**
-         * To be written into a bat file which will be executed.
-         * We need to ensure the proper formatting for the Windows BAT file.
+         * To be written into a script file which will be executed.
+         * We need to ensure the proper formatting with respect to quotation rules..
          */
         Script,;
     }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/CommandLine.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/CommandLine.java
@@ -173,11 +173,11 @@ public final class CommandLine implements Iterable<String> {
     private String toQuotedIfNeeded(String value) {
         // BAT files have issues when then string doesn't contain a space
         // and we would use quotation marks.
-        if (format == CommandFormat.BatFile) {
+        if (format == CommandFormat.Script) {
             if (value.indexOf(' ') >= 0) {
-                return escapeSpecialCharactersIfNeeded(toQuoted(value));
+                return toQuoted(value);
             }
-            return escapeSpecialCharactersIfNeeded(value);
+            return value;
         }
         // ProcessBuilder resolves it on its own.
         return value;
@@ -189,17 +189,6 @@ public final class CommandLine implements Iterable<String> {
     }
 
 
-    private String escapeSpecialCharactersIfNeeded(String value) {
-        // BAT files try to interpret % as a variable,
-        // ie %t means current date and time
-        // BAT files also can interpret quotation marks, so we need to escape them.
-        if (format == CommandFormat.BatFile) {
-            return value.replaceAll("%", "%%").replaceAll("\"", "^\"");
-        }
-        return value;
-    }
-
-
     private static String toJavaPath(Path path) {
         // Even windows can work with /, however it has some rules.
         // ProcessBuilder escapes what is needed automatically - but that is not a case of
@@ -207,7 +196,7 @@ public final class CommandLine implements Iterable<String> {
         // Paths with backslash can be used without quotation marks - not in bat,
         // because space is a separator.
         // Strings with backspaces quoted are taken as strings -> backslash means escaping.
-        return path.normalize().toAbsolutePath().toString().replace('\\', '/');
+        return path.normalize().toAbsolutePath().toString();
     }
 
     static enum CommandFormat {
@@ -220,6 +209,6 @@ public final class CommandLine implements Iterable<String> {
          * To be written into a bat file which will be executed.
          * We need to ensure the proper formatting for the Windows BAT file.
          */
-        BatFile,;
+        Script,;
     }
 }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFEmbeddedLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFEmbeddedLauncher.java
@@ -48,12 +48,14 @@ class GFEmbeddedLauncher extends GFLauncher {
     private static final String GFE_JAR = "GFE_JAR";
     private static final String INSTALL_HOME = "S1AS_HOME";
     private static final String JAVA_HOME = "JAVA_HOME";
-    // private static final String DOMAIN_DIR = "GFE_DOMAIN";
     private static final String GENERAL_MESSAGE = " *********  GENERAL MESSAGE ********\n"
-            + "You must setup four different environmental variables to run embedded" + " with asadmin.  They are\n"
-            + "GFE_JAR - path to the embedded jar\n" + "S1AS_HOME - path to installation directory.  This can be empty or not exist yet.\n"
-            + "JAVA_HOME - path to a JDK installation.  JRE installation is generally not good enough\n"
-            + "GFE_DEBUG_PORT - optional debugging port.  It will start suspended.\n" + "\n*********  SPECIFIC MESSAGE ********\n";
+            + "You must setup four different environmental variables to run embedded with asadmin."
+            + " They are\n"
+            + "GFE_JAR - path to the embedded jar\n"
+            + "S1AS_HOME - path to installation directory. This can be empty or not exist yet.\n"
+            + "JAVA_HOME - path to a JDK installation. JRE installation is generally not good enough\n"
+            + "GFE_DEBUG_PORT - optional debugging port. It will start suspended.\n"
+            + "\n*********  SPECIFIC MESSAGE ********\n";
 
     private final String[] DERBY_FILES = { "derby.jar", "derbyclient.jar", };
 
@@ -263,8 +265,8 @@ class GFEmbeddedLauncher extends GFLauncher {
     }
 
     private void setupInstallationDir() throws GFLauncherException {
-        String err = "You must set the environmental variable S1AS_HOME to point "
-                + "at a GlassFish installation or at an empty directory or at a " + "location where an empty directory can be created.";
+        String err = "You must set the environmental variable S1AS_HOME to point at a GlassFish installation"
+            + " or at an empty directory or at a location where an empty directory can be created.";
         String installDirName = System.getenv(INSTALL_HOME);
 
         if (!ok(installDirName)) {
@@ -281,7 +283,7 @@ class GFEmbeddedLauncher extends GFLauncher {
     }
 
     private void setupEmbeddedJars() throws GFLauncherException {
-        String err = "You must set the environmental variable GFE_JAR to point " + "at the Embedded jarfile.";
+        String err = "You must set the environmental variable GFE_JAR to point at the Embedded jarfile.";
 
         String gfeJarName = System.getenv(GFE_JAR);
 
@@ -297,7 +299,7 @@ class GFEmbeddedLauncher extends GFLauncher {
 
         gfeJar = SmartFile.sanitize(gfeJar);
 
-        err = "You must set the environmental variable GFE_RUNSERVER_JAR to point " + "at the server startup jar.";
+        err = "You must set the environmental variable GFE_RUNSERVER_JAR to point at the server startup jar.";
 
         String runServerJarName = System.getenv(GFE_RUNSERVER_JAR);
 

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFEmbeddedLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFEmbeddedLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -73,7 +73,7 @@ class GFEmbeddedLauncher extends GFLauncher {
 
     @Override
     List<File> getMainClasspath() throws GFLauncherException {
-        throw new GFLauncherException("not needed?!?");
+        return List.of();
     }
 
     @Override
@@ -174,7 +174,9 @@ class GFEmbeddedLauncher extends GFLauncher {
         CommandLine cmdLine = new CommandLine(CommandFormat.ProcessBuilder);
         cmdLine.append(javaExe.toPath());
         addThreadDump(cmdLine);
-        cmdLine.appendClassPath(getClasspath());
+        if (getClasspath().length > 0) {
+            cmdLine.appendClassPath(getClasspath());
+        }
         addDebug(cmdLine);
         cmdLine.append(getMainClass());
         cmdLine.append("--installdir");

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/InstallNodeSshCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/InstallNodeSshCommand.java
@@ -303,9 +303,9 @@ public class InstallNodeSshCommand extends InstallNodeBaseCommand {
      */
     private void checkIfAlreadyInstalled(SSHSession session, String host, Path sshInstallDir)
         throws CommandException, SSHException {
-        //check if an installation already exists on remote host
-        String asadmin = Constants.v4 ? "/lib/nadmin' version --local --terse" : "/bin/asadmin' version --local --terse";
-        String cmd = "'" + sshInstallDir + "/" + SystemPropertyConstants.getComponentName() + asadmin;
+        String asadmin = Constants.v4 ? "/lib/nadmin" : "/bin/asadmin";
+        String cmd = "\"" + sshInstallDir + "/" + SystemPropertyConstants.getComponentName() + asadmin
+            + "\" version --local --terse";
         int status = session.exec(cmd);
         if (status == 0) {
             throw new CommandException(Strings.get("install.dir.exists", sshInstallDir));

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/connect/NodeRunnerSsh.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/connect/NodeRunnerSsh.java
@@ -24,6 +24,7 @@ import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.glassfish.api.admin.SSHCommandExecutionException;
 import org.glassfish.cluster.ssh.launcher.SSHException;
@@ -87,9 +88,9 @@ public class NodeRunnerSsh {
         try {
             // We can just use "nadmin" even on Windows since the SSHD provider
             // will locate the command (.exe or .bat) for us
-            fullcommand.add(installDir + "/lib/nadmin");
+            fullcommand.add("\"" + installDir + "/lib/nadmin\"");
             fullcommand.addAll(args);
-            lastCommandRun = commandListToString(fullcommand);
+            lastCommandRun = fullcommand.stream().collect(Collectors.joining(" "));
             LOG.log(DEBUG, () -> "Running command on " + node.getNodeHost() + ": " + lastCommandRun);
             final StringBuilder commandOutput = new StringBuilder();
             try (SSHSession session = sshL.openSession()) {
@@ -104,15 +105,5 @@ public class NodeRunnerSsh {
             cee.setCommandRun(lastCommandRun);
             throw cee;
         }
-    }
-
-
-    private String commandListToString(List<String> command) {
-        StringBuilder fullCommand = new StringBuilder();
-        for (String s : command) {
-            fullCommand.append(' ');
-            fullCommand.append(s);
-        }
-        return fullCommand.toString();
     }
 }

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHKeyInstaller.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHKeyInstaller.java
@@ -141,7 +141,7 @@ public class SSHKeyInstaller {
 
             // append the public key file contents to authorized_keys file on remote host
             final SFTPPath authKeyFile = remoteSshDir.resolve(AUTH_KEY_FILE);
-            String mergeCommand = "cat " + remoteKeyTmp + " >> " + authKeyFile;
+            String mergeCommand = "cat \"" + remoteKeyTmp + "\" >> \"" + authKeyFile + "\"";
             LOG.log(DEBUG, () -> "mergeCommand = " + mergeCommand);
             if (session.exec(mergeCommand) != 0) {
                 throw new IOException("Failed to propogate the public key " + pubKey + " to " + ssh.getHost());

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHSession.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHSession.java
@@ -22,7 +22,6 @@ import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.ChannelShell;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
-import com.sun.enterprise.util.io.FileUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -35,6 +34,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.glassfish.cluster.ssh.sftp.SFTPClient;
 import org.glassfish.cluster.ssh.sftp.SFTPPath;
@@ -162,7 +162,7 @@ public class SSHSession implements AutoCloseable {
      * @throws SSHException
      */
     public int exec(List<String> command, List<String> stdinLines, StringBuilder output) throws SSHException {
-        return exec(commandListToQuotedString(command), listInputStream(stdinLines, capabilities.getCharset()), output);
+        return exec(command.stream().collect(Collectors.joining(" ")), listInputStream(stdinLines, capabilities.getCharset()), output);
     }
 
 
@@ -177,7 +177,7 @@ public class SSHSession implements AutoCloseable {
      * @throws SSHException
      */
     public int exec(List<String> command, List<String> stdinLines) throws SSHException {
-        return exec(commandListToQuotedString(command), stdinLines);
+        return exec(command.stream().collect(Collectors.joining(" ")), stdinLines);
     }
 
 
@@ -301,38 +301,6 @@ public class SSHSession implements AutoCloseable {
         if (session.isConnected()) {
             session.disconnect();
         }
-    }
-
-
-    /**
-     * Take a command in the form of a list and convert it to a command string.
-     * If any string in the list has spaces then the string is quoted before
-     * being added to the final command string.
-     *
-     * @param command
-     * @return
-     */
-    private static String commandListToQuotedString(List<String> command) {
-        if (command.size() == 1) {
-            return command.get(0);
-        }
-        StringBuilder commandBuilder  = new StringBuilder();
-        boolean first = true;
-
-        for (String s : command) {
-            if (!first) {
-                commandBuilder.append(" ");
-            } else {
-                first = false;
-            }
-            if (s.contains(" ")) {
-                // Quote parts of the command that contain a space
-                commandBuilder.append(FileUtils.quoteString(s));
-            } else {
-                commandBuilder.append(s);
-            }
-        }
-        return commandBuilder.toString();
     }
 
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/io/FileUtils.java
@@ -813,37 +813,6 @@ public final class FileUtils {
     }
 
 
-    /**
-     * Given a string (typically a path), quote the string such that spaces
-     * are protected from interpretation by a Unix or Windows command shell.
-     * Note that this method does not handle quoting for all styles of special
-     * characters. Just for the basic case of strings with spaces.
-     *
-     * @param s input string
-     * @return a String which is quoted to protect spaces
-     */
-    public static String quoteString(String s) {
-        if (s == null) {
-            throw new IllegalArgumentException("null string");
-        }
-
-        if (!s.contains("\'")) {
-            return ("\'" + s + "\'");
-        } else if (!s.contains("\"")) {
-            return ("\"" + s + "\"");
-        } else {
-            // Contains a single quote and a double quote. Use backslash
-            // On Unix. Double quotes on Windows. This method does not claim
-            // to support this case well if at all
-            if (OS.isWindows()) {
-                return("\"" + s + "\"");
-            } else {
-                return(s.replaceAll("\040", "\134 "));
-            }
-        }
-    }
-
-
     static boolean isValidString(String s) {
         return s != null && !s.isEmpty();
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/IdmService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/IdmService.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -164,9 +165,10 @@ public class IdmService implements PostConstruct, IdentityManagement {
 
     private boolean setFromStdin() {
         logger.fine("Reading the master password from stdin> ");
-        String s;
-        try {
-            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        // We will close the standard input as we don't use it any more.
+        // On windows it would block deletion of the temporary file otherwise.
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+            String s;
             while ((s = br.readLine()) != null) {
                 int ind = s.indexOf(MP_PROPERTY);
                 if (ind == -1) {
@@ -184,6 +186,14 @@ public class IdmService implements PostConstruct, IdentityManagement {
         } catch (Exception e) {
             logger.fine("Stdin isn't behaving, ignoring it ..." + e.getMessage());
             return false;
+        } finally {
+            try {
+                System.in.close();
+            } catch (IOException e) {
+                logger.fine("Error closing stdin: " + e.getMessage());
+            } finally {
+                System.setIn(null);
+            }
         }
     }
 

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/jspc.bat
@@ -16,12 +16,12 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
@@ -34,5 +34,4 @@ set "EL_IMPL=%AS_INSTALL_LIB%\expressly;%AS_INSTALL_LIB%\jakarta.el-api.jar"
 set "JSTL_IMPL=%AS_INSTALL_LIB%\jakarta.servlet.jsp.jstl.jar"
 set "AS_LIB=%~dp0..\lib"
 set "JAKARTAEE_API=%AS_LIB%\jakartaee.jar"
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -cp "%JSP_IMPL%;%JAKARTAEE_API%;%AS_LIB%" org.glassfish.wasp.JspC -sysClasspath "%JSP_IMPL%;%EL_IMPL%;%JSTL_IMPL%;%JAKARTAEE_API%;%AS_LIB%" -schemas "/schemas/" -dtds "/dtds/" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/startserv.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" start-domain --verbose %*

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv.bat
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/stopserv.bat
@@ -17,17 +17,16 @@ REM  SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 REM
 
 VERIFY OTHER 2>nul
+setlocal EnableExtensions EnableDelayedExpansion
 if ERRORLEVEL 0 goto ok
 echo "Unable to enable extensions"
 exit /B 1
 
 :ok
-endlocal
 set "AS_CONFIG=%~dp0..\config"
 set "AS_CONFIG_BAT=%AS_CONFIG%\config.bat"
 call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-setlocal EnableExtensions EnableDelayedExpansion
 "%JAVA%" -jar "%AS_INSTALL%\modules\admin-cli.jar" stop-domain %*


### PR DESCRIPTION
- Fixes #25429 partially
  - It is not possible to fix ti completely.
  - We can however avoid using powershell for local execution. Windows then will kill the instance after user logs out.
  - For SSH nodes Windows kills instance immediately after SSH ends. That is why we use the Scheduler to start instance not as a child of the SSH process, windows then let them live. User needs permissions to schedule tasks and to execute powershell scripts.
- Fixes problems with spaces which BAT files cannot resolve (just strings) while PowerShell is much better in this (CSV-like array).
- Created issue #25457 to improve the documentation.
- Fixes endlocal effect in "user" bat scripts (asadmin, nadmin, appclient) which set env variables outside their own scope. See https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setlocal for details.

### Manual Testing
* Passed `glassfish-itest-tools` tests in the project directory renamed to have spaces in name.
* Tested using **https://github.com/eclipse-ee4j/glassfish/discussions/25343** with a space in the windows node path.
   ```
   change-admin-password
   enable-secure-admin
   restart-domain
   create-node-ssh --nodehost 192.168.56.101 --installdir '/Users/vboxuser/glassfish 7' --sshuser vboxuser --sshkeyfile /home/dmatej/.ssh/id_rsa_nopassphrase --install true win2025
   create-cluster ClusterOne
   create-instance --cluster ClusterOne --node win2025 InstanceWin2025
   start-instance InstanceWin2025
   stop-instance InstanceWin2025
   start-cluster ClusterOne
   stop-instance InstanceWin2025
   ``` 
   Then I moved to the windows node running in VirtualBox - there is few unhappy surprises like firewalls interrupting connections of stopped processes, session isolation so you cannot use jcmd and ProcessBuilder to access processes by pid if they were started in different sessions, etc. However we are still able to face it.
   ```
   C:\Users\vboxuser>".\glassfish 7\glassfish\bin\asadmin" start-local-instance InstanceWin2025
   C:\Users\vboxuser>".\glassfish 7\glassfish\bin\asadmin" stop-local-instance InstanceWin2025
   ```

### Limitaions
* To use SSH Nodes on windows Server 2025 you need privileges
* Windows Server 2025 limits visible processes to current session - even jcmd executed locally cannot see JVMs started using SSH. So using start-local-instance and stop-local-instance is possible just "symmetrically", you cannot stop process by PID started via SSH. However DAS can as it uses SSH too.
* Instances started using local commands are killed once user logs off the system - with the end of the session.