### PR TITLE
Improved Derby and CommonClassLoaderService initialization

### DIFF
--- a/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DatabaseCommand.java
+++ b/appserver/admin/cli-optional/src/main/java/com/sun/enterprise/admin/cli/optional/DatabaseCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -28,7 +28,7 @@ import org.glassfish.api.Param;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
 
-import static com.sun.enterprise.util.SystemPropertyConstants.DERBY_ROOT_PROPERTY;
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.DERBY_ROOT_PROP_NAME;
 import static com.sun.enterprise.util.SystemPropertyConstants.INSTALL_ROOT_PROPERTY;
 import static com.sun.enterprise.util.SystemPropertyConstants.JAVA_ROOT_PROPERTY;
 
@@ -77,7 +77,7 @@ public abstract class DatabaseCommand extends CLICommand {
         }
 
         javaHome = new File(getSystemProperty(JAVA_ROOT_PROPERTY));
-        dbLocation = new File(getSystemProperty(DERBY_ROOT_PROPERTY));
+        dbLocation = new File(getSystemProperty(DERBY_ROOT_PROP_NAME));
         checkIfDbInstalled(dbLocation);
 
         sClasspath.add(new File(installRoot, "lib/asadmin/cli-optional.jar"));
@@ -137,7 +137,7 @@ public abstract class DatabaseCommand extends CLICommand {
 
                 "com.sun.enterprise.admin.cli.optional.DerbyControl",
                 "ping",
-                dbHost, dbPort, Boolean.valueOf(bRedirect).toString() };
+                dbHost, dbPort, Boolean.toString(bRedirect) };
 
         }
 
@@ -148,7 +148,7 @@ public abstract class DatabaseCommand extends CLICommand {
 
                 "com.sun.enterprise.admin.cli.optional.DerbyControl",
                 "ping",
-                dbHost, dbPort, Boolean.valueOf(bRedirect).toString() };
+                dbHost, dbPort, Boolean.toString(bRedirect) };
     }
 
     /**

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCStartupContext.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/acc/ACCStartupContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,6 +30,9 @@ import java.util.Properties;
 
 import org.jvnet.hk2.annotations.Service;
 
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.DERBY_ROOT_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.INSTALL_ROOT_PROP_NAME;
+
 /**
  * Start-up context for the ACC.  Note that this context is used also for
  * Java Web Start launches.
@@ -39,8 +42,6 @@ import org.jvnet.hk2.annotations.Service;
 @Service
 @Singleton
 public class ACCStartupContext extends StartupContext {
-
-    private static final String DERBY_ROOT_PROPERTY = "AS_DERBY_INSTALL";
 
     public ACCStartupContext() {
         super(accEnvironment());
@@ -53,11 +54,12 @@ public class ACCStartupContext extends StartupContext {
      * @return
      */
     private static Properties accEnvironment() {
-        final Properties environment = AsenvConf.parseAsEnv(getRootDirectory()).toProperties();
-        environment.setProperty("com.sun.aas.installRoot", getRootDirectory().getAbsolutePath());
-        final File javadbDir = new File(getRootDirectory().getParentFile(), "javadb");
+        final File rootDirectory = getRootDirectory();
+        final Properties environment = AsenvConf.parseAsEnv(rootDirectory).toProperties();
+        environment.setProperty(INSTALL_ROOT_PROP_NAME, rootDirectory.getAbsolutePath());
+        final File javadbDir = new File(rootDirectory.getParentFile(), "javadb");
         if (javadbDir.isDirectory()) {
-            environment.setProperty(DERBY_ROOT_PROPERTY, javadbDir.getAbsolutePath());
+            environment.setProperty(DERBY_ROOT_PROP_NAME, javadbDir.getAbsolutePath());
         }
         return environment;
     }
