### PR TITLE
Add sniffer for MicroProfile REST Client

### DIFF
--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -866,7 +866,6 @@
                 <dependency>
                     <groupId>org.eclipse.microprofile.rest.client</groupId>
                     <artifactId>microprofile-rest-client-api</artifactId>
-                    <version>${microprofile.rest-client.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish.jersey.ext</groupId>

--- a/appserver/microprofile/connectors/pom.xml
+++ b/appserver/microprofile/connectors/pom.xml
@@ -34,8 +34,12 @@
     <dependencies>
         <!-- APIs -->
         <dependency>
-            <groupId>io.helidon.microprofile.config</groupId>
-            <artifactId>helidon-microprofile-config</artifactId>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
         </dependency>
 
         <!-- Internal Dependencies -->
@@ -51,4 +55,12 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/RestClientSniffer.java
+++ b/appserver/microprofile/connectors/src/main/java/org/glassfish/microprofile/connector/RestClientSniffer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 Contributors to Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.connector;
+
+import java.lang.annotation.Annotation;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.api.deployment.archive.ArchiveType;
+import org.glassfish.api.deployment.archive.ReadableArchive;
+import org.glassfish.hk2.classmodel.reflect.Types;
+import org.glassfish.internal.deployment.GenericSniffer;
+import org.jvnet.hk2.annotations.Service;
+
+@Service
+public class RestClientSniffer extends GenericSniffer {
+
+    private static final String[] containers = { "org.glassfish.microprofile.config.ConfigContainer" };
+
+    public RestClientSniffer() {
+        super("mp-rest-client", null, null);
+    }
+
+    @Override
+    public boolean handles(DeploymentContext context) {
+
+        // Check if REST Client builder is used statically
+        final var types = context.getTransientAppMetaData(Types.class.getName(), Types.class);
+        final boolean mpRestClientUsed = types != null && types.getBy(RestClientBuilder.class.getName()) != null;
+
+        return mpRestClientUsed || super.handles(context);
+    }
+
+    @Override
+    public boolean handles(ReadableArchive location) {
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<? extends Annotation>[] getAnnotationTypes() {
+        return new Class[]{
+                RegisterRestClient.class
+        };
+    }
+
+    @Override
+    public String[] getContainersNames() {
+        return containers;
+    }
+
+    @Override
+    public boolean supportsArchiveType(ArchiveType archiveType) {
+        return archiveType != null && archiveType.toString().equals("war");
+    }
+}

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -665,6 +665,13 @@
                 <artifactId>microprofile-jwt-auth</artifactId>
                 <version>${omnifaces-jwt-auth.version}</version>
             </dependency>
+            
+            <!-- MicroProfile REST Client -->
+            <dependency>
+                <groupId>org.eclipse.microprofile.rest.client</groupId>
+                <artifactId>microprofile-rest-client-api</artifactId>
+                <version>${microprofile.rest-client.version}</version>
+            </dependency>
 
             <!-- Other -->
             <dependency>

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ContainerRegistry.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ContainerRegistry.java
@@ -58,8 +58,8 @@ public class ContainerRegistry {
         return sniffers;
     }
 
-    public synchronized EngineInfo<?, ?> getContainer(String containerType) {
-        return containers.get(containerType);
+    public synchronized EngineInfo<?, ?> getContainer(String name) {
+        return containers.get(name);
     }
 
     public synchronized EngineInfo<?, ?> removeContainer(EngineInfo<?, ?> container) {


### PR DESCRIPTION
MP REST Client depends on MP Config, so initialize Config container even if MP Config sniffer doesn't detect the need for it.

Also make container initialization more robust, based on all containers, not only the first one. This would initialize all containers now also if another sniffer initialized the first container but not all others. If multiple sniffers initialize the same container, the last one overwrites the metadata in the map but the container is initialized only once.
