### PR TITLE
Improvements in GJULE

### DIFF
--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LogRecordBuffer.java
@@ -20,10 +20,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
 import org.glassfish.main.jul.record.GlassFishLogRecord;
+import org.glassfish.main.jul.tracing.GlassFishLoggingTracer;
 
 /**
  * The buffer for log records.
@@ -46,8 +46,7 @@ import org.glassfish.main.jul.record.GlassFishLogRecord;
 class LogRecordBuffer {
 
     private final BlockingQueue<GlassFishLogRecord> pendingRecords = new LinkedBlockingQueue<>();
-    private final CapacitySemaphore availableCapacity = new CapacitySemaphore();
-    private final ReentrantLock lock = new ReentrantLock();
+    private final CapacitySemaphore availableCapacity;
 
     private volatile int capacity;
     private volatile int maxWait;
@@ -91,8 +90,7 @@ class LogRecordBuffer {
     LogRecordBuffer(final int capacity, final int maxWait) {
         this.capacity = capacity;
         this.maxWait = maxWait;
-
-        this.availableCapacity.release(capacity);
+        this.availableCapacity = new CapacitySemaphore(capacity);
     }
 
 
@@ -103,27 +101,22 @@ class LogRecordBuffer {
      * @param newMaxWait maximal time in seconds to wait for the free capacity. If &lt; 1, can wait
      *            forever.
      */
