### PR TITLE
Expose services with local parent locator scope (e.g. @RunLevel) to the service locator in system apps

### DIFF
--- a/appserver/web/web-glue/pom.xml
+++ b/appserver/web/web-glue/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2023 Contributors to the Eclipse Foundation.
+    Copyright 2023, 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -215,6 +215,11 @@
             <groupId>org.glassfish.annotations</groupId>
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModuleListener.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModuleListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -62,6 +62,7 @@ import org.glassfish.web.LogFacade;
 import org.glassfish.web.deployment.runtime.SunWebAppImpl;
 import org.glassfish.web.deployment.runtime.WebProperty;
 import org.glassfish.web.deployment.util.WebValidatorWithCL;
+import org.glassfish.web.hk2.CombiningServiceLocator;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
@@ -276,12 +277,15 @@ final class WebModuleListener implements LifecycleListener {
 
     }
 
+    ServiceLocator webAppServices;
+
     private ServiceLocator createWebAppServices(WebModule webModule, ServiceLocator defaultServices) {
         ServiceLocator webAppServices = ServiceLocatorFactory.getInstance().create(webModule.getComponentId(), defaultServices);
         initializeServicesFromClassLoader(webAppServices, Thread.currentThread().getContextClassLoader());
 
-        return webAppServices;
+        return new CombiningServiceLocator(webAppServices, defaultServices);
     }
+
 
     private static void initializeServicesFromClassLoader(ServiceLocator serviceLocator, ClassLoader classLoader) {
         DynamicConfigurationService dcs =
@@ -446,4 +450,5 @@ final class WebModuleListener implements LifecycleListener {
             wrapper.addInitParameter("fileEncoding", fileEncoding);
         }
     }
+
 }

--- a/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModuleListener.java
+++ b/appserver/web/web-glue/src/main/java/com/sun/enterprise/web/WebModuleListener.java
@@ -277,8 +277,6 @@ final class WebModuleListener implements LifecycleListener {
 
     }
 
