### PR TITLE
Several smaller fixes and improvements

### DIFF
--- a/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EjbClassGeneratorFactoryBenchmarkTest.java
+++ b/appserver/ejb/ejb-container/src/test/java/com/sun/ejb/EjbClassGeneratorFactoryBenchmarkTest.java
@@ -18,6 +18,7 @@ package com.sun.ejb;
 
 import com.sun.ejb.codegen.EjbClassGeneratorFactory;
 
+import java.lang.System.Logger;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +36,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
+import static java.lang.System.Logger.Level.INFO;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
@@ -49,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @TestMethodOrder(OrderAnnotation.class)
 public class EjbClassGeneratorFactoryBenchmarkTest {
+    private static final Logger LOG = System.getLogger(EjbClassGeneratorFactoryBenchmarkTest.class.getName());
 
     /**
      * The value shall be high enough to pass on all standard environments,
@@ -78,7 +81,9 @@ public class EjbClassGeneratorFactoryBenchmarkTest {
         Collection<RunResult> results = new Runner(options).run();
         assertThat(results, hasSize(1));
         Result<?> primaryResult = results.iterator().next().getPrimaryResult();
-        assertThat(primaryResult.getScore(), lessThan(firstRunScore / 3));
+        double ratio = primaryResult.getScore() / firstRunScore;
+        LOG.log(INFO, "Score: {0}, firstRunScore: {1}, ratio: {2}", primaryResult.getScore(), firstRunScore, ratio);
+        assertThat("Expected ration", ratio, lessThan(1 / 3d));
     }
 
 
@@ -100,7 +105,7 @@ public class EjbClassGeneratorFactoryBenchmarkTest {
         } else {
             builder.warmupIterations(0);
         }
-        builder.forks(1).threads(100).shouldFailOnError(true)
+        builder.forks(1).threads(Runtime.getRuntime().availableProcessors() * 4).shouldFailOnError(true)
             .measurementIterations(1)
             .measurementTime(TimeValue.milliseconds(measurementTime)).timeout(TimeValue.seconds(5L))
             .timeUnit(TimeUnit.MICROSECONDS).mode(mode);

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/DetachedTerseAsadminResult.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/DetachedTerseAsadminResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -35,6 +35,9 @@ public class DetachedTerseAsadminResult extends AsadminResult {
     }
 
 
+    /**
+     * @return id of the detached command job usable as a parameter of the asadmin attach command
+     */
     public String getJobId() {
         return jobId;
     }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -59,6 +59,7 @@ import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author David Matejcek
@@ -80,9 +81,10 @@ public class AsadminLoggingITest {
     public void collectLogFiles() {
         AsadminResult result = ASADMIN.exec("collect-log-files");
         assertThat(result, asadminOK());
-        String path = StringUtils.substringBetween(result.getStdOut(), "Created Zip file under ", ".\n");
+        String path = StringUtils.substringBetween(result.getStdOut(), "Created Zip file under ", ".zip.") + ".zip";
         assertNotNull(path, () -> "zip file path parsed from " + result.getStdOut());
         File zipFile = new File(path);
+        assertTrue(zipFile.exists(), () -> "zip file exists: " + zipFile);
         assertAll(
             () -> assertThat(zipFile.length(), greaterThan(2_000L)),
             () -> assertThat(zipFile.getName(), endsWith(".zip"))

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminVersionITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminVersionITest.java
@@ -42,7 +42,7 @@ public class AsadminVersionITest {
 
     @AfterAll
     public static void startDomainAgain() {
-        assertThat(ASADMIN.exec("start-domain"), asadminOK());
+        assertThat(ASADMIN.exec(60_000, "start-domain"), asadminOK());
     }
 
 

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/PathWithSpacesITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/PathWithSpacesITest.java
@@ -57,6 +57,6 @@ public class PathWithSpacesITest {
 
     @Test
     void start() throws Exception {
-        assertThat(asadmin.exec("start-domain", "spaces"), asadminOK());
+        assertThat(asadmin.exec(60_000, "start-domain", "spaces"), asadminOK());
     }
 }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/JobManagerITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/JobManagerITest.java
@@ -63,7 +63,7 @@ public class JobManagerITest {
             "--cleanup-initial-delay=0s",
             "--cleanup-poll-interval=0s"), asadminOK());
         assertThat(ASADMIN.exec(COMMAND_PROGRESS_SIMPLE), asadminOK());
-        assertThat(ASADMIN.exec("restart-domain"), asadminOK());
+        assertThat(ASADMIN.exec(60_000, "restart-domain"), asadminOK());
         assertThat(ASADMIN.exec("list-jobs").getStdOut(), stringContainsInOrder(COMMAND_PROGRESS_SIMPLE, "COMPLETED"));
         JobTestExtension.doAndDisableJobCleanup();
     }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
@@ -55,7 +55,7 @@ public class LoggingRestITest extends RestTestBase {
     public static void fillUpLog() {
         // The server log may become empty due to log rotation.
         // Restart domain to fill it up.
-        AsadminResult result = getAsadmin().exec("restart-domain");
+        AsadminResult result = getAsadmin().exec(60_000, "restart-domain");
         assertThat(result, asadminOK());
     }
 

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/AdminCommandEventBroker.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/admin/AdminCommandEventBroker.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -57,7 +58,7 @@ public interface AdminCommandEventBroker<T> {
      *
      * @param listener Listener to remove
      */
-    void unregisterListener(AdminCommandListener listener);
+    void unregisterListener(AdminCommandListener<T> listener);
 
     /**
      * Returns true if exist exists registered listener for given eventName

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/EngineRef.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/EngineRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -132,6 +132,9 @@ public class EngineRef {
      * @return
      */
     public boolean stop(ApplicationContext context) {
+        if (applicationContainer == null) {
+            return true;
+        }
         return applicationContainer.stop(context);
     }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminCommandInstanceImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminCommandInstanceImpl.java
@@ -173,8 +173,7 @@ public class AdminCommandInstanceImpl extends AdminCommandStateImpl implements J
         final String user = subjectUsernames.isEmpty() ? null : subjectUsernames.get(0);
         final JobInfo jobInfo = new JobInfo(getId(), commandName, executionDate, report.getActionExitCode().name(),
             user, report.getMessage(), getJobsFile(), finalState.name(), completionDate);
-        jobManager.addToCompletedJobs(jobInfo);
-        jobManager.purgeJob(jobInfo.jobId);
+        jobManager.moveToCompletedJobs(jobInfo);
         if (originalState.equals(State.RUNNING_RETRYABLE) || originalState.equals(State.REVERTING)) {
             File jobFile = getJobsFile();
             if (jobFile == null) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobManagerService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobManagerService.java
@@ -290,7 +290,8 @@ public class JobManagerService implements JobManager, EventListener {
         return jobPersistence.remove(job);
     }
 
-    public void addToCompletedJobs(JobInfo job) {
+    public void moveToCompletedJobs(JobInfo job) {
+        purgeJob(job.jobId);
         completedJobsInfo.put(job.jobId, new CompletedJob(job.jobId, job.commandCompletionDate, job.getJobsFile()));
         jobPersistence.add(job);
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobManagerService.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/JobManagerService.java
@@ -275,8 +275,8 @@ public class JobManagerService implements JobManager, EventListener {
         }
     }
 
-    public ExecutorService getThreadPool() {
-        return pool;
+    public void startAsyncListener(RunnableAdminCommandListener listener) {
+        pool.execute(listener);
     }
 
     @Override

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/RunnableAdminCommandListener.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/RunnableAdminCommandListener.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.v3.admin;
+
+import com.sun.enterprise.admin.remote.AdminCommandStateImpl;
+import com.sun.enterprise.v3.common.PropsFileActionReporter;
+
+import java.lang.System.Logger;
+
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.ActionReport.ExitCode;
+import org.glassfish.api.admin.AdminCommandEventBroker;
+import org.glassfish.api.admin.AdminCommandEventBroker.AdminCommandListener;
+import org.glassfish.api.admin.AdminCommandEventBroker.BrokerListenerRegEvent;
+import org.glassfish.api.admin.AdminCommandState;
+import org.glassfish.api.admin.AdminCommandState.State;
+import org.glassfish.api.admin.CommandRunner.CommandInvocation;
+
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.TRACE;
+import static org.glassfish.api.admin.AdminCommandEventBroker.BrokerListenerRegEvent.EVENT_NAME_LISTENER_REG;
+import static org.glassfish.api.admin.AdminCommandState.EVENT_STATE_CHANGED;
+
+/**
+ * Asynchronous admin command lister running in a separate thread.
+ */
+public abstract class RunnableAdminCommandListener implements Runnable, AdminCommandListener<Object> {
+
+    private static final Logger LOG = System.getLogger(RunnableAdminCommandListener.class.getName());
+
+    private final CommandInvocation commandInvocation;
+    private AdminCommandEventBroker<Object> broker;
+
+    protected RunnableAdminCommandListener(CommandInvocation commandInvocation) {
+        this.commandInvocation = commandInvocation;
+        commandInvocation.listener(".*", this);
+    }
+
+
+    /**
+     * Process command events additional to events processed by this class
+     * using {@link #onAdminCommandEvent(String, Object)}.
+     *
+     * @param name Name of the event
+     * @param event Event object
+     */
+    protected abstract void processCommandEvent(final String name, Object event);
+
+    /**
+     * When the thread finishes, executes this method to finalize the run.
+     * It is suitable for closing resources or performing any cleanup.
+     * It should not throw any exceptions, as it is called in the separate thread.
+     */
+    protected abstract void finalizeRun();
+
+    @Override
+    public final void run() {
+        try {
+            commandInvocation.execute();
+        } catch (Throwable e) {
+            LOG.log(ERROR, "Command invocation failed - " + e.getMessage(), e);
+            ActionReport report = createActionReport(ExitCode.FAILURE, "Command invocation failed.", e);
+            AdminCommandState acs = new AdminCommandStateImpl(State.COMPLETED, report, true, "unknown");
+            onAdminCommandEvent(EVENT_STATE_CHANGED, acs);
+        } finally {
+            LOG.log(TRACE, "Executing Command invocation finalization.");
+            if (broker != null) {
+                broker.unregisterListener(this);
+            }
+            finalizeRun();
+            synchronized(this) {
+                notifyAll();
+            }
+        }
+    }
+
+    @Override
+    public final void onAdminCommandEvent(final String name, Object event) {
+        if (name == null || event == null) {
+            return;
+        }
+        if (EVENT_NAME_LISTENER_REG.equals(name)) {
+            BrokerListenerRegEvent blre = (BrokerListenerRegEvent) event;
+            broker = blre.getBroker();
+            return;
+        }
+        if (name.startsWith(AdminCommandEventBroker.LOCAL_EVENT_PREFIX)) {
+            // Prevent events from client to be send back to client
+            return;
+        }
+        processCommandEvent(name, event);
+    }
+
+    /**
+     * Blocks until {@link #run()} method has finishes executing.
+     */
+    protected synchronized void awaitFinish() {
+        try {
+            wait();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private ActionReport createActionReport(ExitCode exitCode, String message, Throwable cause) {
+        ActionReport report = new PropsFileActionReporter();
+        report.setActionExitCode(exitCode);
+        report.setFailureCause(cause);
+        report.setMessage(message);
+        return report;
+    }
+}


### PR DESCRIPTION
* Fixed NPE in `EngineRef` seen in logs after failed deployment of ear
* Improved repeatability of the performance test
  * Randomly failed on GH CI Windows
  * GH CI cpu has 4 threads, I have 32, Jenkins 6
  * Using 100 threads, on GH CI the cache reduced times to 30%, on my machine it was 1%
  * Now I changed the count of threads to be 4 times multiplied number of CPU threads instead of hardcoded 100.
  * Windows CI: `Score: 21.791, firstRunScore: 161,177.844, ratio: 0`
  * Linux CI: `Score: 14.226, firstRunScore: 120,941.361, ratio: 0`
  * Jenkins CI:`Score: 358.308, firstRunScore: 166,443.59, ratio: 0.002`
  * My machine: `Score: 76.745, firstRunScore: 75,216.353, ratio: 0.001`
* Renamed method following changes in #25574 
* Javadocs in itest-tools, improved printing logs
* admin-tests - increased timeout for asadmin start-domain and restart-domain commands to 60 s
* AsadminLoggingITest - improved parsing of the file path from the response
* DetachAttachITest - I tried to improve the server side again a bit, it doesn't fail on my machine again, seems for now CI is happy too, despite I did not find the exact cause. Se we will see.
