### PR TITLE
Do not declare `Main-Class`es

### DIFF
--- a/appserver/admin/cli/pom.xml
+++ b/appserver/admin/cli/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -50,19 +51,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.glassfish.admin.cli.AsadminMain</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -265,16 +266,6 @@
                         </Export-Package>
                     </instructions>
               </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.sun.enterprise.admin.cli.AdminMain</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
Replace
```
Error: Unable to initialize main class com.sun.enterprise.admin.cli.AdminMain
Caused by: java.lang.NoClassDefFoundError: org/glassfish/api/admin/CommandValidationException
```

with
```
no main manifest attribute, in admin-cli.jar
```

