### PR TITLE
Added keeping server.logs from tests on GH CI + synced files

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,15 +1,11 @@
 
 name: Build on Ubuntu
-
 on:
   pull_request:
-    branches: [ "master" ]
-
+    branches: [ "master", "7.0", "8.0" ]
 jobs:
   build:
-
     runs-on: ubuntu-24.04
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK
@@ -24,4 +20,9 @@ jobs:
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
       run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
-
+    - name: Upload server logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: server-logs
+        path: '**/server.log*'
+        retention-days: 3

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,14 +1,11 @@
-name: Build on MacOS
 
+name: Build on MacOS
 on:
   pull_request:
-    branches: [ "master" ]
-
+    branches: [ "master", "7.0", "8.0" ]
 jobs:
   build:
-
     runs-on: macos-15
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK
@@ -23,3 +20,9 @@ jobs:
       run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true' -Pfastest
     - name: Test Starts
       run: mvn -B -e -ntp install -Pstaging '-Dcheckstyle.skip=true' -pl :glassfish-itest-tools
+    - name: Upload server logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: server-logs
+        path: '**/server.log*'
+        retention-days: 3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,15 +1,11 @@
 
 name: Build on Windows
-
 on:
   pull_request:
-    branches: [ "master" ]
-
+    branches: [ "master", "7.0", "8.0" ]
 jobs:
   build:
-
     runs-on: windows-2025
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK
@@ -21,4 +17,10 @@ jobs:
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: mvn -B --no-transfer-progress -e clean install -Pstaging -Pqa '-Dcheckstyle.skip=true'
+      run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
+    - name: Upload server logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: server-logs
+        path: '**/server.log*'
+        retention-days: 3


### PR DESCRIPTION
Sometimes GF fails to start/listen in GH CI tests, but we have no idea why.
Now we can download them for 3 days since the build:

https://github.com/eclipse-ee4j/glassfish/actions/runs/15844568546?pr=25579#artifacts
https://github.com/eclipse-ee4j/glassfish/actions/runs/15844568544
https://github.com/eclipse-ee4j/glassfish/actions/runs/15844568551

...