### PR TITLE
Property Fallback VirtualThreadsManagedThreadFactory

### DIFF
--- a/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
+++ b/appserver/concurrent/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ConcurrentRuntime.java
@@ -266,12 +266,18 @@ public class ConcurrentRuntime {
 
     public ManagedThreadFactoryImpl createManagedThreadFactory(ManagedThreadFactoryCfg config, ContextServiceImpl contextService) {
         SimpleJndiName jndiName = config.getServiceConfig().getJndiName();
-        if (config.getUseVirtualThreads() && System.getProperty("java.vm.specification.version").compareTo("17") > 0) {
-            ManagedThreadFactoryImpl virtFactory = new VirtualThreadsManagedThreadFactory(jndiName.toString(), contextService);
-            return virtFactory;
-        } else {
-            return new GlassFishManagedThreadFactory(jndiName, contextService, config.getThreadPriority());
+        ManagedThreadFactoryImpl virtFactory = null;
+        if (config.getUseVirtualThreads()) {
+            try {
+                virtFactory = new VirtualThreadsManagedThreadFactory(jndiName.toString(), contextService);
+            } catch (Exception e) {
+                LOG.severe(() -> "Unable to create VirtualThreadsManagedThreadFactory with virtual threads: " + e.getMessage() + ", using fallback");
+            }
         }
+        if (virtFactory == null) {
+            virtFactory = new GlassFishManagedThreadFactory(jndiName, contextService, config.getThreadPriority());
+        }
+        return virtFactory;
     }
 
 


### PR DESCRIPTION
In `ConcurrentRuntime`, creation of `ManagedThreadFactory` uses the same process as `ManagedExecutorService` and `ManagedScheduledExecutorService`. E.g. in case the virtual threads cannot be used, it logs this information and falls back to the default behavior.

I tested Concurrency TCK in Open JDK 17 and it works properly:

```
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 295, Failures: 0, Errors: 0, Skipped: 27
```