### PR TITLE
Give a clearer error message if datasource is not defined.

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRuntime.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRuntime.java
@@ -500,7 +500,12 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
         } catch (NamingException ne) {
             if (force && isDAS()) {
                 _logger.log(Level.FINE, "jdbc.unable_to_lookup_resource", ri);
-                return lookupDataSourceInDAS(ri);
+                try {
+                    return lookupDataSourceInDAS(ri);
+                } catch (ConnectorRuntimeException ex) {
+                    ne.addSuppressed(ex);
+                    throw ne;
+                }
             }
             throw ne;
         }
@@ -532,7 +537,12 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
         } catch (NamingException ne) {
             if (force && isDAS()) {
                 _logger.log(Level.FINE, "jdbc.unable_to_lookup_resource", ri);
-                return lookupDataSourceInDAS(ri);
+                try {
+                    return lookupDataSourceInDAS(ri);
+                } catch (ConnectorRuntimeException ex) {
+                    ne.addSuppressed(ex);
+                    throw ne;
+                }
             }
             throw ne;
         }
@@ -553,17 +563,13 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
      * @param resourceInfo jndi name of the resource
      * @return DataSource representing the resource.
      */
-    private <T> T lookupDataSourceInDAS(ResourceInfo resourceInfo) {
-        try {
+    private <T> T lookupDataSourceInDAS(ResourceInfo resourceInfo) throws ConnectorRuntimeException {
             Collection<ConnectorRuntimeExtension> extensions = serviceLocator
                 .getAllServices(ConnectorRuntimeExtension.class);
             for (ConnectorRuntimeExtension extension : extensions) {
                 return extension.lookupDataSourceInDAS(resourceInfo);
             }
             return null;
-        } catch (ConnectorRuntimeException cre) {
-            throw new RuntimeException(cre.getMessage(), cre);
-        }
     }
 
     /**


### PR DESCRIPTION
First exception gives a good error message, but then an extension is used as a fallback, and then it gives a very confusing message, like:

ConnectorRuntimeException: Invalid resource: org.glassfish.resourcebase.resources.api.ResourceInfo@f7d823e4[jndiName=java:app/jdbc/CargoTrackerDatabase__pm, applicationName=Eclipse_Cargo_Tracker, moduleName=null]

It refers to JNDI name with the cryptic __pm suffix, and says "Invalid resource", instead of syaing that the datasource could not be looked up

This improvement will print into about the first exception, followed by the second exception as suppressed.
