### PR TITLE
Faster detection of implicit CDI archives during deployment

### DIFF
--- a/appserver/web/gf-weld-connector/pom.xml
+++ b/appserver/web/gf-weld-connector/pom.xml
@@ -60,4 +60,13 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
+++ b/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
@@ -199,7 +199,7 @@ public class WeldUtils {
         Set<URI> implicitBeanArchivePaths = (Set<URI>)context.getTransientAppMetadata().get(METADATA_KEY);
 
         if (implicitBeanArchivePaths == null) {
-            implicitBeanArchivePaths = findImplicitBeanArchivePaths(implicitBeanArchivePaths, context);
+            implicitBeanArchivePaths = findImplicitBeanArchivePaths(context);
             context.addTransientAppMetaData(METADATA_KEY, implicitBeanArchivePaths);
         }
 
@@ -211,8 +211,8 @@ public class WeldUtils {
         return false;
     }
 
-    private static Set<URI> findImplicitBeanArchivePaths(Set<URI> pathsWithImplicitCDIBeans, DeploymentContext context) {
-        pathsWithImplicitCDIBeans = new HashSet<>();
+    private static Set<URI> findImplicitBeanArchivePaths(DeploymentContext context) {
+        Set<URI> pathsWithImplicitCDIBeans = new HashSet<>();
         Types types = getTypes(context);
         if (types != null) {
             for (Type type : types.getAllTypes()) {

--- a/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
+++ b/appserver/web/gf-weld-connector/src/main/java/org/glassfish/weld/connector/WeldUtils.java
@@ -195,25 +195,49 @@ public class WeldUtils {
      * @return true, if there is at least one bean annotated with a qualified annotation in the specified paths
      */
     public static boolean hasCDIEnablingAnnotations(DeploymentContext context, Collection<URI> paths) {
-        List<String> result = new ArrayList<String>();
+        final String METADATA_KEY = "implicitBeanPaths";
+        Set<URI> implicitBeanArchivePaths = (Set<URI>)context.getTransientAppMetadata().get(METADATA_KEY);
 
+        if (implicitBeanArchivePaths == null) {
+            implicitBeanArchivePaths = findImplicitBeanArchivePaths(implicitBeanArchivePaths, context);
+            context.addTransientAppMetaData(METADATA_KEY, implicitBeanArchivePaths);
+        }
+
+        for (URI path : paths) {
+            if (implicitBeanArchivePaths.contains(path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<URI> findImplicitBeanArchivePaths(Set<URI> pathsWithImplicitCDIBeans, DeploymentContext context) {
+        pathsWithImplicitCDIBeans = new HashSet<>();
         Types types = getTypes(context);
         if (types != null) {
             for (Type type : types.getAllTypes()) {
                 if (!(type instanceof AnnotationType)) {
-                    for (AnnotationModel annotationModel : type.getAnnotations()) {
-                        AnnotationType annotationType = annotationModel.getType();
-                        if (isCDIEnablingAnnotation(annotationType) && type.wasDefinedIn(paths)) {
-                            if (!result.contains(annotationType.getName())) {
-                                result.add(annotationType.getName());
+                    if (!allDefiningUrisKnown(type, pathsWithImplicitCDIBeans)) {
+                        for (AnnotationModel annotationModel : type.getAnnotations()) {
+                            AnnotationType annotationType = annotationModel.getType();
+                            if (isCDIEnablingAnnotation(annotationType)) {
+                                pathsWithImplicitCDIBeans.addAll(type.getDefiningURIs());
                             }
                         }
                     }
                 }
             }
         }
+        return pathsWithImplicitCDIBeans;
+    }
 
-        return !result.isEmpty();
+    private static boolean allDefiningUrisKnown(Type type, Set<URI> pathsWithImplicitCDIBeans) {
+        for (URI definingUri : type.getDefiningURIs()) {
+            if (!pathsWithImplicitCDIBeans.contains(definingUri)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Speed up detection of implicit CDI archives - creates an index of archives with an implicit CDI bean class for all classes in the deployment and caches it for later checks of implicit archives during deployment.

Also fixes an issue that sniffers were added multiple times to a collection of application sniffers.

I did a simple measurement - deploying a 19 MB WAR with 22 JAR files in the lib directory, which contain around 12,000 class files.

The best deployment time I got before the optimizations, was 1.98s:

![Screenshot from 2025-05-27 02-45-25](https://github.com/user-attachments/assets/b2621f03-22b3-4d6e-b00e-a92fa012de13)

With these optimizations, I repeated the same steps, with the best deployment time of 1.31s - around half a second boost:

![image](https://github.com/user-attachments/assets/73c2d02b-0b98-4a8b-96ea-a8cb8699d806)