-    public void reconfigure(final int newCapacity, final int newMaxWait) {
-        if (maxWait != newMaxWait) {
-            maxWait = newMaxWait;
+    public synchronized void reconfigure(final int newCapacity, final int newMaxWait) {
+        if (this.maxWait != newMaxWait) {
+            this.maxWait = newMaxWait;
         }
 
-        int permits = newCapacity - capacity;
-        if (permits == 0) {
+        final int permitsToAdd = newCapacity - capacity;
+        if (permitsToAdd == 0) {
+            // no need to change the capacity
             return;
         }
-
-        lock.lock();
-        try {
-            if (permits > 0) {
-                availableCapacity.release(permits);
-            } else {
-                availableCapacity.reducePermits(Math.abs(permits));
-            }
-            capacity = newCapacity;
-        } finally {
-            lock.unlock();
+        if (permitsToAdd > 0) {
+            this.availableCapacity.release(permitsToAdd);
+        } else {
+            this.availableCapacity.reducePermits(-permitsToAdd);
         }
+        this.capacity = newCapacity;
     }
 
 
@@ -157,14 +150,15 @@ class LogRecordBuffer {
      * @return {@link GlassFishLogRecord} or null if interrupted.
      */
     public GlassFishLogRecord pollOrWait() {
-        GlassFishLogRecord logRecord = null;
         try {
-            logRecord = pendingRecords.take();
-            availableCapacity.release();
+            GlassFishLogRecord logRecord = pendingRecords.take();
+            if (availableCapacity.availablePermits() < this.capacity) {
+                availableCapacity.release();
+            }
+            return logRecord;
         } catch (InterruptedException e) {
-            // do nothing
+            return null;
         }
-        return logRecord;
     }
 
     /**
@@ -172,7 +166,7 @@ class LogRecordBuffer {
      */
     public GlassFishLogRecord poll() {
         GlassFishLogRecord logRecord = pendingRecords.poll();
-        if (logRecord != null) {
+        if (logRecord != null && availableCapacity.availablePermits() < this.capacity) {
             availableCapacity.release();
         }
         return logRecord;
@@ -201,42 +195,27 @@ class LogRecordBuffer {
         try {
             if (availableCapacity.tryAcquire(maxWait, TimeUnit.SECONDS)) {
                 pendingRecords.add(record);
+                availableCapacity.release();
                 return;
             }
         } catch (final InterruptedException e) {
-            // do nothing
+            GlassFishLoggingTracer.stacktrace(getClass(),
+                "addWithTimeout - interrupted, adding waiting records before shutdown.");
+            pendingRecords.add(record);
+            return;
         }
 
-        lock.lock();
-        try {
-            try {
-                if (availableCapacity.tryAcquire(0, TimeUnit.SECONDS)) {
-                    pendingRecords.add(record);
-                    return;
-                }
-            } catch (InterruptedException e) {
-                // do nothing
-            }
+        availableCapacity.drainPermits();
+        pendingRecords.clear();
 
-            int currentCapacity = capacity;
+        // Note: the record is not meaningful for the message. The cause is in another place.
+        pendingRecords.add(new GlassFishLogRecord(Level.SEVERE, //
+                this + ": The buffer was forcibly cleared after " + maxWait + " s timeout for adding another log record." //
+                        + " Log records were lost." //
+                        + " It might be caused by a recursive deadlock," //
+                        + " you can increase the capacity or the timeout to avoid this.", false));
 
-            availableCapacity.reducePermits(currentCapacity);
-
-            pendingRecords.clear();
-
-            availableCapacity.drainPermits();
-
-            // Note: the record is not meaningful for the message. The cause is in another place.
-            pendingRecords.add(new GlassFishLogRecord(Level.SEVERE, //
-                    this + ": The buffer was forcibly cleared after " + maxWait + " s timeout for adding another log record." //
-                            + " Log records were lost." //
-                            + " It might be caused by a recursive deadlock," //
-                            + " you can increase the capacity or the timeout to avoid this.", false));
-
-            availableCapacity.release(currentCapacity - 1);
-        } finally {
-            lock.unlock();
-        }
+        availableCapacity.release(capacity - 1);
     }
 
 
@@ -245,16 +224,13 @@ class LogRecordBuffer {
      */
     private void addWithUnlimitedWaiting(final GlassFishLogRecord record) {
         try {
-            if (availableCapacity.tryAcquire(0, TimeUnit.SECONDS)) {
-                pendingRecords.add(record);
-                return;
-            }
-
-            Thread.yield();
             availableCapacity.acquire();
             pendingRecords.add(record);
+            availableCapacity.release();
         } catch (final InterruptedException e) {
-            // do nothing
+            GlassFishLoggingTracer.stacktrace(getClass(),
+                "addWithUnlimitedWaiting - interrupted, adding waiting records before shutdown.");
+            pendingRecords.add(record);
         }
     }
 
@@ -273,13 +249,20 @@ class LogRecordBuffer {
 
         private static final long serialVersionUID = -4575150599241117311L;
 
-        public CapacitySemaphore() {
-            super(0, true);
+        private CapacitySemaphore(int capacity) {
+            super(capacity, true);
         }
 
         @Override
         protected void reducePermits(int reduction) {
             super.reducePermits(reduction);
+        }
+
+
+        @Override
+        public String toString() {
+            return super.toString() + "[availablePermits=" + availablePermits() + "][waitingThreadsForPermits="
+                + getQueueLength() + "]";
         }
     }
 }

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/tracing/GlassFishLoggingTracer.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/tracing/GlassFishLoggingTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -136,15 +136,17 @@ public final class GlassFishLoggingTracer {
     /**
      * Logs the message and the exception's stacktrace to STDERR.
      *
-     * @param source
-     * @param message
-     * @param cause
+     * @param source class where the error is processed.
+     * @param message description of the error
+     * @param cause may be null
      */
     public static void error(final Class<?> source, final String message, final Throwable cause) {
         LOCK.lock();
         try {
             ERR.println(source.getCanonicalName() + ": " + message);
-            cause.printStackTrace(ERR);
+            if (cause != null) {
+                cause.printStackTrace(ERR);
+            }
             ERR.flush();
         } finally {
             LOCK.unlock();

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.Timeout;
 
 import static org.glassfish.main.jul.env.LoggingSystemEnvironment.getOriginalStdErr;
 import static org.glassfish.main.jul.env.LoggingSystemEnvironment.getOriginalStdOut;
@@ -53,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author David Matejcek
  */
 @TestMethodOrder(OrderAnnotation.class)
+@Timeout(value = 1, unit = TimeUnit.SECONDS)
 public class GlassFishLogHandlerTest {
 
     private static GlassFishLogHandler handler;
@@ -110,7 +113,8 @@ public class GlassFishLogHandlerTest {
         );
 
         System.out.println("Tommy, can you hear me?");
-        // output stream is pumped in parallel to the error stream, order is not guaranteed between streams
+        // Now the new log record was added to the LoggingOutputStream's logRecordBuffer.
+        // We have to wait until the pump will process it.
         waitForSize(logFile, 1);
         Logger.getLogger("some.usual.logger").info("Some info message");
         waitForSize(logFile, 2);

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -18,16 +18,19 @@ package org.glassfish.main.jul.handler;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 import org.glassfish.main.jul.JULHelperFactory;
 import org.glassfish.main.jul.record.GlassFishLogRecord;
+import org.glassfish.main.jul.tracing.GlassFishLoggingTracer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
@@ -45,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 /**
  * @author David Matejcek
  */
+@Timeout(value = 1, unit = TimeUnit.SECONDS)
 public class LoggingPrintStreamTest {
 
     private LogCollectorHandler handler;
@@ -54,10 +58,11 @@ public class LoggingPrintStreamTest {
 
     @BeforeEach
     public void init() {
+        GlassFishLoggingTracer.setTracingEnabled(true);
         logger = JULHelperFactory.getHelper().getJULLogger(getClass());
         logger.setLevel(Level.ALL);
         handler = new LogCollectorHandler(logger);
-        stream = LoggingPrintStream.create(logger, FINE, 100, UTF_8);
+        stream = LoggingPrintStream.create(logger, FINE, 15, UTF_8);
     }
 
 
@@ -69,6 +74,7 @@ public class LoggingPrintStreamTest {
         if (stream != null) {
             stream.close();
         }
+        GlassFishLoggingTracer.setTracingEnabled(false);
     }
 
 

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/rotation/LogFileManagerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/rotation/LogFileManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -116,12 +116,12 @@ public class LogFileManagerTest {
         assertEquals(file.length(), manager.getFileSize());
 
         // limit is 100, so flush will roll.
-        manager.write(RandomStringUtils.randomAlphabetic(101));
+        manager.write(RandomStringUtils.insecure().next(101));
         manager.flush();
         assertEquals(0, manager.getFileSize());
 
         // disableOutput does not affect roll.
-        manager.write(RandomStringUtils.randomAlphabetic(101));
+        manager.write(RandomStringUtils.insecure().next(101));
         manager.disableOutput();
         manager.flush();
         assertEquals(0, manager.getFileSize());


### PR DESCRIPTION
- Fixed race condition of LogRecordBuffer - simplified semaphore management and locking.
- Replaced deprecated method call in tests
- Nullsafe trace
- Using different way to create a new log file

Original randomly seen issue: https://github.com/eclipse-ee4j/glassfish/actions/runs/14802807474/job/41737209891
- I managed to reproduce it locally using Eclipse IDE Debugger stepping the `LoggingPrintStreamTest` which again lost last record.