### PR TITLE
Reproducing and fixing the gjule test instability

### DIFF
--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/GlassFishLogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -491,13 +491,6 @@ public class GlassFishLogHandler extends Handler implements ExternallyManagedLog
         private LoggingPump(String threadName, LogRecordBuffer buffer) {
             super(threadName, buffer);
         }
-
-
-        @Override
-        protected boolean isShutdownRequested() {
-            return !configuration.isEnabled() || !isReady();
-        }
-
 
         @Override
         protected int getFlushFrequency() {

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingPumpThread.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/LoggingPumpThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,13 +41,6 @@ abstract class LoggingPumpThread extends Thread {
         this.buffer = buffer;
     }
 
-
-    /**
-     * @return true if the pump should stop
-     */
-    protected abstract boolean isShutdownRequested();
-
-
     /**
      * @return count of records processed until the {@link #flushOutput()} is called.
      */
@@ -68,7 +61,7 @@ abstract class LoggingPumpThread extends Thread {
     @Override
     public final void run() {
         trace(GlassFishLogHandler.class, () -> "Logging pump for " + buffer + " started.");
-        while (!isShutdownRequested()) {
+        while (!isInterrupted()) {
             try {
                 publishBatchFromBuffer();
             } catch (final Exception e) {

--- a/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SyslogHandler.java
+++ b/nucleus/glassfish-jul-extension/src/main/java/org/glassfish/main/jul/handler/SyslogHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -126,12 +126,6 @@ public class SyslogHandler extends Handler {
 
         private LoggingPump(final String threadName, final LogRecordBuffer buffer) {
             super(threadName, buffer);
-        }
-
-
-        @Override
-        protected boolean isShutdownRequested() {
-            return pump == null;
         }
 
 


### PR DESCRIPTION
I was not able to reproduce it on locally, but it happens in around
* 1 of 200 builds on Jenkins
* 1 of 2 builds on GH CI Windows
* 1 of 3 builds on GH CI Linux

However recently I have found I am systematically repeating same mistake related to `InterruptedException`, see 
* https://www.baeldung.com/java-interrupted-exception
* https://stackoverflow.com/questions/3976344/handling-interruptedexception-in-java
* https://dzone.com/articles/how-to-handle-the-interruptedexception

Stupid me (and everybody reviewing my code, so at least I am not alone)! 

```
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:    GlassFishLogHandlerTest.enableStandardStreamsLoggers(TestInfo) � Timeout enableStandardStreamsLoggers(org.junit.jupiter.api.TestInfo) timed out after 5 seconds
Error:    GlassFishLogHandlerTest.roll � Timeout roll() timed out after 5 seconds
[INFO] 
Error:  Tests run: 233, Failures: 0, Errors: 2, Skipped: 2
```

Yet the lesson which led me here (story):
We had another rarely unstable test, the `ProcessManagerTest`. Never reproducible locally, just on GitHub Actions. Then I did some cleanup, refactoring, moved this and that, and I noticed something. I added log to stdout. I didn't reproduce or find anything. However when I pushed the code without the stdout line - it failed on GitHub! And it failed locally too. I started thinking ... is it a bug in Java? Is it Linux? Is it broken `cat`? I rewrote that to `echo`, same behavior. 2000 repeats, 9 failures. And then I have seen that. The `InterruptedException` is thrown just when your thread sleeps, waits, is blocked somehow, however when the `cat` command was too fast and reading did not block for a nano, there was no exception and my loop was running until test timeout.