### PR TITLE
Fixed checking of free ports on create-domain with --checkports=false

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         curl -s -S -o ./apache-maven-3.9.9-bin.zip https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip
         unzip -q ./apache-maven-3.9.9-bin.zip
+        ss -tulpn
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/ConfigCustomizationToken.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/ConfigCustomizationToken.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -77,5 +78,12 @@ public class ConfigCustomizationToken {
 
     public void setValue(String tokenValue) {
         this.value = tokenValue;
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigCustomizationToken[" + "name='" + name + ", value='" + value + "' description='" + description
+            + "', validationExpression='" + validationExpression + "', tokenTypeDetails=" + tokenTypeDetails
+            + ", customizationType=" + customizationType + ']';
     }
 }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/FileTypeDetails.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/FileTypeDetails.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,5 +33,11 @@ public class FileTypeDetails implements TokenTypeDetails {
 
     public FileExistCondition getExistCondition() {
         return mustExist;
+    }
+
+
+    @Override
+    public String toString() {
+        return "FileTypeDetails[mustExist=" + mustExist + ']';
     }
 }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/PortTypeDetails.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/modularity/customization/PortTypeDetails.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -28,5 +29,11 @@ public class PortTypeDetails implements TokenTypeDetails {
 
     public String getBaseOffset() {
         return baseOffset;
+    }
+
+
+    @Override
+    public String toString() {
+        return "PortTypeDetails[baseOffset=" + baseOffset + ']';
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/CreateDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/CreateDomainCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -409,18 +410,13 @@ public final class CreateDomainCommand extends CLICommand {
      */
     private void createTheDomain(final String domainPath, Properties domainProperties) throws DomainException, CommandValidationException {
 
-        //
-        // fix for bug# 4930684
-        // domain name is validated before the ports
-        //
-        String domainFilePath = (domainPath + File.separator + domainName);
-        if (FileUtils.safeGetCanonicalFile(new File(domainFilePath)).exists()) {
+        if (FileUtils.safeGetCanonicalFile(new File(domainPath, domainName)).exists()) {
             throw new CommandValidationException(strings.get("DomainExists", domainName));
         }
         DomainConfig domainConfig = null;
         if (template == null || template.endsWith(".jar")) {
-            domainConfig = new DomainConfig(domainName, domainPath, adminUser, adminPassword, masterPassword, saveMasterPassword, adminPort,
-                    instancePort, domainProperties);
+            domainConfig = new DomainConfig(domainName, domainPath, adminUser, adminPassword, masterPassword,
+                saveMasterPassword, adminPort, instancePort, domainProperties);
             domainConfig.put(DomainConfig.K_VALIDATE_PORTS, Boolean.valueOf(checkPorts));
             domainConfig.put(DomainConfig.KEYTOOLOPTIONS, keytoolOptions);
             domainConfig.put(DomainConfig.K_TEMPLATE_NAME, template);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/CustomTokenClient.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/CustomTokenClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,17 +42,14 @@ import static java.text.MessageFormat.format;
  */
 public class CustomTokenClient {
 
-    /** Place holder for the PORT BASE value in domain.xml */
-    public static final String PORTBASE_PLACE_HOLDER = "PORT_BASE";
-
     /** Place holder for the custom tokens in domain.xml */
-    public static final String CUSTOM_TOKEN_PLACE_HOLDER = "TOKENS_HERE";
-    public static final String DEFAULT_TOKEN_PLACE_HOLDER = "DEFAULT_TOKENS_HERE";
+    private static final String CUSTOM_TOKEN_PLACE_HOLDER = "TOKENS_HERE";
+    private static final String DEFAULT_TOKEN_PLACE_HOLDER = "DEFAULT_TOKENS_HERE";
 
-    private final DomainConfig _domainConfig;
+    private final DomainConfig domainConfig;
 
     public CustomTokenClient(DomainConfig domainConfig) {
-        _domainConfig = domainConfig;
+        this.domainConfig = domainConfig;
     }
 
     /**
@@ -64,17 +61,14 @@ public class CustomTokenClient {
     public Map<String, String> getSubstitutableTokens() throws DomainException {
         CustomizationTokensProvider provider = CustomizationTokensProviderFactory.createCustomizationTokensProvider();
         Map<String, String> generatedTokens = new HashMap<>();
-        String lineSeparator = System.lineSeparator();
         int noOfTokens = 0;
         try {
             List<ConfigCustomizationToken> customTokens = provider.getPresentConfigCustomizationTokens();
             if (!customTokens.isEmpty()) {
-                StringBuffer generatedSysTags = new StringBuffer();
-
-                // Check presence of token place-holder
+                StringBuilder generatedSysTags = new StringBuilder();
                 Set<Integer> usedPorts = new HashSet<>();
-                Properties domainProps = _domainConfig.getDomainProperties();
-                String portBase = (String) _domainConfig.get(DomainConfig.K_PORTBASE);
+                Properties domainProps = domainConfig.getDomainProperties();
+                Integer portBase = getPortBase(domainConfig);
 
                 Map<String, String> filePaths = new HashMap<>(3, 1);
                 filePaths.put(SystemPropertyConstants.INSTALL_ROOT_PROPERTY,
@@ -88,77 +82,27 @@ public class CustomTokenClient {
                     String name = token.getName();
                     // Check for valid custom token parameters.
                     if (isNullOrEmpty(name) || isNullOrEmpty(token.getValue()) || isNullOrEmpty(token.getDescription())) {
-                        throw new IllegalArgumentException(format(
-                            "Invalid token, Empty/null values are not allowed for token name/value/description: {0}/{1}/{2}",
-                            name, token.getValue(), token.getDescription()));
+                        throw new DomainException(format(
+                            "Invalid token, Empty/null values are not allowed for token name, value and description: {0}",
+                            token));
                     }
                     switch (token.getCustomizationType()) {
-                    case PORT:
-                        Integer port = null;
-                        if (domainProps.containsKey(name)) {
-                            port = Integer.valueOf(domainProps.getProperty(token.getName()));
-                            if (!NetUtils.isPortFree(port)) {
-                                throw new DomainException(format("Given port {0} is not free.", port));
-                            }
-                        } else {
-                            Integer firstPortTried = port;
-                            if (portBase != null && token.getTokenTypeDetails() instanceof PortTypeDetails) {
-                                PortTypeDetails portTypeDetails = (PortTypeDetails) token.getTokenTypeDetails();
-                                port = Integer.parseInt(portBase) + Integer.parseInt(portTypeDetails.getBaseOffset());
-                                if (!generatedTokens.containsKey(PORTBASE_PLACE_HOLDER)) {
-                                    // Adding a token to persist port base value as a system tag
-                                    generatedTokens.put(PORTBASE_PLACE_HOLDER,
-                                            SystemPropertyTagBuilder.buildSystemTag(PORTBASE_PLACE_HOLDER, portBase));
-                                }
-                            } else {
-                                port = Integer.valueOf(token.getValue());
-                            }
-                            // Find next available unused port by incrementing the port value by 1
-                            while (!NetUtils.isPortFree(port) && !usedPorts.contains(port)) {
-                                if (port > NetUtils.MAX_PORT) {
-                                    throw new DomainException(format("No free port available in range {0} - {1} or it is prohibited.", firstPortTried, NetUtils.MAX_PORT));
-                                }
-                                port++;
-                            }
-                        }
-                        usedPorts.add(port);
-                        generatedSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token, port.toString()));
-                        break;
-                    case FILE:
-                        String path = token.getValue();
-                        for (Map.Entry<String, String> entry : filePaths.entrySet()) {
-                            if (path.contains(entry.getKey())) {
-                                path = path.replace(entry.getKey(), entry.getValue());
-                                break;
-                            }
-                        }
-                        if (token.getTokenTypeDetails() instanceof FileTypeDetails) {
-                            FileTypeDetails details = (FileTypeDetails) token.getTokenTypeDetails();
-                            File file = new File(path);
-                            switch (details.getExistCondition()) {
-                            case MUST_EXIST:
-                                if (!file.exists()) {
-                                    throw new DomainException(format("Missing file : {0}", file));
-                                }
-                                break;
-                            case MUST_NOT_EXIST:
-                                if (file.exists()) {
-                                    throw new DomainException(format(
-                                        "File {0} must not exist for the domain creation process to succeed", file));
-                                }
-                                break;
-                            case NO_OP:
-                                break;
-                            }
-                        }
-                        generatedSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token, path));
-                        break;
-                    case STRING:
-                        generatedSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token));
-                        break;
+                        case PORT:
+                            Integer port = resolvePort(token, portBase, generatedTokens, usedPorts, domainProps);
+                            generatedSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token, port.toString()));
+                            break;
+                        case FILE:
+                            String path = resolvePath(token, filePaths);
+                            generatedSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token, path));
+                            break;
+                        case STRING:
+                            generatedSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token));
+                            break;
+                        default:
+                            throw new DomainException(format("Unknown token type: {0}", token.getCustomizationType()));
                     }
                     if (--noOfTokens > 0) {
-                        generatedSysTags.append(lineSeparator);
+                        generatedSysTags.append(System.lineSeparator());
                     }
                 }
                 String tags = generatedSysTags.toString();
@@ -173,7 +117,7 @@ public class CustomTokenClient {
                 for (ConfigCustomizationToken token : defaultTokens) {
                     defaultSysTags.append(SystemPropertyTagBuilder.buildSystemTag(token));
                     if (--noOfTokens > 0) {
-                        defaultSysTags.append(lineSeparator);
+                        defaultSysTags.append(System.lineSeparator());
                     }
                 }
                 generatedTokens.put(DEFAULT_TOKEN_PLACE_HOLDER, defaultSysTags.toString());
@@ -184,6 +128,90 @@ public class CustomTokenClient {
             throw new DomainException(ex);
         }
         return generatedTokens;
+    }
+
+    private String resolvePath(ConfigCustomizationToken token, Map<String, String> filePaths) throws DomainException {
+        String path = token.getValue();
+        for (Map.Entry<String, String> entry : filePaths.entrySet()) {
+            if (path.contains(entry.getKey())) {
+                path = path.replace(entry.getKey(), entry.getValue());
+                break;
+            }
+        }
+        if (token.getTokenTypeDetails() instanceof FileTypeDetails) {
+            FileTypeDetails details = (FileTypeDetails) token.getTokenTypeDetails();
+            File file = new File(path);
+            switch (details.getExistCondition()) {
+                case MUST_EXIST:
+                    if (!file.exists()) {
+                        throw new DomainException(format("Missing file: {0}, token: {1}", file, token));
+                    }
+                    break;
+                case MUST_NOT_EXIST:
+                    if (file.exists()) {
+                        throw new DomainException(format(
+                            "File {0} must not exist for the domain creation process to succeed, token: {1}",
+                            file, token));
+                    }
+                    break;
+                case NO_OP:
+                    break;
+                default:
+                    throw new DomainException(format("Unknown file existence condition: {0} for token: {1}",
+                        details.getExistCondition(), token));
+            }
+        }
+        return path;
+    }
+
+
+    private Integer getPortBase(DomainConfig domainConfig2) {
+        String portBase = (String) domainConfig.get(DomainConfig.K_PORTBASE);
+        return portBase == null ? null : Integer.valueOf(portBase);
+    }
+
+
+    /**
+     * Limitations of this implementation:
+     * <ul>
+     * <li>When using the portBase (not null), all ports have to be generated. Otherwise, preset
+     * port values would have to be put to usedPorts before generating the ports.
+     * </ul>
+     * @param checkPorts
+     */
+    private Integer resolvePort(ConfigCustomizationToken token, Integer portBase, Map<String, String> generatedTokens,
+        Set<Integer> usedPorts, Properties domainProps) throws DomainException {
+        Integer port = null;
+        String name = token.getName();
+        if (domainProps.containsKey(name)) {
+            port = Integer.valueOf(domainProps.getProperty(name));
+        } else {
+            if (portBase != null && token.getTokenTypeDetails() instanceof PortTypeDetails) {
+                PortTypeDetails portTypeDetails = (PortTypeDetails) token.getTokenTypeDetails();
+                int firstPortTried = portBase + Integer.parseInt(portTypeDetails.getBaseOffset());
+                generatedTokens.computeIfAbsent(name, k -> SystemPropertyTagBuilder.buildSystemTag(name, portBase));
+                port = generateFreePort(usedPorts, token, firstPortTried);
+            } else {
+                port = Integer.valueOf(token.getValue());
+            }
+        }
+        usedPorts.add(port);
+        return port;
+    }
+
+    /** Find next available unused port by incrementing the port value by 1 */
+    private int generateFreePort(Set<Integer> usedPorts, ConfigCustomizationToken token, Integer firstPortTried)
+        throws DomainException {
+        int port = firstPortTried;
+        while (usedPorts.contains(port) || !NetUtils.isPortFree(port)) {
+            if (port > NetUtils.MAX_PORT) {
+                throw new DomainException(format(
+                    "No free port is available in range {0} - {1} or it is prohibited. Token: {2}",
+                    firstPortTried, NetUtils.MAX_PORT, token));
+            }
+            port++;
+        }
+        return port;
     }
 
     /**
@@ -223,8 +251,8 @@ public class CustomTokenClient {
         /**
          * Build the System tag for the given name & value.
          */
-        private static String buildSystemTag(String name, String value) {
-            String builtTag = placeHolderTagWithoutDesc.replace(valuePlaceHolder, value);
+        private static String buildSystemTag(String name, Integer value) {
+            String builtTag = placeHolderTagWithoutDesc.replace(valuePlaceHolder, value.toString());
             builtTag = builtTag.replace(namePlaceHolder, name);
             return builtTag;
         }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -91,7 +91,6 @@ public class DomainBuilder {
      *
      * @throws DomainException If exception occurs in initializing the template jar.
      */
-    // TODO : localization of index.html
     private void initialize() throws DomainException {
         String templateJarPath = (String) _domainConfig.get(DomainConfig.K_TEMPLATE_NAME);
         if (templateJarPath == null || templateJarPath.isEmpty()) {


### PR DESCRIPTION
* Added listing port usage on Ubuntu build
  * Today builds on GH CI failed declaring that 7676 was already taken. The problem was resolved in the evening without any changes on my side. Unfortunately I did not have this output yet.
* CustomTokenClient fix 
  - it checked ports when it was disabled
  - Added toString methods to get better error description
  - Refactored CustomTokenClient - split to private methods
  - Fixed condition: `while (usedPorts.contains(port) || !NetUtils.isPortFree(port))`
    - originally if the port WAS NOT used, the iteration continued.
    - now if it is already used (was already was checked, order is not always
      ascending), we skip it
    - the condition was moved just to `basePort` usage; original last `if` branch was never successful (`usedPorts` was always empty).
    - The port validation is already done in CreateDomainCommand class, so I removed checking default ports here. Locally it reported default port 7676 despite it was reset to different port by `CreateDomainCommand` and `DomainPortValidator`.