@@ -69,7 +71,7 @@ public class ACCStartupContext extends StartupContext {
          */
         URI jarURI = null;
         try {
-            jarURI = ACCClassLoader.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+            jarURI = ACCStartupContext.class.getProtectionDomain().getCodeSource().getLocation().toURI();
         } catch (URISyntaxException ex) {
             throw new RuntimeException(ex);
         }

--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorConstants.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +16,8 @@
  */
 
 package com.sun.appserv.connectors.internal.api;
+
+import com.sun.enterprise.util.SystemPropertyConstants;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -310,9 +312,13 @@ public interface ConnectorConstants extends ResourceConstants {
     String RA = "ResourceAdapter";
     String JDBC = "Jdbc";
 
-    String INSTALL_ROOT = "com.sun.aas.installRoot";
+    /**
+     * @deprecated Duplicates SystemPropertyConstants.INSTALL_ROOT_PROPERTY
+     */
+    @Deprecated(forRemoval = true, since = "7.0.25")
+    String INSTALL_ROOT = SystemPropertyConstants.INSTALL_ROOT_PROPERTY;
 
-
+    String DB_VENDOR_MAPPING_ROOT = "org.glassfish.connectors.dbVendorMappingRoot";
 
     // name by which connector's implemenation of message-bean-client-factory service is available.
     // MDB-Container can use this constant to get connector's implementation of the factory

--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorsClassLoaderUtil.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorsClassLoaderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -44,6 +44,8 @@ import org.glassfish.api.event.Events;
 import org.glassfish.internal.api.ClassLoaderHierarchy;
 import org.glassfish.internal.api.DelegatingClassLoader;
 import org.jvnet.hk2.annotations.Service;
+
+import static com.sun.enterprise.util.SystemPropertyConstants.INSTALL_ROOT_PROPERTY;
 
 
 /**
@@ -150,7 +152,7 @@ public class ConnectorsClassLoaderUtil {
         if (processEnv.getProcessType().isEmbedded() && !rarsInitializedInEmbeddedServerMode) {
             synchronized (ConnectorsClassLoaderUtil.class) {
                 if (!rarsInitializedInEmbeddedServerMode) {
-                    String installDir = System.getProperty(ConnectorConstants.INSTALL_ROOT) + File.separator;
+                    String installDir = System.getProperty(INSTALL_ROOT_PROPERTY) + File.separator;
                     for (String jdbcRarName : ConnectorConstants.jdbcSystemRarNames) {
                         String rarPath = ConnectorsUtil.getSystemModuleLocation(jdbcRarName);
                         File rarDir = new File(rarPath);

--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorsUtil.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -82,6 +82,7 @@ import org.jvnet.hk2.config.types.PropertyBag;
 
 import static com.sun.appserv.connectors.internal.api.ConnectorConstants.DEFAULT_RESOURCE_ADAPTER_SHUTDOWN_TIMEOUT;
 import static com.sun.appserv.connectors.internal.api.ConnectorConstants.JNDI_SUFFIX_VALUES;
+import static com.sun.enterprise.util.SystemPropertyConstants.INSTALL_ROOT_PROPERTY;
 import static com.sun.enterprise.util.SystemPropertyConstants.SLASH;
 
 /**
@@ -144,7 +145,7 @@ public class ConnectorsUtil {
      * @return directory location
      */
     public static String getSystemModuleLocation(String moduleName) {
-        String j2eeModuleDirName = System.getProperty(ConnectorConstants.INSTALL_ROOT) +
+        String j2eeModuleDirName = System.getProperty(INSTALL_ROOT_PROPERTY) +
                 File.separator + "lib" +
                 File.separator + "install" +
                 File.separator + "applications" +

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
@@ -19,17 +19,19 @@ package com.sun.enterprise.connectors.util;
 
 import com.sun.appserv.connectors.internal.api.ConnectorConstants;
 import com.sun.enterprise.connectors.ConnectorRuntime;
-import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.logging.LogDomains;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Modifier;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -40,15 +42,17 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.ZipEntry;
 
 import org.jvnet.hk2.annotations.Service;
 
 import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.DERBY_ROOT_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.INSTALL_ROOT_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.INSTANCE_ROOT_PROP_NAME;
 
 /**
  * Driver Loader to load the jdbc drivers and get driver/datasource classnames
@@ -57,12 +61,12 @@ import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.DERBY_ROO
  * @author Shalini M
  */
 @Service
+@Singleton
 public class DriverLoader implements ConnectorConstants {
 
-    private static Logger logger =
-    LogDomains.getLogger(DriverLoader.class, LogDomains.RSR_LOGGER);
+    private static Logger logger = LogDomains.getLogger(DriverLoader.class, LogDomains.RSR_LOGGER);
 
-    private static final String DRIVER_INTERFACE_NAME="java.sql.Driver";
+    private static final String DRIVER_INTERFACE_NAME = "java.sql.Driver";
     private static final String SERVICES_DRIVER_IMPL_NAME = "META-INF/services/java.sql.Driver";
     private static final String DATABASE_VENDOR_DERBY = "DERBY";
     private static final String DATABASE_VENDOR_JAVADB = "JAVADB";
@@ -83,66 +87,119 @@ public class DriverLoader implements ConnectorConstants {
     private static final String DATABASE_VENDOR_40 = "40";
 
     private static final String DATABASE_VENDOR_SQLSERVER = "SQLSERVER";
-    private static final String DBVENDOR_MAPPINGS_ROOT =
-            System.getProperty(ConnectorConstants.INSTALL_ROOT) + File.separator +
-            "lib" + File.separator + "install" + File.separator + "databases" +
-            File.separator + "dbvendormapping" + File.separator;
-    private final static String DS_PROPERTIES = "ds.properties";
-    private final static String CPDS_PROPERTIES = "cpds.properties";
-    private final static String XADS_PROPERTIES = "xads.properties";
-    private final static String DRIVER_PROPERTIES = "driver.properties";
-    private final String VENDOR_PROPERTIES = "dbvendor.properties";
+    private static final String DS_PROPERTIES = "ds.properties";
+    private static final String CPDS_PROPERTIES = "cpds.properties";
+    private static final String XADS_PROPERTIES = "xads.properties";
+    private static final String DRIVER_PROPERTIES = "driver.properties";
+    private static final String VENDOR_PROPERTIES = "dbvendor.properties";
+    private static final String VALIDATIONCLASSNAMES_PROPERTIES = "validationclassnames.properties";
+
+
+    private File mappingsRoot;
+
+    @PostConstruct
+    private void initPaths() {
+        this.mappingsRoot = resolveDbVendorMappingRoot();
+    }
+
+
+    private static File resolveDbVendorMappingRoot() {
+        File connDbVendorMappingRoot = getSystemPropertyAsFile(DB_VENDOR_MAPPING_ROOT);
+        if (connDbVendorMappingRoot != null) {
+            return connDbVendorMappingRoot;
+        }
+        File installRoot = getSystemPropertyAsFile(INSTALL_ROOT_PROP_NAME);
+        if (installRoot == null) {
+            return null;
+        }
+        File defaultRoot = installRoot.toPath().normalize()
+            .resolve(Path.of("lib", "install", "databases", "dbvendormapping")).toFile();
+        if (defaultRoot.exists()) {
+            return defaultRoot;
+        }
+        return null;
+    }
 
     /**
      * Get a set of common database vendor names supported in glassfish.
      * @return database vendor names set.
      */
     public Set<String> getDatabaseVendorNames() {
-        File dbVendorFile = new File(DBVENDOR_MAPPINGS_ROOT + VENDOR_PROPERTIES);
+        if (mappingsRoot == null) {
+            return Set.of();
+        }
+        File dbVendorFile = new File(mappingsRoot, VENDOR_PROPERTIES);
         Properties fileProperties = loadFile(dbVendorFile);
         Set<String> dbvendorNames = new TreeSet<>();
-
-        Enumeration e = fileProperties.propertyNames();
-        while(e.hasMoreElements()) {
-            String vendor = (String) e.nextElement();
+        for (String vendor : fileProperties.stringPropertyNames()) {
             dbvendorNames.add(vendor);
         }
         return dbvendorNames;
     }
 
-    public static File getResourceTypeFile(String resType) {
-        File mappingFile = null;
-        if(ConnectorConstants.JAVAX_SQL_DATASOURCE.equals(resType)) {
-            mappingFile = new File(DBVENDOR_MAPPINGS_ROOT + DS_PROPERTIES);
-        } else if(ConnectorConstants.JAVAX_SQL_XA_DATASOURCE.equals(resType)) {
-            mappingFile = new File(DBVENDOR_MAPPINGS_ROOT + XADS_PROPERTIES);
-        } else if(ConnectorConstants.JAVAX_SQL_CONNECTION_POOL_DATASOURCE.equals(resType)) {
-            mappingFile = new File(DBVENDOR_MAPPINGS_ROOT + CPDS_PROPERTIES);
-        } else if(ConnectorConstants.JAVA_SQL_DRIVER.equals(resType)) {
-            mappingFile = new File(DBVENDOR_MAPPINGS_ROOT + DRIVER_PROPERTIES);
+
+    public Properties getValidationClassMappingFile() {
+        if (mappingsRoot == null) {
+            return loadFile(null);
         }
-        return mappingFile;
+        return loadFile(new File(this.mappingsRoot, VALIDATIONCLASSNAMES_PROPERTIES));
+    }
+
+    public String getDatabaseVendorName(String className) {
+        if (mappingsRoot == null) {
+            return null;
+        }
+        String dbVendor = getDatabaseVendorName(loadFile(new File(mappingsRoot, DS_PROPERTIES)), className);
+        if (dbVendor == null) {
+            dbVendor = getDatabaseVendorName(loadFile(new File(mappingsRoot, CPDS_PROPERTIES)), className);
+        }
+        if (dbVendor == null) {
+            dbVendor = getDatabaseVendorName(loadFile(new File(mappingsRoot, XADS_PROPERTIES)), className);
+        }
+        if (dbVendor == null) {
+            dbVendor = getDatabaseVendorName(loadFile(new File(mappingsRoot, DRIVER_PROPERTIES)), className);
+        }
+        return dbVendor;
+    }
+
+    private File getResourceTypeFile(String resType) {
+        if (mappingsRoot == null) {
+            return null;
+        }
+        if (ConnectorConstants.JAVAX_SQL_DATASOURCE.equals(resType)) {
+            return new File(mappingsRoot, DS_PROPERTIES);
+        } else if (ConnectorConstants.JAVAX_SQL_XA_DATASOURCE.equals(resType)) {
+            return new File(mappingsRoot, XADS_PROPERTIES);
+        } else if (ConnectorConstants.JAVAX_SQL_CONNECTION_POOL_DATASOURCE.equals(resType)) {
+            return new File(mappingsRoot, CPDS_PROPERTIES);
+        } else if (ConnectorConstants.JAVA_SQL_DRIVER.equals(resType)) {
+            return new File(mappingsRoot, DRIVER_PROPERTIES);
+        } else {
+            return null;
+        }
+    }
+
+    private String getDatabaseVendorName(Properties classNameProperties, String className) {
+        Set<String> vendors = classNameProperties.stringPropertyNames();
+        for (String vendor : vendors) {
+            String value = classNameProperties.getProperty(vendor);
+            if (className.equalsIgnoreCase(value)) {
+                return vendor;
+            }
+        }
+        return null;
     }
 
     public static Properties loadFile(File mappingFile) {
         Properties fileProperties = new Properties();
-        if (mappingFile != null && mappingFile.exists()) {
-            try {
-
-                FileInputStream fis = new FileInputStream(mappingFile);
-                try {
-                    fileProperties.load(fis);
-                } finally {
-                    fis.close();
-                }
-            } catch (IOException ioe) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine("IO Exception during properties load : "
-                            + mappingFile.getAbsolutePath());
-                }
-            }
-        } else if (logger.isLoggable(Level.FINE)) {
-            logger.fine("File not found : " + mappingFile.getAbsolutePath());
+        if (mappingFile == null || !mappingFile.exists()) {
+            logger.fine(() -> "File not found: " + mappingFile);
+            return fileProperties;
+        }
+        try (FileInputStream fis = new FileInputStream(mappingFile)) {
+            fileProperties.load(fis);
+        } catch (IOException ioe) {
+            logger.log(Level.WARNING, "IO Exception during properties load: " + mappingFile);
         }
         return fileProperties;
     }
@@ -225,7 +282,7 @@ public class DriverLoader implements ConnectorConstants {
         Set<File> allJars = new HashSet<>();
         for(File lib : jarFileLocations) {
             if (lib.isDirectory()) {
-                File[] files = lib.listFiles(new JarFileFilter());
+                File[] files = lib.listFiles((dir, name) -> name.endsWith(".jar"));
                 if (files != null) {
                     for (File file : files) {
                         allJars.add(file);
@@ -259,18 +316,18 @@ public class DriverLoader implements ConnectorConstants {
         JarFile jarFile = null;
         try {
             jarFile = new JarFile(f);
-            Enumeration e = jarFile.entries();
+            Enumeration<JarEntry> e = jarFile.entries();
             while(e.hasMoreElements()) {
 
-                ZipEntry zipEntry = (ZipEntry) e.nextElement();
+                JarEntry jarEntry = e.nextElement();
 
-                if (zipEntry != null) {
+                if (jarEntry != null) {
 
-                    String entry = zipEntry.getName();
+                    String entry = jarEntry.getName();
                     if (DRIVER_INTERFACE_NAME.equals(resType)) {
                         if (SERVICES_DRIVER_IMPL_NAME.equals(entry)) {
 
-                            InputStream metaInf = jarFile.getInputStream(zipEntry);
+                            InputStream metaInf = jarFile.getInputStream(jarEntry);
                             implClass = processMetaInf(metaInf);
                             if (implClass != null) {
                                 if (isLoaded(implClass, resType)) {
@@ -450,8 +507,8 @@ public class DriverLoader implements ConnectorConstants {
         return classname;
     }
 
-    private boolean isVendorSpecific(File f, String dbVendor, String className,
-            String origDbVendor) {
+
+    private boolean isVendorSpecific(File f, String dbVendor, String className, String origDbVendor) {
         //File could be a jdbc jar file or a normal jar file
         boolean isVendorSpecific = false;
 
@@ -494,25 +551,42 @@ public class DriverLoader implements ConnectorConstants {
 
     private List<File> getJdbcDriverLocations() {
     List<File> jarFileLocations = new ArrayList<>();
-        jarFileLocations.add(getLocation(DERBY_ROOT_PROP_NAME));
-        jarFileLocations.add(getLocation(SystemPropertyConstants.INSTALL_ROOT_PROPERTY));
-        jarFileLocations.add(getLocation(SystemPropertyConstants.INSTANCE_ROOT_PROPERTY));
+        File derby = getLocation(DERBY_ROOT_PROP_NAME);
+        if (derby != null) {
+            jarFileLocations.add(derby);
+        }
+        File installRoot = getLocation(INSTALL_ROOT_PROP_NAME);
+        if (installRoot != null) {
+            jarFileLocations.add(installRoot);
+        }
+        File instanceRoot = getLocation(INSTANCE_ROOT_PROP_NAME);
+        if (instanceRoot != null) {
+            jarFileLocations.add(instanceRoot);
+        }
         return jarFileLocations;
     }
 
     private File getLocation(String property) {
-        return new File(System.getProperty(property) + File.separator + "lib");
-    }
-
-    private static class JarFileFilter implements FilenameFilter {
-
-        private static final String JAR_EXT = ".jar";
-
-        @Override
-        public boolean accept(File dir, String name) {
-            return name.endsWith(JAR_EXT);
+        File directory = getSystemPropertyAsFile(property);
+        if (directory == null) {
+            return null;
         }
+        return new File(directory, "lib");
     }
+
+
+    /**
+     * @return null if the file does not exist or the property is not set
+     */
+    private static File getSystemPropertyAsFile(String property) {
+        String propertyValue = System.getProperty(property);
+        if (propertyValue == null || propertyValue.isBlank()) {
+            return null;
+        }
+        File file = new File(propertyValue);
+        return file.exists() ? file : null;
+    }
+
 
     /**
      * Utility method that checks if a classname is vendor specific.
@@ -533,34 +607,19 @@ public class DriverLoader implements ConnectorConstants {
      * @return null if no manifest entry found.
      */
     private String getVendorFromManifest(File f) {
-        String vendor = null;
-        JarFile jarFile = null;
-        try {
-            jarFile = new JarFile(f);
-            Manifest manifest = jarFile.getManifest();
-            if(manifest != null) {
-                Attributes mainAttributes = manifest.getMainAttributes();
-                if(mainAttributes != null) {
-                    vendor = mainAttributes.getValue(Attributes.Name.IMPLEMENTATION_VENDOR.toString());
-                    if (vendor == null) {
-                        vendor = mainAttributes.getValue(Attributes.Name.IMPLEMENTATION_VENDOR_ID.toString());
-                    }
-                }
+        try (JarFile jarFile = new JarFile(f)) {
+            final Manifest manifest = jarFile.getManifest();
+            if (manifest == null) {
+                return null;
             }
+            final Attributes mainAttributes = manifest.getMainAttributes();
+            if (mainAttributes == null) {
+                return null;
+            }
+            return mainAttributes.getValue(Attributes.Name.IMPLEMENTATION_VENDOR);
         } catch (IOException ex) {
             logger.log(Level.WARNING, "Exception while reading manifest file : ", ex);
-        } finally {
-            if (jarFile != null) {
-                try {
-                    jarFile.close();
-                } catch (IOException ex) {
-                    if (logger.isLoggable(Level.FINE)) {
-                        logger.log(Level.FINE, "Exception while closing JarFile '"
-                                + jarFile.getName() + "' :", ex);
-                    }
-                }
-            }
+            return null;
         }
-        return vendor;
     }
 }

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/DriverLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -47,6 +47,8 @@ import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 
 import org.jvnet.hk2.annotations.Service;
+
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.DERBY_ROOT_PROP_NAME;
 
 /**
  * Driver Loader to load the jdbc drivers and get driver/datasource classnames
@@ -492,7 +494,7 @@ public class DriverLoader implements ConnectorConstants {
 
     private List<File> getJdbcDriverLocations() {
     List<File> jarFileLocations = new ArrayList<>();
-        jarFileLocations.add(getLocation(SystemPropertyConstants.DERBY_ROOT_PROPERTY));
+        jarFileLocations.add(getLocation(DERBY_ROOT_PROP_NAME));
         jarFileLocations.add(getLocation(SystemPropertyConstants.INSTALL_ROOT_PROPERTY));
         jarFileLocations.add(getLocation(SystemPropertyConstants.INSTANCE_ROOT_PROPERTY));
         return jarFileLocations;

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/internal/GetDatabaseVendorNames.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/internal/GetDatabaseVendorNames.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -52,16 +53,14 @@ public class GetDatabaseVendorNames implements AdminCommand {
     private ConnectorRuntime connectorRuntime;
 
 
-    /**
-     * @inheritDoc
-     */
+    @Override
     public void execute(AdminCommandContext context) {
         final ActionReport report = context.getActionReport();
 
         try {
             Set<String> vendorNames = connectorRuntime.getDatabaseVendorNames();
             Properties extraProperties = new Properties();
-            extraProperties.put("vendorNames", new ArrayList(vendorNames));
+            extraProperties.put("vendorNames", new ArrayList<>(vendorNames));
             report.setExtraProperties(extraProperties);
         } catch (Exception e) {
             report.setMessage("_get-database-vendor-names failed : " + e.getMessage());

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -177,6 +178,7 @@ public class SystemPropertyConstants {
 
     public static final String JDMK_HOME_PROPERTY = "com.sun.aas.jdmkHome";
 
+    @Deprecated
     public static final String DERBY_ROOT_PROPERTY = "com.sun.aas.derbyRoot";
 
     /** Java ES Monitoring Framework install directory */

--- a/nucleus/common/common-util/src/main/java/org/glassfish/server/ServerEnvironmentImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/server/ServerEnvironmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,6 +21,7 @@ import com.sun.enterprise.module.bootstrap.StartupContext;
 import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
 import com.sun.enterprise.util.SystemPropertyConstants;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 
 import java.io.File;
@@ -30,7 +31,6 @@ import java.util.Properties;
 
 import org.glassfish.api.admin.RuntimeType;
 import org.glassfish.api.admin.ServerEnvironment;
-import org.glassfish.hk2.api.PostConstruct;
 import org.jvnet.hk2.annotations.Service;
 
 /**
@@ -43,7 +43,7 @@ import org.jvnet.hk2.annotations.Service;
  * @author Byron Nevins
  */
 @Service
-public class ServerEnvironmentImpl implements ServerEnvironment, PostConstruct {
+public class ServerEnvironmentImpl implements ServerEnvironment {
 
     /** Folder where all generated code like compiled jsps, stubs is stored */
     public static final String kGeneratedDirName = "generated";
@@ -107,7 +107,7 @@ public class ServerEnvironmentImpl implements ServerEnvironment, PostConstruct {
     /**
      * This is where the real initialization happens.
      */
-    @Override
+    @PostConstruct
     public void postConstruct() {
 
         // todo : dochez : this will need to be reworked...

--- a/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/cfg/BootstrapKeys.java
+++ b/nucleus/core/bootstrap/src/main/java/com/sun/enterprise/glassfish/bootstrap/cfg/BootstrapKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -71,6 +71,9 @@ public final class BootstrapKeys {
     public static final String FILE_SCHEME = "file";
 
     public static final String AUTO_DELETE = "org.glassfish.embeddable.autoDelete";
+
+    public static final String DERBY_ROOT_PROP_NAME = "com.sun.aas.derbyRoot";
+
 
     private BootstrapKeys() {
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/CommonClassLoaderServiceImpl.java
@@ -17,8 +17,6 @@
 
 package com.sun.enterprise.v3.server;
 
-import com.sun.enterprise.module.bootstrap.StartupContext;
-import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.io.FileUtils;
 
 import jakarta.inject.Inject;
@@ -26,13 +24,13 @@ import jakarta.inject.Inject;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import java.util.Objects;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.logging.Level;
@@ -45,6 +43,10 @@ import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.kernel.KernelLoggerInfo;
 import org.jvnet.hk2.annotations.Service;
+
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.DERBY_ROOT_PROP_NAME;
+import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.INSTALL_ROOT_PROP_NAME;
+import static java.util.logging.Level.CONFIG;
 
 /**
  * This class is responsible for setting up Common Class Loader. As the
@@ -70,6 +72,9 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Service
 public class CommonClassLoaderServiceImpl implements PostConstruct {
+
+    private static final Logger LOG = KernelLoggerInfo.getLogger();
+
     /**
      * The common classloader.
      */
@@ -79,78 +84,62 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
     APIClassLoaderServiceImpl acls;
 
     @Inject
-    ServerEnvironment env;
+    private ServerEnvironment env;
 
-    final static Logger logger = KernelLoggerInfo.getLogger();
-    private ClassLoader APIClassLoader;
+    private ClassLoader apiClassLoader;
     private String commonClassPath = "";
 
     private static final String SERVER_EXCLUDED_ATTR_NAME = "GlassFish-ServerExcluded";
 
     @Override
     public void postConstruct() {
-        APIClassLoader = acls.getAPIClassLoader();
-        assert (APIClassLoader != null);
+        apiClassLoader = Objects.requireNonNull(acls.getAPIClassLoader(), "API ClassLoader is null!");
         createCommonClassLoader();
     }
 
     private void createCommonClassLoader() {
         List<File> cpElements = new ArrayList<>();
         File domainDir = env.getInstanceRoot();
-        // I am forced to use System.getProperty, as there is no API that makes
-        // the installRoot available. Sad, but true. Check dev forum on this.
-        final String installRoot = System.getProperty(
-            SystemPropertyConstants.INSTALL_ROOT_PROPERTY);
-
-        // See https://glassfish.dev.java.net/issues/show_bug.cgi?id=5872
-        // In case of embedded GF, we may not have an installRoot.
-        if (installRoot!=null) {
-            File installDir = new File(installRoot);
-            File installLibPath = new File(installDir, "lib");
-            if (installLibPath.isDirectory()) {
-                Collections.addAll(cpElements,
-                    installLibPath.listFiles(new CompiletimeJarFileFilter()));
-            }
-        } else {
-            logger.logp(Level.WARNING, "CommonClassLoaderServiceImpl",
-                "createCommonClassLoader",
-                KernelLoggerInfo.systemPropertyNull,
-                SystemPropertyConstants.INSTALL_ROOT_PROPERTY);
+        final String installRoot = System.getProperty(INSTALL_ROOT_PROP_NAME);
+        if (installRoot == null) {
+            throw new IllegalStateException("The system property is not set: " + INSTALL_ROOT_PROP_NAME);
         }
-        File domainClassesDir = new File(domainDir, "lib/classes/"); // NOI18N
+        File installDir = new File(installRoot);
+        File installLibDir = new File(installDir, "lib");
+        if (installLibDir.isDirectory()) {
+            Collections.addAll(cpElements, installLibDir.listFiles(new CompiletimeJarFileFilter()));
+        }
+        final File domainLibDir = new File(domainDir, "lib");
+        final File domainClassesDir = new File(domainLibDir, "classes");
         if (domainClassesDir.exists()) {
             cpElements.add(domainClassesDir);
         }
-        final File domainLib = new File(domainDir, "lib/"); // NOI18N
-        if (domainLib.isDirectory()) {
-            Collections.addAll(cpElements,
-                domainLib.listFiles(new JarFileFilter()));
+        if (domainLibDir.isDirectory()) {
+            Collections.addAll(cpElements, domainLibDir.listFiles(new JarFileFilter()));
         }
-        // See issue https://glassfish.dev.java.net/issues/show_bug.cgi?id=13612
-        // We no longer add derby jars to launcher class loader, we add them to common class loader instead.
-        cpElements.addAll(findDerbyClient());
+        cpElements.addAll(findDerbyJars(installDir));
         List<URL> urls = new ArrayList<>();
-        for (File f : cpElements) {
+        for (File file : cpElements) {
             try {
-                urls.add(f.toURI().toURL());
-            } catch (MalformedURLException e) {
-                logger.log(Level.WARNING, KernelLoggerInfo.invalidClassPathEntry,
-                    new Object[] {f, e});
+                urls.add(file.toURI().toURL());
+            } catch (IOException e) {
+                LOG.log(Level.WARNING, KernelLoggerInfo.invalidClassPathEntry, new Object[] {file, e});
             }
         }
         commonClassPath = urlsToClassPath(urls.stream());
         if (urls.isEmpty()) {
-            logger.logp(Level.FINE, "CommonClassLoaderManager",
+            LOG.logp(Level.FINE, "CommonClassLoaderManager",
                 "Skipping creation of CommonClassLoader as there are no libraries available", "urls = {0}", urls);
         } else {
             // Skip creation of an unnecessary classloader in the hierarchy,
             // when all it would have done was to delegate up.
-            commonClassLoader = new GlassfishUrlClassLoader(urls.toArray(URL[]::new), APIClassLoader);
+            commonClassLoader = new GlassfishUrlClassLoader(urls.toArray(URL[]::new), apiClassLoader);
+            LOG.log(Level.FINE, "Created common classloader: {0}", commonClassLoader);
         }
     }
 
     public ClassLoader getCommonClassLoader() {
-        return commonClassLoader != null ? commonClassLoader : APIClassLoader;
+        return commonClassLoader == null ? apiClassLoader : commonClassLoader;
     }
 
     /**
@@ -161,7 +150,7 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
     public void addToClassPath(URL url) {
         validateUrl(url);
         if (commonClassLoader == null) {
-            commonClassLoader = new GlassfishUrlClassLoader(new URL[] {url}, APIClassLoader);
+            commonClassLoader = new GlassfishUrlClassLoader(new URL[] {url}, apiClassLoader);
         } else {
             commonClassLoader.addURL(url);
         }
@@ -189,87 +178,57 @@ public class CommonClassLoaderServiceImpl implements PostConstruct {
         return urls.map(FileUtils::toFile).map(File::getAbsolutePath).collect(Collectors.joining(File.pathSeparator));
     }
 
-    private List<File> findDerbyClient() {
-        final String DERBY_HOME_PROP = "AS_DERBY_INSTALL";
-        StartupContext startupContext = env.getStartupContext();
-        Properties arguments = null;
+    private List<File> findDerbyJars(File installDir) {
+        Path derbyHome = getDerbyDir(installDir);
+        LOG.log(CONFIG, "Using derby home: {0}", derbyHome);
 
-        if (startupContext != null) {
-            arguments = startupContext.getArguments();
-        }
-
-        String derbyHome = null;
-
-        if (arguments != null) {
-            derbyHome = arguments.getProperty(DERBY_HOME_PROP,
-                System.getProperty(DERBY_HOME_PROP));
-        }
-
-        File derbyLib = null;
-        if (derbyHome != null) {
-            derbyLib = new File(derbyHome, "lib");
-        }
-        if (derbyLib == null || !derbyLib.exists()) {
-            logger.info(KernelLoggerInfo.cantFindDerby);
+        final File derbyLib = derbyHome.resolve("lib").toFile();
+        if (!derbyLib.exists()) {
+            LOG.info(KernelLoggerInfo.cantFindDerby);
             return Collections.emptyList();
         }
 
-        return Arrays.asList(derbyLib.listFiles(new FilenameFilter(){
-            @Override
-            public boolean accept(File dir, String name) {
-                // Include only files having .jar extn and exclude all localisation jars, because they are
-                // already mentioned in the Class-Path header of the main jars
-                return (name.endsWith(".jar") && !name.startsWith("derbyLocale_"));
-            }
-        }));
+        return Arrays
+            .asList(derbyLib.listFiles((dir, name) -> name.endsWith(".jar") && !name.startsWith("derbyLocale_")));
+    }
+
+    private static Path getDerbyDir(File installDir) {
+        String derbyHomeProperty = System.getProperty(DERBY_ROOT_PROP_NAME);
+        if (derbyHomeProperty == null) {
+            return installDir.toPath().resolve(Path.of("..", "javadb"));
+        }
+        Path derbyHome = Path.of(derbyHomeProperty);
+        if (derbyHome.isAbsolute()) {
+            return derbyHome;
+        }
+        return new File(installDir, "config").toPath().resolve(derbyHome);
     }
 
     private static class JarFileFilter implements FilenameFilter {
-        private final String JAR_EXT = ".jar"; // NOI18N
 
         @Override
         public boolean accept(File dir, String name) {
-            return name.endsWith(JAR_EXT);
+            return name.endsWith(".jar");
         }
     }
 
     private static class CompiletimeJarFileFilter extends JarFileFilter {
-        /*
-         * See https://glassfish.dev.java.net/issues/show_bug.cgi?id=9526
-         */
+
         @Override
-        public boolean accept(File dir, String name)
-        {
+        public boolean accept(File dir, String name) {
             if (super.accept(dir, name)) {
                 File file = new File(dir, name);
-                JarFile jar = null;
-                try
-                {
-                    jar = new JarFile(file);
+                try (JarFile jar = new JarFile(file)) {
                     Manifest manifest = jar.getManifest();
                     if (manifest != null) {
-                        String exclude = manifest.getMainAttributes().
-                            getValue(SERVER_EXCLUDED_ATTR_NAME);
-                        if (exclude != null && exclude.equalsIgnoreCase("true")) {
+                        String exclude = manifest.getMainAttributes().getValue(SERVER_EXCLUDED_ATTR_NAME);
+                        if ("true".equalsIgnoreCase(exclude)) {
                             return false;
                         }
                     }
-                }
-                catch (IOException e)
-                {
-                    logger.log(Level.WARNING, KernelLoggerInfo.exceptionProcessingJAR,
+                } catch (IOException e) {
+                    LOG.log(Level.WARNING, KernelLoggerInfo.exceptionProcessingJAR,
                         new Object[] {file.getAbsolutePath(), e});
-                } finally {
-                    try
-                    {
-                        if (jar != null) {
-                            jar.close();
-                        }
-                    }
-                    catch (IOException e)
-                    {
-                        // ignore
-                    }
                 }
                 return true;
             }

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/admin/CommandRunnerImplServiceTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/admin/CommandRunnerImplServiceTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,6 @@ import org.glassfish.api.admin.CommandRunner.CommandInvocation;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.internal.api.InternalSystemAdministrator;
 import org.glassfish.main.core.kernel.test.KernelJUnitExtension;
-import org.glassfish.tests.utils.mock.MockGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,9 +47,6 @@ public class CommandRunnerImplServiceTest {
 
     @Inject
     private ServiceLocator locator;
-
-    @Inject
-    private MockGenerator mockGenerator;
 
     private CommandRunnerImpl commandRunner;
     private InternalSystemAdministrator sysAdmin;

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/admin/CreateProfilerTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/admin/CreateProfilerTest.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,6 @@ import jakarta.inject.Inject;
 
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
@@ -66,9 +65,6 @@ public class CreateProfilerTest {
 
     @Inject
     private ServiceLocator locator;
-
-    @Inject
-    private Logger logger;
 
     @Inject
     private MockGenerator mockGenerator;

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/AppServerStartupTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/server/AppServerStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -61,10 +61,12 @@ import org.glassfish.internal.api.InitRunLevel;
 import org.glassfish.internal.api.PostStartupRunLevel;
 import org.glassfish.kernel.event.EventsImpl;
 import org.glassfish.main.core.apiexporter.APIExporterImpl;
+import org.glassfish.main.core.kernel.test.KernelJUnitExtension;
 import org.glassfish.server.ServerEnvironmentImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.jvnet.hk2.annotations.Service;
 
 import static java.util.Collections.singletonList;
@@ -91,6 +93,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @author Tom Beerbower
  */
+@ExtendWith(KernelJUnitExtension.class)
 public class AppServerStartupTest {
 
     /**

--- a/nucleus/core/kernel/src/test/java/org/glassfish/main/core/kernel/test/KernelJUnitExtension.java
+++ b/nucleus/core/kernel/src/test/java/org/glassfish/main/core/kernel/test/KernelJUnitExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,15 +17,11 @@
 package org.glassfish.main.core.kernel.test;
 
 import com.sun.enterprise.admin.util.InstanceStateService;
-import com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys;
-import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.admin.ObjectInputStreamWithServiceLocator;
 
-import java.nio.file.Path;
 import java.util.Set;
 
 import org.glassfish.tests.utils.junit.HK2JUnit5Extension;
-import org.glassfish.tests.utils.junit.JUnitSystem;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 
@@ -35,14 +31,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @author David Matejcek
  */
 public class KernelJUnitExtension extends HK2JUnit5Extension {
-
-    static {
-        Path installRoot = JUnitSystem.detectBasedir();
-        Path instanceRoot = installRoot.resolve(Path.of("target", "test-domain"));
-        FileUtils.mkdirsMaybe(instanceRoot.toFile());
-        System.setProperty(BootstrapKeys.INSTALL_ROOT_PROP_NAME, installRoot.toString());
-        System.setProperty(BootstrapKeys.INSTANCE_ROOT_PROP_NAME, instanceRoot.toString());
-    }
 
     @Override
     protected String getDomainXml(final Class<?> testClass) {

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2JUnit5Extension.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/junit/HK2JUnit5Extension.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
- * Copyright (c) 2021 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,6 +43,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.hk2.api.DynamicConfiguration;
 import org.glassfish.hk2.api.DynamicConfigurationService;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -53,6 +53,7 @@ import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.server.ServerEnvironmentImpl;
 import org.glassfish.tests.utils.mock.MockGenerator;
 import org.glassfish.tests.utils.mock.TestDocument;
+import org.glassfish.tests.utils.mock.TestServerEnvironment;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -262,12 +263,8 @@ public class HK2JUnit5Extension
         addOneConstant(locator, mockGenerator);
         addOneConstant(locator, startupContext);
         addOneConstant(locator, modulesRegistry);
-        String installRoot = startupContext.getArguments().getProperty(INSTALL_ROOT_PROP_NAME);
-        if (installRoot == null) {
-            addOneConstant(locator, new ServerEnvironmentImpl());
-        } else {
-            addOneConstant(locator, new ServerEnvironmentImpl(new File(installRoot)));
-        }
+        addOneConstant(locator, new TestServerEnvironment(startupContext), "TestServerEnvironment",
+            ServerEnvironment.class, ServerEnvironmentImpl.class);
     }
 
 

--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/mock/TestServerEnvironment.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/mock/TestServerEnvironment.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.utils.mock;
+
+import com.sun.enterprise.module.bootstrap.StartupContext;
+
+import jakarta.inject.Singleton;
+
+import org.glassfish.server.ServerEnvironmentImpl;
+import org.jvnet.hk2.annotations.Service;
+
+@Service
+@Singleton
+public class TestServerEnvironment extends ServerEnvironmentImpl {
+
+    private StartupContext startupContext;
+
+
+    public TestServerEnvironment(StartupContext startupContext) {
+        this.startupContext = startupContext;
+    }
+
+
+    @Override
+    public StartupContext getStartupContext() {
+        return startupContext;
+    }
+}


### PR DESCRIPTION
- The Install root is resolved from the `StartupContext`, however it is not mandatory.
- `AppServerStartupTest` intentionally does not depend on `KernelJUnitExtension`, I did not notice that when I made previous changes
- `KernelJUnitExtension` should not set any System properties
- `HK2JUnit5Extension` uses own `ServerEnvironmentImpl` extension which provides the preconfigured `StartupContext` and not null.
- Improved `DriverLoader` and its landscape
- Introduced `org.glassfish.connectors.dbVendorMappingRoot` system property
- `DriverLoader` is a singleton now
- Improved resource management
- Reduced copy and paste
