### PR TITLE
Improve --add-opens - naming module

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,13 +18,10 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-    - name: Install Maven
-      run: |
-        curl -s -S -o ./apache-maven-3.9.9-bin.zip https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip
-        unzip -q ./apache-maven-3.9.9-bin.zip
-        ss -tulpn
+    - name: List ports
+      run: ss -tulpn
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: ./apache-maven-3.9.9/bin/mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
+      run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
 

--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -217,7 +217,7 @@
         <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-        <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
@@ -415,7 +415,7 @@
              <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-             <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+             <jvm-options>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</jvm-options>
              <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>

--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/GlassFishNamingBuilder.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/GlassFishNamingBuilder.java
@@ -19,13 +19,10 @@ package com.sun.enterprise.naming;
 
 import com.sun.enterprise.naming.impl.SerialInitContextFactory;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
-import java.lang.reflect.Field;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Hashtable;
 
 import javax.naming.Context;
@@ -33,14 +30,12 @@ import javax.naming.NamingException;
 import javax.naming.NoInitialContextException;
 import javax.naming.spi.InitialContextFactory;
 import javax.naming.spi.InitialContextFactoryBuilder;
-import javax.naming.spi.NamingManager;
 
-import org.glassfish.hk2.api.PostConstruct;
-import org.glassfish.hk2.api.PreDestroy;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.glassfish.internal.api.InitRunLevel;
 import org.glassfish.internal.api.ServerContext;
 import org.glassfish.logging.annotation.LogMessageInfo;
+import org.glassfish.main.jdke.JavaApiGaps;
 import org.jvnet.hk2.annotations.Service;
 
 import static com.sun.enterprise.naming.util.LogFacade.logger;
@@ -62,8 +57,7 @@ import static java.util.logging.Level.WARNING;
  */
 @Service
 @RunLevel(value = InitRunLevel.VAL, mode = RunLevel.RUNLEVEL_MODE_NON_VALIDATING)
-public class GlassFishNamingBuilder implements InitialContextFactoryBuilder, PostConstruct, PreDestroy {
-    private static final String FIELD_INITCTX_FACTORY_BUILDER = "initctx_factory_builder";
+public class GlassFishNamingBuilder implements InitialContextFactoryBuilder {
 
     @LogMessageInfo(message = "Failed to load {0} using CommonClassLoader")
     public static final String FAILED_TO_LOAD_CLASS = "AS-NAMING-00001";
@@ -83,13 +77,27 @@ public class GlassFishNamingBuilder implements InitialContextFactoryBuilder, Pos
     @Inject
     private ServerContext serverContext;
 
+
+    @PostConstruct
+    public void postConstruct() throws NamingException {
+        if (isUsingBuilder()) {
+            JavaApiGaps.setInitialContextFactoryBuilder(GlassFishNamingBuilder.this);
+        }
+    }
+
+    @PreDestroy
+    public void preDestroy() throws NamingException {
+        if (isUsingBuilder()) {
+            JavaApiGaps.unsetInitialContextFactoryBuilder();
+        }
+    }
+
     @Override
     public InitialContextFactory createInitialContextFactory(Hashtable<?, ?> environment) throws NamingException {
         if (environment != null) {
             // As per the documentation of Context.INITIAL_CONTEXT_FACTORY,
             // it represents a fully qualified class name.
             String className = (String) environment.get(Context.INITIAL_CONTEXT_FACTORY);
-
             if (className != null) {
                 try {
                     return (InitialContextFactory) (loadClass(className).getDeclaredConstructor().newInstance());
@@ -131,69 +139,6 @@ public class GlassFishNamingBuilder implements InitialContextFactoryBuilder, Pos
             }
 
             throw e;
-        }
-    }
-
-    @Override
-    public void postConstruct() {
-        try {
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                try {
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                        @Override
-                        public Void run() throws NamingException {
-                            if (isUsingBuilder()) {
-                                NamingManager.setInitialContextFactoryBuilder(GlassFishNamingBuilder.this);
-                            }
-                            return null; //Nothing to return
-                        }
-                    });
-                } catch (PrivilegedActionException e) {
-                    Object obj = e.getCause();
-                    if (obj instanceof NamingException) {
-                        throw (NamingException) obj;
-                    }
-                }
-            } else if (isUsingBuilder()) {
-                NamingManager.setInitialContextFactoryBuilder(this);
-            }
-
-        } catch (NamingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public void preDestroy() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    if (isUsingBuilder()) {
-                        resetInitialContextFactoryBuilder();
-                    }
-                    return null;
-                }
-            });
-        } else {
-            if (isUsingBuilder()) {
-                resetInitialContextFactoryBuilder();
-            }
-        }
-    }
-
-    private void resetInitialContextFactoryBuilder() {
-        try {
-            Field initctxFactoryBuilderField = NamingManager.class.getDeclaredField(FIELD_INITCTX_FACTORY_BUILDER);
-            initctxFactoryBuilderField.setAccessible(true);
-            initctxFactoryBuilderField.set(null, null);
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException(
-                "Reflection to the field " + NamingManager.class.getName() + "," + FIELD_INITCTX_FACTORY_BUILDER
-                    + " is prohibited, you have to use --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED",
-                e);
         }
     }
 

