### PR TITLE
Ensure build CDI extensions are always returned from DeploymentImpl

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -288,18 +288,18 @@ public class DeploymentImpl implements CDI11Deployment {
             if (!(beanDeploymentArchive instanceof RootBeanDeploymentArchive)) {
                 ClassLoader classLoader = new FilteringClassLoader(((BeanDeploymentArchiveImpl) beanDeploymentArchive)
                     .getModuleClassLoaderForBDA());
-                extensions = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class)
+                Iterable<Metadata<Extension>> classPathExtensions = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class)
                     .loadExtensions(classLoader);
 
-                if (extensions != null) {
-                    for (Metadata<Extension> beanDeploymentArchiveExtension : extensions) {
+                if (classPathExtensions != null) {
+                    for (Metadata<Extension> beanDeploymentArchiveExtension : classPathExtensions) {
                         extensionsList.add(beanDeploymentArchiveExtension);
                     }
                 }
             }
         }
 
-        return extensionsList;
+        return extensions = extensionsList;
     }
 
     @Override


### PR DESCRIPTION
They were returned only on the first call of the getExtensions() method. Subsequent calls returned only extensions loaded from classpath because the build extensions were not added to the cached list in the `extensions` variable.