### PR TITLE
Improved stopping local servers

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -300,21 +300,28 @@ public abstract class LocalServerCommand extends CLICommand {
     }
 
     /**
-     * Asks remote server for the PID
+     * Asks remote server for the PID and compares it with the pid file.
+     * If the remote server doesn't respond, returns pid from the file.
      *
-     * @return PID or -1 if unreachable
+     * @return PID or null if unreachable
      */
-    protected final int getServerPid() {
+    protected final Long getServerPid() {
+        Long pidFromFile = ProcessUtils.loadPid(getServerDirs().getPidFile());
         try {
             RemoteCLICommand command = new RemoteCLICommand("__locations", programOpts, env);
             ActionReport report = command.executeAndReturnActionReport("__locations");
             if (report.getActionExitCode() == ExitCode.SUCCESS) {
-                return Integer.parseInt(report.findProperty("Pid"));
+                long pidFromAdmin = Long.parseLong(report.findProperty("Pid"));
+                if (pidFromFile == null || !pidFromFile.equals(pidFromAdmin)) {
+                    logger.log(Level.SEVERE,
+                        "PID should be the same: PID from file = " + pidFromFile + ", pidFromAdmin = " + pidFromAdmin);
+                }
+                return pidFromAdmin;
             }
-            return -1;
+            return null;
         } catch (Exception e) {
-            logger.log(Level.FINEST, "The server PID could not be resolved.", e);
-            return -1;
+            logger.log(Level.SEVERE, "The server PID could not be resolved, sending PID from file: " + pidFromFile, e);
+            return pidFromFile;
         }
     }
 
@@ -327,48 +334,38 @@ public abstract class LocalServerCommand extends CLICommand {
      * @param newAdminAddress new admin endpoint - usually same as old, but it could change with restart.
      * @throws CommandException if we time out.
      */
-    protected final void waitForRestart(final int oldPid, final HostAndPort oldAdminAddress,
+    protected final void waitForRestart(final Long oldPid, final HostAndPort oldAdminAddress,
         final HostAndPort newAdminAddress) throws CommandException {
         logger.log(Level.FINEST, "waitForRestart(oldPid={0}, oldAdminAddress={1}, newAdminAddress={2})",
             new Object[] {oldPid, oldAdminAddress, newAdminAddress});
 
         final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final boolean printDots = !programOpts.isTerse();
-        final boolean stopped;
-        if (isLocal()) {
-            stopped = ProcessUtils.waitWhileIsAlive(oldPid, timeout, printDots);
-        } else {
-            stopped = ProcessUtils.waitWhileListening(oldAdminAddress, timeout, printDots);
-        }
+        final boolean stopped = oldPid == null || ProcessUtils.waitWhileIsAlive(oldPid, timeout, printDots);
         if (!stopped) {
             throw new CommandException(I18N.get("restartDomain.noGFStart"));
         }
         logger.log(CONFIG, "Server instance is stopped, now we wait for the start on {0}", newAdminAddress);
-        if (isLocal()) {
-            // Could change
-            programOpts.setHostAndPort(newAdminAddress);
-        }
+        // Could change
+        programOpts.setHostAndPort(newAdminAddress);
         final Supplier<Boolean> signStart = () -> {
             if (!ProcessUtils.isListening(newAdminAddress)) {
                 // nobody is listening
                 return false;
             }
-            if (isLocal()) {
-                try {
-                    resetServerDirs();
-                    setLocalPassword();
-                } catch (Exception e) {
-                    logger.log(Level.FINEST, "The endpoint is alive, but we failed to reset the local password.", e);
-                    return false;
-                }
-            }
-            int newPid = getServerPid();
-            if (newPid < 0) {
-                // is listening, but not responding
+            try {
+                resetServerDirs();
+                setLocalPassword();
+            } catch (Exception e) {
+                logger.log(Level.FINEST, "The endpoint is alive, but we failed to reset the local password.", e);
                 return false;
             }
-            logger.log(Level.FINEST, "The server started and responded - it's pid is {0}", newPid);
-            return true;
+            Long newPid = ProcessUtils.loadPid(getServerDirs().getPidFile());
+            if (newPid == null) {
+                return false;
+            }
+            logger.log(Level.FINEST, "The server pid is {0}", newPid);
+            return ProcessUtils.isAlive(newPid);
         };
         if (!ProcessUtils.waitFor(signStart, Duration.ofMillis(CLIConstants.WAIT_FOR_DAS_TIME_MS), printDots)) {
             throw new CommandException(I18N.get("restartDomain.noGFStart"));

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -70,7 +70,7 @@ public class RestartDomainCommand extends StopDomainCommand {
         }
 
         // Save old values before executing restart
-        final int oldPid = getServerPid();
+        final Long oldPid = getServerPid();
         final HostAndPort oldAdminAddress = getAdminAddress();
         final HostAndPort newAdminEndpoint = getAdminAddress("server");
         RemoteCLICommand cmd = new RemoteCLICommand("restart-domain", programOpts, env);
@@ -122,6 +122,6 @@ public class RestartDomainCommand extends StopDomainCommand {
             opts.add(getDomainName());
         }
 
-        return cmd.execute(opts.toArray(new String[opts.size()]));
+        return cmd.execute(opts.toArray(String[]::new));
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -168,8 +168,7 @@ public class StopDomainCommand extends LocalDomainCommand {
     protected void doCommand() throws CommandException {
         // run the remote stop-domain command and throw away the output
         final RemoteCLICommand cmd = new RemoteCLICommand(getName(), programOpts, env);
-        final File watchedPid = isLocal() ? getServerDirs().getPidFile() : null;
-        final Long oldPid = ProcessUtils.loadPid(watchedPid);
+        final Long oldPid = getServerPid();
         final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final boolean printDots = !programOpts.isTerse();
         try {
@@ -180,7 +179,7 @@ public class StopDomainCommand extends LocalDomainCommand {
             }
             final boolean dead;
             if (isLocal()) {
-                dead = ProcessUtils.waitWhileIsAlive(oldPid, timeout, printDots);
+                dead = oldPid == null || ProcessUtils.waitWhileIsAlive(oldPid, timeout, printDots);
             } else {
                 dead = ProcessUtils.waitWhileListening(addr, timeout, printDots);
             }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/RestartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/RestartLocalInstanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -56,7 +56,7 @@ public class RestartLocalInstanceCommand extends StopLocalInstanceCommand {
         }
 
         // Save old values before executing restart
-        final int oldPid = getServerPid();
+        final Long oldPid = getServerPid();
         final HostAndPort adminAddress = getAdminAddress(getServerDirs().getServerName());
         // run the remote restart-instance command and throw away the output
         RemoteCLICommand cmd = new RemoteCLICommand("_restart-instance", programOpts, env);

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StopLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StopLocalInstanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -150,7 +150,7 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
          */
         programOpts.setInteractive(false);
 
-        final Long pid = ProcessUtils.loadPid(getServerDirs().getPidFile());
+        final Long pid = getServerPid();
         final boolean printDots = !programOpts.isTerse();
         final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final RemoteCLICommand cmd = new RemoteCLICommand("_stop-instance", programOpts, env);
@@ -172,7 +172,7 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
             if (printDots) {
                 System.out.print(Strings.get("StopInstance.waitForDeath") + " ");
             }
-            final boolean dead = ProcessUtils.waitWhileIsAlive(pid, timeout, printDots);
+            final boolean dead = pid == null || ProcessUtils.waitWhileIsAlive(pid, timeout, printDots);
             if (!dead) {
                 throw new CommandException(Strings.get("StopInstance.instanceNotDead", DEATH_TIMEOUT_MS / 1000));
             }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/StartServerHook.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/StartServerHook.java
@@ -84,7 +84,7 @@ class StartServerShutdownHook extends Thread {
         try {
             // We do want to be the last thread alive.
             Thread.onSpinWait();
-            waitForThreads(FILTER_OTHER_HOOKS);
+            waitForThreads();
             // We do want this in the server.log.
             LOG.log(INFO, "Starting process {0} in directory {1}", this.builder.command(), this.builder.directory());
             stopLogging();
@@ -121,8 +121,8 @@ class StartServerShutdownHook extends Thread {
     }
 
 
-    private void waitForThreads(Predicate<Thread> filter) {
-        final Thread[] threads = getThreadsToDie(filter);
+    private void waitForThreads() {
+        final Thread[] threads = getThreadsToDie();
         log(() -> "Waiting for shutdown of threads:\n" + toString(threads));
         while(true) {
             Thread thread = getFirstAlive(threads);
@@ -140,12 +140,12 @@ class StartServerShutdownHook extends Thread {
     }
 
 
-    private Thread[] getThreadsToDie(Predicate<Thread> filter) {
+    private Thread[] getThreadsToDie() {
         final Thread[] threads = new Thread[Thread.activeCount() + 10];
         Thread.enumerate(threads);
         log(() -> "Found threads:\n" + toString(threads));
         return Stream.of(threads).filter(Objects::nonNull).filter(t -> t != this).filter(t -> !t.isDaemon())
-            .filter(filter).toArray(Thread[]::new);
+            .filter(FILTER_OTHER_HOOKS).toArray(Thread[]::new);
     }
 
 


### PR DESCRIPTION
- admin-tests were sometimes failing, because the oldPid was null
- It is better to rely on the pid file than on server responding, however on the future 710 branch I noticed few "grey zone effects" as it is yet bit faster than 7.0.x and stop command was executed too early:
  - pid file can be created, however the content is not flushed yet, so it is empty.
  - pid file may exist and have the pid number, however server is not listening yet.
  - pid file may exist and have the pid number, server is listening, however it is not ready
  - to serve requests (I am not sure if I ever noticed this, however it might be something to consider; we check the pid to know what to do next - use/kill/stop?).
- when stopping the sever, it can be similar:
  - kill -9 will not remove the pid file. However we can use Process to check if such pid is valid.
  - if the process is listening on port, but all files are gone, we cannot know if it is "our" process and it is not our problem. User did something wrong, user have to resolve it, usually kill the process manually. Other scenarios should not happen and if they would happen, they would be probably considered as bugs (if I did not forget something now).
- Then: the pid file should be created as soon as possible and deleted right before the process dies.