### PR TITLE
Abandoning withAnt which suddenly stopped working

### DIFF
--- a/appserver/tests/common_test.sh
+++ b/appserver/tests/common_test.sh
@@ -52,6 +52,7 @@ test_init(){
   echo APS_HOME is ${APS_HOME}
   java -version
   ant -version
+  exit 1;
   mkdir -p ${WORKSPACE}/results/junitreports
   printf "\n\n"
 }
@@ -77,15 +78,15 @@ copy_test_artifacts() {
   sleep 1; # imq sometimes stops after the domain
   printf "\n%s \n\n" "===== COPY TEST ARTIFACTS ====="
   mkdir -p ${WORKSPACE}/results/junitreports
-  
+
   tar -cf ${WORKSPACE}/results/domainArchive.tar.gz ${S1AS_HOME}/domains
-  
+
   cp ${S1AS_HOME}/domains/domain1/logs/server.log* ${WORKSPACE}/results/ || true
   cp ${TEST_RUN_LOG} ${WORKSPACE}/results/ || true
   cp ${APS_HOME}/test_results*.* ${WORKSPACE}/results/ || true
   cp `pwd`/*/*logs.zip ${WORKSPACE}/results/ || true
   cp `pwd`/*/*/*logs.zip ${WORKSPACE}/results/ || true
-  
+
   tar -caf ${WORKSPACE}/${1}-results.tar.gz ${WORKSPACE}/results || true
 }
 
@@ -160,7 +161,7 @@ change_junit_report_class_names(){
   if sed --version >/dev/null 2>&1; then
       ${SED} -i 's/\([a-zA-Z-]\w*\)\./\1-/g' ${WORKSPACE}/results/junitreports/*.xml
       ${SED} -i "s/\bclassname=\"/classname=\"${TEST_ID}./g" ${WORKSPACE}/results/junitreports/*.xml
-  else 
+  else
       ${SED} -i '' 's/\([a-zA-Z-]\w*\)\./\1-/g' ${WORKSPACE}/results/junitreports/*.xml
       ${SED} -i '' "s/\bclassname=\"/classname=\"${TEST_ID}./g" ${WORKSPACE}/results/junitreports/*.xml
   fi


### PR DESCRIPTION
I have created an issue on GitLab, because this doesn't help too, however it might be a bit better than using withAnt. At least sometimes it logs something.
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6251

```
hudson.remoting.ProxyException: java.net.SocketTimeoutException: Connect timed out
	at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:558)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:609)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
	at java.base/java.net.Socket.connect(Socket.java:633)
	at java.base/sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:304)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:178)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:533)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:638)
	at java.base/sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:266)
	at java.base/sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:380)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:193)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1257)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1143)
	at java.base/sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:179)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.connect(HttpsURLConnectionImpl.java:142)
	at hudson.FilePath.installIfNecessaryFrom(FilePath.java:973)
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: 70ba6de1-ee98-4e6c-b37c-e0322cb61d6c
Caused: hudson.remoting.ProxyException: java.io.IOException: Failed to install https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.zip to /home/jenkins/agent/tools/hudson.tasks.Ant_AntInstallation/apache-ant-latest
	at hudson.FilePath.installIfNecessaryFrom(FilePath.java:1058)
	at hudson.FilePath.installIfNecessaryFrom(FilePath.java:954)
	at hudson.tools.DownloadFromUrlInstaller.performInstallation(DownloadFromUrlInstaller.java:77)
	at hudson.tools.InstallerTranslator.getToolHome(InstallerTranslator.java:67)
	at hudson.tools.ToolLocationNodeProperty.getToolHome(ToolLocationNodeProperty.java:109)
	at hudson.tools.ToolInstallation.translateFor(ToolInstallation.java:221)
	at PluginClassLoader for ant//hudson.tasks.Ant$AntInstallation.forNode(Ant.java:440)
	at PluginClassLoader for ant//hudson.tasks.Ant$AntInstallation.forNode(Ant.java:352)
	at PluginClassLoader for workflow-basic-steps//org.jenkinsci.plugins.workflow.steps.ToolStep$Execution.run(ToolStep.java:157)
	at PluginClassLoader for workflow-basic-steps//org.jenkinsci.plugins.workflow.steps.ToolStep$Execution.run(ToolStep.java:138)
	at PluginClassLoader for workflow-step-api//org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:49)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:853)

```