### PR TITLE
DomainBuilder must not swallow failures

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/DomainException.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/DomainException.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -13,13 +14,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package com.sun.enterprise.admin.servermgmt;
 
 /**
  * Superclass for all domain management exceptions.
  */
 public class DomainException extends RepositoryException {
+    private static final long serialVersionUID = -875053117161725741L;
+
     /**
      * Constructs a new DomainException object.
      *

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/RepositoryException.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/RepositoryException.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,19 +15,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * RepositoryException.java
- *
- * Created on August 22, 2003, 11:21 AM
- */
-
 package com.sun.enterprise.admin.servermgmt;
 
 /**
  *
  * @author kebbs
  */
-public class RepositoryException extends java.lang.Exception {
+public class RepositoryException extends Exception {
+
+    private static final long serialVersionUID = 6453511878361248508L;
 
     /**
      * Constructs a new InstanceException object.
@@ -71,7 +68,7 @@ public class RepositoryException extends java.lang.Exception {
             } else if (causeMsg != null && !causeMsg.equals(msg)) {
                 msg += PREFIX + causeMsg + POSTFIX;
             } else {
-                msg += PREFIX + cause.toString() + POSTFIX;
+                msg += PREFIX + cause + POSTFIX;
             }
         }
         return msg;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainBuilder.java
@@ -48,8 +48,6 @@ import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.sun.enterprise.admin.servermgmt.SLogger.UNHANDLED_EXCEPTION;
-import static com.sun.enterprise.admin.servermgmt.SLogger.getLogger;
 import static com.sun.enterprise.admin.servermgmt.domain.DomainConstants.DOMAIN_XML_FILE;
 import static java.text.MessageFormat.format;
 import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
@@ -261,20 +259,13 @@ public class DomainBuilder {
             domainSecurity.processAdminKeyFile(adminKeyFile, user, password, adminUserGroups);
             try {
                 domainSecurity.createSSLCertificateDatabase(configDir, _domainConfig, masterPassword);
-            } catch (Exception e) {
+            } catch (RepositoryException e) {
                 System.err.println("Domain creation process involves a step that creates primary key and"
                     + "\n self-signed server certificate. This step failed for the reason shown below."
                     + "\n This could be because JDK provided keytool program could not be found (e.g."
                     + "\n you are running with JRE) or for some other reason. No need to panic, as you"
-                    + "\n can always use JDK-keytool program to do the needful. A temporary JKS-keystore"
-                    + "\n will be created. You should replace it with proper keystore before using it for SSL."
-                    + "\n Refer to documentation for details. Actual error is:\n" + e.getMessage());
-                File keystoreFile = new File(configDir, DomainConstants.KEYSTORE_FILE);
-                try (FileOutputStream fos = new FileOutputStream(keystoreFile)) {
-                    fos.write(_keystoreBytes);
-                } catch (Exception ex) {
-                    getLogger().log(Level.SEVERE, UNHANDLED_EXCEPTION, ex);
-                }
+                    + "\n can always use JDK-keytool program to do the needful.");
+                throw e;
             }
             domainSecurity.changeMasterPasswordInMasterPasswordFile(
                 new File(domainDir, DomainConstants.MASTERPASSWORD_FILE), masterPassword, saveMasterPassword);


### PR DESCRIPTION
- If we are not able to generate certificates, report an exception, don't continue with domain creation.
- Failure generating certificates caused creating a new domain using the fallback and obsoleted certificate and especially publicly available private key.