### PR TITLE
Bump actions/stale from v3 to v9

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked as inactive and old and will be closed in 7 days if there is no further activity. If you want the issue to remain open please add a comment'


### PR DESCRIPTION
To get the feature from https://github.com/actions/stale/releases/tag/v6.0.0:

> default `close-issue-reason` is now `not_planned`

(Tested int external repo that GF's current action configuration is still accepted by newer version.)