### PR TITLE
Fixed another race condition in ProcessManager

### DIFF
--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/universal/process/ProcessManagerTest.java
@@ -20,7 +20,6 @@ package com.sun.enterprise.universal.process;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,8 +46,6 @@ import static org.junit.jupiter.api.condition.OS.WINDOWS;
  * @author bnevins
  */
 public class ProcessManagerTest {
-    private static final Logger LOG = System.getLogger(ProcessManagerTest.class.getName());
-
     private static final List<String> HUGE_INPUT = hugeInput();
     private static File textfile;
 
@@ -59,12 +58,13 @@ public class ProcessManagerTest {
 
     /**
      * The cat doesn't expect the STDIN when it received an input file, does the work and
-     * terminates.
+     * terminates while we are still writing to the input which causes IOException
+     * "Stream closed" or something like that).
      */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    public void test1() throws ProcessManagerException {
+    public void writeToStdInAfterProcessTerminated() {
         final ProcessManager pm = new ProcessManager("cat", textfile.getAbsolutePath());
         pm.setStdinLines(HUGE_INPUT);
         pm.setEcho(false);
@@ -75,8 +75,8 @@ public class ProcessManagerTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testCommandExecution() {
-        ProcessManager pm = new ProcessManager("sh", "-c", "echo hello; sleep 1");
+    void parseCommandOutput() {
+        ProcessManager pm = new ProcessManager("sh", "-c", "echo hello");
         pm.setEcho(false);
         int exitCode = assertDoesNotThrow(pm::execute);
         assertAll(
@@ -88,8 +88,8 @@ public class ProcessManagerTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testWaitUntilTextInStdOut() {
-        ProcessManager pm = new ProcessManager("sh", "-c", "echo \"start\nhello\ncontinue\"; sleep 10");
+    void waitForTextInStdOutAndAbandonBeforeProcessTerminated() {
+        ProcessManager pm = new ProcessManager("sh", "-c", "echo \"start\nhello\"; sleep 1; echo \"continue\"; sleep 8");
         pm.setEcho(false);
         pm.setTextToWaitFor("hello");
         int exitCode = assertDoesNotThrow(pm::execute);
@@ -102,7 +102,7 @@ public class ProcessManagerTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testWaitUntilTextInStdErr() {
+    void waitForTextInStdErrAndAbandonBeforeProcessTerminated() {
         ProcessManager pm = new ProcessManager("sh", "-c", "echo \"start\nhello\ncontinue\" >&2; sleep 10");
         pm.setEcho(false);
         pm.setTextToWaitFor("continue");
@@ -113,25 +113,49 @@ public class ProcessManagerTest {
         );
     }
 
-    @Test
+    @RepeatedTest(1000)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testDetectTextInStdOutIfProcessStops() throws Exception {
+    void waitForTextInStdOutAfterProcessTerminated() throws Exception {
         ProcessManager pm = new ProcessManager("sh", "-c", "echo \"start\nhello\ncontinue\"");
         pm.setEcho(false);
         pm.setTextToWaitFor("hello");
         int exitCode = assertDoesNotThrow(pm::execute);
-        Thread.sleep(100L);
         assertAll(
                 () -> assertEquals(0, exitCode),
-                () -> assertEquals("start\nhello\n", pm.getStdout())
+                // Can return whole string, depends if reader thread finishes first or the process
+                () -> assertThat(pm.getStdout(), startsWith("start\nhello\n"))
         );
     }
 
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testSetEnvironment() {
+    void waitForTextTimeout() {
+        ProcessManager pm = new ProcessManager("sh", "-c", "echo \"Iamnothere\"; sleep 10");
+        pm.setEcho(false);
+        pm.setTextToWaitFor("somethingelse");
+        pm.setTimeout(10);
+        assertThrows(ProcessManagerTimeoutException.class, pm::execute);
+    }
+
+    @Test
+    @Timeout(value = 2, unit = TimeUnit.SECONDS)
+    @DisabledOnOs(WINDOWS)
+    void waitForTextTerminated() {
+        ProcessManager pm = new ProcessManager("sh", "-c", "echo \"Iamnothere\"");
+        pm.setEcho(false);
+        pm.setTextToWaitFor("somethingelse");
+        pm.setTimeout(10000);
+        ProcessManagerException e = assertThrows(ProcessManagerException.class, pm::execute);
+        assertEquals("Process finished with exit code 0, but did not produce expected output: somethingelse",
+            e.getMessage());
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @DisabledOnOs(WINDOWS)
+    void setEnvProperty() {
         String value = String.valueOf(System.currentTimeMillis());
         ProcessManager pm = new ProcessManager("sh", "-c", "echo ${PM_TEST_ENV_VAR}; sleep 1");
         pm.setEcho(false);
@@ -148,10 +172,10 @@ public class ProcessManagerTest {
      * As of 2025 on AMD Ryzen 9 7945HX this test had incidence 9 failures of 2000 runs
      * when I forgot to add the new line in {@link ReaderThread#finish}.
      */
-    @RepeatedTest(value = 2000)
+    @RepeatedTest(1000)
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testSetStdinLines() {
+    void catAllStdInLines() {
         List<String> inputLines = Arrays.asList("line1", "line2", "line3");
         String expectedOutput = String.join("\n", inputLines) + "\n";
         ProcessManager pm = new ProcessManager("cat");
@@ -165,11 +189,11 @@ public class ProcessManagerTest {
     }
 
     @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testSetTimeoutLessThanExecutionTime() {
+    void timeoutShort() {
         int sleepTimeSeconds = 2;
-        int timeoutMsec = (sleepTimeSeconds - 1) * 1000; // timeout is shorter than sleep time
+        int timeoutMsec = 10; // timeout is shorter than sleep time
         ProcessManager pm = new ProcessManager("sleep", String.valueOf(sleepTimeSeconds));
         pm.setTimeout(timeoutMsec);
         assertThrows(ProcessManagerTimeoutException.class, pm::execute);
@@ -178,7 +202,7 @@ public class ProcessManagerTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     @DisabledOnOs(WINDOWS)
-    void testSetTimeoutGreaterThanExecutionTime() {
+    void timeoutLong() {
         int sleepTimeSeconds = 1;
         int timeoutMsec = sleepTimeSeconds * 2 * 1000; // timeout is 2 times longer than sleep time
         ProcessManager pm = new ProcessManager("sleep", String.valueOf(sleepTimeSeconds));


### PR DESCRIPTION
- Reproduced locally by tests more often first
- Happened when process stopped, then output processing thread was interrupted before it could consume the rest of the output. Some 5% executions.
- The code had to be restructured again to have clear lifecycle phases, tools and responsibilities.
- Follows #25538 which still was not perfect.
