### PR TITLE
Issue 24900 Documentation improvements. Some ConnectionPool changes. Removal of selfmanaged option.

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ActiveOutboundResourceAdapter.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ActiveOutboundResourceAdapter.java
@@ -143,8 +143,8 @@ public class ActiveOutboundResourceAdapter extends ActiveResourceAdapterImpl {
      * @throws ConnectorRuntimeException when unable to support any of the requested work-context type.
      */
     private void validateWorkContextSupport(ConnectorDescriptor desc) throws ConnectorRuntimeException {
-        Set workContexts = desc.getRequiredWorkContexts();
-        Iterator workContextsIterator = workContexts.iterator();
+        Set<?> workContexts = desc.getRequiredWorkContexts();
+        Iterator<?> workContextsIterator = workContexts.iterator();
 
         WorkContextHandler workContextHandler = connectorRuntime_.getWorkContextHandler();
         workContextHandler.init(moduleName_, jcl_);
@@ -266,7 +266,6 @@ public class ActiveOutboundResourceAdapter extends ActiveResourceAdapterImpl {
         }
     }
 
-
     /**
      * Remove all the proxy objects (Work-Manager) from connector registry
      *
@@ -275,7 +274,6 @@ public class ActiveOutboundResourceAdapter extends ActiveResourceAdapterImpl {
     private void removeProxiesFromRegistry(String moduleName_) {
         ConnectorRuntime.getRuntime().removeWorkManagerProxy(moduleName_);
     }
-
 
     /**
      * Creates an instance of <code>ManagedConnectionFactory</code>

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -48,26 +48,26 @@ public class ConnectorConnectionPool implements Serializable {
 
     private static final Logger LOG = LogDomains.getLogger(ConnectorConnectionPool.class, LogDomains.RSR_LOGGER);
 
-    protected ConnectorDescriptorInfo connectorDescriptorInfo_;
+    protected ConnectorDescriptorInfo connectorDescriptorInfo;
 
-    protected String steadyPoolSize_;
-    protected String maxPoolSize_;
-    protected String maxWaitTimeInMillis_;
-    protected String poolResizeQuantity_;
-    protected String idleTimeoutInSeconds_;
-    protected boolean failAllConnections_;
+    protected String steadyPoolSize;
+    protected String maxPoolSize;
+    protected String maxWaitTimeInMillis;
+    protected String poolResizeQuantity;
+    protected String idleTimeoutInSeconds;
+    protected boolean failAllConnections;
     //This property will *always* initially be set to:
     // true - by ConnectorConnectionPoolDeployer
     // false - by JdbcConnectionPoolDeployer
-    protected boolean matchConnections_;
+    protected boolean matchConnections;
 
-    protected int transactionSupport_;
-    protected boolean isConnectionValidationRequired_;
+    protected int transactionSupport;
+    protected boolean isConnectionValidationRequired;
 
 
-    private boolean lazyConnectionAssoc_;
-    private boolean lazyConnectionEnlist_;
-    private boolean associateWithThread_;
+    private boolean lazyConnectionAssoc;
+    private boolean lazyConnectionEnlist;
+    private boolean associateWithThread;
     private boolean partitionedPool;
     private boolean poolingOn = true;
     private boolean pingDuringPoolCreation;
@@ -75,13 +75,13 @@ public class ConnectorConnectionPool implements Serializable {
     private String poolWaitQueue;
     private String dataStructureParameters;
     private String resourceGatewayClass;
-    private boolean nonTransactional_;
-    private boolean nonComponent_;
+    private boolean nonTransactional;
+    private boolean nonComponent;
 
     private long dynamicReconfigWaitTimeout;
 
     private ConnectorSecurityMap[] securityMaps;
-    private boolean isAuthCredentialsDefinedInPool_;
+    private boolean isAuthCredentialsDefinedInPool;
 
     private String maxConnectionUsage;
 
@@ -92,15 +92,15 @@ public class ConnectorConnectionPool implements Serializable {
     private boolean validateAtmostEveryIdleSecs;
     //This property will be set by ConnectorConnectionPoolDeployer or
     //JdbcConnectionPoolDeployer.
-    private boolean preferValidateOverRecreate_;
+    private boolean preferValidateOverRecreate;
 
-    private String validateAtmostOncePeriod_;
+    private String validateAtmostOncePeriod;
 
-    private String conCreationRetryAttempts_;
-    private String conCreationRetryInterval_;
+    private String conCreationRetryAttempts;
+    private String conCreationRetryInterval;
 
-    private String connectionLeakTracingTimeout_;
-    private boolean connectionReclaim_;
+    private String connectionLeakTracingTimeout;
+    private boolean connectionReclaim;
 
     private final SimpleJndiName name;
     private String applicationName;
@@ -122,16 +122,13 @@ public class ConnectorConnectionPool implements Serializable {
         this.applicationName = applicationName;
     }
 
-
     public String getModuleName() {
         return moduleName;
     }
 
-
     public void setModuleName(String moduleName) {
         this.moduleName = moduleName;
     }
-
 
     public boolean isApplicationScopedResource() {
         return applicationName != null;
@@ -147,20 +144,24 @@ public class ConnectorConnectionPool implements Serializable {
      * @param enabled enables/disables ping during creation.
      */
     public void setPingDuringPoolCreation(boolean enabled) {
-        pingDuringPoolCreation = enabled;
+        this.pingDuringPoolCreation = enabled;
     }
 
+    /**
+     * Getter of "--pooling, pooling" attribute
+     * @return true if pooling is on, otherwise false
+     */
     public boolean isPoolingOn() {
         return poolingOn;
     }
 
     /**
-     * Setter method of pooling attribute
+     * Setter method of "--pooling, pooling" attribute
      *
      * @param enabled enables/disables pooling
      */
     public void setPooling(boolean enabled) {
-        poolingOn = enabled;
+        this.poolingOn = enabled;
     }
 
     public SimpleJndiName getName() {
@@ -168,178 +169,163 @@ public class ConnectorConnectionPool implements Serializable {
     }
 
     public void setAuthCredentialsDefinedInPool(boolean authCred) {
-        this.isAuthCredentialsDefinedInPool_ = authCred;
+        this.isAuthCredentialsDefinedInPool = authCred;
     }
 
     public boolean getAuthCredentialsDefinedInPool() {
-        return this.isAuthCredentialsDefinedInPool_;
+        return this.isAuthCredentialsDefinedInPool;
     }
 
     /**
      * Getter method of ConnectorDescriptorInfo which contains some the ra.xml
-     * values pertainining to managed connection factory
+     * values pertaining to managed connection factory
      *
      * @return ConnectorDescriptorInfo which contains ra.xml values
      *         pertaining to managed connection factory
      */
-
     public ConnectorDescriptorInfo getConnectorDescriptorInfo() {
-        return connectorDescriptorInfo_;
+        return connectorDescriptorInfo;
     }
 
     /**
      * Setter method of ConnectorDescriptorInfo which contains some the ra.xml
-     * values pertainining to managed connection factory
+     * values pertaining to managed connection factory
      *
      * @param connectorDescriptorInfo which contains ra.xml values
      *                                pertaining to managed connection factory
      */
-
     public void setConnectorDescriptorInfo(
             ConnectorDescriptorInfo connectorDescriptorInfo) {
-        connectorDescriptorInfo_ = connectorDescriptorInfo;
+        this.connectorDescriptorInfo = connectorDescriptorInfo;
     }
 
-
     /**
-     * Getter method of SteadyPoolSize property
+     * Getter method of "--steadypoolsize, steady-pool-size" property
      *
      * @return Steady Pool Size value
      */
-
     public String getSteadyPoolSize() {
-        return steadyPoolSize_;
+        return steadyPoolSize;
     }
 
     /**
-     * Setter method of SteadyPoolSize property
+     * Setter method of "--steadypoolsize, steady-pool-size" property
      *
      * @param steadyPoolSize Steady pool size value
      */
 
     public void setSteadyPoolSize(String steadyPoolSize) {
-        steadyPoolSize_ = steadyPoolSize;
+        this.steadyPoolSize = steadyPoolSize;
     }
 
     /**
-     * Getter method of MaxPoolSize property
+     * Getter method of "--maxpoolsize, max-pool-size" property
      *
      * @return maximum Pool Size value
      */
-
     public String getMaxPoolSize() {
-        return maxPoolSize_;
+        return maxPoolSize;
     }
 
     /**
-     * Setter method of MaxPoolSize property
+     * Setter method of "--maxpoolsize, max-pool-size" property
      *
      * @param maxPoolSize maximum pool size value
      */
-
     public void setMaxPoolSize(String maxPoolSize) {
-        maxPoolSize_ = maxPoolSize;
+        this.maxPoolSize = maxPoolSize;
     }
 
     /**
-     * Getter method of MaxWaitTimeInMillis property
+     * Getter method of "--maxwait, max-wait-time-in-millis" property
      *
-     * @return maximum wait time in milli value
+     * @return maximum wait time in milliseconds
      */
-
     public String getMaxWaitTimeInMillis() {
-        return maxWaitTimeInMillis_;
+        return maxWaitTimeInMillis;
     }
 
     /**
-     * Setter method of MaxWaitTimeInMillis property
+     * Setter method of "--maxwait, max-wait-time-in-millis" property
      *
      * @param maxWaitTimeInMillis maximum wait time in millis value
      */
-
     public void setMaxWaitTimeInMillis(String maxWaitTimeInMillis) {
-        maxWaitTimeInMillis_ = maxWaitTimeInMillis;
+        this.maxWaitTimeInMillis = maxWaitTimeInMillis;
     }
 
     /**
-     * Getter method of PoolResizeQuantity property
+     * Getter method of "--poolresize, pool-resize-quantity" property
      *
      * @return pool resize quantity value
      */
-
     public String getPoolResizeQuantity() {
-        return poolResizeQuantity_;
+        return poolResizeQuantity;
     }
 
     /**
-     * Setter method of PoolResizeQuantity property
+     * Setter method of "--poolresize, pool-resize-quantity" property
      *
      * @param poolResizeQuantity pool resize quantity value
      */
 
     public void setPoolResizeQuantity(String poolResizeQuantity) {
-        poolResizeQuantity_ = poolResizeQuantity;
+        this.poolResizeQuantity = poolResizeQuantity;
     }
 
     /**
-     * Getter method of IdleTimeoutInSeconds property
+     * Getter method of "--idletimeout, idle-timeout-in-seconds" property
      *
      * @return idle Timeout in seconds value
      */
-
     public String getIdleTimeoutInSeconds() {
-        return idleTimeoutInSeconds_;
+        return idleTimeoutInSeconds;
     }
 
     /**
-     * Setter method of IdleTimeoutInSeconds property
+     * Setter method of "--idletimeout, idle-timeout-in-seconds" property
      *
      * @param idleTimeoutInSeconds Idle timeout in seconds value
      */
-
     public void setIdleTimeoutInSeconds(String idleTimeoutInSeconds) {
-        idleTimeoutInSeconds_ = idleTimeoutInSeconds;
+        this.idleTimeoutInSeconds = idleTimeoutInSeconds;
     }
 
     /**
-     * Getter method of FailAllConnections property
+     * Getter method of "--failconnection, fail-all-connections" property
      *
      * @return whether to fail all connections or not
      */
-
     public boolean isFailAllConnections() {
-        return failAllConnections_;
+        return failAllConnections;
     }
 
     /**
-     * Setter method of FailAllConnections property
+     * Setter method of "--failconnection, fail-all-connections" property
      *
      * @param failAllConnections fail all connections value
      */
-
     public void setFailAllConnections(boolean failAllConnections) {
-        failAllConnections_ = failAllConnections;
+        this.failAllConnections = failAllConnections;
     }
 
     /**
-     * Getter method of matchConnections property
+     * Getter method of "--matchconnections, match-connections" property
      *
      * @return whether to match connections always with resource adapter
      *         or not
      */
-
     public boolean matchConnections() {
-        return matchConnections_;
+        return matchConnections;
     }
 
     /**
-     * Setter method of matchConnections property
+     * Setter method of "--matchconnections, match-connections" property
      *
      * @param matchConnections fail all connections value
      */
-
     public void setMatchConnections(boolean matchConnections) {
-        matchConnections_ = matchConnections;
+        this.matchConnections = matchConnections;
     }
 
     /**
@@ -354,11 +340,12 @@ public class ConnectorConnectionPool implements Serializable {
      * @return the transaction support level for this pool
      */
     public int getTransactionSupport() {
-        return transactionSupport_;
+        return transactionSupport;
     }
 
     /**
-     * Sets the transaction support level for this pool
+     * Sets the transaction support level for this pool.<br>
+     * Property: "--transactionsupport, transaction-support"<br>
      * The valid values are<br>
      *
      * @param transactionSupport int representing transaction support<br>
@@ -369,159 +356,155 @@ public class ConnectorConnectionPool implements Serializable {
      *                           </ul>
      */
     public void setTransactionSupport(int transactionSupport) {
-        transactionSupport_ = transactionSupport;
+        this.transactionSupport = transactionSupport;
     }
 
     /**
-     * Sets the connection-validation-required pool attribute
+     * Sets the "--isconnectvalidatereq, is-connection-validation-required" pool attribute
      *
      * @param validation boolean representing validation requirement
      */
     public void setConnectionValidationRequired(boolean validation) {
-        isConnectionValidationRequired_ = validation;
+        isConnectionValidationRequired = validation;
     }
 
     /**
-     * Queries the connection-validation-required pool attribute
+     * Queries the "--isconnectvalidatereq, is-connection-validation-required" pool attribute
      *
      * @return boolean representing validation requirement
      */
     public boolean isIsConnectionValidationRequired() {
-        return isConnectionValidationRequired_;
+        return isConnectionValidationRequired;
     }
 
     /**
-     * Queries the lazy-connection-association pool attribute
+     * Queries the "--lazyconnectionassociation, lazy-connection-association" pool attribute
      *
      * @return boolean representing lazy-connection-association status
      */
     public boolean isLazyConnectionAssoc() {
-        return lazyConnectionAssoc_;
+        return lazyConnectionAssoc;
     }
 
     /**
-     * Setter method of lazyConnectionAssociation attribute
+     * Setter method of "--lazyconnectionassociation, lazy-connection-association" attribute
      *
      * @param enabled enables/disables lazy-connection-association
      */
     public void setLazyConnectionAssoc(boolean enabled) {
-        lazyConnectionAssoc_ = enabled;
+        this.lazyConnectionAssoc = enabled;
     }
 
     /**
-     * Queries the lazy-connection-enlistment pool attribute
+     * Queries the "--lazyconnectionenlistment, lazy-connection-enlistment" pool attribute
      *
      * @return boolean representing lazy-connection-enlistment status
      */
     public boolean isLazyConnectionEnlist() {
-        return lazyConnectionEnlist_;
+        return lazyConnectionEnlist;
     }
 
     /**
-     * Setter method of lazy-connection-enlistment attribute
+     * Setter method of "--lazyconnectionenlistment, lazy-connection-enlistment" attribute
      *
      * @param enabled enables/disables lazy-connection-enlistment
      */
     public void setLazyConnectionEnlist(boolean enabled) {
-        lazyConnectionEnlist_ = enabled;
+        this.lazyConnectionEnlist = enabled;
     }
 
     /**
-     * Queries the associate-with-thread pool attribute
+     * Queries the "--associatewiththread, associate-with-thread" pool attribute
      *
      * @return boolean representing associate-with-thread status
      */
     public boolean isAssociateWithThread() {
-        return associateWithThread_;
+        return associateWithThread;
     }
 
     /**
-     * Setter method of associate-with-thread attribute
+     * Setter method of "--associatewiththread, associate-with-thread" attribute
      *
      * @param enabled enables/disables associate-with-thread
      */
     public void setAssociateWithThread(boolean enabled) {
-        associateWithThread_ = enabled;
+        this.associateWithThread = enabled;
     }
 
     /**
-     * Queries the non-transactional pool attribute
+     * Queries the "--nontransactionalconnections, non-transactional-connections" pool attribute
      *
      * @return boolean representing non-transactional status
      */
     public boolean isNonTransactional() {
-        return nonTransactional_;
+        return nonTransactional;
     }
 
     /**
-     * Setter method of non-transactional attribute
+     * Setter method of "--nontransactionalconnections, non-transactional-connections" attribute
      *
      * @param enabled enables/disables non-transactional status
      */
     public void setNonTransactional(boolean enabled) {
-        nonTransactional_ = enabled;
+        this.nonTransactional = enabled;
     }
 
     /**
-     * Queries the non-component pool attribute
+     * Queries the "--allownoncomponentcallers, allow-non-component-callers" pool attribute
      *
      * @return boolean representing non-component status
      */
     public boolean isNonComponent() {
-        return nonComponent_;
+        return nonComponent;
     }
 
     /**
-     * Setter method of non-component attribute
+     * Setter method of "--allownoncomponentcallers, allow-non-component-callers" attribute
      *
      * @param enabled enables/disables non-component status
      */
     public void setNonComponent(boolean enabled) {
-        nonComponent_ = enabled;
+        this.nonComponent = enabled;
     }
 
     /**
-     * Queries the connection-leak-tracing-timeout pool attribute
+     * Queries the "--leaktimeout, connection-leak-timeout-in-seconds" pool attribute
      *
      * @return boolean representing connection-leak-tracing-timeout status
      */
     public String getConnectionLeakTracingTimeout() {
-        return connectionLeakTracingTimeout_;
+        return connectionLeakTracingTimeout;
     }
 
     /**
-     * Setter method of connection-leak-tracing-timeout attribute
+     * Setter method of "--leaktimeout, connection-leak-timeout-in-seconds" attribute
      *
      * @param timeout value after which connection is assumed to be leaked.
      */
     public void setConnectionLeakTracingTimeout(String timeout) {
-        connectionLeakTracingTimeout_ = timeout;
+        this.connectionLeakTracingTimeout = timeout;
     }
 
-
     /**
-     * Setter method for Security Maps
+     * Setter method for "security-map" pool attributes
      *
      * @param securityMapArray SecurityMap[]
      */
-
     public void setSecurityMaps(ConnectorSecurityMap[] securityMapArray) {
         this.securityMaps = securityMapArray;
     }
 
     /**
-     * Getter method for Security Maps
+     * Getter method for "security-map" pool attributes
      *
      * @return SecurityMap[]
      */
-
     public ConnectorSecurityMap[] getSecurityMaps() {
         return this.securityMaps;
     }
 
-
     /**
-     * Queries the validate-atmost-every-idle-seconds pool attribute
+     * Queries the "--validateatmostonceperiod, validate-atmost-once-period-in-seconds" pool attribute
      *
      * @return boolean representing validate-atmost-every-idle-seconds
      *         status
@@ -531,7 +514,7 @@ public class ConnectorConnectionPool implements Serializable {
     }
 
     /**
-     * Setter method of validate-atmost-every-idle-seconds pool attribute
+     * Setter method of "--validateatmostonceperiod, validate-atmost-once-period-in-seconds" pool attribute
      *
      * @param enabled enables/disables validate-atmost-every-idle-seconds
      *                property
@@ -541,16 +524,16 @@ public class ConnectorConnectionPool implements Serializable {
     }
 
     /**
-     * Setter method of max-connection-usage pool attribute
+     * Setter method of "--maxconnectionusagecount, max-connection-usage-count" pool attribute
      *
-     * @param count max-connection-usage count
+     * @param count value for max-connection-usage-count
      */
     public void setMaxConnectionUsage(String count) {
-        maxConnectionUsage = count;
+        this.maxConnectionUsage = count;
     }
 
     /**
-     * Queries the max-connection-usage pool attribute
+     * Queries the "--maxconnectionusagecount, max-connection-usage-count" pool attribute
      *
      * @return boolean representing max-connection-usage count
      */
@@ -559,81 +542,81 @@ public class ConnectorConnectionPool implements Serializable {
     }
 
     /**
-     * Queries the connection-creation-retry-interval pool attribute
+     * Queries the "--creationretryinterval, connection-creation-retry-interval-in-seconds" pool attribute
      *
      * @return boolean representing connection-creation-retry-interval
      *         duration
      */
     public String getConCreationRetryInterval() {
-        return conCreationRetryInterval_;
+        return conCreationRetryInterval;
     }
 
     /**
-     * Setter method of connection-creation-retry-interval attribute
+     * Setter method of "--creationretryinterval, connection-creation-retry-interval-in-seconds" attribute
      *
      * @param retryInterval connection-creation-retry-interval  duration
      */
     public void setConCreationRetryInterval(String retryInterval) {
-        this.conCreationRetryInterval_ = retryInterval;
+        this.conCreationRetryInterval = retryInterval;
     }
 
     /**
-     * Queries the connection-creation-retry-attempt pool attribute
+     * Queries the "--creationretryattempts, connection-creation-retry-attempts" pool attribute
      *
      * @return boolean representing connection-creation-retry-attempt count
      */
     public String getConCreationRetryAttempts() {
-        return conCreationRetryAttempts_;
+        return conCreationRetryAttempts;
     }
 
     /**
-     * Setter method of connection-creation-retry-attempt attribute
+     * Setter method of "--creationretryattempts, connection-creation-retry-attempts" attribute
      *
      * @param retryAttempts connection-creation-retry-attempt interval
      *                      duration
      */
     public void setConCreationRetryAttempts(String retryAttempts) {
-        this.conCreationRetryAttempts_ = retryAttempts;
+        this.conCreationRetryAttempts = retryAttempts;
     }
 
     /**
-     * Queries the validate-atmost-period pool attribute
+     * Queries the "--validateatmostonceperiod, validate-atmost-once-period-in-seconds" pool attribute
      *
      * @return boolean representing validate-atmost-period duration
      */
     public String getValidateAtmostOncePeriod() {
-        return validateAtmostOncePeriod_;
+        return validateAtmostOncePeriod;
     }
 
     /**
-     * Setter method of validate-atmost-period attribute
+     * Setter method of "--validateatmostonceperiod, validate-atmost-once-period-in-seconds" attribute
      *
      * @param validateAtmostOncePeriod validate-atmost-period duration
      */
     public void setValidateAtmostOncePeriod(String validateAtmostOncePeriod) {
-        this.validateAtmostOncePeriod_ = validateAtmostOncePeriod;
+        this.validateAtmostOncePeriod = validateAtmostOncePeriod;
     }
 
     /**
-     * Queries the connection-reclaim attribute
+     * Queries the "--leakreclaim, connection-leak-reclaim" attribute
      *
      * @return boolean representing connection-reclaim status
      */
     public boolean isConnectionReclaim() {
-        return connectionReclaim_;
+        return connectionReclaim;
     }
 
     /**
-     * Setter method of connection-reclaim attribute
+     * Setter method of "--leakreclaim, connection-leak-reclaim" attribute
      *
      * @param connectionReclaim onnection-reclaim status
      */
     public void setConnectionReclaim(boolean connectionReclaim) {
-        this.connectionReclaim_ = connectionReclaim;
+        this.connectionReclaim = connectionReclaim;
     }
 
     /**
-     * return the String representation of the pool.
+     * Return the String representation of the pool.
      *
      * @return String representation of pool
      */
@@ -656,57 +639,57 @@ public class ConnectorConnectionPool implements Serializable {
             sb.append("\nfailAllConnections: ");
             sb.append(isFailAllConnections());
             sb.append("\nTransaction Support Level: ");
-            sb.append(transactionSupport_);
-            sb.append("\nisConnectionValidationRequired_ ");
-            sb.append(isConnectionValidationRequired_);
-            sb.append("\npreferValidateOverRecreate_ ");
-            sb.append(preferValidateOverRecreate_);
+            sb.append(transactionSupport);
+            sb.append("\nisConnectionValidationRequired ");
+            sb.append(isConnectionValidationRequired);
+            sb.append("\npreferValidateOverRecreate ");
+            sb.append(preferValidateOverRecreate);
 
-            sb.append("\nmatchConnections_ ");
-            sb.append(matchConnections_);
-            sb.append("\nassociateWithThread_ ");
-            sb.append(associateWithThread_);
-            sb.append("\nlazyConnectionAssoc_ ");
-            sb.append(lazyConnectionAssoc_);
-            sb.append("\nlazyConnectionEnlist_ ");
-            sb.append(lazyConnectionEnlist_);
-            sb.append("\nmaxConnectionUsage_ ");
+            sb.append("\nmatchConnections ");
+            sb.append(matchConnections);
+            sb.append("\nassociateWithThread ");
+            sb.append(associateWithThread);
+            sb.append("\nlazyConnectionAssoc ");
+            sb.append(lazyConnectionAssoc);
+            sb.append("\nlazyConnectionEnlist ");
+            sb.append(lazyConnectionEnlist);
+            sb.append("\nmaxConnectionUsage ");
             sb.append(maxConnectionUsage);
 
-            sb.append("\npingPoolDuringCreation_ ");
+            sb.append("\npingPoolDuringCreation ");
             sb.append(pingDuringPoolCreation);
 
-            sb.append("\npoolingOn_ ");
+            sb.append("\npoolingOn ");
             sb.append(poolingOn);
 
-            sb.append("\nvalidateAtmostOncePeriod_ ");
-            sb.append(validateAtmostOncePeriod_);
+            sb.append("\nvalidateAtmostOncePeriod ");
+            sb.append(validateAtmostOncePeriod);
 
-            sb.append("\nconnectionLeakTracingTimeout_");
-            sb.append(connectionLeakTracingTimeout_);
-            sb.append("\nconnectionReclaim_");
-            sb.append(connectionReclaim_);
+            sb.append("\nconnectionLeakTracingTimeout");
+            sb.append(connectionLeakTracingTimeout);
+            sb.append("\nconnectionReclaim");
+            sb.append(connectionReclaim);
 
-            sb.append("\nconnectionCreationRetryAttempts_");
-            sb.append(conCreationRetryAttempts_);
-            sb.append("\nconnectionCreationRetryIntervalInMilliSeconds_");
-            sb.append(conCreationRetryInterval_);
+            sb.append("\nconnectionCreationRetryAttempts");
+            sb.append(conCreationRetryAttempts);
+            sb.append("\nconnectionCreationRetryIntervalInMilliSeconds");
+            sb.append(conCreationRetryInterval);
 
-            sb.append("\nnonTransactional_ ");
-            sb.append(nonTransactional_);
-            sb.append("\nnonComponent_ ");
-            sb.append(nonComponent_);
+            sb.append("\nnonTransactional ");
+            sb.append(nonTransactional);
+            sb.append("\nnonComponent ");
+            sb.append(nonComponent);
 
             sb.append("\nConnectorDescriptorInfo -> ");
             sb.append("\nrarName: ");
-            if (connectorDescriptorInfo_ != null) {
-                sb.append(connectorDescriptorInfo_.getRarName());
+            if (connectorDescriptorInfo != null) {
+                sb.append(connectorDescriptorInfo.getRarName());
                 sb.append("\nresource adapter class: ");
-                sb.append(connectorDescriptorInfo_.getResourceAdapterClassName());
+                sb.append(connectorDescriptorInfo.getResourceAdapterClassName());
                 sb.append("\nconnection def name: ");
-                sb.append(connectorDescriptorInfo_.getConnectionDefinitionName());
+                sb.append(connectorDescriptorInfo.getConnectionDefinitionName());
                 sb.append("\nMCF Config properties-> ");
-                for (Object o : connectorDescriptorInfo_.getMCFConfigProperties()) {
+                for (Object o : connectorDescriptorInfo.getMCFConfigProperties()) {
                     ConnectorConfigProperty  ep = (ConnectorConfigProperty) o;
                     sb.append(ep.getName());
                     sb.append(":");
@@ -774,11 +757,11 @@ public class ConnectorConnectionPool implements Serializable {
     }
 
     public boolean isPreferValidateOverRecreate() {
-        return preferValidateOverRecreate_;
+        return preferValidateOverRecreate;
     }
 
     public void setPreferValidateOverRecreate(boolean preferValidateOverRecreate) {
-        preferValidateOverRecreate_ = preferValidateOverRecreate;
+        this.preferValidateOverRecreate = preferValidateOverRecreate;
     }
 
     public long getDynamicReconfigWaitTimeout() {
@@ -788,7 +771,6 @@ public class ConnectorConnectionPool implements Serializable {
     public void setDynamicReconfigWaitTimeout(long dynamicReconfigWaitTimeout) {
         this.dynamicReconfigWaitTimeout = dynamicReconfigWaitTimeout;
     }
-
 
     public PoolInfo getPoolInfo() {
         return new PoolInfo(name, applicationName, moduleName);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorDescriptorInfo.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorDescriptorInfo.java
@@ -32,30 +32,27 @@ import java.util.Set;
  *
  * @author Srikanth P
  */
-
 public final class ConnectorDescriptorInfo implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private String rarName_;
-    private String resourceAdapterClass_;
-    private String connectionDefinitionName_;
-    private String managedConnectionFactoryClass_;
-    private String connectionFactoryClass_;
-    private String connectionFactoryInterface_;
-    private String connectionClass_;
-    private String connectionInterface_;
-    private Set<ConnectorConfigProperty> mcfConfigProperties_;
-    private Set<ConnectorConfigProperty > resourceAdapterConfigProperties_;
+    private String rarName;
+    private String resourceAdapterClass;
+    private String connectionDefinitionName;
+    private String managedConnectionFactoryClass;
+    private String connectionFactoryClass;
+    private String connectionFactoryInterface;
+    private String connectionClass;
+    private String connectionInterface;
+    private Set<ConnectorConfigProperty> mcfConfigProperties;
+    private Set<ConnectorConfigProperty > resourceAdapterConfigProperties;
 
     /**
      * Default constructor
      */
     public ConnectorDescriptorInfo() {
-
-        mcfConfigProperties_ = new LinkedHashSet< >();
-        resourceAdapterConfigProperties_ = new LinkedHashSet< >();
+        this.mcfConfigProperties = new LinkedHashSet< >();
+        this.resourceAdapterConfigProperties = new LinkedHashSet< >();
     }
-
 
     /**
      * Clone method
@@ -64,16 +61,16 @@ public final class ConnectorDescriptorInfo implements Serializable {
      */
     public ConnectorDescriptorInfo doClone() {
         ConnectorDescriptorInfo cdi = new ConnectorDescriptorInfo();
-        cdi.setMCFConfigProperties(mcfConfigProperties_);
-        cdi.setResourceAdapterConfigProperties(resourceAdapterConfigProperties_);
-        cdi.setRarName(rarName_);
-        cdi.setResourceAdapterClassName(resourceAdapterClass_);
-        cdi.setConnectionDefinitionName(connectionDefinitionName_);
-        cdi.setManagedConnectionFactoryClass(managedConnectionFactoryClass_);
-        cdi.setConnectionFactoryClass(connectionFactoryClass_);
-        cdi.setConnectionFactoryInterface(connectionFactoryInterface_);
-        cdi.setConnectionClass(connectionClass_);
-        cdi.setConnectionInterface(connectionInterface_);
+        cdi.setMCFConfigProperties(mcfConfigProperties);
+        cdi.setResourceAdapterConfigProperties(resourceAdapterConfigProperties);
+        cdi.setRarName(rarName);
+        cdi.setResourceAdapterClassName(resourceAdapterClass);
+        cdi.setConnectionDefinitionName(connectionDefinitionName);
+        cdi.setManagedConnectionFactoryClass(managedConnectionFactoryClass);
+        cdi.setConnectionFactoryClass(connectionFactoryClass);
+        cdi.setConnectionFactoryInterface(connectionFactoryInterface);
+        cdi.setConnectionClass(connectionClass);
+        cdi.setConnectionInterface(connectionInterface);
         return cdi;
     }
 
@@ -89,17 +86,16 @@ public final class ConnectorDescriptorInfo implements Serializable {
         this();
         if (mcfConfigProperties != null) {
             for (ConnectorConfigProperty mcfConfigProperty : mcfConfigProperties) {
-                mcfConfigProperties_.add(mcfConfigProperty);
+                this.mcfConfigProperties.add(mcfConfigProperty);
             }
 
             if (resourceAdapterConfigProperties != null) {
                 for (ConnectorConfigProperty mcfConfigProperty : mcfConfigProperties) {
-                    resourceAdapterConfigProperties_.add(mcfConfigProperty);
+                    this.resourceAdapterConfigProperties.add(mcfConfigProperty);
                 }
             }
         }
     }
-
 
     /**
      * Adds an MCF config property to the existing array/Set of MCF config
@@ -109,10 +105,9 @@ public final class ConnectorDescriptorInfo implements Serializable {
      */
     public void addMCFConfigProperty(ConnectorConfigProperty configProperty) {
         if (configProperty != null) {
-            mcfConfigProperties_.add(configProperty);
+            mcfConfigProperties.add(configProperty);
         }
     }
-
 
     /**
      * Removes an config property from the existing array/Set of MCF config
@@ -122,10 +117,9 @@ public final class ConnectorDescriptorInfo implements Serializable {
      */
     public void removeMCFConfigProperty(ConnectorConfigProperty configProperty) {
         if (configProperty != null) {
-            mcfConfigProperties_.remove(configProperty);
+            mcfConfigProperties.remove(configProperty);
         }
     }
-
 
     /**
      * Setter method for MCFConfigProperties property.
@@ -133,9 +127,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param configProperties Set MCF config properties
      */
     public void setMCFConfigProperties(Set<ConnectorConfigProperty> configProperties) {
-        mcfConfigProperties_ = configProperties;
+        mcfConfigProperties = configProperties;
     }
-
 
     /**
      * Setter method for MCFConfigProperties property.
@@ -145,7 +138,7 @@ public final class ConnectorDescriptorInfo implements Serializable {
     public void setMCFConfigProperties(ConnectorConfigProperty[] configProperties) {
         if (configProperties != null) {
             for (ConnectorConfigProperty element : configProperties) {
-                mcfConfigProperties_.add(element);
+                mcfConfigProperties.add(element);
             }
         }
     }
@@ -156,7 +149,7 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return Set of managed connection factory config properties
      */
     public Set<ConnectorConfigProperty> getMCFConfigProperties() {
-        return mcfConfigProperties_;
+        return mcfConfigProperties;
     }
 
     /**
@@ -167,10 +160,9 @@ public final class ConnectorDescriptorInfo implements Serializable {
      */
     public void addResourceAdapterConfigProperty(ConnectorConfigProperty  configProperty) {
         if (configProperty != null) {
-            resourceAdapterConfigProperties_.add(configProperty);
+            resourceAdapterConfigProperties.add(configProperty);
         }
     }
-
 
     /**
      * Removes a Resource Adapter config property to the existing array/Set
@@ -180,10 +172,9 @@ public final class ConnectorDescriptorInfo implements Serializable {
      */
     public void removeResourceAdapterConfigProperty(ConnectorConfigProperty configProperty) {
         if (configProperty != null) {
-            resourceAdapterConfigProperties_.remove(configProperty);
+            resourceAdapterConfigProperties.remove(configProperty);
         }
     }
-
 
     /**
      * Setter method for ResourceAdapterConfigProperties property.
@@ -191,9 +182,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param configProperties Set ResourceAdapter config properties
      */
     public void setResourceAdapterConfigProperties(Set<ConnectorConfigProperty> configProperties) {
-        resourceAdapterConfigProperties_ = configProperties;
+        resourceAdapterConfigProperties = configProperties;
     }
-
 
     /**
      * Setter method for ResourceAdapterConfigProperties property.
@@ -203,11 +193,10 @@ public final class ConnectorDescriptorInfo implements Serializable {
     public void setResourceAdapterConfigProperties(ConnectorConfigProperty[] configProperties) {
         if (configProperties != null) {
             for (ConnectorConfigProperty configProperty : configProperties) {
-                resourceAdapterConfigProperties_.add(configProperty);
+                resourceAdapterConfigProperties.add(configProperty);
             }
         }
     }
-
 
     /**
      * Getter method for ResourceAdapterConfigProperties property
@@ -215,9 +204,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return Set of resource adapter config properties
      */
     public Set<ConnectorConfigProperty> getResourceAdapterConfigProperties() {
-        return resourceAdapterConfigProperties_;
+        return resourceAdapterConfigProperties;
     }
-
 
     /**
      * Getter method for RarName property
@@ -225,9 +213,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return rarName
      */
     public String getRarName() {
-        return rarName_;
+        return rarName;
     }
-
 
     /**
      * Setter method for RarName property
@@ -235,9 +222,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param rarName rar name
      */
     public void setRarName(String rarName) {
-        rarName_ = rarName;
+        this.rarName = rarName;
     }
-
 
     /**
      * Getter method for ResourceAdapterClassName property
@@ -245,9 +231,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return Resource adapter class name
      */
     public String getResourceAdapterClassName() {
-        return resourceAdapterClass_;
+        return resourceAdapterClass;
     }
-
 
     /**
      * Setter method for ResourceAdapterClassName property
@@ -255,7 +240,7 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param resourceAdapterClass Resource adapter class name
      */
     public void setResourceAdapterClassName(String resourceAdapterClass) {
-        resourceAdapterClass_ = resourceAdapterClass;
+        this.resourceAdapterClass = resourceAdapterClass;
     }
 
     /**
@@ -264,7 +249,7 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return connection definition name
      */
     public String getConnectionDefinitionName() {
-        return connectionDefinitionName_;
+        return connectionDefinitionName;
     }
 
     /**
@@ -273,9 +258,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param connectionDefinitionName connection definition name
      */
     public void setConnectionDefinitionName(String connectionDefinitionName) {
-        connectionDefinitionName_ = connectionDefinitionName;
+        this.connectionDefinitionName = connectionDefinitionName;
     }
-
 
     /**
      * Getter method for ManagedConnectionFactoryClass property
@@ -283,9 +267,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return managed connection factory class
      */
     public String getManagedConnectionFactoryClass() {
-        return managedConnectionFactoryClass_;
+        return managedConnectionFactoryClass;
     }
-
 
     /**
      * Setter method for ManagedConnectionFactoryClass property
@@ -293,9 +276,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param managedConnectionFactoryClass managed connection factory class
      */
     public void setManagedConnectionFactoryClass(String managedConnectionFactoryClass) {
-        managedConnectionFactoryClass_ = managedConnectionFactoryClass;
+        this.managedConnectionFactoryClass = managedConnectionFactoryClass;
     }
-
 
     /**
      * Getter method for ConnectionFactoryClass property
@@ -303,9 +285,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return connection factory class
      */
     public String getConnectionFactoryClass() {
-        return connectionFactoryClass_;
+        return connectionFactoryClass;
     }
-
 
     /**
      * Setter method for ConnectionFactoryClass property
@@ -313,9 +294,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param connectionFactoryClass connection factory class
      */
     public void setConnectionFactoryClass(String connectionFactoryClass) {
-        connectionFactoryClass_ = connectionFactoryClass;
+        this.connectionFactoryClass = connectionFactoryClass;
     }
-
 
     /**
      * Getter method for ConnectionFactoryInterface property
@@ -323,9 +303,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return connection factory interface class
      */
     public String getConnectionFactoryInterface() {
-        return connectionFactoryInterface_;
+        return connectionFactoryInterface;
     }
-
 
     /**
      * Setter method for ConnectionFactoryInterface property
@@ -333,9 +312,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param connectionFactoryInterface connection factory interface class
      */
     public void setConnectionFactoryInterface(String connectionFactoryInterface) {
-        connectionFactoryInterface_ = connectionFactoryInterface;
+        this.connectionFactoryInterface = connectionFactoryInterface;
     }
-
 
     /**
      * Getter method for ConnectionClass property
@@ -343,9 +321,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return connection class
      */
     public String getConnectionClass() {
-        return connectionClass_;
+        return connectionClass;
     }
-
 
     /**
      * Setter method for ConnectionClass property
@@ -353,9 +330,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param connectionClass connection Class
      */
     public void setConnectionClass(String connectionClass) {
-        connectionClass_ = connectionClass;
+        this.connectionClass = connectionClass;
     }
-
 
     /**
      * Getter method for ConnectionInterface property
@@ -363,9 +339,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @return connectionInterface class
      */
     public String getConnectionInterface() {
-        return connectionInterface_;
+        return connectionInterface;
     }
-
 
     /**
      * Setter method for ConnectionInterface property
@@ -373,9 +348,8 @@ public final class ConnectorDescriptorInfo implements Serializable {
      * @param connectionInterface connection interface class
      */
     public void setConnectionInterface(String connectionInterface) {
-        connectionInterface_ = connectionInterface;
+        this.connectionInterface = connectionInterface;
     }
-
 
     /**
      * Compare the MCF Config properties in this object with the
@@ -390,7 +364,6 @@ public final class ConnectorDescriptorInfo implements Serializable {
         return compareMCFConfigProperties(cdi, new HashSet<>());
     }
 
-
     /**
      * Compare the MCF Config properties in this object with the
      * passed ones. The properties in the Set of excluded properties
@@ -404,7 +377,7 @@ public final class ConnectorDescriptorInfo implements Serializable {
      */
     public ReconfigAction compareMCFConfigProperties(ConnectorDescriptorInfo cdi, Set<String> excluded) {
         Set<ConnectorConfigProperty> mcfConfigProps = cdi.getMCFConfigProperties();
-        if (mcfConfigProps.size() != mcfConfigProperties_.size()) {
+        if (mcfConfigProps.size() != mcfConfigProperties.size()) {
             // return false;
             // Cannot determine anything due to size disparity - assume restart
             return ReconfigAction.RECREATE_POOL;
@@ -419,7 +392,7 @@ public final class ConnectorDescriptorInfo implements Serializable {
                 continue;
             }
 
-            for (ConnectorConfigProperty property : mcfConfigProperties_) {
+            for (ConnectorConfigProperty property : mcfConfigProperties) {
                 if (isEnvPropEqual(mcfConfigProp, property)) {
                     // we have a match
                     same = true;
@@ -437,7 +410,6 @@ public final class ConnectorDescriptorInfo implements Serializable {
 
         return ReconfigAction.NO_OP;
     }
-
 
     /**
      * The ConnectorConfigProperty ::equals method only checks for name equality

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRegistry.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRegistry.java
@@ -55,7 +55,6 @@ import org.glassfish.resourcebase.resources.api.ResourceInfo;
  *
  * @author Binod P.G and Srikanth P
  */
-
 public class ConnectorRegistry {
 
     static final Logger _logger = LogDomains.getLogger(ConnectorRegistry.class, LogDomains.RSR_LOGGER);
@@ -104,7 +103,6 @@ public class ConnectorRegistry {
         _logger.log(Level.FINE, "Initialized the connector registry");
     }
 
-
     /**
      * Adds the object implementing ActiveResourceAdapter
      * interface to the registry.
@@ -116,7 +114,6 @@ public class ConnectorRegistry {
         resourceAdapters.put(rarModuleName, rar);
         _logger.log(Level.FINE, "Added the active resource adapter {0} to connector registry", rarModuleName);
     }
-
 
     /**
      * get the version counter of  a resource info
@@ -258,7 +255,6 @@ public class ConnectorRegistry {
         return true;
     }
 
-
     /**
      * Retrieves the object implementing ActiveResourceAdapter interface
      * from the registry. Key is the rarName.
@@ -313,7 +309,6 @@ public class ConnectorRegistry {
             }
         }
     }
-
 
     /**
      * Adds the bean validator to the registry.
@@ -376,7 +371,6 @@ public class ConnectorRegistry {
         return factories.containsKey(poolInfo);
     }
 
-
     /**
      * Remove MCF instance pertaining to the poolName from the registry.
      *
@@ -404,7 +398,6 @@ public class ConnectorRegistry {
         factories.put(poolInfo, pmd);
         _logger.log(Level.FINE, "Added MCF to connector registry for {0}", poolInfo);
     }
-
 
     /**
      * Retrieve MCF instance pertaining to the poolName from the registry.
@@ -456,7 +449,6 @@ public class ConnectorRegistry {
         return ar.getDescriptor();
     }
 
-
     /**
      * Gets the runtime equivalent of policies enforced by the Security Maps
      * pertaining to a pool from the Pool's Meta Data.
@@ -503,7 +495,6 @@ public class ConnectorRegistry {
             resourceAdapterConfig.put(rarName, raConfig);
         }
     }
-
 
     /**
      * Remove the resource adapter config properties object from registry

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRuntime.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ConnectorRuntime.java
@@ -131,7 +131,6 @@ import static com.sun.appserv.connectors.internal.api.ConnectorsUtil.isModuleSco
 import static com.sun.appserv.connectors.internal.api.ConnectorsUtil.isStandAloneRA;
 import static com.sun.logging.LogDomains.RSR_LOGGER;
 
-
 /**
  * This class is the entry point to connector backend module. It exposes different API's called by external entities
  * like JPA, admin to perform various connector backend related operations. It delegates calls to various connetcor
@@ -462,7 +461,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     }
 
     /**
-     * Returns the MCF instances in scenarions where a pool has to return multiple mcfs. Should be used only during JMS RA
+     * Returns the MCF instances in scenarios where a pool has to return multiple mcfs. Should be used only during JMS RA
      * recovery.
      *
      * @param poolInfo Name of the pool.MCFs pertaining to this pool is created/returned.
@@ -474,7 +473,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     }
 
     /**
-     * provides connection manager for a pool
+     * Provides connection manager for a pool
      *
      * @param poolInfo pool name
      * @param forceNoLazyAssoc when set to true, lazy association feature will be turned off (even if it is ON via pool
@@ -552,7 +551,6 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
         return serverEnvironmentImpl.isDas();
     }
 
-
     /**
      * Get a wrapper datasource specified by the jdbcjndi name This API is intended to be used in the DAS. The motivation
      * for having this API is to provide the CMP backend/ JPA-Java2DB a means of acquiring a connection during the codegen
@@ -573,7 +571,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     }
 
     /**
-     * Get a sql connection from the DataSource specified by the jdbcJndiName. This API is intended to be used in the DAS.
+     * Get an sql connection from the DataSource specified by the jdbcJndiName. This API is intended to be used in the DAS.
      * The motivation for having this API is to provide the CMP backend a means of acquiring a connection during the codegen
      * phase. If a user is trying to deploy an app on a remote server, without this API, a resource reference has to be
      * present both in the DAS and the server instance. This makes the deployment more complex for the user since a resource
@@ -592,7 +590,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     }
 
     /**
-     * Get a sql connection from the DataSource specified by the jdbcJndiName. This API is intended to be used in the DAS.
+     * Get an sql connection from the DataSource specified by the jdbcJndiName. This API is intended to be used in the DAS.
      * The motivation for having this API is to provide the CMP backend a means of acquiring a connection during the codegen
      * phase. If a user is trying to deploy an app on a remote server, without this API, a resource reference has to be
      * present both in the DAS and the server instance. This makes the deployment more complex for the user since a resource
@@ -796,7 +794,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     }
 
     /**
-     * Checks if a conncetor connection pool has been deployed to this server instance
+     * Checks if a connector connection pool has been deployed to this server instance
      *
      * @param poolInfo connection pool name
      * @return boolean indicating whether the resource is deployed or not
@@ -840,7 +838,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
      * @param connectionDefinitionName Connection definition name against which connection pool is being created
      * @param rarName Name of the resource adapter
      * @param props Properties of MCF which are present in domain.xml These properties override the ones present in ra.xml
-     * @param securityMaps Array fo security maps.
+     * @param securityMaps List with security maps.
      * @throws ConnectorRuntimeException When creation of pool fails.
      */
     public void createConnectorConnectionPool(ConnectorConnectionPool ccp, String connectionDefinitionName, String rarName,
@@ -1007,7 +1005,7 @@ public class ConnectorRuntime implements com.sun.appserv.connectors.internal.api
     }
 
     /**
-     * unregister the connector naming event listner
+     * unregister the connector naming event listener
      *
      * @param listener connector-naming-event-listener
      */

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectionPoolObjectsUtils.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectionPoolObjectsUtils.java
@@ -48,7 +48,6 @@ import javax.security.auth.Subject;
 import org.glassfish.resourcebase.resources.api.PoolInfo;
 import org.jvnet.hk2.config.types.Property;
 
-
 /**
  * This is an util class for creating poolObjects of the type
  * ConnectorConnectionPool from ConnectorDescriptor and also using the
@@ -71,7 +70,6 @@ public final class ConnectionPoolObjectsUtils {
     private ConnectionPoolObjectsUtils() {
         // disallow instantiation
     }
-
 
     /**
      * Creates default ConnectorConnectionPool consisting of default
@@ -106,13 +104,19 @@ public final class ConnectionPoolObjectsUtils {
      * @param connectorPoolObj Connector Connection Pool
      */
     private static void setDefaultAdvancedPoolAttributes(ConnectorConnectionPool connectorPoolObj) {
-        //Other advanced attributes like connection-leak-reclaim, lazy-connection-enlistment,
-        //lazy-connection-association, associate-with-thread are boolean values which are not required
-        //to be explicitly initialized to default values.
+        // Other advanced attributes like --leakreclaim, --lazyconnectionenlistment,
+        // --lazyconnectionassociation, --associatewiththread are boolean values which are not required
+        // to be explicitly initialized to default values.
+
+        // --matchconnections
         connectorPoolObj.setMaxConnectionUsage(ConnectorConnectionPool.DEFAULT_MAX_CONNECTION_USAGE);
+        // --leaktimeout`
         connectorPoolObj.setConnectionLeakTracingTimeout(ConnectorConnectionPool.DEFAULT_LEAK_TIMEOUT);
+        // --creationretryattempts
         connectorPoolObj.setConCreationRetryAttempts(ConnectorConnectionPool.DEFAULT_CON_CREATION_RETRY_ATTEMPTS);
+        // --creationretryinterval
         connectorPoolObj.setConCreationRetryInterval(ConnectorConnectionPool.DEFAULT_CON_CREATION_RETRY_INTERVAL);
+        // --validateatmostonceperiod
         connectorPoolObj.setValidateAtmostOncePeriod(ConnectorConnectionPool.DEFAULT_VALIDATE_ATMOST_ONCE_PERIOD);
     }
 
@@ -261,7 +265,6 @@ public final class ConnectionPoolObjectsUtils {
         return null;
     }
 
-
     public static String getValueFromMCF(String prop, PoolInfo poolInfo, ManagedConnectionFactory mcf) {
         String result = null;
         try {
@@ -272,7 +275,6 @@ public final class ConnectionPoolObjectsUtils {
         }
         return result == null ? "" : result;
     }
-
 
     public static Subject createSubject(ManagedConnectionFactory mcf, final ResourcePrincipalDescriptor principalDescriptor) {
         final Subject tempSubject = new Subject();
@@ -292,12 +294,10 @@ public final class ConnectionPoolObjectsUtils {
         return tempSubject;
     }
 
-
     public static boolean isPoolSystemPool(org.glassfish.connectors.config.ConnectorConnectionPool domainCcp) {
         String poolName = domainCcp.getName();
         return isPoolSystemPool(poolName);
     }
-
 
     public static boolean isPoolSystemPool(String poolName) {
         Pattern pattern = Pattern.compile("#");
@@ -333,7 +333,6 @@ public final class ConnectionPoolObjectsUtils {
                 return false;
         }
     }
-
 
     /**
      * Validates and sets the values for LazyConnectionEnlistment and LazyConnectionAssociation.
@@ -387,14 +386,12 @@ public final class ConnectionPoolObjectsUtils {
         }
     }
 
-
     private static boolean toBoolean(Object prop, boolean defaultVal) {
         if (prop == null) {
             return defaultVal;
         }
         return Boolean.valueOf(((String) prop).toLowerCase(Locale.getDefault()));
     }
-
 
     public static int getTransactionSupportFromRaXml(String rarName) throws ConnectorRuntimeException {
         ConnectorDescriptor descriptor = ConnectorRuntime.getRuntime().getConnectorDescriptor(rarName);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/ConnectorConnectionPoolDeployer.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/deployer/ConnectorConnectionPoolDeployer.java
@@ -292,8 +292,8 @@ public class ConnectorConnectionPoolDeployer
             }
 
             //Below are useful in pooled environment only.
-            //Throw warning for connection validation/validate-atmost-once/
-            //match-connections/max-connection-usage-count/idele-timeout
+            //Throw warning for connection-validation/validate-atmost-once-period/
+            //match-connections/max-connection-usage-count/idle-timeout
             if(Boolean.parseBoolean(domainCcp.getIsConnectionValidationRequired())) {
                 LOG.log(Level.WARNING, "conn_pool_obj_utils.pooling_disabled_conn_validation_invalid_combination",
                         domainCcp.getName());

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManager.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManager.java
@@ -86,7 +86,7 @@ public interface PoolManager extends TransactedPoolManager {
      * maximum number of connections
      * @throws PoolingException when unable to create/initialize pool
      */
-    void createEmptyConnectionPool(PoolInfo poolInfo, PoolType poolType, Hashtable env) throws PoolingException;
+    void createEmptyConnectionPool(PoolInfo poolInfo, PoolType poolType, Hashtable<?, ?> env) throws PoolingException;
 
     /**
      * Returns the resource back to the pool IF errorOccurred is false. If errorOccurred is true the resource is removed

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManagerImpl.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/PoolManagerImpl.java
@@ -97,7 +97,7 @@ public class PoolManagerImpl extends AbstractPoolManager implements ComponentInv
     }
 
     @Override
-    public void createEmptyConnectionPool(PoolInfo poolInfo, PoolType pooltype, Hashtable env) throws PoolingException {
+    public void createEmptyConnectionPool(PoolInfo poolInfo, PoolType pooltype, Hashtable<?, ?> env) throws PoolingException {
         // Create and initialise the connection pool
         createAndInitPool(poolInfo, pooltype, env);
 
@@ -128,7 +128,7 @@ public class PoolManagerImpl extends AbstractPoolManager implements ComponentInv
      * @param env the jndi information to find the ConnectorConnectionPool configuration used to configure the pool
      * @throws PoolingException when unable to create/initialize pool
      */
-    void createAndInitPool(final PoolInfo poolInfo, PoolType poolType, Hashtable env) throws PoolingException {
+    void createAndInitPool(final PoolInfo poolInfo, PoolType poolType, Hashtable<?, ?> env) throws PoolingException {
         ResourcePool pool = getPool(poolInfo);
         if (pool == null) {
             pool = ResourcePoolFactoryImpl.newInstance(poolInfo, poolType, env);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ResourcePool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ResourcePool.java
@@ -121,11 +121,8 @@ public interface ResourcePool {
 
     void emptyFreeConnectionsInPool();
 
-    // accessors for self mgmt
-
     /**
-     * Gets the max-pool-size attribute of this pool. Envisaged to be used by the Self management framework to query the
-     * pool size attribute for tweaking it using the setMaxPoolSize method
+     * Gets the max-pool-size attribute of this pool.
      *
      * @return max-pool-size value for this pool
      * @see setMaxPoolSize
@@ -133,18 +130,15 @@ public interface ResourcePool {
     int getMaxPoolSize();
 
     /**
-     * Gets the steady-pool-size attribute of this pool. Envisaged to be used by the Self management framework to query the
-     * pool size attribute for tweaking it using the setSteadyPoolSize method
+     * Gets the steady-pool-size attribute of this pool.
      *
      * @return steady-pool-size value for this pool
      * @see setSteadyPoolSize
      */
     int getSteadyPoolSize();
 
-    // mutators for self mgmt
     /**
-     * Sets the max-pool-size value for this pool. This attribute is expected to be set by the self-management framework for
-     * an optimum max-pool-size. The corresponding accessor gets this value.
+     * Sets the max-pool-size value for this pool.
      *
      * @param size - The new max-pool-size value
      * @see getMaxPoolSize
@@ -152,23 +146,12 @@ public interface ResourcePool {
     void setMaxPoolSize(int size);
 
     /**
-     * Sets the steady-pool-size value for this pool. This attribute is expected to be set by the self-management framework
-     * for an optimum steady-pool-size. The corresponding accessor gets this value.
+     * Sets the steady-pool-size value for this pool.
      *
      * @param size - The new steady-pool-size value
      * @see getSteadyPoolSize
      */
     void setSteadyPoolSize(int size);
-
-    /**
-     * Sets/Resets the flag indicating if this pool is self managed. This method would be typically called by the self
-     * management framework to indicate to the world (and this pool) that this pool is self managed. Its very important that
-     * the self mgmt framework properly sets this flag to control the dynamic reconfig behavior of this pool. If this flag
-     * is set to true, all dynamic reconfigs affecting the max/steady pool size of this pool will be ignored.
-     *
-     * @param selfManaged - true to switch on self management, false otherwise
-     */
-    void setSelfManaged(boolean selfManaged);
 
     /**
      * Set the pool life cycle listener

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/UnpooledResource.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/UnpooledResource.java
@@ -22,8 +22,6 @@ import com.sun.enterprise.resource.ResourceHandle;
 import com.sun.enterprise.resource.ResourceSpec;
 import com.sun.enterprise.resource.allocator.ResourceAllocator;
 
-import jakarta.transaction.Transaction;
-
 import java.util.Hashtable;
 
 import org.glassfish.resourcebase.resources.api.PoolInfo;
@@ -59,7 +57,7 @@ public class UnpooledResource extends ConnectionPool {
     }
 
     @Override
-    protected ResourceHandle prefetch(ResourceSpec spec, ResourceAllocator alloc, Transaction tran) {
+    protected ResourceHandle prefetch(ResourceSpec spec, ResourceAllocator alloc) {
         return null;
     }
 
@@ -70,7 +68,7 @@ public class UnpooledResource extends ConnectionPool {
     }
 
     @Override
-    protected ResourceHandle getUnenlistedResource(ResourceSpec spec, ResourceAllocator alloc, Transaction tran) throws PoolingException {
+    protected ResourceHandle getUnenlistedResource(ResourceSpec spec, ResourceAllocator alloc) throws PoolingException {
 
         this.poolSize.increment();
         final ResourceHandle handle;
@@ -90,11 +88,11 @@ public class UnpooledResource extends ConnectionPool {
 
     @Override
     public void resourceErrorOccurred(ResourceHandle resourceHandle) throws IllegalStateException {
-        freeResource(resourceHandle);
+        freeUnenlistedResource(resourceHandle);
     }
 
     @Override
-    protected void freeResource(ResourceHandle resourceHandle) {
+    protected void freeUnenlistedResource(ResourceHandle resourceHandle) {
         this.poolSize.decrement();
         deleteResource(resourceHandle);
     }

--- a/docs/application-development-guide/src/main/asciidoc/jdbc.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/jdbc.adoc
@@ -349,7 +349,7 @@ environment:
 * `connection-validation`
 * `validate-atmost-once-period`
 * `match-connections`
-* `max-connection-usage`
+* `max-connection-usage-count`
 * `idle-timeout`
 
 [[associating-connections-with-threads]]

--- a/docs/reference-manual/src/main/asciidoc/create-connector-connection-pool.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-connector-connection-pool.adoc
@@ -39,7 +39,7 @@ asadmin [asadmin-options] create-connector-connection-pool [--help]
 [--maxconnectionusagecount=count]
 [--validateatmostonceperiod=interval]
 [--transactionsupport transactionsupport]
-[--descrip[tion description]
+[--description description]
 [--ping {false|true}]
 [--pooling {true|false}]
 [--property (name=value)[:name=value]*]
@@ -185,15 +185,6 @@ asadmin-options::
   from 0 to `MAX_INTEGER`. Default value is 2.
 `--property`::
   Optional attribute name/value pairs for configuring the pool.
-+
-  `LazyConnectionEnlistment`;;
-    Deprecated. Use the equivalent option. Default value is false.
-  `LazyConnectionAssociation`;;
-    Deprecated. Use the equivalent option. Default value is false.
-  `AssociateWithThread`;;
-    Deprecated. Use the equivalent option. Default value is false.
-  `MatchConnections`;;
-    Deprecated. Use the equivalent option. Default value is false.
 `--raname`::
   The name of the resource adapter.
 `--steadypoolsize`::

--- a/docs/reference-manual/src/main/asciidoc/create-jdbc-connection-pool.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-jdbc-connection-pool.adoc
@@ -406,20 +406,14 @@ Possible values of `--wrapjdbcobjects` are as follows:
     timeout period, so as to complete the transaction. New connection
     requests will wait for the pool reconfiguration to complete and
     connections will be acquired using the modified pool configuration.
-  `LazyConnectionEnlistment`;;
-    Deprecated. Use the equivalent attribute. The default value is
-    false.
-  `LazyConnectionAssociation`;;
-    Deprecated. Use the equivalent attribute. The default value is
-    false.
-  `AssociateWithThread`;;
-    Deprecated. Use the equivalent attribute. The default value is
-    false.
-  `MatchConnections`;;
-    Deprecated. Use the equivalent attribute. The default value is true.
-  `Prefer-Validate-Over-Recreate`;;
+  `prefer-validate-over-recreate`;;
     Specifies whether pool resizer should validate idle connections
-    before destroying and recreating them. The default value is true.
+    before destroying and recreating them. The default value is false.
+    This property has no effect on non-idle connections. If set to `true`, 
+    idle connections are validated during pool resizing, and only those
+    found to be invalid are destroyed and recreated. If `false`, all idle
+    connections are destroyed and recreated during pool resizing. The 
+    default is `false`.
   `time-to-keep-queries-in-minutes`;;
     Specifies the number of minutes that will be cached for use in
     calculating frequently used queries. Takes effect when SQL tracing

--- a/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingXMLNames.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/common/util/logging/LoggingXMLNames.java
@@ -72,7 +72,6 @@ public class LoggingXMLNames {
     public static final String cmp = "cmp";
     public static final String util = "util";
     public static final String resourceadapter = "resource-adapter";
-    public static final String selfmanagement = "self-management";
 
     private static final String LEVEL = ".level";
 
@@ -110,8 +109,7 @@ public class LoggingXMLNames {
         entry(jdo, LogDomains.JDO_LOGGER + LEVEL),
         entry(cmp, LogDomains.CMP_LOGGER + LEVEL),
         entry(util, LogDomains.UTIL_LOGGER + LEVEL),
-        entry(resourceadapter, LogDomains.RSR_LOGGER + LEVEL),
-        entry(selfmanagement, LogDomains.SELF_MANAGEMENT_LOGGER + LEVEL)
+        entry(resourceadapter, LogDomains.RSR_LOGGER + LEVEL)
     );
 }
 

--- a/nucleus/common/common-util/src/main/java/com/sun/logging/LogDomains.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/logging/LogDomains.java
@@ -113,11 +113,6 @@ public class LogDomains {
     public static final String SAAJ_LOGGER = DOMAIN_ROOT + "enterprise.system.webservices.saaj";
 
     /**
-     * Self Management Logger
-     */
-    public static final String SELF_MANAGEMENT_LOGGER = DOMAIN_ROOT + "enterprise.system.core.selfmanagement";
-
-    /**
      * SQL Tracing Logger
      */
     public static final String SQL_TRACE_LOGGER = DOMAIN_ROOT + "enterprise.resource.sqltrace";


### PR DESCRIPTION
- #24900 

Improve some documentation. 
Remove deprecated items which no longer exist in the code from the documentation. 
Fix some TODO statements: 
- few code changes in ConnectionPool and subclasses AssocWithThreadResourcePool and UnpooledResource. 
- remove "selfmanaged" option, value was always false, option no longer existed in domain.xml