--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/GlassFishNamingBuilder.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/GlassFishNamingBuilder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -62,6 +63,8 @@ import static java.util.logging.Level.WARNING;
 @Service
 @RunLevel(value = InitRunLevel.VAL, mode = RunLevel.RUNLEVEL_MODE_NON_VALIDATING)
 public class GlassFishNamingBuilder implements InitialContextFactoryBuilder, PostConstruct, PreDestroy {
+    private static final String FIELD_INITCTX_FACTORY_BUILDER = "initctx_factory_builder";
+
     @LogMessageInfo(message = "Failed to load {0} using CommonClassLoader")
     public static final String FAILED_TO_LOAD_CLASS = "AS-NAMING-00001";
 
@@ -183,11 +186,14 @@ public class GlassFishNamingBuilder implements InitialContextFactoryBuilder, Pos
 
     private void resetInitialContextFactoryBuilder() {
         try {
-            Field initctxFactoryBuilderField = NamingManager.class.getDeclaredField("initctx_factory_builder");
+            Field initctxFactoryBuilderField = NamingManager.class.getDeclaredField(FIELD_INITCTX_FACTORY_BUILDER);
             initctxFactoryBuilderField.setAccessible(true);
             initctxFactoryBuilderField.set(null, null);
         } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(
+                "Reflection to the field " + NamingManager.class.getName() + "," + FIELD_INITCTX_FACTORY_BUILDER
+                    + " is prohibited, you have to use --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED",
+                e);
         }
     }
 

--- a/appserver/extras/embedded/tests/pom.xml
+++ b/appserver/extras/embedded/tests/pom.xml
@@ -31,6 +31,10 @@
 
     <name>GlassFish Embedded Modules - Tests</name>
 
+    <properties>
+        <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/appserver/resources/resources-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/resources-connector/src/test/resources/DomainTest.xml
@@ -153,7 +153,7 @@
         <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
-        <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</jvm-options>
         <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
       </java-config>
       <thread-pools>

--- a/appserver/tests/appserv-tests/config/common.xml
+++ b/appserver/tests/appserv-tests/config/common.xml
@@ -1428,7 +1428,7 @@ AS_ADMIN_MASTERPASSWORD=${master.password}
     <echo message="Running standalone app client with classpath: ${appclient.standalone.classpath}" level="verbose" />
     <java fork="on" failonerror="true" classname="${mainClass}">
         <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-        <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+        <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
         <jvmarg value="--add-modules" />
         <jvmarg value="ALL-MODULE-PATH" />
         <jvmarg value="${appclient.standalone.debug}" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/basic/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/basic/build.xml
