### PR TITLE
Add missing EE 11 schemas

### DIFF
--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/application-client_11.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/application-client_11.xsd
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="11">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2024 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application client 10
+      deployment descriptor.  The deployment descriptor must
+      be named "META-INF/application-client.xml" in the
+      application client's jar file.  All application client
+      deployment descriptors must indicate the application
+      client schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd"
+      version="10">
+      ...
+      </application-client>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="application-client"
+               type="jakartaee:application-clientType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application-client element is the root element of an
+        application client deployment descriptor.  The application
+        client deployment descriptor describes the enterprise bean 
+        components and external resources referenced by the 
+        application client.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of an
+          application client's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name must
+          be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:unique name="ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an enterprise bean 
+          reference. The enterprise bean reference is an entry 
+          in the application client's environment and is relative to the
+          java:comp/env context. The name must be unique within the
+          application client.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the application client
+          code. The name is a JNDI name relative to the
+          java:comp/env context and must be unique within an
+          application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the
+          name of a message destination reference; its value is
+          the message destination reference name used in the
+          application client code. The name is a JNDI name
+          relative to the java:comp/env context and must be unique
+          within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="application-clientType">
+    <xsd:sequence>
+      <xsd:element name="module-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="callback-handler"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The callback-handler element names a class provided by
+            the application.  The class must have a no args
+            constructor and must implement the
+            jakarta.security.auth.callback.CallbackHandler
+            interface.  The class will be instantiated by the
+            application client container and used by the container
+            to collect authentication information from the user.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="10"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 10.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/beans_4_1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/beans_4_1.xsd
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ Copyright 2021, Red Hat, Inc., and individual contributors
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~ http://www.apache.org/licenses/LICENSE-2.0
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+           elementFormDefault="qualified"
+           targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+           version="4.1">
+
+  <xs:annotation>
+    <xs:documentation>
+      <![CDATA[[
+         Jakarta Contexts and Dependency Injection (CDI) defines
+         a set of complementary services that help improve the structure
+         of application code. beans.xml is used to enable CDI services
+         for the current bean archive as well as to enable named
+         interceptors, decorators and alternatives for the current bean
+         archive.
+         
+
+         This is the XML Schema for the beans.xml deployment
+         descriptor for CDI 4.1.  The deployment descriptor must be named
+         "META-INF/beans.xml" or "WEB-INF/beans.xml" in a war file.
+         All application deployment descriptors may indicate
+         the application schema by using the Java EE namespace:
+
+         https://jakarta.ee/xml/ns/jakartaee
+
+         and may indicate the version of the schema by
+         using the version element as shown below:
+
+         <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+         version="4.1">
+            ...
+         </beans>
+
+        The deployment descriptor may indicate the published version of
+        the schema using the xsi:schemaLocation attribute for the Java EE
+        namespace with the following location:
+
+        https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd
+
+     ]]>
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:element name="beans">
+    <xs:annotation>
+      <xs:documentation>
+        Bean classes of enabled beans must be
+        deployed in bean archives. A library jar, EJB jar,
+        application client jar or rar archive is a bean archive if
+        it has a file named beans.xml in the META-INF directory. The
+        WEB-INF/classes directory of a war is a bean archive if
+        there is a file named beans.xml in the WEB-INF directory of
+        the war. A directory in the JVM classpath is a bean archive
+        if it has a file named beans.xml in the META-INF directory.
+
+        When running in a CDI Lite environment, the bean-discovery-mode
+        attribute is the only configuration value read from a beans.xml file.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all >
+        <xs:element ref="jakartaee:interceptors" minOccurs="0"/>
+        <xs:element ref="jakartaee:decorators" minOccurs="0" />
+        <xs:element ref="jakartaee:alternatives" minOccurs="0" />
+        <xs:element ref="jakartaee:scan" minOccurs="0" />
+        <xs:element ref="jakartaee:trim" minOccurs="0"/>
+      </xs:all>
+      <xs:attribute name="version" default="4.1">
+        <xs:annotation>
+          <xs:documentation>
+            The version of CDI this beans.xml is for. If the version is "4.1" (or
+            later), then the attribute bean-discovery-mode must be added.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:token">
+            <xs:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="bean-discovery-mode" use="optional" default="annotated">
+        <xs:annotation>
+          <xs:documentation>
+            It is strongly recommended you use "annotated". This is now the default and it
+            is also the default as of 4.1 when an empty beans.xml file is seen. When running
+            in a CDI Lite  environment, this is the only aspect of the beans.xml file that
+            is used.
+
+            If the bean discovery mode is "all", then all types in this
+            archive will be considered. If the bean discovery mode is
+            "annotated", then only those types with bean defining annotations will be
+            considered. If the bean discovery mode is "none", then no
+            types will be considered.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="annotated">
+              <xs:annotation>
+                <xs:documentation>
+                  Only those types with bean defining annotations will be
+                  considered.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="all">
+              <xs:annotation>
+                <xs:documentation>
+                  All types in this archive will be considered.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+              <xs:annotation>
+                <xs:documentation>
+                  This archive will be ignored.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="scan">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[The <scan> element allows exclusion of classes and packages from consideration. Various filters may be applied, and may be conditionally activated.]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="exclude">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[The exclude filter allows exclusion of classes and packages through the use of Ant-style glob matches. For example, <exclude name="com.acme.**"> would exclude all classes and subpackages of com.acme.]]>
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice maxOccurs="unbounded" minOccurs="0">
+              <xs:element name="if-class-available">
+                <xs:annotation>
+                  <xs:documentation>
+                    <![CDATA[Activates the filter only if the class specified can be loaded.]]>
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[If the named class can be loaded then, then the filter will be activated.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="if-class-not-available">
+                <xs:annotation>
+                  <xs:documentation>
+                    <![CDATA[Activates the filter only if the class specified cannot be loaded.]]>
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[If the named class cannot be loaded then, then the filter will be activated.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="if-system-property">
+                <xs:annotation>
+                  <xs:documentation>
+                    <![CDATA[If both name and value are specified, then the named system property must be set, and have the specified value for the filter to be activated. If only the name is specified, then the named system property must be set for the filter to be activated.]]>
+                  </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[The name of the system property that must be set for the filter to be active.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="value" type="xs:string" use="optional">
+                    <xs:annotation>
+                      <xs:documentation>
+                        <![CDATA[Optional. The value that the system property must have for the filter to be active.]]>
+                      </xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="name" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[The name of the class or package to exclude. Ant-style glob matches are supported. For example, <exclude name="com.acme.**"> would exclude all classes and subpackages of com.acme.]]>
+                </xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:pattern value="([a-zA-Z_$][a-zA-Z\d_$]*\.)*([a-zA-Z_$][a-zA-Z\d_$]*|\*|\*\*)"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="interceptors">
+    <xs:annotation>
+      <xs:documentation>
+        By default, a bean archive has no enabled
+        interceptors bound via interceptor bindings. An interceptor
+        must be explicitly enabled by listing its class under the
+        &lt;interceptors&gt; element of the beans.xml file of the
+        bean archive. The order of the interceptor declarations
+        determines the interceptor ordering. Interceptors which
+        occur earlier in the list are called first. If the same
+        class is listed twice under the &lt;interceptors&gt;
+        element, the container automatically detects the problem and
+        treats it as a deployment problem.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="class" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;class&gt; element
+              must specify the name of an interceptor class. If
+              there is no class with the specified name, or if
+              the class with the specified name is not an
+              interceptor class, the container automatically
+              detects the problem and treats it as a deployment
+              problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="decorators">
+    <xs:annotation>
+      <xs:documentation>
+        By default, a bean archive has no enabled
+        decorators. A decorator must be explicitly enabled by
+        listing its bean class under the &lt;decorators&gt; element
+        of the beans.xml file of the bean archive. The order of the
+        decorator declarations determines the decorator ordering.
+        Decorators which occur earlier in the list are called first.
+        If the same class is listed twice under the
+        &lt;decorators&gt; element, the container automatically
+        detects the problem and treats it as a deployment problem.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="class" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;class&gt; element
+              must specify the name of a decorator class. If
+              there is no class with the specified name, or if
+              the class with the specified name is not a
+              decorator class, the container automatically
+              detects the problem and treats it as a deployment
+              problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="alternatives">
+    <xs:annotation>
+      <xs:documentation>
+        An alternative is a bean that must be
+        explicitly declared in the beans.xml file if it should be
+        available for lookup, injection or EL resolution. By
+        default, a bean archive has no selected alternatives. An
+        alternative must be explicitly declared using the
+        &lt;alternatives&gt; element of the beans.xml file of the
+        bean archive. The &lt;alternatives&gt; element contains a
+        list of bean classes and stereotypes. An alternative is
+        selected for the bean archive if either: the alternative is
+        a managed bean or session bean and the bean class of the
+        bean is listed, or the alternative is a producer method,
+        field or resource, and the bean class that declares the
+        method or field is listed, or any @Alternative stereotype of
+        the alternative is listed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="class" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;class&gt; element
+              must specify the name of an alternative bean class.
+              If there is no class with the specified name, or if
+              the class with the specified name is not an
+              alternative bean class, the container automatically
+              detects the problem and treats it as a deployment
+              problem. If the same class is listed twice under
+              the &lt;alternatives&gt; element, the container
+              automatically detects the problem and treats it as
+              a deployment problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+        <xs:element name="stereotype" type="xs:string">
+          <xs:annotation>
+            <xs:documentation>
+              Each child &lt;stereotype&gt;
+              element must specify the name of an @Alternative
+              stereotype annotation. If there is no annotation
+              with the specified name, or the annotation is not
+              an @Alternative stereotype, the container
+              automatically detects the problem and treats it as
+              a deployment problem. If the same stereotype is
+              listed twice under the &lt;alternatives&gt;
+              element, the container automatically detects the
+              problem and treats it as a deployment problem.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="trim" type="xs:string" fixed="">
+      <xs:annotation>
+        <xs:documentation>
+          If an explicit bean archive contains the &lt;trim/&lt; element in its beans.xml file, types that don’t have
+          either a bean defining annotation (as defined in Bean defining annotations) or any scope annotation,
+          are removed from the set of discovered types.
+        </xs:documentation>
+      </xs:annotation>
+  </xs:element>
+
+</xs:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/validation-configuration-3.1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/validation-configuration-3.1.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jakarta Validation API
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="https://jakarta.ee/xml/ns/validation/configuration"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:config="https://jakarta.ee/xml/ns/validation/configuration"
+           version="3.1">
+
+    <xs:annotation>
+        <xs:documentation><![CDATA[
+            This is the XML Schema for the Jakarta Validation configuration file.
+            The configuration file must be named "META-INF/validation.xml".
+
+            Jakarta Validation configuration files must indicate the Jakarta Validation
+            XML schema by using the validation namespace:
+
+            https://jakarta.ee/xml/ns/validation/configuration
+
+            and indicate the version of the schema by using the version attribute
+            as shown below:
+
+            <validation-config
+                xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="
+                    https://jakarta.ee/xml/ns/validation/configuration
+                    https://jakarta.ee/xml/ns/validation/validation-configuration-3.1.xsd"
+                version="3.1">
+                [...]
+            </validation-config>
+        ]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="validation-config" type="config:validation-configType"/>
+    <xs:complexType name="validation-configType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="default-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="message-interpolator" minOccurs="0"/>
+            <xs:element type="xs:string" name="traversable-resolver" minOccurs="0"/>
+            <xs:element type="xs:string" name="constraint-validator-factory" minOccurs="0"/>
+            <xs:element type="xs:string" name="parameter-name-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="clock-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="value-extractor" maxOccurs="unbounded"
+                    minOccurs="0"/>
+            <xs:element type="config:executable-validationType" name="executable-validation"
+                    minOccurs="0"/>
+            <xs:element type="xs:string" name="constraint-mapping" maxOccurs="unbounded"
+                    minOccurs="0"/>
+            <xs:element type="config:propertyType" name="property" maxOccurs="unbounded"
+                    minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="version" type="config:versionType" fixed="3.0" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="executable-validationType">
+        <xs:sequence>
+            <xs:element type="config:default-validated-executable-typesType"
+                    name="default-validated-executable-types" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="default-validated-executable-typesType">
+        <xs:sequence>
+            <xs:element name="executable-type" maxOccurs="unbounded" minOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="NONE"/>
+                        <xs:enumeration value="CONSTRUCTORS"/>
+                        <xs:enumeration value="NON_GETTER_METHODS"/>
+                        <xs:enumeration value="GETTER_METHODS"/>
+                        <xs:enumeration value="ALL"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="propertyType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="versionType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[0-9]+(\.[0-9]+)*" />
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/validation-mapping-3.1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/validation-mapping-3.1.xsd
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jakarta Validation API
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="https://jakarta.ee/xml/ns/validation/mapping"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:map="https://jakarta.ee/xml/ns/validation/mapping"
+           version="3.1">
+
+    <xs:annotation>
+        <xs:documentation><![CDATA[
+            This is the XML Schema for Jakarta Validation constraint mapping files.
+
+            Jakarta Validation constraint mapping files must indicate the Jakarta Validation
+            XML schema by using the constraint mapping namespace:
+
+            https://jakarta.ee/xml/ns/validation/mapping
+
+            and indicate the version of the schema by using the version attribute
+            as shown below:
+
+            <constraint-mappings
+                xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="
+                    https://jakarta.ee/xml/ns/validation/mapping
+                    https://jakarta.ee/xml/ns/validation/validation-mapping-3.1.xsd"
+                version="3.1">
+                ...
+            </constraint-mappings>
+        ]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="constraint-mappings" type="map:constraint-mappingsType"/>
+
+    <xs:complexType name="payloadType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="groupsType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="groupSequenceType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="groupConversionType">
+        <xs:attribute type="xs:string" name="from" use="optional"/>
+        <xs:attribute type="xs:string" name="to" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="constraint-mappingsType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="default-package" minOccurs="0"/>
+            <xs:element type="map:beanType"
+                        name="bean"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+            <xs:element type="map:constraint-definitionType"
+                        name="constraint-definition"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="version" type="map:versionType" fixed="3.0" use="required"/>
+    </xs:complexType>
+    <xs:simpleType name="versionType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[0-9]+(\.[0-9]+)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="validated-byType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="include-existing-validators" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="constraintType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="message" minOccurs="0"/>
+            <xs:element type="map:groupsType"
+                        name="groups"
+                        minOccurs="0"/>
+            <xs:element type="map:payloadType"
+                        name="payload"
+                        minOccurs="0"/>
+            <xs:element type="map:elementType"
+                        name="element"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="annotation" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="elementType" mixed="true">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+            <xs:element type="map:annotationType"
+                        name="annotation"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="containerElementTypeType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="type-argument-index" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="0" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="classType">
+        <xs:sequence>
+            <xs:element type="map:groupSequenceType"
+                        name="group-sequence"
+                        minOccurs="0"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="beanType">
+        <xs:sequence>
+            <xs:element type="map:classType"
+                        name="class"
+                        minOccurs="0">
+            </xs:element>
+            <xs:element type="map:fieldType"
+                        name="field"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:getterType"
+                        name="getter"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constructorType"
+                        name="constructor"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:methodType"
+                        name="method"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="class" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"
+                default="true"/>
+    </xs:complexType>
+    <xs:complexType name="annotationType">
+        <xs:sequence>
+            <xs:element type="map:elementType"
+                        name="element"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="getterType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="methodType">
+        <xs:sequence>
+            <xs:element type="map:parameterType"
+                        name="parameter"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:crossParameterType"
+                        name="cross-parameter"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element type="map:returnValueType"
+                        name="return-value"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="constructorType">
+        <xs:sequence>
+            <xs:element type="map:parameterType"
+                        name="parameter"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:crossParameterType"
+                        name="cross-parameter"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element type="map:returnValueType"
+                        name="return-value"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="parameterType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="type" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="returnValueType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="crossParameterType">
+        <xs:sequence>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="constraint-definitionType">
+        <xs:sequence>
+            <xs:element type="map:validated-byType"
+                        name="validated-by"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="annotation" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="fieldType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+</xs:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-facelettaglibrary_4_1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-facelettaglibrary_4_1.xsd
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="4.1">
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>The XML Schema for the Tag Libraries in the Jakarta Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 4.1).</p>
+      
+      <p>Jakarta Faces 4.1 Facelet Tag Libraries that wish to conform to 
+      this schema must declare it in the following manner.</p>
+      
+      &lt;facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_1.xsd"
+      version="4.1"&gt;
+      
+      ...
+      
+      &lt;/facelet-taglib&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_1.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="jakartaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          tag-names must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag"/>
+      <xsd:field xpath="jakartaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Behavior IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Converter IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Validator IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        The top level XML element in a facelet tag library XML file.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="jakartaee:string"/>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="short-name"
+                       type="jakartaee:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <![CDATA[
+                <p>
+                
+                An advisory short name for usages of tags from this tag library.
+                
+                </p>
+                ]]>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="jakartaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="jakartaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="jakartaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="jakartaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="jakartaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="jakartaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="jakartaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="jakartaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="jakartaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="jakartaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+        
+        <dl>
+        
+        <dt>description</dt><dd><p> a description of the attribute
+        </p></dd>
+        
+        <dt>name</dt><dd><p> the name of the attribute
+        </p></dd>
+        
+        <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+        </p></dd>
+        
+        <dt>type</dt><dd><p> the type of the attribute
+        </p></dd>
+        
+        </dl>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+            
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="jakartaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="jakartaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+              
+              <code>
+              
+              <p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+              
+              <p>ReturnType        ::= Type</p>
+              
+              <p>MethodName        ::= Identifier</p>
+              
+              <p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+              
+              <p>Parameter         ::= Type</p>
+              
+              </code>
+              
+              <p>Where:</p>
+              
+              <ul>
+              
+              <li><p><code>Type</code> is a basic type or a fully qualified
+              Java class name (including package name), as per the 'Type'
+              production in the Java Language Specification, Second Edition,
+              Chapter 18.</p></li>
+              
+              <li><p><code>Identifier</code> is a Java identifier, as per the
+              'Identifier' production in the Java Language Specification,
+              Second Edition, Chapter 18.</p></li>
+              
+              </ul>
+              
+              <p>Example:</p>
+              
+              <p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for tag It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the behavior element encapsulates
+        information specific to a Faces Behavior.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for behavior. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2
+        changed_modified_2_3">Within</span> a tag element, the component
+        element encapsulates information specific to a Faces UIComponent.</p>
+        
+        <div class="changed_added_2_2 changed_deleted_2_3">
+        
+        <p>As of 3.0 of the specification, this requirement is no longer
+        present: This element must have exactly one of
+        <code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+        or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="resource-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A valid resource identifier
+            as specified in the Jakarta Faces Specification Document section 2.6.1.3 "Resource Identifiers".
+            For example:</p>
+            
+            <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-extension"
+                   type="jakartaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for component It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the converter element encapsulates
+        information specific to a Faces Converter.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for converter It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the validator element encapsulates
+        information specific to a Faces Validator.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for validator It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        This type contains the recognized versions of
+        facelet-taglib supported.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="4.1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+        
+        <p>The name must conform to the lexical rules for an NCName</p>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-facesconfig_4_1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-facesconfig_4_1.xsd
@@ -1,0 +1,3447 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            attributeFormDefault="unqualified"
+            elementFormDefault="qualified"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            version="4.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      <p>The XML Schema for the Jakarta Faces Application
+      Configuration File (Version 4.1).</p>
+      
+      <p>All Jakarta Faces configuration files must indicate
+      the Jakarta Faces schema by indicating the
+      Jakarta Faces namespace:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee</p>
+      
+      <p>and by indicating the version of the schema by
+      using the version element as shown below:</p>
+      
+      <pre>&lt;faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="4.1"&gt;
+      ...
+      &lt;/faces-config&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="faces-config"
+               type="jakartaee:faces-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>The "faces-config" element is the root of the configuration
+        information hierarchy, and contains nested elements for all
+        of the other configuration settings.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>Behavior IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>Converter IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-for-class-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>'converter-for-class' element values must be unique
+          within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-for-class"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p> Validator IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "faces-config" element is the root of the configuration
+        information hierarchy, and contains nested elements for all
+        of the other configuration settings.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="application"
+                   type="jakartaee:faces-config-applicationType"/>
+      <xsd:element name="ordering"
+                   type="jakartaee:faces-config-orderingType"/>
+      <xsd:element name="absolute-ordering"
+                   type="jakartaee:faces-config-absoluteOrderingType"
+                   minOccurs="0"/>
+      <xsd:element name="factory"
+                   type="jakartaee:faces-config-factoryType"/>
+      <xsd:element name="component"
+                   type="jakartaee:faces-config-componentType"/>
+      <xsd:element name="converter"
+                   type="jakartaee:faces-config-converterType"/>
+      <xsd:element name="flow-definition"
+                   type="jakartaee:faces-config-flow-definitionType"/>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> <span class="changed_modified_2_2">The</span> "name" element 
+            within the top level "faces-config"
+            element declares the name of this application
+            configuration resource.  Such names are used
+            in the document ordering scheme specified in section
+            11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document.</p>
+            
+            <p class="changed_added_2_2">This value is taken to be the 
+            defining document id of any &lt;flow-definition&gt; elements 
+            defined in this Application Configuration Resource file.  If this
+            element is not specified, the runtime must take the empty string 
+            as its value.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="navigation-rule"
+                   type="jakartaee:faces-config-navigation-ruleType"/>
+      <xsd:element name="protected-views"
+                   type="jakartaee:faces-config-protected-viewsType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="referenced-bean"
+                   type="jakartaee:faces-config-referenced-beanType"/>
+      <xsd:element name="render-kit"
+                   type="jakartaee:faces-config-render-kitType"/>
+      <xsd:element name="lifecycle"
+                   type="jakartaee:faces-config-lifecycleType"/>
+      <xsd:element name="validator"
+                   type="jakartaee:faces-config-validatorType"/>
+      <xsd:element name="behavior"
+                   type="jakartaee:faces-config-behaviorType"/>
+      <xsd:element name="faces-config-extension"
+                   type="jakartaee:faces-config-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean"
+                   use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          Faces application is complete, or whether
+          the class files available to this module and packaged with
+          this application should be examined for annotations
+          that specify configuration information.
+          
+          This attribute is only inspected on the application 
+          configuration resource file located at "WEB-INF/faces-config.xml".
+          The presence of this attribute on any application configuration
+          resource other than the one located at "WEB-INF/faces-config.xml",
+          including any files named using the jakarta.faces.CONFIG_FILES
+          attribute, must be ignored.
+          
+          If metadata-complete is set to "true", the Faces
+          runtime must ignore any annotations that specify configuration
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the Faces runtime must examine the class
+          files of the application for annotations, as specified by
+          the specification.
+          
+          If "WEB-INF/faces-config.xml" is not present, the 
+          Faces runtime will assume metadata-complete to be "false".
+          
+          The value of this attribute will have no impact on
+          runtime annotations such as @ResourceDependency or
+          @ListenerFor.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:faces-config-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for faces-config.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Please see section 
+        11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the specification of this element.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="after"
+                   type="jakartaee:faces-config-ordering-orderingType"
+                   minOccurs="0"/>
+      <xsd:element name="before"
+                   type="jakartaee:faces-config-ordering-orderingType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ordering-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element contains a sequence of "id" elements, each of which
+        refers to an application configuration resource by the "id"
+        declared on its faces-config element.  This element can also contain
+        a single "others" element which specifies that this document comes
+        before or after other documents within the application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:faces-config-ordering-othersType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ordering-othersType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element indicates that the ordering sub-element in which
+        it was placed should take special action regarding the ordering
+        of this application resource relative to other
+        application configuration resources.
+        See section 11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the complete specification.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-absoluteOrderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Only relevant if this is placed within the /WEB-INF/faces-config.xml.
+        Please see 
+        section 11.3.8 "Ordering of Artifacts" of the Jakarta Faces Specification Document
+        for the specification for details.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:faces-config-ordering-othersType"
+                   minOccurs="0"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "application" element provides a mechanism to define the
+        various per-application-singleton implementation artifacts for
+        a particular web application that is utilizing
+        Jakarta Faces.  For nested elements that are not specified,
+        the Jakarta Faces implementation must provide a suitable 
+        default.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="action-listener"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "action-listener" element contains the fully
+            qualified class name of the concrete
+            ActionListener implementation class that will be
+            called during the Invoke Application phase of the
+            request processing lifecycle.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-render-kit-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "default-render-kit-id" element allows the
+            application to define a renderkit to be used other
+            than the standard one.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-bundle"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The base name of a resource bundle representing
+            the message resources for this application.  See
+            the JavaDocs for the "java.util.ResourceBundle"
+            class for more information on the syntax of
+            resource bundle names.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="navigation-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "navigation-handler" element contains the
+            fully qualified class name of the concrete
+            NavigationHandler implementation class that will
+            be called during the Invoke Application phase
+            of the request processing lifecycle, if the
+            default ActionListener (provided by the Jakarta Faces 
+            implementation) is used.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "view-handler" element contains the fully
+            qualified class name of the concrete ViewHandler
+            implementation class that will be called during
+            the Restore View and Render Response phases of the
+            request processing lifecycle.  The faces
+            implementation must provide a default
+            implementation of this class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="state-manager"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "state-manager" element contains the fully
+            qualified class name of the concrete StateManager
+            implementation class that will be called during
+            the Restore View and Render Response phases of the
+            request processing lifecycle.  The faces
+            implementation must provide a default
+            implementation of this class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="el-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "el-resolver" element contains the fully
+            qualified class name of the concrete
+            jakarta.el.ELResolver implementation class
+            that will be used during the processing of
+            EL expressions.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "resource-handler" element contains the
+            fully qualified class name of the concrete
+            ResourceHandler implementation class that
+            will be used during rendering and decoding
+            of resource requests The standard
+            constructor based decorator pattern used for
+            other application singletons will be
+            honored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-library-contracts"
+                   type="jakartaee:faces-config-application-resource-library-contractsType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "resource-library-contracts" element
+            specifies the mappings between views in the application and resource
+            library contracts that, if present in the application, must be made
+            available for use as templates of the specified views.
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-expression-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3">The "search-expression-handler"
+            element contains the fully qualified class name of the
+            concrete jakarta.faces.component.search.SearchExpressionHandler
+            implementation class that will be used for processing of a
+            search expression.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-keyword-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The "search-keyword-resolver"
+            element contains the fully qualified class name of the
+            concrete jakarta.faces.component.search.SearchKeywordResolver
+            implementation class that will be used during the processing
+            of a search expression keyword.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="system-event-listener"
+                   type="jakartaee:faces-config-system-event-listenerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="locale-config"
+                   type="jakartaee:faces-config-locale-configType"/>
+      <xsd:element name="resource-bundle"
+                   type="jakartaee:faces-config-application-resource-bundleType"/>
+      <xsd:element name="application-extension"
+                   type="jakartaee:faces-config-application-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="default-validators"
+                   type="jakartaee:faces-config-default-validatorsType"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-bundleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The resource-bundle element inside the application element
+        references a java.util.ResourceBundle instance by name
+        using the var element.  ResourceBundles referenced in this
+        manner may be returned by a call to
+        Application.getResourceBundle() passing the current
+        FacesContext for this request and the value of the var
+        element below.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="base-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The fully qualified class name of the
+            java.util.ResourceBundle instance.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="var"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The name by which this ResourceBundle instance
+            is retrieved by a call to
+            Application.getResourceBundle().</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-library-contractsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">The "resource-library-contracts" element
+        specifies the mappings between views in the application and resource
+        library contracts that, if present in the application, must be made
+        available for use as templates of the specified views.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="contract-mapping"
+                   type="jakartaee:faces-config-application-resource-library-contracts-contract-mappingType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p classes="changed_added_2_2">Declare a mapping between a collection
+            of views in the application and the list of contracts (if present in the application)
+            that may be used as a source for templates and resources for those views.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-library-contracts-contract-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">The "contract-mapping" element
+        specifies the mappings between a collection of views in the application and resource
+        library contracts that, if present in the application, must be made
+        available for use as templates of the specified views.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "url-pattern" element
+            specifies the collection of views in this application that 
+            are allowed to use the corresponding contracts.
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="contracts"
+                   type="jakartaee:string"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "contracts" element
+            is a comma separated list of resource library contracts that,
+            if available to the application, may be used by the views
+            matched by the corresponding "url-pattern"
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for application.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "factory" element provides a mechanism to define the
+        various Factories that comprise parts of the implementation
+        of Jakarta Faces.  For nested elements that are not
+        specified, the Jakarta Faces implementation must provide a 
+        suitable default.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="application-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "application-factory" element contains the
+            fully qualified class name of the concrete
+            ApplicationFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(APPLICATION_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="exception-handler-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "exception-handler-factory" element contains the
+            fully qualified class name of the concrete
+            ExceptionHandlerFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(EXCEPTION_HANDLER_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="external-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "external-context-factory" element contains the
+            fully qualified class name of the concrete
+            ExternalContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(EXTERNAL_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="faces-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "faces-context-factory" element contains the
+            fully qualified class name of the concrete
+            FacesContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FACES_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facelet-cache-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "facelet-cache-factory" element contains the
+            fully qualified class name of the concrete
+            FaceletCacheFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FACELET_CACHE_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="partial-view-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "partial-view-context-factory" element contains the
+            fully qualified class name of the concrete
+            PartialViewContextFactory implementation class that will
+            be called when FactoryFinder.getFactory
+            (FactoryFinder.PARTIAL_VIEW_CONTEXT_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lifecycle-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "lifecycle-factory" element contains the fully
+            qualified class name of the concrete LifecycleFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(LIFECYCLE_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view-declaration-language-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "view-declaration-language-factory" element contains
+            the fully qualified class name of the concrete
+            ViewDeclarationLanguageFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(VIEW_DECLARATION_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-handler-delegate-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "tag-handler-delegate-factory" element contains
+            the fully qualified class name of the concrete
+            ViewDeclarationLanguageFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(TAG_HANDLER_DELEGATE_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="render-kit-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-factory" element contains the fully
+            qualified class name of the concrete RenderKitFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(RENDER_KIT_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="visit-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "visit-context-factory" element contains the fully
+            qualified class name of the concrete VisitContextFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(VISIT_CONTEXT_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flash-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "flash-factory" element contains the
+            fully qualified class name of the concrete
+            FaceletFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FLASH_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flow-handler-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "flow-handler-factory" element contains the
+            fully qualified class name of the concrete
+            FlowHandlerFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FLOW_HANDLER_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-window-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The "client-window-factory" element contains the fully 
+            qualified class name of the concrete ClientWindowFactory implementation class that 
+            will be called when FactoryFinder.getFactory(CLIENT_WINDOW_FACTORY) is called.</p>  
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-expression-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The
+            "search-expression-context-factory" element contains the
+            fully qualified class name of the concrete
+            SearchExpressionContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(SEARCH_EXPRESSION_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="factory-extension"
+                   type="jakartaee:faces-config-factory-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-factory-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for factory.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "attribute" element represents a named, typed, value
+        associated with the parent UIComponent via the generic
+        attributes mechanism.</p>
+        
+        <p>Attribute names must be unique within the scope of the parent
+        (or related) component.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="attribute-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "attribute-name" element represents the name under
+            which the corresponding value will be stored, in the
+            generic attributes of the UIComponent we are related
+            to.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "attribute-class" element represents the Java type
+            of the value associated with this attribute name.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-value"
+                   type="jakartaee:faces-config-default-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="suggested-value"
+                   type="jakartaee:faces-config-suggested-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="attribute-extension"
+                   type="jakartaee:faces-config-attribute-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-attribute-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for attribute.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "component" element represents a concrete UIComponent
+        implementation class that should be registered under the
+        specified type identifier, along with its associated
+        properties and attributes.  Component types must be unique
+        within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        are recognized by the implementation logic of this component.
+        Nested "property" elements identify JavaBeans properties of
+        the component class that may be exposed for manipulation
+        via tools.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-type" element represents the name under
+            which the corresponding UIComponent class should be
+            registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-class" element represents the fully
+            qualified class name of a concrete UIComponent
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet"
+                   type="jakartaee:faces-config-facetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="component-extension"
+                   type="jakartaee:faces-config-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for component.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-locale" element declares the default locale
+        for this application instance.</p>
+        
+        <p class="modified_added_2_3">
+        To facilitate BCP 47 this element first needs to be parsed by the
+        Locale.forLanguageTag method. If it does not return a Locale with
+        a language the old specification below needs to take effect.
+        </p>
+        
+        <p>It must be specified as :language:[_:country:[_:variant:]]
+        without the colons, for example "ja_JP_SJIS".  The
+        separators between the segments may be '-' or '_'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-localeType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-value" contains the value for the property or
+        attribute in which this element resides.  This value differs
+        from the "suggested-value" in that the property or attribute
+        must take the value, whereas in "suggested-value" taking the
+        value is optional.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-el-expressionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> EL expressions present within a faces config file
+        must start with the character sequence of '#{' and
+        end with '}'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="#\{.*\}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-facetType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Define the name and other design-time information for a facet
+        that is associated with a renderer or a component.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="facet-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "facet-name" element represents the facet name
+            under which a UIComponent will be added to its parent.
+            It must be of type "Identifier".</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet-extension"
+                   type="jakartaee:faces-config-facet-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-facet-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for facet.  It may contain implementation
+        specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-from-view-idType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2">The</span>
+        value of from-view-id must contain one of the following
+        values:</p>
+        
+        <ul>
+        
+        <li><p>The exact match for a view identifier that is recognized
+        by the the ViewHandler implementation being used (such as
+        "/index.jsp" if you are using the default ViewHandler).</p></li>
+        
+        <li><p class="changed_added_2_2">The exact match of a flow node id
+        in the current flow, or a flow id of another flow.</p></li>
+        
+        <li><p> A proper prefix of a view identifier, plus a trailing
+        "*" character.  This pattern indicates that all view
+        identifiers that match the portion of the pattern up to the
+        asterisk will match the surrounding rule.  When more than one
+        match exists, the match with the longest pattern is selected.
+        </p></li>
+        
+        <li><p>An "*" character, which means that this pattern applies
+        to all view identifiers.  </p></li>
+        
+        </ul>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-from-actionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "from-action" element contains an action reference
+        expression that must have been executed (by the default
+        ActionListener for handling application level events)
+        in order to select the navigation rule.  If not specified,
+        this rule will be relevant no matter which action reference
+        was executed (or if no action reference was executed).</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ifType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>The "if" element defines a condition that must resolve
+        to true in order for the navigation case on which it is
+        defined to be matched, with the existing match criteria
+        (action method and outcome) as a prerequiste, if present.
+        The condition is defined declaratively using a value
+        expression in the body of this element. The expression is
+        evaluated at the time the navigation case is being matched.
+        If the "from-outcome" is omitted and this element is
+        present, the navigation handler will match a null outcome
+        and use the condition return value to determine if the
+        case should be considered a match.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>When used in a <code>&lt;switch&gt;</code> within a flow, if the
+        expresion returns <code>true</code>, the
+        <code>&lt;from-outcome&gt;</code> sibling element's outcome is used as
+        the id of the node in the flow graph to which control must be
+        passed.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-parameter-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2"></p>
+        
+        <div class="changed_added_2_2">
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "converter" element represents a concrete Converter
+        implementation class that should be registered under the
+        specified converter identifier.  Converter identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Converter.  Nested "property"
+        elements identify JavaBeans properties of the Converter
+        implementation class that may be configured to affect the
+        operation of the Converter.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="converter-id"
+                     type="jakartaee:string">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p> The "converter-id" element represents the
+              identifier under which the corresponding
+              Converter class should be registered.</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="converter-for-class"
+                     type="jakartaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p> The "converter-for-class" element represents the
+              fully qualified class name for which a Converter
+              class will be registered.</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="converter-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "converter-class" element represents the fully
+            qualified class name of a concrete Converter
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Converter.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Converter implementation class
+            that may be configured to affect the operation of
+            the Converter.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:faces-config-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for converter.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-lifecycleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "lifecycle" element provides a mechanism to specify
+        modifications to the behaviour of the default Lifecycle
+        implementation for this web application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="phase-listener"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "phase-listener" element contains the fully
+            qualified class name of the concrete PhaseListener
+            implementation class that will be registered on
+            the Lifecycle.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lifecycle-extension"
+                   type="jakartaee:faces-config-lifecycle-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-lifecycle-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for lifecycle.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The localeType defines valid locale defined by ISO-639-1
+        and ISO-3166.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="([a-z]{2})[_|\-]?([\p{L}]{2})?[_|\-]?(\w+)?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-locale-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "locale-config" element allows the app developer to
+        declare the supported locales for this application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="default-locale"
+                   type="jakartaee:faces-config-default-localeType"
+                   minOccurs="0"/>
+      <xsd:element name="supported-locale"
+                   type="jakartaee:faces-config-supported-localeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-validatorsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-validators" element allows the app developer to
+        register a set of validators, referenced by identifier, that
+        are automatically assigned to any EditableValueHolder component
+        in the application, unless overridden or disabled locally.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="validator-id"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-id" element represents the identifier
+            of a registered validator.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+ 
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definitionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Top level element for a flow
+        definition.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>If there is no <code>&lt;start-node&gt;</code> element declared, it
+        is assumed to be <code>&lt;flowName&gt;.xhtml</code>.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="start-node"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Declare the id of the starting node in the
+            flow graph.  The start node may be any of the node types mentioned in
+            the class javadocs for <code><a target="_"
+            href="jakarta/faces/flow/FlowHandler.html">FlowHandler</a></code>.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view"
+                   type="jakartaee:faces-config-flow-definition-viewType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="switch"
+                   type="jakartaee:faces-config-flow-definition-switchType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="flow-return"
+                   type="jakartaee:faces-config-flow-definition-flow-returnType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="navigation-rule"
+                   type="jakartaee:faces-config-navigation-ruleType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="flow-call"
+                   type="jakartaee:faces-config-flow-definition-flow-callType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="method-call"
+                   type="jakartaee:faces-config-flow-definition-faces-method-callType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="initializer"
+                   type="jakartaee:faces-config-flow-definition-initializerType"
+                   minOccurs="0"/>
+      <xsd:element name="finalizer"
+                   type="jakartaee:faces-config-flow-definition-finalizerType"
+                   minOccurs="0"/>
+      <xsd:element name="inbound-parameter"
+                   type="jakartaee:faces-config-flow-definition-inbound-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow.  The id
+          must be unique within the Application configuration Resource
+          file in which this flow is defined.  The value of this attribute, 
+          combined with the value of the &lt;faces-config&gt;&lt;name&gt; element
+          must globally identify the flow within the application.<p> 
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-faces-method-callType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Invoke a method, passing parameters if necessary.
+        The return from the method is used as the outcome for where to go next in the
+        flow.  If the method is a void method, the default outcome is used.<p> 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method"
+                   type="jakartaee:faces-config-flow-definition-faces-method-call-methodType"/>
+      <xsd:element name="default-outcome"
+                   type="jakartaee:string"/>
+      <xsd:element name="parameter"
+                   type="jakartaee:faces-config-flow-definition-flow-call-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A parameter to pass when calling the method
+            identified in the "method" element that is a sibling of this element.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-faces-method-call-methodType">
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A parameter to pass when calling the method
+        identified in the "method" element that is a sibling of this element.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="class"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The optional "class" element within a "parameter" element 
+            will be interpreted as the fully qualified class name for the type
+            of the "value" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "parameter"
+            must be a literal string or an EL Expression whose "get" will be called when the "method"
+            associated with this element is invoked.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-viewType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a view node in a flow graph.</p>
+        
+        <p>This element must contain exactly one
+        <code>&lt;vdl-document&gt;</code> element.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="vdl-document"
+                   type="jakartaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2 changed_modified_2_3">
+            Define the path to the vdl-document for the enclosing view.
+            <p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this view.  It must be
+          unique within the flow.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-switchType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a switch node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain one or more
+        <code>&lt;case&gt;</code> elements.  When control passes to the
+        <code>&lt;switch&gt;</code> node, each of the cases must be considered
+        in order and control must past to the <code>&lt;from-outcome&gt;</code>
+        of the first one whose <code>&lt;if&gt;</code> expression evaluates to 
+        <code>true</code>.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="case"
+                   type="jakartaee:faces-config-flow-definition-switch-caseType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Defines a case that must be
+            considered in the list of cases in the
+            <code>&lt;switch&gt;</code>.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Defines the default case that will
+            be taken if none of the other cases in the
+            <code>&lt;switch&gt;</code> are taken.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this switch.  It must be
+          unique within the flow.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-switch-caseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Defines a case that will
+        be considered in the <code>&lt;switch&gt;</code>.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="if"
+                   type="jakartaee:faces-config-ifType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">If this EL expression evaluates to
+            <code>true</code>, the corresponding <code>from-outcome</code> will 
+            be the outcome taken by the enclosing <code>&lt;switch&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The "from-outcome" element contains a logical outcome
+            string returned by the execution of an application
+            action method selected via an "actionRef" property
+            (or a literal value specified by an "action" property)
+            of a UICommand component.  If specified, this rule
+            will be relevant only if the outcome value matches
+            this element's value.  If not specified, this rule
+            will be relevant if the outcome value is non-null
+            or, if the "if" element is present, will be relevant
+            for any outcome value, with the assumption that the
+            condition specified in the "if" element ultimately
+            determines if this rule is a match.</p>
+            
+            <p class="changed_added_2_2">If used in a faces flow, this element
+            represents the node id to which control will be passed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID">
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-returnType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a return node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain exactly one <code>&lt;from-outcome&gt;</code> element.</p>
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">This element
+            represents the node id to which control will be passed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow-return.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-callType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a call node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain exactly one <code>&lt;flow-reference&gt;</code> element, 
+        which must contain exactly one <code>&lt;flow-id&gt;</code> element.</p>
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="flow-reference"
+                   type="jakartaee:faces-config-flow-definition-flow-call-flow-referenceType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The flow id of the called flow.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="outbound-parameter"
+                   type="jakartaee:faces-config-flow-definition-flow-call-outbound-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A parameter to pass when calling the flow
+            identified in the "flow-reference" element that is a sibling of this element.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow-return.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-flow-referenceType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Identifiy the called flow.</p>
+        
+        <div class="changed_added_2_2">
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="flow-document-id"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The document id of the called flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flow-id"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The id of the called flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-initializerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is entered.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-finalizerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is exited.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-inbound-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A named parameter whose value will be populated
+        with a correspondingly named parameter within an "outbound-parameter" element.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "name" element within an "inbound-parameter"
+            element declares the name of this parameter
+            to be passed into a flow.  There must be 
+            a sibling "value" element in the same parent as this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "inbound-parameter"
+            must be an EL Expression whose value will be set with the correspondingly
+            named "outbound-parameter" when this flow is entered, if such a 
+            parameter exists.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-outbound-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A named parameter whose value will be 
+        passed to a correspondingly named parameter within an "inbound-parameter" element
+        on the target flow.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "name" element within an "outbound-parameter" element 
+            declares the name of this parameter to be passed out of a flow.  There must be 
+            a sibling "value" element in the same parent as this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "outbound-parameter"
+            must be a literal string or an EL Expression whose "get" will be called when the "flow-call"
+            containing this element is traversed to go to a new flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-caseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> <span class="changed_modified_2_2">The</span>
+        "navigation-case" element describes a particular
+        combination of conditions that must match for this case to
+        be executed, and the view id of the component tree that
+        should be selected next.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="from-action"
+                   type="jakartaee:faces-config-from-actionType"
+                   minOccurs="0"/>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The "from-outcome" element contains a logical outcome
+            string returned by the execution of an application
+            action method selected via an "actionRef" property
+            (or a literal value specified by an "action" property)
+            of a UICommand component.  If specified, this rule
+            will be relevant only if the outcome value matches
+            this element's value.  If not specified, this rule
+            will be relevant if the outcome value is non-null
+            or, if the "if" element is present, will be relevant
+            for any outcome value, with the assumption that the
+            condition specified in the "if" element ultimately
+            determines if this rule is a match.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="if"
+                   type="jakartaee:faces-config-ifType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Please see section 7.4.2 "Default NavigationHandler Algorithm" of the Jakarta Faces Specification Document
+            for the specification of this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="to-view-id"
+                   type="jakartaee:faces-config-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p><span class="changed_modified_2_2">The "to-view-id" element 
+            contains the view identifier (<span class="changed_added_2_2">or 
+            flow node id, or flow id</span>)
+            of the next view (<span class="changed_added_2_2">or flow node or 
+            flow</span>) that should be displayed if this
+            navigation rule is matched. If the contents is a
+            value expression, it should be resolved by the
+            navigation handler to obtain the view (
+            <span class="changed_added_2_2">or flow node or flow</span>) 
+            identifier.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="to-flow-document-id"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The document id of the called flow.
+            If this element appears in a &lt;navigation-case&gt; nested within 
+            a &lt;flow-definition&gt;, it must be ignored because navigation
+            cases within flows may only navigate among the view nodes of that 
+            flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="redirect"
+                   type="jakartaee:faces-config-redirectType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-ruleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "navigation-rule" element represents an individual
+        decision rule that will be utilized by the default
+        NavigationHandler implementation to make decisions on
+        what view should be displayed next, based on the
+        view id being processed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="from-view-id"
+                   type="jakartaee:faces-config-from-view-idType"/>
+      <xsd:element name="navigation-case"
+                   type="jakartaee:faces-config-navigation-caseType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="navigation-rule-extension"
+                   type="jakartaee:faces-config-navigation-rule-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-rule-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for navigation-rule.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-null-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "null-value" element indicates that the managed
+        property in which we are nested will be explicitly
+        set to null if our managed bean is automatically
+        created.  This is different from omitting the managed
+        property element entirely, which will cause no
+        property setter to be called for this property.</p>
+        
+        <p>The "null-value" element can only be used when the
+        associated "property-class" identifies a Java class,
+        not a Java primitive.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "property" element represents a JavaBean property of the
+        Java class represented by our parent element.</p>
+        
+        <p>Property names must be unique within the scope of the Java
+        class that is represented by the parent element, and must
+        correspond to property names that will be recognized when
+        performing introspection against that class via
+        java.beans.Introspector.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="property-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-name" element represents the JavaBeans
+            property name under which the corresponding value
+            may be stored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property-class"
+                   type="jakartaee:java-typeType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-class" element represents the Java type
+            of the value associated with this property name.
+            If not specified, it can be inferred from existing
+            classes; however, this element should be specified if
+            the configuration file is going to be the source for
+            generating the corresponding classes.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-value"
+                   type="jakartaee:faces-config-default-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="suggested-value"
+                   type="jakartaee:faces-config-suggested-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="property-extension"
+                   type="jakartaee:faces-config-property-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-protected-viewsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Any view that matches any of the
+        url-patterns in this element may only be reached from another Jakarta Faces 
+        view in the same web application. Because the runtime is aware of
+        which views are protected, any navigation from an unprotected
+        view to a protected view is automatically subject to
+        protection.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-property-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for property.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirectType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "redirect" element indicates that navigation to the
+        specified "to-view-id" should be accomplished by
+        performing an HTTP redirect rather than the usual
+        ViewHandler mechanisms.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="redirect-param"
+                   type="jakartaee:faces-config-redirect-redirectParamType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="include-view-params"
+                   type="xsd:boolean"
+                   use="optional"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirect-viewParamType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element was introduced due to a specification
+        error, and is now deprecated.  The correct name for
+        this element is "redirect-param" and its meaning is
+        documented therein.  The "view-param" element is
+        maintained to preserve backwards compatibility.
+        Implementations must treat this element the same as
+        "redirect-param".</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:string"/>
+      <xsd:element name="value"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirect-redirectParamType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "redirect-param" element, only valid within
+        a "redirect" element, contains child "name"
+        and "value" elements that must be included in the
+        redirect url when the redirect is performed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:string"/>
+      <xsd:element name="value"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-referenced-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "referenced-bean" element represents at design time the
+        promise that a Java object of the specified type will exist at
+        runtime in some scope, under the specified key.  This can be
+        used by design time tools to construct user interface dialogs
+        based on the properties of the specified class.  The presence
+        or absence of a referenced bean element has no impact on the
+        Jakarta Faces runtime environment inside a web application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="referenced-bean-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "referenced-bean-name" element represents the
+            attribute name under which the corresponding
+            referenced bean may be assumed to be stored, in one
+            of 'request', 'session', 'view', 'application'
+            or a custom scope.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="referenced-bean-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "referenced-bean-class" element represents the
+            fully qualified class name of the Java class
+            (either abstract or concrete) or Java interface
+            implemented by the corresponding referenced bean.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-render-kitType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "render-kit" element represents a concrete RenderKit
+        implementation that should be registered under the specified
+        render-kit-id.  If no render-kit-id is specified, the
+        identifier of the default RenderKit
+        (RenderKitFactory.DEFAULT_RENDER_KIT) is assumed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="render-kit-id"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-id" element represents an identifier
+            for the RenderKit represented by the parent
+            "render-kit" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="render-kit-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-class" element represents the fully
+            qualified class name of a concrete RenderKit
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer"
+                   type="jakartaee:faces-config-rendererType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="client-behavior-renderer"
+                   type="jakartaee:faces-config-client-behavior-rendererType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="render-kit-extension"
+                   type="jakartaee:faces-config-render-kit-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-client-behavior-rendererType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "client-behavior-renderer" element represents a concrete
+        ClientBehaviorRenderer implementation class that should be
+        registered under the specified behavior renderer type identifier,
+        in the RenderKit associated with the parent "render-kit"
+        element.  Client Behavior renderer type must be unique within the RenderKit
+        associated with the parent "render-kit" element.</p>
+        
+        <p>Nested "attribute" elements identify generic component
+        attributes that are recognized by this renderer.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="client-behavior-renderer-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "client-behavior-renderer-type" element represents a renderer type
+            identifier for the Client Behavior Renderer represented by the parent
+            "client-behavior-renderer" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-behavior-renderer-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "client-behavior-renderer-class" element represents the fully
+            qualified class name of a concrete Client Behavior Renderer
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-rendererType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "renderer" element represents a concrete Renderer
+        implementation class that should be registered under the
+        specified component family and renderer type identifiers,
+        in the RenderKit associated with the parent "render-kit"
+        element.  Combinations of component family and
+        renderer type must be unique within the RenderKit
+        associated with the parent "render-kit" element.</p>
+        
+        <p>Nested "attribute" elements identify generic component
+        attributes that are recognized by this renderer.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-family"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-family" element represents the
+            component family for which the Renderer represented
+            by the parent "renderer" element will be used.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "renderer-type" element represents a renderer type
+            identifier for the Renderer represented by the parent
+            "renderer" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "renderer-class" element represents the fully
+            qualified class name of a concrete Renderer
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet"
+                   type="jakartaee:faces-config-facetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="renderer-extension"
+                   type="jakartaee:faces-config-renderer-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-renderer-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for renderer.  It may contain implementation
+        specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-render-kit-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for render-kit.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-suggested-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "suggested-value" contains the value for the property or
+        attribute in which this element resides.  This value is
+        advisory only and is intended for tools to use when
+        populating pallettes.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-supported-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "supported-locale" element allows authors to declare
+        which locales are supported in this application instance.</p>
+        
+        <p class="modified_added_2_3">
+        To facilitate BCP 47 this element first needs to be parsed by the
+        Locale.forLanguageTag method. If it does not return a Locale with
+        a language the old specification below needs to take effect.
+        </p>
+        
+        <p>It must be specified as :language:[_:country:[_:variant:]]
+        without the colons, for example "ja_JP_SJIS".  The
+        separators between the segments may be '-' or '_'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-localeType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "behavior" element represents a concrete Behavior
+        implementation class that should be registered under the
+        specified behavior identifier.  Behavior identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Behavior.  Nested "property"
+        elements identify JavaBeans properties of the Behavior
+        implementation class that may be configured to affect the
+        operation of the Behavior.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="behavior-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "behavior-id" element represents the identifier
+            under which the corresponding Behavior class should
+            be registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="behavior-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "behavior-class" element represents the fully
+            qualified class name of a concrete Behavior
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Behavior.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Behavior implementation class
+            that may be configured to affect the operation of
+            the Behavior.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:faces-config-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for behavior.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "validator" element represents a concrete Validator
+        implementation class that should be registered under the
+        specified validator identifier.  Validator identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Validator.  Nested "property"
+        elements identify JavaBeans properties of the Validator
+        implementation class that may be configured to affect the
+        operation of the Validator.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="validator-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-id" element represents the identifier
+            under which the corresponding Validator class should
+            be registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-class" element represents the fully
+            qualified class name of a concrete Validator
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Validator.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Validator implementation class
+            that may be configured to affect the operation of
+            the Validator.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:faces-config-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for validator.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "value" element is the String representation of
+        a literal value to which a scalar managed property
+        will be set, or a value binding expression ("#{...}")
+        that will be used to calculate the required value.
+        It will be converted as specified for the actual
+        property type.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="jakartaee:faces-config-el-expressionType xsd:string"/>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-system-event-listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The presence of this element within the "application" element in
+        an application configuration resource file indicates the
+        developer wants to add an SystemEventListener to this
+        application instance.  Elements nested within this element allow
+        selecting the kinds of events that will be delivered to the
+        listener instance, and allow selecting the kinds of classes that
+        can be the source of events that are delivered to the listener
+        instance.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="system-event-listener-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "system-event-listener-class" element contains
+            the fully qualified class name of the concrete
+            SystemEventListener implementation class that will be
+            called when events of the type specified by the
+            "system-event-class" are sent by the runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="system-event-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "system-event-class" element contains the fully
+            qualified class name of the SystemEvent subclass for
+            which events will be delivered to the class whose fully
+            qualified class name is given by the
+            "system-event-listener-class" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="source-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "source-class" element, if present, contains the
+            fully qualified class name of the class that will be the
+            source for the event to be delivered to the class whose
+            fully qualified class name is given by the
+            "system-event-listener-class" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This type contains the recognized versions of
+        faces-config supported.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="4.1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-fragment_6_1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-fragment_6_1.xsd
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="6.1">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the Servlet 6.1 deployment descriptor.
+      The deployment descriptor must be named "META-INF/web-fragment.xml"
+      in the web fragment's jar file.  All Servlet deployment descriptors
+      must indicate the web application schema by using the Jakarta EE
+      namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <web-fragment xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="6.1">
+      ...
+      </web-fragment>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-fragment_6_1.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="web-common_6_1.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="web-fragment"
+               type="jakartaee:web-fragmentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-fragment element is the root of the deployment
+        descriptor for a web fragment.  Note that the sub-elements
+        of this element can be in the arbitrary order. Because of
+        that, the multiplicity of the elements of distributable,
+        session-config, welcome-file-list, jsp-config, login-config,
+        and locale-encoding-mapping-list was changed from "?" to "*"
+        in this schema.  However, the deployment descriptor instance
+        file must not contain multiple elements of session-config,
+        jsp-config, and login-config. When there are multiple elements of
+        welcome-file-list or locale-encoding-mapping-list, the container
+        must concatenate the element contents.  The multiple occurence
+        of the element distributable is redundant and the container
+        treats that case exactly in the same way when there is only
+        one distributable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="web-common-servlet-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The servlet element contains the name of a servlet.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet"/>
+      <xsd:field xpath="jakartaee:servlet-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-filter-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The filter element contains the name of a filter.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:filter"/>
+      <xsd:field xpath="jakartaee:filter-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-local-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-local-ref-name element contains the name of an 
+          enterprise bean reference. The enterprise bean reference
+          is an entry in the web application's environment and is relative
+          to the java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an  
+          enterprise bean reference. The enterprise bean reference 
+          is an entry in the web application's environment and is relative 
+          to the java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the name of
+          a message destination reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.  The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of a web
+          application's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name
+          must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:key name="web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="web-common-role-name-references"
+                refer="jakartaee:web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet/jakartaee:security-role-ref"/>
+      <xsd:field xpath="jakartaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-fragmentType">
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"/>
+      <xsd:group ref="jakartaee:web-commonType"/>
+      <xsd:element name="ordering"
+                   type="jakartaee:orderingType"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="jakartaee:web-common-attributes"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Please see section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="after"
+                   type="jakartaee:ordering-orderingType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="before"
+                   type="jakartaee:ordering-orderingType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ordering-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element contains a sequence of "name" elements, each of
+        which
+        refers to an application configuration resource by the "name"
+        declared on its web.xml fragment.  This element can also contain
+        a single "others" element which specifies that this document
+        comes
+        before or after other documents within the application.
+        See section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:ordering-othersType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-jsptaglibrary_4_0.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-jsptaglibrary_4_0.xsd
@@ -1,0 +1,1109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="4.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the JSP Taglibrary 
+      descriptor.  All Taglibrary descriptors must 
+      indicate the tag library schema by using the Taglibrary 
+      namespace: 
+      
+      https://jakarta.ee/xml/ns/jakartaee 
+      
+      and by indicating the version of the schema by 
+      using the version element as shown below: 
+      
+      <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="4.0">
+      ...
+      </taglib>
+      
+      The instance documents may indicate the published 
+      version of the schema using xsi:schemaLocation attribute 
+      for Jakarta EE namespace with the following location: 
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_4_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="taglib"
+               type="jakartaee:tldTaglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The taglib tag is the document root.
+        The definition of taglib is provided
+        by the tldTaglibType. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="tag-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The taglib element contains, among other things, tag and 
+          tag-file elements.
+          The name subelements of these elements must each be unique.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag|jakartaee:tag-file"/>
+      <xsd:field xpath="jakartaee:name"/>
+    </xsd:unique>
+    <xsd:unique name="function-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The taglib element contains function elements.
+          The name subelements of these elements must each be unique.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:function"/>
+      <xsd:field xpath="jakartaee:name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="body-contentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies the type of body that is valid for a tag.
+        This value is used by the JSP container to validate 
+        that a tag invocation has the correct body syntax and 
+        by page composition tools to assist the page author 
+        in providing a valid tag body.
+        		    
+        There are currently four values specified:
+        
+        tagdependent    The body of the tag is interpreted by the tag
+        		implementation itself, and is most likely 
+        		in a different "language", e.g embedded SQL 
+        		statements.
+        
+        JSP             The body of the tag contains nested JSP 
+        		syntax.
+        
+        empty           The body must be empty
+        
+        scriptless      The body accepts only template text, EL 
+        		Expressions, and JSP action elements.  No 
+        		scripting elements are allowed.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="tagdependent"/>
+        <xsd:enumeration value="JSP"/>
+        <xsd:enumeration value="empty"/>
+        <xsd:enumeration value="scriptless"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the canonical name of a tag or attribute being
+        defined.
+        
+        The name must conform to the lexical rules for an NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdNMTOKENType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        A validator that can be used to validate
+        the conformance of a JSP page to using this tag library is
+        defined by a validatorType.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="validator-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the TagLibraryValidator class that can be used
+            to validate the conformance of a JSP page to using this
+            tag library.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+                   type="jakartaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The init-param element contains a name/value pair as an
+            initialization param. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The tag defines a unique tag in this tag library.  It has one
+        attribute, id.
+        
+        The tag element may have several subelements defining:
+        
+        description       Optional tag-specific information
+        
+        display-name      A short name that is intended to be 
+        		  displayed by tools
+        
+        icon              Optional icon element that can be used 
+        		  by tools
+        
+        name              The unique action name
+        
+        tag-class         The tag handler class implementing
+        		  jakarta.servlet.jsp.tagext.JspTag
+        
+        tei-class         An optional subclass of
+        		  jakarta.servlet.jsp.tagext.TagExtraInfo
+        
+        body-content      The body content type
+        
+        variable          Optional scripting variable information
+        
+        attribute         All attributes of this action that are
+        		  evaluated prior to invocation.
+        
+        dynamic-attributes Whether this tag supports additional 
+        		   attributes with dynamic names.  If 
+        		   true, the tag-class must implement the 
+        		   jakarta.servlet.jsp.tagext.DynamicAttributes
+        		   interface.  Defaults to false.
+        
+        example           Optional informal description of an 
+        		  example of a use of this tag
+        
+        tag-extension     Zero or more extensions that provide extra
+        		  information about this tag, for tool 
+        		  consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:tld-canonical-nameType"/>
+      <xsd:element name="tag-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the subclass of jakarta.servlet.jsp.tagext.JspTag
+            that implements the request time semantics for 
+            this tag. (required)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tei-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the subclass of jakarta.servlet.jsp.tagext.TagExtraInfo
+            for this tag. (optional)
+            
+            If this is not given, the class is not consulted at
+            translation time.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="body-content"
+                   type="jakartaee:body-contentType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Specifies the format for the body of this tag.
+            The default in JSP 1.2 was "JSP" but because this 
+            is an invalid setting for simple tag handlers, there 
+            is no longer a default in JSP 2.0.  A reasonable 
+            default for simple tag handlers is "scriptless" if 
+            the tag can have a body.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="variable"
+                   type="jakartaee:variableType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:tld-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="dynamic-attributes"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0"/>
+      <xsd:element name="example"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The example element contains an informal description
+            of an example of the use of a tag.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Tag extensions are for tool use only and must not affect
+            the behavior of a container.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tagFileType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines an action in this tag library that is implemented
+        as a .tag file.
+        
+        The tag-file element has two required subelements:
+        
+        description       Optional tag-specific information
+        
+        display-name      A short name that is intended to be 
+        		  displayed by tools
+        
+        icon              Optional icon element that can be used 
+        		  by tools
+        
+        name              The unique action name
+        
+        path              Where to find the .tag file implementing this
+        		  action, relative to the root of the web
+        		  application or the root of the JAR file for a
+        		  tag library packaged in a JAR.  This must
+        		  begin with /WEB-INF/tags if the .tag file
+        		  resides in the WAR, or /META-INF/tags if the
+        		  .tag file resides in a JAR.
+        
+        example           Optional informal description of an 
+        		  example of a use of this tag
+        
+        tag-extension     Zero or more extensions that provide extra
+        		  information about this tag, for tool 
+        		  consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:tld-canonical-nameType"/>
+      <xsd:element name="path"
+                   type="jakartaee:pathType"/>
+      <xsd:element name="example"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The example element contains an informal description
+            of an example of the use of a tag.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Tag extensions are for tool use only and must not affect
+            the behavior of a container.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The function element is used to provide information on each
+        function in the tag library that is to be exposed to the EL.
+        
+        The function element may have several subelements defining:
+        
+        description         Optional tag-specific information
+        
+        display-name        A short name that is intended to be 
+        		    displayed by tools
+        
+        icon                Optional icon element that can be used 
+        		    by tools
+        
+        name                A unique name for this function
+        
+        function-class      Provides the name of the Java class that 
+        		    implements the function
+        
+        function-signature  Provides the signature, as in the Java 
+        		    Language Specification, of the Java 
+        		    method that is to be used to implement 
+        		    the function.
+        
+        example             Optional informal description of an 
+        		    example of a use of this function
+        
+        function-extension  Zero or more extensions that provide extra
+        		    information about this function, for tool 
+        		    consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:tld-canonical-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A unique name for this function.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Provides the fully-qualified class name of the Java
+            class containing the static method that implements 
+            the function.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Provides the signature, of the static Java method that is
+            to be used to implement the function.  The syntax of the
+            function-signature element is as follows:
+            
+            	FunctionSignature ::= ReturnType S MethodName S?
+            			      '(' S? Parameters? S? ')'
+            
+            ReturnType        ::= Type
+            
+            	MethodName        ::= Identifier
+            
+            	Parameters        ::=   Parameter
+            			      | ( Parameter S? ',' S? Parameters )
+            
+            Parameter         ::= Type
+            
+            	Where:
+            
+            	    * Type is a basic type or a fully qualified
+            	      Java class name (including package name),
+            	      as per the 'Type' production in the Java 
+            	      Language Specification, Second Edition, 
+            	      Chapter 18.
+            
+            * Identifier is a Java identifier, as per
+            	      the 'Identifier' production in the Java 
+            	      Language Specification, Second
+            	      Edition, Chapter 18.
+            
+            Example: 
+            
+            java.lang.String nickName( java.lang.String, int )
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="example"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The example element contains an informal description
+            of an example of the use of this function.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="function-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Function extensions are for tool use only and must not 
+            affect the behavior of a container.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tldTaglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The taglib tag is the document root, it defines:
+        
+        description     a simple string describing the "use" of this
+        		taglib, should be user discernable
+        
+        display-name    the display-name element contains a 
+        		short name that is intended to be displayed 
+        		by tools
+        
+        icon            optional icon that can be used by tools
+        
+        tlib-version    the version of the tag library implementation 
+        
+        short-name      a simple default short name that could be 
+        		used by a JSP authoring tool to create 
+        		names with a mnemonic value; for example, 
+        		the it may be used as the prefered prefix 
+        		value in taglib directives
+        
+        uri             a uri uniquely identifying this taglib
+        
+        validator       optional TagLibraryValidator information
+        
+        listener        optional event listener specification
+        
+        tag             tags in this tag library
+        
+        tag-file        tag files in this tag library
+        
+        function        zero or more EL functions defined in this 
+        		tag library
+        
+        taglib-extension zero or more extensions that provide extra
+        		information about this taglib, for tool 
+        		consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tlib-version"
+                   type="jakartaee:dewey-versionType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Describes this version (number) of the taglibrary.
+            It is described as a dewey decimal. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="short-name"
+                   type="jakartaee:tld-canonical-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a simple default name that could be used by
+            a JSP authoring tool to create names with a 
+            mnemonicvalue; for example, it may be used as the 
+            preferred prefix value in taglib directives.  Do 
+            not use white space, and do not start with digits 
+            or underscore. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="uri"
+                   type="jakartaee:xsdAnyURIType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a public URI that uniquely identifies this
+            version of the taglibrary.  Leave it empty if it
+            does not apply.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator"
+                   type="jakartaee:validatorType"
+                   minOccurs="0">
+      </xsd:element>
+      <xsd:element name="listener"
+                   type="jakartaee:listenerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+      <xsd:element name="tag"
+                   type="jakartaee:tagType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-file"
+                   type="jakartaee:tagFileType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="function"
+                   type="jakartaee:functionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Taglib extensions are for tool use only and must not 
+            affect the behavior of a container.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="4.0"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          Describes the JSP version (number) this taglibrary
+          requires in order to function (dewey decimal)
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="variableType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The variableType provides information on the scripting
+        variables defined by using this tag.  It is a (translation 
+        time) error for a tag that has one or more variable 
+        subelements to have a TagExtraInfo class that returns a 
+        non-null value from a call to getVariableInfo().
+        
+        The subelements of variableType are of the form:
+        
+        description              Optional description of this 
+        			 variable
+        
+        name-given               The variable name as a constant
+        
+        name-from-attribute      The name of an attribute whose 
+        			 (translation time) value will 
+        			 give the name of the
+        			 variable.  One of name-given or
+        			 name-from-attribute is required.
+        
+        variable-class           Name of the class of the variable.
+        			 java.lang.String is default.
+        
+        declare                  Whether the variable is declared 
+        			 or not.  True is the default.
+        
+        scope                    The scope of the scripting varaible
+        			 defined.  NESTED is default.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:choice>
+        <xsd:element name="name-given"
+                     type="jakartaee:java-identifierType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The name for the scripting variable.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="name-from-attribute"
+                     type="jakartaee:java-identifierType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The name of an attribute whose
+              (translation-time) value will give the name of 
+              the variable.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="variable-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The optional name of the class for the scripting
+            variable.  The default is java.lang.String.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="declare"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Whether the scripting variable is to be defined
+            or not.  See TagExtraInfo for details.  This 
+            element is optional and "true" is the default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="scope"
+                   type="jakartaee:variable-scopeType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element is optional and "NESTED" is the default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="variable-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines scope of the scripting variable.  See
+        TagExtraInfo for details.  The allowed values are, 
+        "NESTED", "AT_BEGIN" and "AT_END".
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NESTED"/>
+        <xsd:enumeration value="AT_BEGIN"/>
+        <xsd:enumeration value="AT_END"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The attribute element defines an attribute for the nesting
+        tag.  The attribute element may have several subelements 
+        defining: 
+        
+        description     a description of the attribute
+        
+        name            the name of the attribute 
+        
+        required        whether the attribute is required or 
+        		optional 
+        
+        rtexprvalue     whether the attribute is a runtime attribute 
+        
+        type            the type of the attributes 
+        
+        fragment        whether this attribute is a fragment
+        
+        deferred-value  present if this attribute is to be parsed as a
+        jakarta.el.ValueExpression
+        
+        deferred-method present if this attribute is to be parsed as a
+        jakarta.el.MethodExpression
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines if the nesting attribute is required or
+            optional.
+            
+            If not present then the default is "false", i.e 
+            the attribute is optional.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:sequence minOccurs="0">
+            <xsd:element name="rtexprvalue"
+                         type="jakartaee:generic-booleanType">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  	  Defines if the nesting attribute can have scriptlet
+                  	  expressions as a value, i.e the value of the
+                  	  attribute may be dynamically calculated at request
+                  	  time, as opposed to a static value determined at
+                  	  translation time.
+                  	  If not present then the default is "false", i.e the
+                  	  attribute has a static value
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="type"
+                         type="jakartaee:fully-qualified-classType"
+                         minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  	  Defines the Java type of the attributes value.  
+                  If this element is omitted, the expected type is 
+                  assumed to be "java.lang.Object".  
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:choice>
+            <xsd:element name="deferred-value"
+                         type="jakartaee:tld-deferred-valueType"
+                         minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Present if the value for this attribute is to be 
+                  passed to the tag handler as a 
+                  jakarta.el.ValueExpression. This allows for deferred 
+                  evaluation of EL expressions. An optional subelement 
+                  will contain the expected type that the value will 
+                  be coerced to after evaluation of the expression.
+                  The type defaults to Object if one is not provided.
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="deferred-method"
+                         type="jakartaee:tld-deferred-methodType"
+                         minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Present if the value for this attribute is to be 
+                  passed to the tag handler as a 
+                  jakarta.el.MethodExpression. This allows for deferred 
+                  evaluation of an EL expression that identifies a 
+                  method to be invoked on an Object. An optional 
+                  subelement will contain the expected method
+                  signature. The signature defaults to "void method()" 
+                  if one is not provided.
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:choice>
+        </xsd:sequence>
+        <xsd:element name="fragment"
+                     type="jakartaee:generic-booleanType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              "true" if this attribute is of type
+              jakarta.servlet.jsp.tagext.JspFragment, representing dynamic
+              content that can be re-evaluated as many times 
+              as needed by the tag handler.  If omitted or "false",
+              the default is still type="java.lang.String"
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-deferred-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines information about how to provide the value for a
+        tag handler attribute that accepts a jakarta.el.ValueExpression.
+        
+        The deferred-value element has one optional subelement:
+        
+        type            the expected type of the attribute
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully-qualified name of the Java type that is the 
+            expected type for this deferred expression.  If this 
+            element is omitted, the expected type is assumed to be 
+            "java.lang.Object".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-deferred-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines information about how to provide the value for a
+        tag handler attribute that accepts a jakarta.el.MethodExpression.
+        
+        The deferred-method element has one optional subelement:
+        
+        method-signature  Provides the signature, as in the Java
+        Language Specifies, that is expected for 
+        the method being identified by the 
+        expression.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method-signature"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Provides the expected signature of the method identified 
+            by the jakarta.el.MethodExpression.
+            
+            This disambiguates overloaded methods and ensures that 
+            the return value is of the expected type.
+            
+            The syntax of the method-signature element is identical 
+            to that of the function-signature element.  See the 
+            documentation for function-signature for more details.
+            
+            The name of the method is for documentation purposes only 
+            and is ignored by the JSP container.
+            
+            Example:
+            
+            boolean validate(java.lang.String)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The tld-extensionType is used to indicate
+        extensions to a specific TLD element.
+        
+        It is used by elements to designate an extension block
+        that is targeted to a specific extension designated by
+        a set of extension elements that are declared by a
+        namespace. The namespace identifies the extension to
+        the tool that processes the extension.
+        
+        The type of the extension-element is abstract. Therefore,
+        a concrete type must be specified by the TLD using
+        xsi:type attribute for each extension-element. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="extension-element"
+                   type="jakartaee:extensibleType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="namespace"
+                   use="required"
+                   type="xsd:anyURI"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="extensibleType"
+                   abstract="true">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The extensibleType is an abstract base type that is used to
+        define the type of extension-elements. Instance documents
+        must substitute a known type to define the extension by
+        using xsi:type attribute to define the actual type of
+        extension-elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-partialresponse_4_1.xsd
+++ b/appserver/deployment/schemas/src/main/resources/glassfish/lib/schemas/web-partialresponse_4_1.xsd
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            attributeFormDefault="unqualified"
+            elementFormDefault="qualified"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            version="4.1"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="jakartaee_11.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2024 Contributors to Eclipse Foundation.
+
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>
+      
+      The XML Schema for the Jakarta Faces (Version 4.1)  
+      Partial Response used in Jakarta Faces Ajax frameworks.
+      
+      </p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="partial-response"
+               type="jakartaee:partial-responseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "partial-response" element is the root of the
+        partial response information hierarchy, and contains
+        nested elements for all possible elements that can exist
+        in the response.</p>
+        
+        <p>This element must have an "id" attribute whose value
+        is the return from calling getContainerClientId() on the
+        UIViewRoot to which this response pertains.
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-responseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "partial-response" element is the root of the
+        partial response information hierarchy, and contains
+        nested elements for all possible elements that can exist
+        in the response.
+        
+        <p>
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="changes"
+                   type="jakartaee:partial-response-changesType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="redirect"
+                   type="jakartaee:partial-response-redirectType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="error"
+                   type="jakartaee:partial-response-errorType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          [
+          <p class="changed_added_2_2">This element must have an "id" attribute whose value
+          is the return from calling getContainerClientId() on the
+          UIViewRoot to which this response pertains.<p> 
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-changesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "changes" element contains a collection of child elements,
+        each of which describes a different change to be applied to the
+        view in the user agent.
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="update"
+                   type="jakartaee:partial-response-updateType"/>
+      <xsd:element name="insert"
+                   type="jakartaee:partial-response-insertType"/>
+      <xsd:element name="delete"
+                   type="jakartaee:partial-response-deleteType"/>
+      <xsd:element name="attributes"
+                   type="jakartaee:partial-response-attributesType"/>
+      <xsd:element name="eval"
+                   type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            [
+            <p>
+            
+            The "eval" element enables this element's
+            contents to be executed as JavaScript.
+            
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="extension"
+                   type="jakartaee:partial-response-extensionType"/>
+    </xsd:choice>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-updateType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "update" element enables DOM elements matching the "id"
+        attribute to be updated with the contents of this element. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:any processContents="skip"
+               namespace="##any"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-insertType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "insert" element enables content to be inserted into the DOM
+        before or after an existing DOM element as specified by the
+        nested "before" or "after" elements.  The elements "before" and
+        "after" are mutually exclusive - one of them must be specified. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="1"
+                maxOccurs="1">
+      <xsd:element name="before">
+
+<!-- **************************************************** -->
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any namespace="##any"
+                     processContents="lax"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="id"
+                         type="xsd:string"
+                         use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="after">
+
+<!-- **************************************************** -->
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any namespace="##any"
+                     processContents="lax"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="id"
+                         type="xsd:string"
+                         use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:choice>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-deleteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "delete" element enables DOM elements matching the "id"
+        attribute to be removed. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-attributesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "attributes" element enables attributes of DOM elements matching the "id"
+        attribute to be updated.  If this element is used, then it must contain at
+        least one "attribute" element. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="attribute"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+
+<!-- **************************************************** -->
+
+        <xsd:complexType>
+          <xsd:attribute name="name"
+                         type="xsd:string"
+                         use="required"/>
+          <xsd:attribute name="value"
+                         type="xsd:string"
+                         use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-redirectType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "redirect" element enables a redirect to the location as specified by the
+        "url" attribute. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="url"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-errorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "error" element contains error information from the server. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="error-name"
+                   type="xsd:string"
+                   minOccurs="1"
+                   maxOccurs="1"/>
+      <xsd:element name="error-message"
+                   type="xsd:string"
+                   minOccurs="1"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        Extension element for partial response.  It may contain
+        implementation specific content.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
According to https://jakarta.ee/xml/ns/jakartaee/#11

Without missing EE 10 schemas, which will be merged from master after this is merged: https://github.com/eclipse-ee4j/glassfish/pull/25532