### PR TITLE
Improving ProcessManager stability

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/JarSigner.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/JarSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,7 +54,7 @@ public class JarSigner {
         command.addAll(parameters);
 
         final ProcessManager processManager = new ProcessManager(command);
-        processManager.setTimeoutMsec(60_000);
+        processManager.setTimeout(60_000);
         processManager.setEcho(true);
 
         int exitCode;

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/KeyTool.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/KeyTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -64,7 +64,7 @@ public class KeyTool {
         command.addAll(parameters);
 
         final ProcessManager processManager = new ProcessManager(command);
-        processManager.setTimeoutMsec(60_000);
+        processManager.setTimeout(60_000);
         processManager.setEcho(true);
 
         int exitCode;

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -238,7 +238,7 @@ public class Asadmin {
         command.addAll(parameters);
 
         final ProcessManager processManager = new ProcessManager(command);
-        processManager.setTimeoutMsec(timeout);
+        processManager.setTimeout(timeout);
         processManager.setEcho(false);
         for (Entry<String, String> env : this.environment.entrySet()) {
             processManager.setEnvironment(env.getKey(), env.getValue());

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/StartServ.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/StartServ.java
@@ -125,7 +125,7 @@ public class StartServ {
         command.addAll(parameters);
 
         final ProcessManager processManager = new ProcessManager(command);
-        processManager.setTimeoutMsec(timeout);
+        processManager.setTimeout(timeout, false);
         processManager.setEcho(false);
         processManager.setTextToWaitFor(textToWaitFor);
         for (Entry<String, String> env : this.environment.entrySet()) {

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/services/SMFService.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/services/SMFService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -399,7 +399,7 @@ public final class SMFService extends ServiceAdapter {
         try {
             final String[] cmd = new String[] { path2Auths, user };
             ProcessManager pm = new ProcessManager(cmd);
-            pm.setTimeoutMsec(DEFAULT_SERVICE_TIMEOUT);
+            pm.setTimeout(DEFAULT_SERVICE_TIMEOUT);
             pm.execute();
             auths.append(pm.getStdout());
             final StringTokenizer st = new StringTokenizer(pm.getStdout(), at);
@@ -422,7 +422,7 @@ public final class SMFService extends ServiceAdapter {
         try {
             final String[] cmd = new String[] {"/usr/bin/svcs", sn};
             ProcessManager pm = new ProcessManager(cmd);
-            pm.setTimeoutMsec(DEFAULT_SERVICE_TIMEOUT);
+            pm.setTimeout(DEFAULT_SERVICE_TIMEOUT);
             int exitCode = pm.execute();
             if (exitCode == 0) {
                 exists = true;
@@ -462,7 +462,7 @@ public final class SMFService extends ServiceAdapter {
     private void validateService() throws Exception {
         final String[] cmda = new String[] { SMFService.SVCCFG, "validate", getManifestFile().getAbsolutePath() };
         final ProcessManager pm = new ProcessManager(cmda);
-        pm.setTimeoutMsec(DEFAULT_SERVICE_TIMEOUT);
+        pm.setTimeout(DEFAULT_SERVICE_TIMEOUT);
         pm.execute();
         if (info.trace) {
             printOut("Validated the SMF Service: " + info.fqsn + " using: " + SMFService.SVCCFG);
@@ -472,7 +472,7 @@ public final class SMFService extends ServiceAdapter {
     private boolean importService() throws Exception {
         final String[] cmda = new String[] { SMFService.SVCCFG, "import", getManifestFile().getAbsolutePath() };
         final ProcessManager pm = new ProcessManager(cmda);
-        pm.setTimeoutMsec(DEFAULT_SERVICE_TIMEOUT);
+        pm.setTimeout(DEFAULT_SERVICE_TIMEOUT);
         if (info.dryRun) {
             cleanupManifest();
         }

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/CreateRemoteNodeCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/CreateRemoteNodeCommand.java
@@ -268,7 +268,7 @@ public abstract class CreateRemoteNodeCommand implements AdminCommand {
         if (logger.isLoggable(Level.INFO)) {
             logger.info("Running command on DAS: " + commandListToString(fullcommand));
         }
-        pm.setTimeoutMsec(DEFAULT_TIMEOUT_MSEC);
+        pm.setTimeout(DEFAULT_TIMEOUT_MSEC);
 
         if (logger.isLoggable(Level.FINER)) {
             pm.setEcho(true);

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/DeleteNodeRemoteCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/DeleteNodeRemoteCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -104,14 +105,17 @@ public abstract class DeleteNodeRemoteCommand implements AdminCommand {
             SshConnector sshC = node.getSshConnector();
             SshAuth sshAuth = sshC.getSshAuth();
 
-            if (sshAuth.getPassword() != null)
+            if (sshAuth.getPassword() != null) {
                 info.add(NodeUtils.PARAM_REMOTEPASSWORD, sshAuth.getPassword());
+            }
 
-            if (sshAuth.getKeyPassphrase() != null)
+            if (sshAuth.getKeyPassphrase() != null) {
                 info.add(NodeUtils.PARAM_SSHKEYPASSPHRASE, sshAuth.getKeyPassphrase());
+            }
 
-            if (sshAuth.getKeyfile() != null)
+            if (sshAuth.getKeyfile() != null) {
                 info.add(NodeUtils.PARAM_SSHKEYFILE, sshAuth.getKeyfile());
+            }
 
             info.add(NodeUtils.PARAM_INSTALLDIR, node.getInstallDir());
             info.add(NodeUtils.PARAM_REMOTEPORT, sshC.getSshPort());
@@ -212,18 +216,20 @@ public abstract class DeleteNodeRemoteCommand implements AdminCommand {
         fullcommand.addAll(cmdLine);
 
         ProcessManager pm = new ProcessManager(fullcommand);
-        if (!pass.isEmpty())
+        if (!pass.isEmpty()) {
             pm.setStdinLines(pass);
+        }
 
         if (logger.isLoggable(Level.INFO)) {
             logger.info("Running command on DAS: " + commandListToString(fullcommand));
         }
-        pm.setTimeoutMsec(DEFAULT_TIMEOUT_MSEC);
+        pm.setTimeout(DEFAULT_TIMEOUT_MSEC);
 
-        if (logger.isLoggable(Level.FINER))
+        if (logger.isLoggable(Level.FINER)) {
             pm.setEcho(true);
-        else
+        } else {
             pm.setEcho(false);
+        }
 
         try {
             exit = pm.execute();

--- a/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHKeyInstaller.java
+++ b/nucleus/cluster/ssh/src/main/java/org/glassfish/cluster/ssh/launcher/SSHKeyInstaller.java
@@ -209,7 +209,7 @@ public class SSHKeyInstaller {
         ProcessManager pm = new ProcessManager(cmdLine);
 
         LOG.log(DEBUG, () -> "Command = " + log);
-        pm.setTimeoutMsec(DEFAULT_TIMEOUT_MSEC);
+        pm.setTimeout(DEFAULT_TIMEOUT_MSEC);
 
         if (LOG.isLoggable(DEBUG)) {
             pm.setEcho(true);

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,73 +18,124 @@
 package com.sun.enterprise.universal.process;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 import java.lang.System.Logger;
-import java.lang.System.Logger.Level;
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.TRACE;
+import static java.lang.System.Logger.Level.WARNING;
 
 
 /**
- * Use this class for painless process spawning.
- * <p>
- * This class was originally written to be compatible with JDK 1.4, using Runtime.exec(),
- * but has been refactored to use ProcessBuilder for better control and configurability.
+ * Extension of {@link ProcessBuilder} that provides additional functionality to manage input and
+ * output of the process.
  *
- * @since JDK 1.4
  * @author bnevins 2005
+ * @author Ondro Mihalyi
+ * @author David Matejcek
  */
-public class ProcessManager {
+public final class ProcessManager {
     private static final Logger LOG = System.getLogger(ProcessManager.class.getName());
 
-    protected final ProcessBuilder builder;
+    private String[] stdinLines;
+    private boolean echo = true;
     private String stdout;
     private String stderr;
-    private int timeout;
     private String textToWaitFor;
-    private boolean echo = true;
-    private String[] stdinLines;
+    private int timeout;
+    private boolean forceExit = true;
 
+    private final ProcessBuilder builder;
+
+    /**
+     * Creates a new ProcessManager with the specified command line.
+     *
+     * @param cmds must not be null or empty.
+     */
     public ProcessManager(String... cmds) {
         builder = new ProcessBuilder(cmds);
     }
 
 
+    /**
+     * Creates a new ProcessManager with the specified command line.
+     *
+     * @param cmdline must not be null or empty.
+     */
     public ProcessManager(List<String> cmdline) {
         builder = new ProcessBuilder(cmdline);
     }
 
 
-    public void setTimeoutMsec(int num) {
-        if (num > 0) {
-            timeout = num;
+    /**
+     * Sets the timeout for the process execution or for the detected text in the output.
+     * If the process does not finish within the specified timeout, it will be terminated.
+     *
+     * @param millis the timeout in milliseconds, must not be negative
+     */
+    public void setTimeout(int millis) {
+        setTimeout(millis, true);
+    }
+
+
+    /**
+     * Sets the timeout for the process execution or for the detected text in the output.
+     * If the process does not finish within the specified timeout, it can be terminated automatically.
+     *
+     * @param millis the timeout in milliseconds, must not be negative
+     * @param forceExit if true, the process will be forcibly terminated if it does not finish within the timeout
+     */
+    public void setTimeout(int millis, boolean forceExit) {
+        if (millis < 0) {
+            throw new IllegalArgumentException("Timeout cannot be negative: " + millis);
         }
+        this.timeout = millis;
+        this.forceExit = forceExit;
     }
 
+
+    /**
+     * Sets an environment variable for the process.
+     *
+     * @param name the name of the environment variable, must not be null
+     * @param value the value of the environment variable, can be null
+     */
     public void setEnvironment(String name, String value) {
-        Map<String, String> env = builder.environment();
-        env.put(name, value);
+        builder.environment().put(name, value);
     }
 
+
+    /**
+     * Sets the working directory for the process.
+     *
+     * @param directory the working directory, must not be null
+     */
     public void setWorkingDir(File directory) {
         builder.directory(directory);
     }
 
+
+    /**
+     * Sets the input lines for the process.
+     * The lines will be written to the process's standard input.
+     *
+     * @param list a list of strings to be written to the process's standard input,
+     *            can be null or empty
+     */
     public void setStdinLines(List<String> list) {
         if (list != null && !list.isEmpty()) {
             stdinLines = list.toArray(String[]::new);
         }
     }
-
 
     /**
      * Should the output of the process be echoed to stdout?
@@ -96,7 +147,8 @@ public class ProcessManager {
     }
 
     /**
-     * If not null, should wait until this text is found in standard output instead of waiting until the process terminates
+     * If not null, should wait until this text is found in standard output instead of waiting until
+     * the process terminates
      *
      * @param textToWaitFor
      */
@@ -104,75 +156,67 @@ public class ProcessManager {
         this.textToWaitFor = textToWaitFor;
     }
 
+
+    /**
+     * Returns the standard output of the process. If the textToWaitFor was set, the output
+     * will contain all lines read from the process until the textToWaitFor was found.
+     *
+     * @return the standard output of the process
+     */
+    public String getStdout() {
+        return stdout;
+    }
+
+
+    /**
+     * Returns the standard error output of the process. If the textToWaitFor was set, the output
+     * will contain all lines read from the process until the textToWaitFor was found.
+     *
+     * @return the standard error output of the process
+     */
+    public String getStderr() {
+        return stderr;
+    }
+
+
+    /**
+     * Executes the command and waits for it to finish while reading its output.
+     *
+     * @return exit code. Can be overridden internally when we are waiting for a specific text in
+     *         output and we succeeded despite the process failed or even did not finish.
+     *         If we have found the output, we don't kill the process.
+     * @throws ProcessManagerException
+     */
     public int execute() throws ProcessManagerException {
-        LOG.log(Level.DEBUG, "Executing command:\n  command={0}  \nenv={1}", builder.command(), builder.environment());
+        LOG.log(DEBUG, "Executing command:\n  command={0}  \nenv={1}", builder.command(), builder.environment());
         final Process process;
         try {
             process = builder.start();
         } catch (IOException e) {
             throw new IllegalStateException("Could not execute command: " + builder.command(), e);
         }
-        ReaderThread threadErr = new ReaderThread(process.getErrorStream(), echo, "stderr", Thread.currentThread(), textToWaitFor);
+        final ReaderThread threadErr = new ReaderThread(process.getErrorStream(), echo, "stderr", textToWaitFor);
         threadErr.start();
-        ReaderThread threadOut = new ReaderThread(process.getInputStream(), echo, "stdout", Thread.currentThread(), textToWaitFor);
+        final ReaderThread threadOut = new ReaderThread(process.getInputStream(), echo, "stdout", textToWaitFor);
         threadOut.start();
+        boolean readRemainingOutput = this.textToWaitFor == null;
         try {
-            try {
-                writeStdin(process);
-                final int result = await(process);
-                if (textToWaitFor != null) {
-                    threadErr.finish(1000L);
-                    threadOut.finish(1000L);
-                    if( !threadOut.isTextFound() && !threadErr.isTextFound()) {
-                        throw new ProcessManagerException("Process finished but text " + textToWaitFor + " not found in output");
-                    }
-                }
-                return result;
-            } catch (InterruptedException e) {
-                if (threadOut.isTextFound() || threadErr.isTextFound()) {
-                    return 0;
-                } else {
-                    throw e;
-                }
-            } finally {
-                stderr = threadErr.finish(1000L);
-                stdout = threadOut.finish(1000L);
+            if (stdinLines != null && stdinLines.length > 0) {
+                writeStdin(process, stdinLines);
             }
-        } catch (ProcessManagerException pme) {
-            throw pme;
-        } catch (Exception e) {
-            throw new ProcessManagerException(e);
+            return waitForResult(process, timeout, threadOut, threadErr);
+        } catch (ProcessManagerTimeoutException e) {
+            // It would block until the process finishes.
+            readRemainingOutput = false;
+            throw e;
         } finally {
-            if (process.isAlive() && textToWaitFor == null) {
+            stderr = threadErr.finish(100L, readRemainingOutput);
+            stdout = threadOut.finish(100L, readRemainingOutput);
+            if (process.isAlive() && this.forceExit) {
                 destroy(process);
             }
         }
     }
-
-    private void destroy(Process process) {
-        process.destroy();
-        // Wait for a while to let the process stop
-        try {
-            boolean exited = process.waitFor(10, TimeUnit.SECONDS);
-            if (!exited) {
-                // If the process hasn't exited, force it to stop
-                process.destroyForcibly();
-            }
-        } catch (InterruptedException e) {
-            LOG.log(Level.INFO, "Interrupted while waiting for process to terminate", e);
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    public String getStdout() {
-        return stdout;
-    }
-
-
-    public String getStderr() {
-        return stderr;
-    }
-
 
     @Override
     public String toString() {
@@ -180,57 +224,98 @@ public class ProcessManager {
     }
 
 
-    private void writeStdin(Process process) throws ProcessManagerException {
-        if (stdinLines == null || stdinLines.length == 0) {
-            return;
-        }
-        if (process == null) {
-            throw new ProcessManagerException("Parameter process was null.");
-        }
-        try (PrintWriter pipe = new PrintWriter(
-            new BufferedWriter(new OutputStreamWriter(process.getOutputStream(), Charset.defaultCharset())))) {
+    private static void writeStdin(Process process, String[] stdinLines) throws ProcessManagerException {
+        try (OutputStreamWriter pipe = new OutputStreamWriter(process.getOutputStream(), Charset.defaultCharset())) {
             for (String stdinLine : stdinLines) {
-                LOG.log(Level.DEBUG, "InputLine --> {0} <--", stdinLine);
-                pipe.println(stdinLine);
-                pipe.flush();
+                LOG.log(DEBUG, "InputLine --> {0} <--", stdinLine);
+                try {
+                    pipe.append(stdinLine);
+                    pipe.append('\n');
+                    pipe.flush();
+                } catch (IOException e) {
+                    throw new ProcessManagerException(
+                        "Could not write " + stdinLine + " to stdin of process: " + process, e);
+                }
             }
-        } catch (Exception e) {
-            throw new ProcessManagerException(e);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to close the writer to STDIN: " + process, e);
         }
     }
 
 
-    private int await(Process process) throws InterruptedException, ProcessManagerException {
-        if (timeout > 0) {
-            if (process.waitFor(timeout, TimeUnit.MILLISECONDS)) {
-                return process.exitValue();
+    private int waitForResult(Process process, int timeoutInMillis, ReaderThread threadOut, ReaderThread threadErr)
+        throws ProcessManagerException {
+        final boolean isDead = waitForDeath(process, timeoutInMillis);
+        if (textToWaitFor == null) {
+            if (isDead) {
+                final int exitCode = process.exitValue();
+                LOG.log(DEBUG, "Process finished with exit code {0}", exitCode);
+                return exitCode;
             }
-            throw new ProcessManagerTimeoutException("Process is still running, timeout " + timeout + " ms exceeded.");
+            throw new ProcessManagerTimeoutException(
+                "Process is still running, timeout " + timeoutInMillis + " ms exceeded.");
         }
-        return process.waitFor();
+        // Is not dead and textToWaitFor is not null.
+        if (threadOut.isTextFound() || threadErr.isTextFound()) {
+            LOG.log(DEBUG, "The process produced the expected text in the output: {0}", textToWaitFor);
+            return 0;
+        }
+        if (isDead) {
+            final int exitCode = process.exitValue();
+            throw new ProcessManagerException("Process finished with exit code " + exitCode
+                + ", but did not produce expected output: " + textToWaitFor);
+        }
+        throw new ProcessManagerTimeoutException("Process did not produce the expected output " + textToWaitFor
+            + ", timeout " + timeoutInMillis + " ms exceeded.");
     }
 
 
-    static class ReaderThread extends Thread {
+    private void destroy(Process process) {
+        process.destroy();
+        final boolean terminated = waitForDeath(process, 10_000);
+        if (!terminated) {
+            LOG.log(WARNING, "Process did not exit after waiting, attempting to forcibly destroy it");
+            process.destroyForcibly();
+        }
+    }
+
+
+    private boolean waitForDeath(Process process, int timeoutInMillis) {
+        try {
+            if (timeoutInMillis > 0) {
+                LOG.log(TRACE, "Started waiting for process death with timeout {0} ms", timeoutInMillis);
+                return process.waitFor(timeoutInMillis, TimeUnit.MILLISECONDS);
+            }
+            process.waitFor();
+        } catch (InterruptedException e) {
+            // The ReaderThread can wake us up.
+            LOG.log(TRACE, "Interrupted while waiting for the process death.", e);
+        } finally {
+            LOG.log(TRACE, "Finished waiting for process death: {0}", process);
+        }
+        return !process.isAlive();
+    }
+
+
+    private static class ReaderThread extends Thread {
         private final BufferedReader reader;
-        private final StringBuilder sb;
+        private final StringBuilder output;
         private final boolean echo;
-        private final AtomicBoolean stop = new AtomicBoolean();
         private final Thread threadWaitingForProcess;
         private final String textToWaitFor;
-        private volatile boolean textFound = false;
+        private volatile boolean textFound;
 
-        ReaderThread(InputStream stream, boolean echo, String threadName) {
-            this(stream, echo, threadName, null, null);
-        }
-
-        ReaderThread(InputStream stream, boolean echo, String threadName, Thread threadWaitingForProcess, String textToWaitFor) {
+        private ReaderThread(InputStream stream, boolean echo, String threadName, String textToWaitFor) {
             setName(threadName);
             this.reader = new BufferedReader(new InputStreamReader(stream, Charset.defaultCharset()));
-            this.sb = new StringBuilder();
+            this.output = new StringBuilder();
             this.echo = echo;
-            this.threadWaitingForProcess = threadWaitingForProcess;
             this.textToWaitFor = textToWaitFor;
+            this.threadWaitingForProcess = Thread.currentThread();
+        }
+
+        public boolean isTextFound() {
+            return textFound;
         }
 
 
@@ -238,60 +323,62 @@ public class ProcessManager {
         public void run() {
             try {
                 while (true) {
-                    String line;
-                    if (reader.ready()) {
-                        line = reader.readLine();
-                    } else if (stop.getAcquire()) {
-                        break;
-                    } else {
-                        Thread.yield();
+                    if (isInterrupted()) {
+                        LOG.log(TRACE, "ReaderThread " + getName() + " was interrupted.");
+                        return;
+                    }
+                    if (!reader.ready()) {
+                        Thread.onSpinWait();
                         continue;
                     }
-                    interruptWaitingThreadIfTextFound(line);
-                    sb.append(line).append('\n');
+                    String line = reader.readLine();
+                    output.append(line).append('\n');
                     if (echo) {
                         System.out.println(line);
                     }
+                    if (textToWaitFor != null && line.contains(textToWaitFor)) {
+                        textFound = true;
+                        threadWaitingForProcess.interrupt();
+                        return;
+                    }
                 }
-            } catch (Exception e) {
-                LOG.log(Level.ERROR, "ReaderThread broke ...", e);
+            } catch (IOException e) {
+                LOG.log(WARNING, () -> "ReaderThread " + getName() + " cannot read the process output.", e);
             } finally {
-                try {
-                    reader.close();
-                } catch (IOException e) {
-                    LOG.log(Level.ERROR, "Failed to close BufferedReader", e);
-                }
+                LOG.log(TRACE, "ReaderThread " + getName() + " stopped.");
             }
-            LOG.log(Level.TRACE, "ReaderThread exiting...");
         }
 
 
         /**
          * Asks the thread to finish it's job and waits until the thread dies.
          * <p>
-         * @param timeout The maximal time for the waiting.
+         * @param timeoutInMillis The maximal time for the waiting.
+         * @param readOutput If true, reads the remaining output from the process.
          *
          * @return the final output of the process.
          */
-        public String finish(long timeout) {
-            stop.setRelease(true);
+        public String finish(long timeoutInMillis, boolean readOutput) {
+            interrupt();
             try {
-                join(timeout);
+                join(timeoutInMillis);
             } catch (InterruptedException ex) {
-                // nothing to do
+                LOG.log(WARNING, "Interrupted while waiting for " + getName() + " to finish", ex);
             }
-            return sb.toString();
-        }
-
-        private void interruptWaitingThreadIfTextFound(String line) {
-            if (threadWaitingForProcess != null && textToWaitFor != null && line.contains(textToWaitFor)) {
-                textFound = true;
-                threadWaitingForProcess.interrupt();
+            try {
+                if (readOutput) {
+                    reader.lines().forEach(line -> output.append(line).append('\n'));
+                }
+            } catch (UncheckedIOException e) {
+                LOG.log(ERROR, "Failed to read remaining output in " + getName(), e);
+            } finally  {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    throw new IllegalStateException("Failed to close reader in " + getName(), e);
+                }
             }
-        }
-
-        public boolean isTextFound() {
-            return textFound;
+            return output.toString();
         }
     }
 }


### PR DESCRIPTION
- Fixes failure visible just on Jenkins CI
  - Process could die before processing all its output and vice versa, or even before we sent all input lines (cat doesn't block waiting).
  - The output was processed even when we did not want to read it, we were
    just waiting for a message.
- Renames setTimeoutMsec to setTimeout
- Adds javadocs