@@ -75,7 +75,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/datasourcedef/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/datasourcedef/build.xml
@@ -74,7 +74,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/ejbandwar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/ejbandwar/build.xml
@@ -100,7 +100,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${jndiroot}"/>
         </java>
     </target>
@@ -116,7 +116,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
 <!--
            <jvmarg value="-Dorg.glassfish.ejb.embedded.keep-temporary-files=true"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/ejbinwar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/ejbinwar/build.xml
@@ -91,7 +91,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${appname}"/>
         </java>
     </target>
@@ -106,7 +106,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${jndiroot}"/>
            <arg line="installed_instance"/>
         </java>
@@ -122,7 +122,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${appname}"/>
            <arg line="servlet"/>
         </java>
@@ -137,7 +137,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${jndiroot}"/>
         </java>
     </target>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/embedasync/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/embedasync/build.xml
@@ -74,7 +74,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/jaxrs/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/jaxrs/build.xml
@@ -136,7 +136,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${appname}"/>
            <arg line="${test}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/mdb/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/mdb/build.xml
@@ -139,7 +139,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <jvmarg value="-Dcom.sun.aas.imqBin=${env.S1AS_HOME}/../mq/bin" />
            <jvmarg value="-Dcom.sun.aas.imqLib=${env.S1AS_HOME}/../mq/lib" />

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithappname/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithappname/build.xml
@@ -83,7 +83,7 @@
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="-Dorg.glassfish.ejb.embedded.keep-temporary-files=true"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${module}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithinheritance/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithinheritance/build.xml
@@ -86,7 +86,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithlibs/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithlibs/build.xml
@@ -86,7 +86,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithmanifest/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/modulewithmanifest/build.xml
@@ -84,7 +84,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/remote/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/remote/build.xml
@@ -83,7 +83,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/skipjar/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/skipjar/build.xml
@@ -87,7 +87,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${jndiroot}"/>
         </java>
     </target>
@@ -104,7 +104,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${jndiroot}"/>
         </java>
     </target>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/testclose/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/testclose/build.xml
@@ -75,7 +75,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/timertest/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/timertest/build.xml
@@ -83,7 +83,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${jndiroot}"/>
            <arg line="${persistent}"/>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/twocontainers/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/twocontainers/build.xml
@@ -74,7 +74,7 @@
           <jvmarg value="--add-modules" />
           <jvmarg value="ALL-MODULE-PATH" />
           <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-          <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+          <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
           <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
           <arg line="${jndiroot}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/twomodules/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/twomodules/build.xml
@@ -80,7 +80,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${appname}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/twomoduleswithlibs/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/embedded/twomoduleswithlibs/build.xml
@@ -114,7 +114,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${appname}"/>
         </java>
     </target>
@@ -129,7 +129,7 @@
            <jvmarg value="--add-modules" />
            <jvmarg value="ALL-MODULE-PATH" />
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <jvmarg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:9009" if:set="env.GLASSFISH_SUSPEND" />
            <arg line="${appname}"/>
         </java>

--- a/appserver/tests/appserv-tests/devtests/ejb/ejb31/security/simple/build.xml
+++ b/appserver/tests/appserv-tests/devtests/ejb/ejb31/security/simple/build.xml
@@ -119,7 +119,7 @@
               classname="${se.client}">
            <sysproperty key="org.omg.CORBA.ORBInitialPort" value="${orb.port}"/>
            <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED" />
-           <jvmarg value="--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED" />
+           <jvmarg value="--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke" />
            <arg line="${jndiroot}"/>
            <arg line="anonymous"/>
         </java>

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -18,8 +18,9 @@
 
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -32,8 +33,9 @@
     <artifactId>embedded</artifactId>
     <packaging>pom</packaging>
     <name>GlassFish Embedded Tests</name>
-    
+
     <properties>
+        <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
         <surefire.workdir>${project.build.directory}/surefire-workdir</surefire.workdir>
         <failsafe.workdir>${project.build.directory}/failsafe-workdir</failsafe.workdir>
     </properties>

