### PR TITLE
Excluded module-info.class files poisoning embedded packages

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -1723,6 +1723,7 @@
                             <includeScope>runtime</includeScope>
                             <includeTypes>jar,glassfish-jar</includeTypes>
                             <includes>**/*.class</includes>
+                            <excludes>module-info.class,META-INF/versions/*/module-info.class</excludes>
                         </configuration>
                     </execution>
                     <execution>

--- a/appserver/extras/embedded/all/src/assembly/package.xml
+++ b/appserver/extras/embedded/all/src/assembly/package.xml
@@ -1,6 +1,6 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 https://maven.apache.org/xsd/assembly-2.1.0.xsd"
 >
     <id>glassfish-embedded-all</id>
     <formats>
@@ -26,6 +26,8 @@
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/hk2-locator/*</exclude>
                     <exclude>META-INF/loggerinfo/*</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
                 </excludes>
             </unpackOptions>
             <includes>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -1408,6 +1408,7 @@
                             <includeScope>runtime</includeScope>
                             <includeTypes>jar,glassfish-jar</includeTypes>
                             <includes>**/*.class</includes>
+                            <excludes>module-info.class,META-INF/versions/*/module-info.class</excludes>
                         </configuration>
                     </execution>
                     <execution>

--- a/appserver/extras/embedded/web/src/assembly/package.xml
+++ b/appserver/extras/embedded/web/src/assembly/package.xml
@@ -1,6 +1,6 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 https://maven.apache.org/xsd/assembly-2.1.0.xsd"
 >
     <id>glassfish-embedded-web</id>
     <formats>
@@ -26,6 +26,8 @@
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/hk2-locator/*</exclude>
                     <exclude>META-INF/loggerinfo/*</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
                 </excludes>
             </unpackOptions>
             <includes>


### PR DESCRIPTION
- Could result in random results
- The module-info was inherited from some dependency