-    ServiceLocator webAppServices;
-
     private ServiceLocator createWebAppServices(WebModule webModule, ServiceLocator defaultServices) {
         ServiceLocator webAppServices = ServiceLocatorFactory.getInstance().create(webModule.getComponentId(), defaultServices);
         initializeServicesFromClassLoader(webAppServices, Thread.currentThread().getContextClassLoader());

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/hk2/CombiningServiceLocator.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/hk2/CombiningServiceLocator.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.web.hk2;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.Descriptor;
+import org.glassfish.hk2.api.Filter;
+import org.glassfish.hk2.api.Injectee;
+import org.glassfish.hk2.api.MethodParameter;
+import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.ServiceHandle;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorState;
+import org.glassfish.hk2.api.Unqualified;
+
+
+/**
+ * <p>
+ * Combines services from 2 service locators. To be used in system apps to get
+ * access to local scopes available only in the parent service locator.
+ * <p>
+ * It does 3 things:
+ *
+ * <ul>
+ * <li>For calls to getService methods, gets the service in the primary locator.
+ * If not found there, gets it from the fallback locator
+ * </li>
+ * <li>For calls to getAllServices methods, concatenates the list of service in
+ * the primary locator and the list of services in the fallback locator. It
+ * removes duplicate services
+ * </li>
+ * <li>Delegates all other calls (including {@code getServiceHandle}) to primary
+ * locator. This is to simplify the solution because accessing local scopes from
+ * the fallback locator is likely not needed in Admin Console in these methods
+ * </li>
+ * </ul>
+ */
+public class CombiningServiceLocator implements ServiceLocator {
+
+    private static final System.Logger LOG = System.getLogger(CombiningServiceLocator.class.getName());
+    private final ServiceLocator primaryLocator;
+    private final ServiceLocator fallbackLocator;
+
+    public CombiningServiceLocator(ServiceLocator primaryLocator, ServiceLocator fallbackLocator) {
+        this.primaryLocator = primaryLocator;
+        this.fallbackLocator = fallbackLocator;
+    }
+
+    @Override
+    public <T> T getService(Class<T> contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return getCombinedService(locator -> locator.getService(contractOrImpl, qualifiers));
+    }
+
+    private <T> T getCombinedService(Function<ServiceLocator, T> selector) {
+        try {
+            return selector.apply(primaryLocator);
+        } catch (MultiException e) {
+            return selector.apply(fallbackLocator);
+        }
+    }
+
+    @Override
+    public <T> T getService(Type contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return getCombinedService(locator -> locator.getService(contractOrImpl, qualifiers));
+    }
+
+    @Override
+    public <T> T getService(Class<T> contractOrImpl, String name, Annotation... qualifiers) throws MultiException {
+        return getCombinedService(locator -> locator.getService(contractOrImpl, name, qualifiers));
+    }
+
+    @Override
+    public <T> T getService(Type contractOrImpl, String name, Annotation... qualifiers) throws MultiException {
+        return getCombinedService(locator -> locator.getService(contractOrImpl, name, qualifiers));
+    }
+
+    @Override
+    public <T> T getService(ActiveDescriptor<T> activeDescriptor, ServiceHandle<?> root) throws MultiException {
+        return getCombinedService(locator -> locator.getService(activeDescriptor, root));
+    }
+
+    @Override
+    public <T> T getService(ActiveDescriptor<T> activeDescriptor, ServiceHandle<?> root, Injectee injectee) throws MultiException {
+        return getCombinedService(locator -> locator.getService(activeDescriptor, root, injectee));
+    }
+
+    @Override
+    public <T> List<T> getAllServices(Class<T> contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return getCombinedServicesWithType(locator -> locator.getAllServiceHandles(contractOrImpl, qualifiers));
+    }
+
+    private <T> List<T> getCombinedServicesWithType(Function<ServiceLocator, List<ServiceHandle<T>>> selector) {
+        return (List<T>) getCombinedServices(locator -> (List<ServiceHandle<?>>) (List<?>) selector.apply(locator));
+    }
+
+    private List<?> getCombinedServices(Function<ServiceLocator, List<ServiceHandle<?>>> selector) {
+        List<ServiceHandle<?>> allServicesFromPrimary;
+        try {
+            allServicesFromPrimary = selector.apply(primaryLocator);
+        } catch (MultiException e) {
+            allServicesFromPrimary = List.of();
+        }
+        List<ServiceHandle<?>> allServicesFromFallback = selector.apply(fallbackLocator);
+        return unionOfLists(allServicesFromPrimary, allServicesFromFallback);
+
+    }
+
+    private List<?> unionOfLists(List<ServiceHandle<?>> primaryList, List<ServiceHandle<?>> fallbackList) {
+        Set<Object> serviceKeysInResult = new HashSet<>();
+        List<Object> result = new ArrayList<>();
+        Iterable<ServiceHandle<?>> iterableOverBothLists = (Iterable<ServiceHandle<?>>) () -> Stream.concat(primaryList.stream(), fallbackList.stream()).iterator();
+        for (ServiceHandle<?> serviceHandle : iterableOverBothLists) {
+            Type serviceType = serviceHandle.getActiveDescriptor().getImplementationType();
+            Long locatorId = serviceHandle.getActiveDescriptor().getLocatorId();
+            List<Object> serviceKey = List.of(serviceType, locatorId);
+            if (!serviceKeysInResult.contains(serviceKey)) {
+                try {
+                    Object service = serviceHandle.getService();
+                    serviceKeysInResult.add(serviceKey);
+                    result.add(service);
+                } catch (MultiException e) {
+                    LOG.log(System.Logger.Level.DEBUG,
+                            () -> "Error getting " + serviceHandle.getActiveDescriptor().getImplementationType()
+                            + " from service locator id=" + serviceHandle.getActiveDescriptor().getLocatorId()
+                            + " (primaryLocator id=" + primaryLocator.getLocatorId() + ","
+                            + " fallbackLocator id=" + fallbackLocator.getLocatorId() + "). " + e.getMessage(), e);
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public <T> List<T> getAllServices(Type contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return (List<T>) getCombinedServices(locator -> (List<ServiceHandle<?>>) locator.getAllServiceHandles(contractOrImpl, qualifiers));
+    }
+
+    @Override
+    public <T> List<T> getAllServices(Annotation qualifier, Annotation... qualifiers) throws MultiException {
+        return (List<T>) getCombinedServices(locator -> locator.getAllServiceHandles(qualifier, qualifiers));
+    }
+
+    @Override
+    public List<?> getAllServices(Filter searchCriteria) throws MultiException {
+        return getCombinedServices(locator -> locator.getAllServiceHandles(searchCriteria));
+    }
+
+    @Override
+    public <T> ServiceHandle<T> getServiceHandle(Class<T> contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getServiceHandle(contractOrImpl, qualifiers);
+    }
+
+    @Override
+    public <T> ServiceHandle<T> getServiceHandle(Type contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getServiceHandle(contractOrImpl, qualifiers);
+    }
+
+    @Override
+    public <T> ServiceHandle<T> getServiceHandle(Class<T> contractOrImpl, String name, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getServiceHandle(contractOrImpl, name, qualifiers);
+    }
+
+    @Override
+    public <T> ServiceHandle<T> getServiceHandle(Type contractOrImpl, String name, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getServiceHandle(contractOrImpl, name, qualifiers);
+    }
+
+    @Override
+    public <T> List<ServiceHandle<T>> getAllServiceHandles(Class<T> contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getAllServiceHandles(contractOrImpl, qualifiers);
+    }
+
+    @Override
+    public List<ServiceHandle<?>> getAllServiceHandles(Type contractOrImpl, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getAllServiceHandles(contractOrImpl, qualifiers);
+    }
+
+    @Override
+    public List<ServiceHandle<?>> getAllServiceHandles(Annotation qualifier, Annotation... qualifiers) throws MultiException {
+        return primaryLocator.getAllServiceHandles(qualifier, qualifiers);
+    }
+
+    @Override
+    public List<ServiceHandle<?>> getAllServiceHandles(Filter searchCriteria) throws MultiException {
+        return primaryLocator.getAllServiceHandles(searchCriteria);
+    }
+
+    @Override
+    public List<ActiveDescriptor<?>> getDescriptors(Filter filter) {
+        return primaryLocator.getDescriptors(filter);
+    }
+
+    @Override
+    public ActiveDescriptor<?> getBestDescriptor(Filter filter) {
+        return primaryLocator.getBestDescriptor(filter);
+    }
+
+    @Override
+    public ActiveDescriptor<?> reifyDescriptor(Descriptor descriptor, Injectee injectee) throws MultiException {
+        return primaryLocator.reifyDescriptor(descriptor, injectee);
+    }
+
+    @Override
+    public ActiveDescriptor<?> reifyDescriptor(Descriptor descriptor) throws MultiException {
+        return primaryLocator.reifyDescriptor(descriptor);
+    }
+
+    @Override
+    public ActiveDescriptor<?> getInjecteeDescriptor(Injectee injectee) throws MultiException {
+        return primaryLocator.getInjecteeDescriptor(injectee);
+    }
+
+    @Override
+    public <T> ServiceHandle<T> getServiceHandle(ActiveDescriptor<T> activeDescriptor, Injectee injectee) throws MultiException {
+        return primaryLocator.getServiceHandle(activeDescriptor, injectee);
+    }
+
+    @Override
+    public <T> ServiceHandle<T> getServiceHandle(ActiveDescriptor<T> activeDescriptor) throws MultiException {
+        return primaryLocator.getServiceHandle(activeDescriptor);
+    }
+
+    @Override
+    public String getDefaultClassAnalyzerName() {
+        return primaryLocator.getDefaultClassAnalyzerName();
+    }
+
+    @Override
+    public void setDefaultClassAnalyzerName(String defaultClassAnalyzer) {
+        primaryLocator.setDefaultClassAnalyzerName(defaultClassAnalyzer);
+    }
+
+    @Override
+    public Unqualified getDefaultUnqualified() {
+        return primaryLocator.getDefaultUnqualified();
+    }
+
+    @Override
+    public void setDefaultUnqualified(Unqualified unqualified) {
+        primaryLocator.setDefaultUnqualified(unqualified);
+    }
+
+    @Override
+    public String getName() {
+        return primaryLocator.getName();
+    }
+
+    @Override
+    public long getLocatorId() {
+        return primaryLocator.getLocatorId();
+    }
+
+    @Override
+    public ServiceLocator getParent() {
+        return primaryLocator.getParent();
+    }
+
+    @Override
+    public void shutdown() {
+        primaryLocator.shutdown();
+    }
+
+    @Override
+    public ServiceLocatorState getState() {
+        return primaryLocator.getState();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return primaryLocator.isShutdown();
+    }
+
+    @Override
+    public boolean getNeutralContextClassLoader() {
+        return primaryLocator.getNeutralContextClassLoader();
+    }
+
+    @Override
+    public void setNeutralContextClassLoader(boolean neutralContextClassLoader) {
+        primaryLocator.setNeutralContextClassLoader(neutralContextClassLoader);
+    }
+
+    @Override
+    public <T> T create(Class<T> createMe) {
+        return primaryLocator.create(createMe);
+    }
+
+    @Override
+    public <T> T create(Class<T> createMe, String strategy) {
+        return primaryLocator.create(createMe, strategy);
+    }
+
+    @Override
+    public void inject(Object injectMe) {
+        primaryLocator.inject(injectMe);
+    }
+
+    @Override
+    public void inject(Object injectMe, String strategy) {
+        primaryLocator.inject(injectMe, strategy);
+    }
+
+    @Override
+    public Object assistedInject(Object injectMe, Method method, MethodParameter... params) {
+        return primaryLocator.assistedInject(injectMe, method, params);
+    }
+
+    @Override
+    public Object assistedInject(Object injectMe, Method method, ServiceHandle<?> root, MethodParameter... params) {
+        return primaryLocator.assistedInject(injectMe, method, root, params);
+    }
+
+    @Override
+    public void postConstruct(Object postConstructMe) {
+        primaryLocator.postConstruct(postConstructMe);
+    }
+
+    @Override
+    public void postConstruct(Object postConstructMe, String strategy) {
+        primaryLocator.postConstruct(postConstructMe, strategy);
+    }
+
+    @Override
+    public void preDestroy(Object preDestroyMe) {
+        primaryLocator.preDestroy(preDestroyMe);
+    }
+
+    @Override
+    public void preDestroy(Object preDestroyMe, String strategy) {
+        primaryLocator.preDestroy(preDestroyMe, strategy);
+    }
+
+    @Override
+    public <U> U createAndInitialize(Class<U> createMe) {
+        return primaryLocator.createAndInitialize(createMe);
+    }
+
+    @Override
+    public <U> U createAndInitialize(Class<U> createMe, String strategy) {
+        return primaryLocator.createAndInitialize(createMe, strategy);
+    }
+
+}

--- a/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/ChildService.java
+++ b/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/ChildService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.web.hk2;
+
+import jakarta.inject.Inject;
+
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Service
+@PerLookup
+public class ChildService {
+    @Inject
+    ServiceLocator locator;
+
+    public ServiceLocator getLocator() {
+        return locator;
+    }
+}

--- a/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/CombiningServiceLocatorTest.java
+++ b/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/CombiningServiceLocatorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.web.hk2;
+
+
+import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.runlevel.RunLevelController;
+import org.glassfish.hk2.runlevel.RunLevelServiceUtilities;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class CombiningServiceLocatorTest {
+
+    TestInfo testInfo;
+
+    @BeforeEach
+    void init(TestInfo testInfo) {
+        this.testInfo = testInfo;
+    }
+
+    @Test
+    void testGetServiceWithLocalContext() {
+        ServiceLocator parentLocator = parentLocatorWithLocalScopeServiceAndPublicServices(ServiceWithLocalScope.class, PublicService.class, ChildService.class);
+        ServiceLocator childLocator = childLocatorWithServices(parentLocator, ChildService.class);
+
+        ServiceWithLocalScope serviceFromParent = parentLocator.getService(ServiceWithLocalScope.class);
+        assertEquals(parentLocator, serviceFromParent.getLocator());
+
+        assertThrows(MultiException.class, () -> childLocator.getService(ServiceWithLocalScope.class), "Child locator shouldn't return service local to parent");
+
+        CombiningServiceLocator combiningLocator = new CombiningServiceLocator(childLocator, parentLocator);
+        ServiceWithLocalScope parentLocalService = combiningLocator.getService(ServiceWithLocalScope.class);
+
+        Assertions.assertNotNull(parentLocalService, "Service with context local to the parent locator available from the combining locator");
+        assertEquals(parentLocator, serviceFromParent.getLocator(), "The service local to parent should be asociated to the parent locator, not to the combining locator");
+
+        PublicService publicService = childLocator.getService(PublicService.class);
+
+        Assertions.assertNotNull(publicService);
+        assertEquals(parentLocator, publicService.getLocator(), "Services created by parent locator should be associated to the parent locator, not to the child locator");
+
+        ChildService childService = childLocator.getService(ChildService.class);
+
+        Assertions.assertNotNull(childService);
+        assertEquals(childLocator, childService.getLocator(), "Services available both in child and parent locators should be associated to the child locator which takes precedence");
+    }
+
+    @Test
+    void testGetAllServicesWithLocalContext() {
+        ServiceLocator parentLocator = parentLocatorWithLocalScopeServiceAndPublicServices(ServiceWithLocalScope.class, PublicService.class);
+        ServiceLocator childLocator = childLocatorWithServices(parentLocator, PublicService.class);
+        CombiningServiceLocator combiningLocator = new CombiningServiceLocator(childLocator, parentLocator);
+
+        assertEquals(1, parentLocator.getAllServices(ServiceWithLocalScope.class).size(),
+                "Parent locator should contain 1 " + ServiceWithLocalScope.class.getSimpleName() + " service");
+
+        assertThrows(MultiException.class, () -> childLocator.getAllServices(ServiceWithLocalScope.class),
+                "Child locator shouldn't have access to " + ServiceWithLocalScope.class.getSimpleName() + " service");
+
+        assertEquals(1, combiningLocator.getAllServices(ServiceWithLocalScope.class).size(), "Combined locator should contain 1 " + ServiceWithLocalScope.class.getSimpleName() + " service");
+
+        assertEquals(1, parentLocator.getAllServices(PublicService.class).size(),
+                "Parent locator should contain 1 " + PublicService.class.getSimpleName() + " service");
+
+        assertEquals(2, childLocator.getAllServices(PublicService.class).size(),
+                "Child locator should contain 2 " + PublicService.class.getSimpleName() + " services (one from parent, one from child)");
+
+        assertEquals(2, combiningLocator.getAllServices(PublicService.class).size(),
+                "Combined locator should contain 2 " + PublicService.class.getSimpleName() + " services (one from parent, one from child)");
+
+    }
+
+    private ServiceLocator parentLocatorWithLocalScopeServiceAndPublicServices(Class<ServiceWithLocalScope> localServiceClass, Class<?>... publicServiceClasses) {
+        ServiceLocator locator = LocatorHelper.create(createLocatorName("parent"), configuration -> {
+            configuration.bind(BuilderHelper.createDescriptorFromClass(localServiceClass));
+            for (Class<?> cls : publicServiceClasses) {
+                configuration.bind(BuilderHelper.createDescriptorFromClass(cls));
+            }
+        });
+        proceedToRunLevel(0, locator);
+        return locator;
+    }
+
+    private ServiceLocator childLocatorWithServices(ServiceLocator parentLocator, Class<?>... classes) {
+        return LocatorHelper.create(createLocatorName("child"), parentLocator, configuration -> {
+            for (Class<?> cls : classes) {
+                configuration.bind(BuilderHelper.createDescriptorFromClass(cls));
+            }
+        });
+    }
+
+    private String createLocatorName(String suffix) {
+        return testInfo.getTestClass().get().getSimpleName() + "::" + testInfo.getTestMethod().get().getName() + "-" + suffix;
+    }
+    private void proceedToRunLevel(int level, ServiceLocator parentLocator) {
+        RunLevelServiceUtilities.enableRunLevelService(parentLocator);
+        RunLevelController runLevelService = parentLocator.getService(RunLevelController.class);
+        runLevelService.proceedTo(level);
+    }
+
+}

--- a/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/LocatorHelper.java
+++ b/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/LocatorHelper.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Originally copied from Eclipse HK2 hk2-locator module
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.web.hk2;
+
+import java.util.function.Consumer;
+
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.DynamicConfigurationService;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ *
+ *
+ */
+public class LocatorHelper {
+    /** This should be thrown from negative tests */
+    public final static String EXPECTED = "Expected Exception";
+
+    private final static ServiceLocatorFactory factory = ServiceLocatorFactory
+            .getInstance();
+
+    /**
+     * Creates an unnamed, untracked service locator
+     *
+     * @return An unnamed, untracked service locator
+     */
+    public static ServiceLocator create() {
+        return factory.create(null);
+    }
+
+    /**
+     * Creates an unnamed, untracked service locator with the given parent
+     *
+     * @param parent
+     *            The non-null parent to be associated with this locator
+     * @return An unnamed, untracked service locator with the given parent
+     */
+    public static ServiceLocator create(ServiceLocator parent) {
+        return factory.create(null, parent);
+    }
+
+    /**
+     * Will create a ServiceLocator after doing test-specific bindings from the
+     * TestModule
+     *
+     * @param name
+     *            The name of the service locator to create. Should be unique
+     *            per test, otherwise this method will fail.
+     * @param configurator
+     *            The test module, that will do test specific bindings. May be
+     *            null
+     * @return A service locator with all the test specific bindings bound
+     */
+    public static ServiceLocator create(String name, Consumer<DynamicConfiguration> configurator) {
+        return create(name, null, configurator);
+    }
+
+    /**
+     * Will create a ServiceLocator after doing test-specific bindings from the
+     * TestModule
+     *
+     * @param name
+     *            The name of the service locator to create. Should be unique
+     *            per test, otherwise this method will fail.
+     * @param parent
+     *            The parent locator this one should have. May be null
+     * @param configurator
+     *            The test module, that will do test specific bindings. May be
+     *            null
+     * @return A service locator with all the test specific bindings bound
+     */
+    public static ServiceLocator create(String name, ServiceLocator parent,
+            Consumer<DynamicConfiguration> configurator) {
+        ServiceLocator retVal = factory.find(name);
+        Assertions.assertNull(
+                retVal, "There is already a service locator of this name, change names to ensure a clean test: " + name);
+
+        retVal = factory.create(name, parent);
+
+        if (configurator == null) return retVal;
+
+        DynamicConfigurationService dcs = retVal
+                .getService(DynamicConfigurationService.class);
+        Assertions.assertNotNull(
+                dcs, "Their is no DynamicConfigurationService.  Epic fail");
+
+        DynamicConfiguration dc = dcs.createDynamicConfiguration();
+        Assertions.assertNotNull(dc, "DynamicConfiguration creation failure");
+
+        configurator.accept(dc);
+
+        dc.commit();
+
+        return retVal;
+    }
+
+    /**
+     * Creates a ServiceLocator equipped with a RunLevelService and the set of
+     * classes given
+     *
+     * @param classes
+     *            The set of classes to also add to the descriptor (should
+     *            probably contain some run level services, right?)
+     * @return The ServiceLocator to use
+     */
+    @SuppressWarnings("unchecked")
+    public static ServiceLocator getServiceLocator(Class<?>... classes) {
+        ServiceLocator locator = ServiceLocatorFactory.getInstance().create(null);
+
+        DynamicConfigurationService dcs = locator.getService(DynamicConfigurationService.class);
+        DynamicConfiguration config = dcs.createDynamicConfiguration();
+
+        for (Class<?> clazz : classes) {
+            if (Factory.class.isAssignableFrom(clazz)) {
+                Class<? extends Factory<Object>> fClass = (Class<? extends Factory<Object>>) clazz;
+
+                config.addActiveFactoryDescriptor(fClass);
+            }
+            else {
+                config.addActiveDescriptor(clazz);
+            }
+        }
+
+        config.commit();
+
+        return locator;
+    }
+}

--- a/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/PublicService.java
+++ b/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/PublicService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.web.hk2;
+
+import jakarta.inject.Inject;
+
+import org.glassfish.hk2.api.PerLookup;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Service
+@PerLookup
+public class PublicService {
+    @Inject
+    ServiceLocator locator;
+
+    public ServiceLocator getLocator() {
+        return locator;
+    }
+}

--- a/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/ServiceWithLocalScope.java
+++ b/appserver/web/web-glue/src/test/java/org/glassfish/web/hk2/ServiceWithLocalScope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.web.hk2;
+
+import jakarta.inject.Inject;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.runlevel.RunLevel;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@RunLevel
+public class ServiceWithLocalScope {
+    @Inject
+    ServiceLocator locator;
+
+    public ServiceLocator getLocator() {
+        return locator;
+    }
+}

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -288,18 +288,18 @@ public class DeploymentImpl implements CDI11Deployment {
             if (!(beanDeploymentArchive instanceof RootBeanDeploymentArchive)) {
                 ClassLoader classLoader = new FilteringClassLoader(((BeanDeploymentArchiveImpl) beanDeploymentArchive)
                     .getModuleClassLoaderForBDA());
-                extensions = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class)
+                Iterable<Metadata<Extension>> classPathExtensions = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class)
                     .loadExtensions(classLoader);
 
-                if (extensions != null) {
-                    for (Metadata<Extension> beanDeploymentArchiveExtension : extensions) {
+                if (classPathExtensions != null) {
+                    for (Metadata<Extension> beanDeploymentArchiveExtension : classPathExtensions) {
                         extensionsList.add(beanDeploymentArchiveExtension);
                     }
                 }
             }
         }
 
-        return extensionsList;
+        return extensions = extensionsList;
     }
 
     @Override


### PR DESCRIPTION
Fixes #25467.
Fixes #25465.

This PR changes the locator of system apps so that it falls back to the parent locator and retrieves services from it directly and not only indirectly via the child locator. The new combining locator searches for services first in the child locator as before, but then delegates to the parent locator directly. This allows retrieving services local to the parent locator, as it was happening before when the parent locator was used as the locator for web apps.

With the change in https://github.com/eclipse-ee4j/glassfish/pull/24898 we introduced a child HK2 locator in webapps, delegating to the previous locator as the parent locator. This was later changed to do this only for system apps (needed for Admin Console) because there were some issues with combining child and parent locator with Faces in Embedded GlassFish.

After that change, the locator doesn't have access to services with scope local to the parent locator, e.g. with the `@RunLevel` scope. Some of these services are accessed directly by Admin Console, e.g. `JmsProviderLifecycle` as described in #25465. Which now results in an exception because the service doesn't have a context in the child locator.

This fix avoids that by asking the parent locator directly if a services is not found or doesn't have a proper context in the child locator.

