### PR TITLE
Fix #25549 Non-GMS Cluster fails to start after GMS Cluster is started

### DIFF
--- a/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/admin/GMSAnnounceBeforeStartClusterCommand.java
+++ b/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/admin/GMSAnnounceBeforeStartClusterCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -98,16 +99,15 @@ public class GMSAnnounceBeforeStartClusterCommand implements AdminCommand {
     @Inject
     GMSAdapterService gmsAdapterService;
 
-    private GroupManagementService gms = null;
-    private boolean gmsStartCluster = false;
-    private List<String> clusterMembers = EMPTY_LIST;
-    private GMSAdapter gmsadapter = null;
-
     static final private List<String> EMPTY_LIST = new LinkedList<String>();
 
 
     @Override
     public void execute(AdminCommandContext context) {
+        GroupManagementService gms = null;
+        GMSAdapter gmsadapter = null;
+        boolean gmsStartCluster = false;
+        List<String> clusterMembers = EMPTY_LIST;
         ActionReport report = context.getActionReport();
         try {
             if (gmsAdapterService.isGmsEnabled()) {

--- a/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/admin/GMSAnnounceBeforeStopClusterCommand.java
+++ b/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/admin/GMSAnnounceBeforeStopClusterCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -97,16 +98,15 @@ public class GMSAnnounceBeforeStopClusterCommand implements AdminCommand {
     @Inject
     private GMSAdapterService gmsAdapterService;
 
-    private GroupManagementService gms = null;
-    private boolean gmsStopCluster = false;
-    private List<String> clusterMembers = EMPTY_LIST;
-    private GMSAdapter gmsadapter = null;
-
     static final private List<String> EMPTY_LIST = new LinkedList<String>();
 
 
     @Override
     public void execute(AdminCommandContext context) {
+        GroupManagementService gms = null;
+        GMSAdapter gmsadapter = null;
+        boolean gmsStopCluster = false;
+        List<String> clusterMembers = EMPTY_LIST;
         ActionReport report = context.getActionReport();
         try {
             if (gmsAdapterService.isGmsEnabled()) {


### PR DESCRIPTION
* Fixes #25549

Some GMS-related objects were instance variables within the command service endpoint, so they weren't getting properly initialized when the start-cluster command was executed.  
  
The same problem occurred when executing stop-cluster, so I fixed it too.