### PR TITLE
Fixed log messages - throwable is not a parameter

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteRestAdminCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -1110,30 +1110,30 @@ public class RemoteRestAdminCommand extends AdminCommandEventBrokerImpl<GfSseInb
                 continue;
 
             } catch (ConnectException ce) {
-                logger.log(FINER, "doHttpCommand: connect exception {0}", ce);
+                logger.log(FINER, "doHttpCommand: connect exception", ce);
                 // this really means nobody was listening on the remote server
                 // note: ConnectException extends IOException and tells us more!
                 String msg = strings.get("ConnectException", host, port + "");
                 throw new CommandException(msg, ce);
             } catch (UnknownHostException he) {
-                logger.log(FINER, "doHttpCommand: host exception {0}", he);
+                logger.log(FINER, "doHttpCommand: host exception", he);
                 // bad host name
                 String msg = strings.get("UnknownHostException", host);
                 throw new CommandException(msg, he);
             } catch (SocketException se) {
-                logger.log(FINER, "doHttpCommand: socket exception {0}", se);
+                logger.log(FINER, "doHttpCommand: socket exception", se);
                 throw new CommandException(se);
             } catch (SSLException se) {
-                logger.log(FINER, "doHttpCommand: SSL exception {0}", se);
+                logger.log(FINER, "doHttpCommand: SSL exception", se);
                 if (secure) {
                     logger.log(SEVERE, AdminLoggerInfo.mServerIsNotSecure, new Object[] { host, port });
                 }
                 throw new CommandException(se);
             } catch (SocketTimeoutException e) {
-                logger.log(FINER, "doHttpCommand: read timeout {0}", e);
+                logger.log(FINER, "doHttpCommand: read timeout", e);
                 throw new CommandException(strings.get("ReadTimeout", (float) readTimeout / 1000), e);
             } catch (IOException e) {
-                logger.log(FINER, "doHttpCommand: IO exception {0}", e);
+                logger.log(FINER, "doHttpCommand: IO exception", e);
                 throw new CommandException(strings.get("IOError", e.getMessage()), e);
             } catch (CommandException e) {
                 throw e;

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/GlassFishLogHandlerTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author David Matejcek
  */
 @TestMethodOrder(OrderAnnotation.class)
-@Timeout(value = 1, unit = TimeUnit.SECONDS)
+@Timeout(value = 5, unit = TimeUnit.SECONDS)
 public class GlassFishLogHandlerTest {
 
     private static GlassFishLogHandler handler;


### PR DESCRIPTION
Trivial mistake - logging then used exception.toStrineg instead of printing the stacktrace.
The stacktrace is here useful to see the "direction" where it came from. 

The logging should be revided later much more - many usages of this method don't log the stacktrace at all.