### PR TITLE
Removed maven download from GitHub CI - 24.04 already contains that

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,13 +18,10 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-    - name: Install Maven
-      run: |
-        curl -s -S -o ./apache-maven-3.9.9-bin.zip https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip
-        unzip -q ./apache-maven-3.9.9-bin.zip
-        ss -tulpn
+    - name: List ports
+      run: ss -tulpn
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: ./apache-maven-3.9.9/bin/mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
+      run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
 


### PR DESCRIPTION
This currently blocks all GitHub builds - Maven 3.9.9 was removed from the Apache website, HTTP 404.