### PR TITLE
The asadmin verify-domain-xml command does not need Globals on classpath

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminVerifyDomainXmlITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminVerifyDomainXmlITest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test;
+
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.junit.jupiter.api.Test;
+
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+/**
+ * @author David Matejcek
+ */
+public class AsadminVerifyDomainXmlITest {
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+
+    @Test
+    public void verifyDomainXml() {
+        assertThat(ASADMIN.exec("verify-domain-xml"), asadminOK());
+    }
+}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/VerifyDomainXmlCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/VerifyDomainXmlCommand.java
@@ -17,6 +17,7 @@
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
+import com.sun.enterprise.admin.cli.CLICommand;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.module.ModulesRegistry;
 import com.sun.enterprise.module.single.StaticModulesRegistry;
@@ -34,7 +35,6 @@ import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandValidationException;
 import org.glassfish.common.util.GlassfishUrlClassLoader;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.internal.api.Globals;
 import org.jvnet.hk2.annotations.Service;
 import org.jvnet.hk2.config.ConfigParser;
 import org.jvnet.hk2.config.Dom;
@@ -85,7 +85,7 @@ public final class VerifyDomainXmlCommand extends LocalDomainCommand {
             final URL[] urlsA = urls.toArray(new URL[urls.size()]);
 
             PrivilegedAction<ClassLoader> action = () -> new GlassfishUrlClassLoader("DomainXmlVerifier", urlsA,
-                Globals.class.getClassLoader());
+                CLICommand.class.getClassLoader());
             ClassLoader cl = AccessController.doPrivileged(action);
             ModulesRegistry registry = new StaticModulesRegistry(cl);
             ServiceLocator serviceLocator = registry.createServiceLocator("default");


### PR DESCRIPTION
- Globals is not used in local commands and might not be available on classpath
- Backported from gjule-vs-gc branch, which is a base for 7.1.0.
