### PR TITLE
Stabilized tests around logging

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -110,7 +110,7 @@ public class LoggingRestITest extends RestTestBase {
         assertThat(response.getStatus(), equalTo(200));
 
         JSONArray array = getJsonArrayFrom(response, "records");
-        assertThat(array.length(), greaterThan(15));
+        assertThat(array.length(), greaterThan(14));
     }
 
     static JSONObject readJsonObjectFrom(Response response) {

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -116,6 +116,7 @@ final class LoggingOutputStream extends ByteArrayOutputStream {
      */
     @Override
     public void close() throws IOException {
+        flush();
         closed.set(true);
         pump.shutdown();
         super.close();

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,6 +32,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -95,6 +96,7 @@ public class LoggingPrintStreamTest {
             () -> assertEquals("", record.getMessage()),
             () -> assertNull(record.getMessageKey()),
             () -> assertNull(record.getParameters()),
+            () -> assertThat(record.getThreadID(), greaterThan(0)),
             () -> assertEquals(Thread.currentThread().getName(), record.getThreadName()),
             () -> assertSame(exception, record.getThrown()),
             () -> assertEquals("testPrintStacktrace", record.getSourceMethodName())


### PR DESCRIPTION
- Fixes #25438 

GlassFishLogManagerLifeCycleTest
- As we have access to the logging status, we can use it to control the test behavior.
- As all tests have timeouts, we don't have to be afraid of deadlocks except cases where we know about them.

LoggingPrintStreamTest
- The thread id was added back (was removed because with Java 24 it is not always 1)

LoggingPrintStreamTest
- Added flush as the first step in close as next step disables pumping records to logger, so parent's flush would not do anything if the last record would be too late.

LoggingRestITest
- Lowered expectation for a number of records, the last one sometimes doesn't make it to the file yet.