--- a/appserver/tests/embedded/scatteredarchive/pom.xml
+++ b/appserver/tests/embedded/scatteredarchive/pom.xml
@@ -32,6 +32,7 @@
     <artifactId>scatteredarchive</artifactId>
     <name>Scattered Archive Test</name>
     <packaging>war</packaging>
+
     <build>
         <finalName>scatteredarchive</finalName>
         <plugins>

--- a/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
@@ -15,7 +15,6 @@
  */
 package com.sun.ts.run;
 
-import com.sun.javatest.Status;
 import com.sun.ts.lib.harness.ExecTSTestCmd;
 
 import java.io.IOException;

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -178,7 +178,7 @@
         <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-        <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
@@ -338,7 +338,7 @@
              <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.nio.fs=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED</jvm-options>
-             <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+             <jvm-options>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</jvm-options>
              <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</jvm-options>
              <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>

--- a/nucleus/common/glassfish-jdk-extensions/pom.xml
+++ b/nucleus/common/glassfish-jdk-extensions/pom.xml
@@ -31,6 +31,10 @@
     <name>GlassFish JDK Extensions</name>
     <description>Things we would like to see in JDK</description>
 
+    <properties>
+        <maven.test.jvmoptions.add-opens>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</maven.test.jvmoptions.add-opens>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/nucleus/common/glassfish-jdk-extensions/src/main/java/module-info.java
+++ b/nucleus/common/glassfish-jdk-extensions/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,9 @@
 module org.glassfish.main.jdke {
 
     requires java.base;
+    requires transitive java.naming;
 
+    exports org.glassfish.main.jdke;
     exports org.glassfish.main.jdke.cl;
     exports org.glassfish.main.jdke.i18n;
     exports org.glassfish.main.jdke.props;

--- a/nucleus/common/glassfish-jdk-extensions/src/main/java/org/glassfish/main/jdke/JavaApiGaps.java
+++ b/nucleus/common/glassfish-jdk-extensions/src/main/java/org/glassfish/main/jdke/JavaApiGaps.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.jdke;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactoryBuilder;
+import javax.naming.spi.NamingManager;
+
+/**
+ * This class collects missing gaps in JDK's public API, which are needed.
+ */
+public final class JavaApiGaps {
+
+    @SuppressWarnings("removal")
+    private static final SecurityManager SECURITY_MANAGER = System.getSecurityManager();
+    private static final String FIELD_INITCTX_FACTORY_BUILDER = "initctx_factory_builder";
+
+
+    private JavaApiGaps() {
+        // Prevent instantiation
+    }
+
+
+    /**
+     * Sets the InitialContextFactoryBuilder in NamingManager if it was not set yet.
+     * <p>
+     * This is used to reset the {@link InitialContextFactoryBuilder} when necessary, because the
+     * class doesn't have any suitable public method for that.
+     *
+     * @param builder the InitialContextFactoryBuilder to set
+     *
+     * @throws NamingException
+     * @throws IllegalStateException if the builder was already set
+     */
+    public static void setInitialContextFactoryBuilder(InitialContextFactoryBuilder builder) throws NamingException {
+        NamingAction action = () -> NamingManager.setInitialContextFactoryBuilder(builder);
+        if (SECURITY_MANAGER == null) {
+            action.execute();
+            return;
+        }
+        doPrivilegedNamingAction(action);
+    }
+
+
+    /**
+     * Sets the InitialContextFactoryBuilder in NamingManager to null.
+     * <p>
+     * This is used to reset the {@link InitialContextFactoryBuilder} when necessary, because the
+     * class doesn't have any suitable public method for that.
+     * @throws NamingException
+     */
+    public static void unsetInitialContextFactoryBuilder() throws NamingException {
+        NamingAction action = () -> set(NamingManager.class, FIELD_INITCTX_FACTORY_BUILDER, null);
+        if (SECURITY_MANAGER == null) {
+            action.execute();
+            return;
+        }
+        doPrivilegedNamingAction(action);
+    }
+
+
+    private static void set(Class<?> type, String fieldName, Object value) {
+        try {
+            Field field = type.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(null, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(
+                "Reflection to the field " + type.getCanonicalName() + "." + fieldName + " failed.", e);
+        }
+    }
+
+
+    private static void doPrivilegedNamingAction(NamingAction action) throws NamingException {
+        try {
+            AccessController.doPrivileged(action);
+        } catch (PrivilegedActionException e) {
+            Throwable cause = e.getCause();
+            // Runtime and Naming exceptions same as if there would be no security manager
+            if (cause instanceof NamingException) {
+                throw (NamingException) cause;
+            } else if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException("Failed to execute privileged naming action.", e);
+        }
+    }
+
+
+    @FunctionalInterface
+    private interface NamingAction extends PrivilegedExceptionAction<Void> {
+        @Override
+        default Void run() throws PrivilegedActionException {
+            try {
+                execute();
+                return null;
+            } catch (Exception e) {
+                throw new PrivilegedActionException(e);
+            }
+        }
+
+        void execute() throws NamingException;
+    }
+}

--- a/nucleus/common/glassfish-jdk-extensions/src/test/java/org/glassfish/main/jdke/JavaApiGapsTest.java
+++ b/nucleus/common/glassfish-jdk-extensions/src/test/java/org/glassfish/main/jdke/JavaApiGapsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.jdke;
+
+import java.util.Hashtable;
+
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+import javax.naming.spi.InitialContextFactoryBuilder;
+
+import org.junit.jupiter.api.Test;
+
+public class JavaApiGapsTest {
+
+    @Test
+    void setAndUnsetNamingManagerInitialContextFactoryBuilder() throws NamingException {
+        JavaApiGaps.setInitialContextFactoryBuilder(new TestInitialContextFactoryBuilder());
+        JavaApiGaps.unsetInitialContextFactoryBuilder();
+    }
+
+
+    private static final class TestInitialContextFactoryBuilder implements InitialContextFactoryBuilder {
+
+        @Override
+        public InitialContextFactory createInitialContextFactory(Hashtable<?, ?> environment) throws NamingException {
+            return null;
+        }
+    }
+}

--- a/nucleus/core/kernel/src/test/resources/DomainTest.xml
+++ b/nucleus/core/kernel/src/test/resources/DomainTest.xml
@@ -149,7 +149,7 @@
         <jvm-options>--add-opens=java.base/java.lang=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.base/java.util=ALL-UNNAMED</jvm-options>
         <jvm-options>--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED</jvm-options>
-        <jvm-options>--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</jvm-options>
+        <jvm-options>--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke</jvm-options>
         <jvm-options>--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</jvm-options>
       </java-config>
       <network-config>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -169,7 +169,7 @@
         <!-- Overrides the value from parent and enables the one we generate. -->
         <project.build.outputTimestamp>2025-04-22T16:51:49Z</project.build.outputTimestamp>
 
-        <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens=java.naming/javax.naming.spi=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
+        <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
         <maven.test.jvmoptions.memory.sizes>-Xss512k -Xms256m -Xmx1g -XX:MaxDirectMemorySize=512m</maven.test.jvmoptions.memory.sizes>
         <maven.test.jvmoptions.memory.gc>-verbose:gc -XX:+UseG1GC -XX:+UseStringDeduplication</maven.test.jvmoptions.memory.gc>
         <maven.test.jvmoptions.display>-Djava.awt.headless=true</maven.test.jvmoptions.display>


### PR DESCRIPTION
* Improved GlassFishNamingBuilder exception when JPMS prohibited our call
* Hacking of the JDK moved to a special class to limit the scope of these hacks and to be well prepared for future JDK changes
- Embedded does not use JPMS at this moment, so it still opens `ALL_UNNAMED`
