### PR TITLE
Stabilizing ClusterITest and EjbClassGeneratorFactoryBenchmarkTest

### DIFF
--- a/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EjbClassGeneratorFactoryBenchmarkTest.java
+++ b/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EjbClassGeneratorFactoryBenchmarkTest.java
@@ -30,6 +30,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.results.Result;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
@@ -41,6 +42,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
+ * The {@link #generate_benchmark()} test should be able to detect race conditions when loading
+ * classes generated in {@link #generate_firstRun()} test
+ *
  * @author David Matejcek
  */
 @TestMethodOrder(OrderAnnotation.class)
@@ -58,16 +62,7 @@ public class EjbClassGeneratorFactoryBenchmarkTest {
     @Test
     @Order(1)
     public void generate_firstRun() throws Exception {
-        Options options = new OptionsBuilder()
-            .include(getClass().getName() + ".*")
-            .warmupIterations(0)
-            .measurementIterations(1).forks(1).measurementTime(TimeValue.milliseconds(50L))
-            // should be able to detect deadlocks and race conditions when generating classes
-            .threads(100).timeout(TimeValue.seconds(5L))
-            .timeUnit(TimeUnit.MICROSECONDS)
-            .mode(Mode.SingleShotTime).shouldFailOnError(true)
-            .build();
-
+        Options options = createOptions(false, 20L, Mode.SingleShotTime);
         Collection<RunResult> results = new Runner(options).run();
         assertThat(results, hasSize(1));
         Result<?> primaryResult = results.iterator().next().getPrimaryResult();
@@ -79,16 +74,7 @@ public class EjbClassGeneratorFactoryBenchmarkTest {
     @Test
     @Order(2)
     public void generate_benchmark() throws Exception {
-        Options options = new OptionsBuilder()
-            .include(getClass().getName() + ".*")
-            .warmupBatchSize(1).warmupForks(0).warmupIterations(1).warmupTime(TimeValue.milliseconds(50L))
-            .measurementIterations(1).forks(1).measurementTime(TimeValue.milliseconds(200L))
-            // should be able to detect race conditions when loading classes generated in previous test
-            .threads(100).timeout(TimeValue.seconds(5L))
-            .timeUnit(TimeUnit.MICROSECONDS)
-            .mode(Mode.AverageTime).shouldFailOnError(true)
-            .build();
-
+        Options options = createOptions(true, 500L, Mode.AverageTime);
         Collection<RunResult> results = new Runner(options).run();
         assertThat(results, hasSize(1));
         Result<?> primaryResult = results.iterator().next().getPrimaryResult();
@@ -104,6 +90,21 @@ public class EjbClassGeneratorFactoryBenchmarkTest {
         }
         assertNotNull(newClass);
         assertEquals("com.sun.ejb._EjbClassGeneratorFactoryBenchmarkTest$TestInterface_Remote", newClass.getName());
+    }
+
+
+    private Options createOptions(boolean warmup, long measurementTime, Mode mode) {
+        ChainedOptionsBuilder builder = new OptionsBuilder().include(getClass().getName() + ".*");
+        if (warmup) {
+            builder.warmupIterations(1).warmupBatchSize(1).warmupForks(0).warmupTime(TimeValue.milliseconds(100L));
+        } else {
+            builder.warmupIterations(0);
+        }
+        builder.forks(1).threads(100).shouldFailOnError(true)
+            .measurementIterations(1)
+            .measurementTime(TimeValue.milliseconds(measurementTime)).timeout(TimeValue.seconds(5L))
+            .timeUnit(TimeUnit.MICROSECONDS).mode(mode);
+        return builder.build();
     }
 
     interface TestInterface {

--- a/appserver/extras/embedded/tests/src/test/java/org/glassfish/main/extras/embedded/test/all/deployment/RemoteDeploymentITestBase.java
+++ b/appserver/extras/embedded/tests/src/test/java/org/glassfish/main/extras/embedded/test/all/deployment/RemoteDeploymentITestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,7 @@ package org.glassfish.main.extras.embedded.test.all.deployment;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Queue;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -29,6 +30,7 @@ import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.embeddable.GlassFishRuntime;
 import org.glassfish.main.extras.embedded.test.app.ejb.RemoteInterface;
+import org.glassfish.tests.utils.ServerUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -37,13 +39,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import static java.lang.String.format;
-import static org.glassfish.tests.utils.ServerUtils.getFreePort;
 import static org.glassfish.tests.utils.ServerUtils.runCommand;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RemoteDeploymentITestBase {
 
+    private static final Queue<Integer> RANDOM_FREE_PORTS = ServerUtils.getFreePorts(3);
     private static final String LOOKUP_STRING =
         "java:global/%s/RemoteBean!org.glassfish.main.extras.embedded.test.app.ejb.RemoteInterface";
 
@@ -64,15 +66,15 @@ public class RemoteDeploymentITestBase {
         runCommand(
             glassfish,
             "set",
-            "configs.config.server-config.iiop-service.iiop-listener.orb-listener-1.port=" + getFreePort());
+            "configs.config.server-config.iiop-service.iiop-listener.orb-listener-1.port=" + RANDOM_FREE_PORTS.remove());
         runCommand(
             glassfish,
             "set",
-            "configs.config.server-config.iiop-service.iiop-listener.SSL.port=" + getFreePort());
+            "configs.config.server-config.iiop-service.iiop-listener.SSL.port=" + RANDOM_FREE_PORTS.remove());
         runCommand(
             glassfish,
             "set",
-            "configs.config.server-config.iiop-service.iiop-listener.SSL_MUTUALAUTH.port=" + getFreePort());
+            "configs.config.server-config.iiop-service.iiop-listener.SSL_MUTUALAUTH.port=" + RANDOM_FREE_PORTS.remove());
     }
 
     @AfterEach

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/ClusterITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/ClusterITest.java
@@ -19,12 +19,14 @@ package org.glassfish.main.admin.test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.StringUtils;
 import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
 import org.glassfish.main.itest.tools.asadmin.Asadmin;
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.glassfish.tests.utils.ServerUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -33,7 +35,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.glassfish.main.admin.test.ConnectionUtils.getURL;
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
-import static org.glassfish.tests.utils.ServerUtils.getFreePort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -52,9 +53,10 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 @TestMethodOrder(OrderAnnotation.class)
 public class ClusterITest {
 
+    private static final Queue<Integer> RANDOM_FREE_PORTS = ServerUtils.getFreePorts(16);
     private static final String TEST_APP_NAME = "testapp";
-    private static final int PORT_INSTANCE_1 = getFreePort();
-    private static final int PORT_INSTANCE_2 = getFreePort();
+    private static final int PORT_INSTANCE_1 = RANDOM_FREE_PORTS.remove();
+    private static final int PORT_INSTANCE_2 = RANDOM_FREE_PORTS.remove();
     private static final String CLUSTER_NAME = "eec1";
     private static final String INSTANCE_NAME_1 = "eein1-with-a-very-very-very-long-name";
     private static final String INSTANCE_NAME_2 = "eein2";
@@ -87,28 +89,29 @@ public class ClusterITest {
     @Test
     @Order(3)
     public void createInstancesTest() {
+        // Create a cluster with two instances
         assertThat(
                 ASADMIN.exec("create-local-instance", "--cluster", CLUSTER_NAME, "--systemproperties",
                         "HTTP_LISTENER_PORT=" + PORT_INSTANCE_1
-                        + ":HTTP_SSL_LISTENER_PORT=" + getFreePort()
-                        + ":IIOP_SSL_LISTENER_PORT=" + getFreePort()
-                        + ":IIOP_LISTENER_PORT=" + getFreePort()
-                        + ":JMX_SYSTEM_CONNECTOR_PORT=" + getFreePort()
-                        + ":IIOP_SSL_MUTUALAUTH_PORT=" + getFreePort()
-                        + ":JMS_PROVIDER_PORT=" + getFreePort()
-                        + ":ASADMIN_LISTENER_PORT=" + getFreePort(),
+                        + ":HTTP_SSL_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":IIOP_SSL_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":IIOP_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":JMX_SYSTEM_CONNECTOR_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":IIOP_SSL_MUTUALAUTH_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":JMS_PROVIDER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":ASADMIN_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove(),
                         INSTANCE_NAME_1), asadminOK());
 
         assertThat(
                 ASADMIN.exec("create-local-instance", "--cluster", CLUSTER_NAME, "--systemproperties",
                         "HTTP_LISTENER_PORT=" + PORT_INSTANCE_2
-                        + ":HTTP_SSL_LISTENER_PORT=" + getFreePort()
-                        + ":IIOP_SSL_LISTENER_PORT=" + getFreePort()
-                        + ":IIOP_LISTENER_PORT=" + getFreePort()
-                        + ":JMX_SYSTEM_CONNECTOR_PORT=" + getFreePort()
-                        + ":IIOP_SSL_MUTUALAUTH_PORT=" + getFreePort()
-                        + ":JMS_PROVIDER_PORT=" + getFreePort()
-                        + ":ASADMIN_LISTENER_PORT=" + getFreePort(),
+                        + ":HTTP_SSL_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":IIOP_SSL_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":IIOP_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":JMX_SYSTEM_CONNECTOR_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":IIOP_SSL_MUTUALAUTH_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":JMS_PROVIDER_PORT=" + RANDOM_FREE_PORTS.remove()
+                        + ":ASADMIN_LISTENER_PORT=" + RANDOM_FREE_PORTS.remove(),
                         INSTANCE_NAME_2), asadminOK());
     }
 


### PR DESCRIPTION
### ClusterITest
- This test randomly failed in another branch on GH CI for no obvious reason. The first idea is that there was some port collision.
- Using generated free port numbers
- Try to stop and delete even unreachable instances

### EjbClassGeneratorFactoryBenchmarkTest
* Local result: 68500 vs 47.
* Random GH CI result before change: 230000 vs 130000 
  * criteria: second must be less than 33%
* Result after this change on GH CI:
  * 133000 vs 99 (Linux)
  * 227000 vs 148 (Windows)
* Change
  * Reduced duplication
  * Increased measurement time from 200 to 500 ms.
  * Increased warmup time from 50 to 100 ms.
  * Reduced measurement time of the first execution from 50 to 20 ms.

### ServerUtils.getFreePort
* There was no prevention of duplicit port numbers which were free at the moment, but then could be used twice in the server configuration so server would not start.