### PR TITLE
The java.security.auth.login.config system property must be an URL

### DIFF
--- a/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/CLIBootstrap.java
+++ b/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/CLIBootstrap.java
@@ -20,6 +20,8 @@ package org.glassfish.appclient.client.acc.agent;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -292,7 +294,7 @@ public class CLIBootstrap {
         command.append(' ').append("-D").append(INSTALL_ROOT.getSystemPropertyName()).append('=').append(quote(gfInfo.home().getAbsolutePath()));
         command.append(' ').append("-Dorg.glassfish.gmbal.no.multipleUpperBoundsException=true");
         command.append(' ').append(SECURITY_POLICY_PROPERTY_EXPR).append(quote(gfInfo.securityPolicy().getAbsolutePath()));
-        command.append(' ').append(SECURITY_AUTH_LOGIN_CONFIG_PROPERTY_EXPR).append(quote(gfInfo.loginConfig().getAbsolutePath()));
+        command.append(' ').append(SECURITY_AUTH_LOGIN_CONFIG_PROPERTY_EXPR).append(quote(gfInfo.loginConfig().toExternalForm()));
     }
 
     /**
@@ -910,8 +912,12 @@ public class CLIBootstrap {
             return new File(libAppclient, "client.policy");
         }
 
-        File loginConfig() {
-            return new File(libAppclient, "appclientlogin.conf");
+        URL loginConfig() {
+            try {
+                return new File(libAppclient, "appclientlogin.conf").toURI().toURL();
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException("Could not create URL for appclientlogin.conf", e);
+            }
         }
     }
 

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityLifecycle.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityLifecycle.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -91,7 +92,7 @@ public class SecurityLifecycle implements PostConstruct, PreDestroy {
             if (Util.isEmbeddedServer()) {
                 // If the user-defined login.conf/server.policy are set as system properties, then they are given priority
                 if (System.getProperty(SYS_PROP_LOGIN_CONF) == null) {
-                    System.setProperty(SYS_PROP_LOGIN_CONF, writeConfigFileToTempDir("login.conf").getAbsolutePath());
+                    System.setProperty(SYS_PROP_LOGIN_CONF, writeConfigFileToTempDir("login.conf").toURI().toURL().toExternalForm());
                 }
                 if (System.getProperty(SYS_PROP_JAVA_SEC_POLICY) == null) {
                     System.setProperty(SYS_PROP_JAVA_SEC_POLICY, writeConfigFileToTempDir("server.policy").getAbsolutePath());


### PR DESCRIPTION
Original state could break some paths using "unusual" but valid characters. The JDK in the method `sun.security.provider.ConfigFile.Spi.init()` does this:

```
    private static URL newURL(String spec) throws MalformedURLException {
        return new URL(spec);
    }
```
If it fails, it uses the string as a file:
```
                    URL configURL;
                    try {
                        configURL = newURL(extra_config);
                    } catch (MalformedURLException mue) {
                        File configFile = new File(extra_config);
                        if (configFile.exists()) {
                            configURL = configFile.toURI().toURL();
                        } else {
                            throw ioException(
                                "extra.config.No.such.file.or.directory.",
                                extra_config);
                        }
                    }
```

However that can lead to a situation when we would provide string, which would be successfully parsed as URL, but such path would not exist. As an example Claude 3.5 offered this, which is nearly exactly what I have seen on Windows:
```
java.security.auth.login.config=C:\folder with spaces\config.conf
```
