### PR TITLE
Improved timeout management for admin commands

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,6 +22,7 @@ jobs:
       run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
     - name: Upload server logs
       uses: actions/upload-artifact@v4
+      if: failure()
       with:
         name: server-logs
         path: '**/server.log*'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,6 +22,7 @@ jobs:
       run: mvn -B -e -ntp install -Pstaging '-Dcheckstyle.skip=true' -pl :glassfish-itest-tools
     - name: Upload server logs
       uses: actions/upload-artifact@v4
+      if: failure()
       with:
         name: server-logs
         path: '**/server.log*'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,6 +20,7 @@ jobs:
       run: mvn -B -e -ntp install -Pstaging -Pqa '-Dcheckstyle.skip=true'
     - name: Upload server logs
       uses: actions/upload-artifact@v4
+      if: failure()
       with:
         name: server-logs
         path: '**/server.log*'

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/MigrateTimers.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/admin/cli/MigrateTimers.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -148,7 +149,7 @@ public class MigrateTimers implements AdminCommand {
         if(target.equals(SystemPropertyConstants.DEFAULT_SERVER_INSTANCE_NAME)) {
             List<Server> instances = fromServerCluster.getInstances();
             for(Server instance : instances) {
-                if(instance.isRunning()) {
+                if(instance.isListeningOnAdminPort()) {
                     target = instance.getName();
                     needRedirect = true;
                 }
@@ -177,7 +178,7 @@ public class MigrateTimers implements AdminCommand {
 
     private boolean isServerRunning(String serverName) {
         Server server = domain.getServerNamed(serverName);
-        return (server == null) ? false : server.isRunning();
+        return server == null ? false : server.isListeningOnAdminPort();
     }
 
     private int migrateTimers( String serverId ) {

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/startup/EjbDeployer.java
@@ -542,12 +542,12 @@ public class EjbDeployer extends JavaEEDeployer<EjbContainerStarter, EjbApplicat
             // Try a random instance in a cluster
             int useInstance = random.nextInt(instances.size());
             Server s0 = instances.get(useInstance);
-            if (s0.isRunning()) {
+            if (s0.isListeningOnAdminPort()) {
                 return s0.getName();
             } else {
                 // Pick the first running instead
                 for (Server s : instances) {
-                    if (s.isRunning()) {
+                    if (s.isListeningOnAdminPort()) {
                         return s.getName();
                     }
                 }

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -87,7 +87,9 @@ public class GlassFishTestEnvironment {
     private static final File PASSWORD_FILE = findPasswordFile("password.txt");
 
     private static final int ASADMIN_START_DOMAIN_TIMEOUT = 30_000;
-    private static final int ASADMIN_START_DOMAIN_TIMEOUT_FOR_DEBUG = 300_000;
+    /** 1 day. Useful for debugging */
+    private static final int ASADMIN_START_DOMAIN_TIMEOUT_FOR_DEBUG = 1000 * 60 * 60 * 24;
+
     private static HttpClient client = null;
 
     static {
@@ -98,17 +100,11 @@ public class GlassFishTestEnvironment {
             getAsadmin().exec(30_000, "stop-domain", "--kill", "--force");
         });
         Runtime.getRuntime().addShutdownHook(hook);
-        Asadmin asadmin = getAsadmin().withEnv(ADMIN_USER, ADMIN_PASSWORD);
-        if (System.getenv("AS_START_TIMEOUT") == null) {
-            // AS_START_TIMEOUT for the detection that "the server is running!"
-            // START_DOMAIN_TIMEOUT for us waiting for the end of the asadmin start-domain process.
-            asadmin.withEnv("AS_START_TIMEOUT", Integer.toString(ASADMIN_START_DOMAIN_TIMEOUT - 5000));
-        }
         final int timeout = isStartDomainSuspendEnabled()
                 ? ASADMIN_START_DOMAIN_TIMEOUT_FOR_DEBUG : ASADMIN_START_DOMAIN_TIMEOUT;
         // This is the absolutely first start - if it fails, all other starts will fail too.
         // Note: --suspend implicitly enables --debug
-        assertThat(asadmin.exec(timeout,"start-domain",
+        assertThat(getAsadmin().exec(timeout,"start-domain",
                 isStartDomainSuspendEnabled() ? "--suspend" : "--debug"), asadminOK());
     }
 

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/AsadminResult.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/AsadminResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,7 +40,7 @@ public class AsadminResult {
         this.error = exitCode != 0 || containsError(stdOut, String.format("Command %s failed.", commandName));
         this.stdOut = stdOut;
         this.stdErr = stdErr;
-        this.output = this.stdOut + this.stdErr;
+        this.output = (this.stdOut + " " + this.stdErr).strip();
     }
 
 

--- a/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
+++ b/appserver/orb/orb-iiop/src/main/java/org/glassfish/enterprise/iiop/impl/IiopFolbGmsClient.java
@@ -290,7 +290,7 @@ public class IiopFolbGmsClient implements CallBack {
         }
 
         if (!assumeInstanceIsRunning) {
-            if (!server.isRunning()) {
+            if (!server.isListeningOnAdminPort()) {
                 return null;
             }
         }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminLoggingITest.java
@@ -72,7 +72,7 @@ public class AsadminLoggingITest {
     @BeforeAll
     public static void fillUpServerLog() {
         // Fill up the server log.
-        AsadminResult result = ASADMIN.exec(60_000, "restart-domain");
+        AsadminResult result = ASADMIN.exec("restart-domain", "--timeout", "60");
         assertThat(result, asadminOK());
     }
 

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminVersionITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/AsadminVersionITest.java
@@ -42,7 +42,7 @@ public class AsadminVersionITest {
 
     @AfterAll
     public static void startDomainAgain() {
-        assertThat(ASADMIN.exec(60_000, "start-domain"), asadminOK());
+        assertThat(ASADMIN.exec("start-domain"), asadminOK());
     }
 
 

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/GJULEvsJDKLogManagerIT.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/GJULEvsJDKLogManagerIT.java
@@ -46,9 +46,9 @@ public class GJULEvsJDKLogManagerIT {
 
     @BeforeAll
     static void setAndBackup() {
-        assertThat(ASADMIN.exec(60000, "stop-domain"), asadminOK());
+        assertThat(ASADMIN.exec("stop-domain", "--timeout", "10"), asadminOK());
         assertThat(ASADMIN.exec(60000, "backup-domain"), asadminOK());
-        assertThat(ASADMIN.exec(60000, "start-domain"), asadminOK());
+        assertThat(ASADMIN.exec("start-domain", "--timeout", "60"), asadminOK());
     }
 
 
@@ -58,13 +58,13 @@ public class GJULEvsJDKLogManagerIT {
         final String sysOptGcLog = OS.isWindows() ? SYSOPT_GC_LOG.replaceAll(":", "\\:") : SYSOPT_GC_LOG;
         assertThat(ASADMIN.exec(10000, "create-jvm-options", sysOptErrLog), asadminOK());
         assertThat(ASADMIN.exec(10000, "create-jvm-options", sysOptGcLog), asadminOK());
-        assertThat(ASADMIN.exec(60000, "restart-domain"), asadminOK());
+        assertThat(ASADMIN.exec("restart-domain", "--timeout", "60"), asadminOK());
     }
 
     @AfterAll
     static void revert() {
-        assertThat(ASADMIN.exec(60000, "stop-domain"), asadminOK());
+        assertThat(ASADMIN.exec(60000, "stop-domain", "--timeout", "10"), asadminOK());
         assertThat(ASADMIN.exec(60000, "restore-domain", "domain1"), asadminOK());
-        assertThat(ASADMIN.exec(60000, "start-domain"), asadminOK());
+        assertThat(ASADMIN.exec(60000, "start-domain", "--timeout", "60"), asadminOK());
     }
 }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/JobManagerITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/JobManagerITest.java
@@ -63,7 +63,7 @@ public class JobManagerITest {
             "--cleanup-initial-delay=0s",
             "--cleanup-poll-interval=0s"), asadminOK());
         assertThat(ASADMIN.exec(COMMAND_PROGRESS_SIMPLE), asadminOK());
-        assertThat(ASADMIN.exec(60_000, "restart-domain"), asadminOK());
+        assertThat(ASADMIN.exec("restart-domain", "--timeout", "60"), asadminOK());
         assertThat(ASADMIN.exec("list-jobs").getStdOut(), stringContainsInOrder(COMMAND_PROGRESS_SIMPLE, "COMPLETED"));
         JobTestExtension.doAndDisableJobCleanup();
     }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/LoggingRestITest.java
@@ -55,7 +55,7 @@ public class LoggingRestITest extends RestTestBase {
     public static void fillUpLog() {
         // The server log may become empty due to log rotation.
         // Restart domain to fill it up.
-        AsadminResult result = getAsadmin().exec(60_000, "restart-domain");
+        AsadminResult result = getAsadmin().exec("restart-domain", "--timeout", "60");
         assertThat(result, asadminOK());
     }
 

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/synchronize/SynchronizeStandaloneInstanceTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/synchronize/SynchronizeStandaloneInstanceTest.java
@@ -75,7 +75,7 @@ public class SynchronizeStandaloneInstanceTest {
     @Test
     public void testSynchronization() {
         // Longer timeout for the synchronization
-        assertThat(ASADMIN.exec(120_000, "start-instance", INSTANCE_NAME), asadminOK());
+        assertThat(ASADMIN.exec("start-instance", "--timeout", "120", INSTANCE_NAME), asadminOK());
     }
 
     private static File createDeployment() {

--- a/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/recovery/GMSCallBack.java
+++ b/appserver/transaction/jts/src/main/java/com/sun/enterprise/transaction/jts/recovery/GMSCallBack.java
@@ -228,7 +228,7 @@ public class GMSCallBack implements CallBack {
     private boolean isInstanceRunning(String instance) {
         for (Server server : servers.getServer()) {
             if (instance.equals(server.getName())) {
-                return server.isRunning();
+                return server.isListeningOnAdminPort();
             }
         }
 

--- a/appserver/transaction/jts/src/main/java/org/glassfish/jts/admin/cli/RecoverTransactionsBase.java
+++ b/appserver/transaction/jts/src/main/java/org/glassfish/jts/admin/cli/RecoverTransactionsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -83,15 +83,12 @@ public class RecoverTransactionsBase {
     }
 
     private boolean isServerRunning(String serverName) {
-        boolean rs = false;
         for(Server server : servers.getServer()) {
             if(serverName.equals(server.getName())) {
-                rs = server.isRunning();
-                break;
+                return server.isListeningOnAdminPort();
             }
         }
-
-        return rs;
+        return false;
     }
 
 }

--- a/docs/reference-manual/src/main/asciidoc/attach.adoc
+++ b/docs/reference-manual/src/main/asciidoc/attach.adoc
@@ -18,7 +18,9 @@ that contain progress information
 
 [source]
 ----
-asadmin [asadmin-options] attach [--help]
+asadmin attach
+[--help|-?]
+[--timeout <timeout>]
 job_id
 ----
 
@@ -46,6 +48,11 @@ asadmin-options::
 `--help`::
 `-?`::
   Displays the help text for the subcommand.
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The job status is unknown
+  in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
@@ -17,11 +17,14 @@ Restarts the DAS of the specified domain
 
 [source]
 ----
-asadmin [asadmin-options] restart-domain [--help]
-[--debug ={true|false}]
-[--domaindir domaindir]
-[--force={true|false}] [--kill={false|true}]
-[domain-name]
+asadmin restart-domain
+[--debug[=<debug(default:false)>]]
+[--domaindir <domaindir>]
+[--force[=<force(default:true)>]]
+[--help|-?]
+[--kill[=<kill(default:false)>]]
+[--timeout <timeout>]
+[domain_name]
 ----
 
 === Description
@@ -93,6 +96,12 @@ The default is the current setting of this option for the domain that
   `true`;;
     The domain is killed. The subcommand uses functionality of the
     operating system to terminate the domain process.
+
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The domain status is unknown
+  in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/restart-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-instance.adoc
@@ -17,8 +17,10 @@ Restarts a running {productName} instance
 
 [source]
 ----
-asadmin [asadmin-options] restart-instance [--help]
-[--debug={false|true}] instance-name
+asadmin restart-instance
+[--debug <debug>]
+[--timeout <timeout>]
+instancename
 ----
 
 === Description
@@ -90,6 +92,12 @@ asadmin-options::
 +
 The default is the current setting of this option for the instance
   that is being restarted.
+
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The instance status is unknown
+  in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/restart-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-local-instance.adoc
@@ -18,11 +18,15 @@ subcommand is run
 
 [source]
 ----
-asadmin [asadmin-options] restart-local-instance [--help]
-[--nodedir nodedir] [--node node]
-[--debug={false|true}]
-[--force={true|false}] [--kill={false|true}]
-[instance-name]
+asadmin restart-local-instance
+[--debug[=<debug(default:false)>]]
+[--force[=<force(default:true)>]]
+[--help|-?]
+[--kill[=<kill(default:false)>]]
+[--node <node>]
+[--nodedir <nodedir>]
+[--timeout <timeout>]
+[instance_name]
 ----
 
 === Description
@@ -76,14 +80,6 @@ asadmin-options::
 `--help`::
 `-?`::
   Displays the help text for the subcommand.
-`--nodedir`::
-  Specifies the directory that contains the instance's node directory.
-  The instance's files are stored in the instance's node directory. The
-  default is as-install``/nodes``.
-`--node`::
-  Specifies the node on which the instance resides. This option may be
-  omitted only if the directory that the `--nodedir` option specifies
-  contains only one node directory. Otherwise, this option is required.
 `--debug`::
   Specifies whether the instance is restarted with
   http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
@@ -122,6 +118,20 @@ The default is the current setting of this option for the instance
   `true`;;
     The instance is killed. The subcommand uses functionality of the
     operating system to terminate the instance process.
+
+`--node`::
+  Specifies the node on which the instance resides. This option may be
+  omitted only if the directory that the `--nodedir` option specifies
+  contains only one node directory. Otherwise, this option is required.
+`--nodedir`::
+  Specifies the directory that contains the instance's node directory.
+  The instance's files are stored in the instance's node directory. The
+  default is as-install``/nodes``.
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The instance status is unknown
+  in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/start-cluster.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-cluster.adoc
@@ -17,9 +17,12 @@ Starts a cluster
 
 [source]
 ----
-asadmin [asadmin-options] start-cluster [--help]
-[--autohadboverride={true|false}]
-[--verbose={false|true}] cluster-name
+asadmin start-cluster
+[--debug[=<debug(default:false)>]]
+[--help|-?]
+[--timeout <timeout>]
+[--verbose[=<verbose(default:false)>]]
+clustername
 ----
 
 === Description
@@ -53,11 +56,27 @@ asadmin-options::
 `--help`::
 `-?`::
   Displays the help text for the subcommand.
-`--autohadboverride`::
-  Do not specify this option. This option is retained for compatibility
-  with earlier releases. If you specify this option, a syntax error does
-  not occur. Instead, the subcommand runs successfully and displays a
-  warning message that the option is ignored.
+`--debug`::
+`-d`::
+  Specifies whether the domain is started with
+  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
+  Platform Debugger Architecture (JPDA)]
+  (https://docs.oracle.com/en/java/javase/11/docs/specs/jpda/conninv.html)
+  debugging enabled. With debugging enabled extra exceptions can be printed.
+  Possible values are as follows:
+
+  `true`;;
+    The instance is started with JPDA debugging enabled and the port
+    number for JPDA debugging is displayed.
+  `false`;;
+    The instance is started with JPDA debugging disabled (default).
+
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The status of instances is
+  unknown in such case.
+
 `--verbose`::
   Specifies whether additional status information is displayed when the
   cluster is started.

--- a/docs/reference-manual/src/main/asciidoc/start-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-domain.adoc
@@ -17,11 +17,18 @@ Starts the DAS of the specified domain
 
 [source]
 ----
-asadmin [asadmin-options] start-domain [--help]
-[--debug={true|false}] [--suspend={true|false}] [--domaindir domain-dir]
-[--dry-run={true|false}] [--upgrade={true|false}]
-[--verbose={true|false}] [--watchdog={true|false}]
-[domain-name]
+asadmin start-domain
+[--debug|-d[=<debug(default:false)>]]
+[--domaindir <domaindir>]
+[--drop-interrupted-commands[=<drop-interrupted-commands(default:false)>]]
+[--dry-run|-n[=<dry-run(default:false)>]]
+[--help|-?]
+[--suspend|-s[=<suspend(default:false)>]]
+[--timeout <timeout>]
+[--upgrade[=<upgrade(default:false)>]]
+[--verbose|-v[=<verbose(default:false)>]]
+[--watchdog|-w[=<watchdog(default:false)>]]
+[domain_name]
 ----
 
 === Description
@@ -76,6 +83,24 @@ asadmin-options::
   `false`;;
     The instance is started with JPDA debugging disabled (default).
 
+`--domaindir`::
+  The domain root directory, which contains the directory of the domain
+  that is to be restarted. If specified, the path must be accessible in
+  the file system. The default location of the domain root directory is
+  as-install``/domains``.
+
+`--drop-interrupted-commands`::
+  If you used --detach with commands supporting checkpoints, this
+  option specifies whether to drop the commands that were interrupted.
+
+`--dry-run`::
+`-n`::
+  Suppresses actual starting of the domain. Instead, `start-domain`
+  displays the full java command that would be used to start the domain,
+  including all options. Reviewing this command can be useful to confirm
+  JVM options and when troubleshooting startup issues. +
+  The default value is `false`.
+
 `--suspend`::
 `-s`::
   Specifies whether the domain is started with
@@ -93,18 +118,12 @@ asadmin-options::
   `false`;;
     The instance is started with JPDA debugging disabled (default).
 
-`--dry-run`::
-`-n`::
-  Suppresses actual starting of the domain. Instead, `start-domain`
-  displays the full java command that would be used to start the domain,
-  including all options. Reviewing this command can be useful to confirm
-  JVM options and when troubleshooting startup issues. +
-  The default value is `false`.
-`--domaindir`::
-  The domain root directory, which contains the directory of the domain
-  that is to be restarted. If specified, the path must be accessible in
-  the file system. The default location of the domain root directory is
-  as-install``/domains``.
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The domain status is unknown
+  in such case.
+
 `--upgrade`::
   Specifies whether the configuration of the domain administration
   server (DAS) is upgraded to the current release. Normally, if the

--- a/docs/reference-manual/src/main/asciidoc/start-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-instance.adoc
@@ -17,9 +17,12 @@ Starts a {productName} instance
 
 [source]
 ----
-asadmin [asadmin-options] start-instance [--help]
-[--debug={false|true}] [--sync={normal|full|none}]
-instance-name
+asadmin start-instance
+[--debug[=<debug(default:false)>]]
+[--help|-?]
+[--sync <sync(default:normal)>]
+[--timeout <timeout>]
+instance_name
 ----
 
 === Description
@@ -102,6 +105,12 @@ If a file below a top level subdirectory is changed without a change
     synchronization. This type of synchronization might delay the
     startup of the instance while the DAS updates all files in the
     instance's directories.
+
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The instance status is unknown
+  in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
@@ -17,12 +17,17 @@ Starts a {productName} instance on the host where the subcommand is run
 
 [source]
 ----
-asadmin [asadmin-options] start-local-instance [--help]
-[--nodedir node-dir] [--node node]
-[--debug={false|true}] [--dry-run={true|false}]
-[--sync={normal|full|none}]
-[--verbose={false|true}] [--watchdog={true|false}]
-[instance-name]
+asadmin start-local-instance
+[--debug|-d[=<debug(default:false)>]]
+[--dry-run|-n[=<dry-run(default:false)>]]
+[--help|-?]
+[--node <node>]
+[--nodedir <nodedir>]
+[--sync <sync(default:normal)>]
+[--timeout <timeout>]
+[--verbose|-v[=<verbose(default:false)>]]
+[--watchdog|-w[=<watchdog(default:false)>]]
+[instance_name]
 ----
 
 === Description
@@ -57,14 +62,6 @@ asadmin-options::
 `--help`::
 `-?`::
   Displays the help text for the subcommand.
-`--nodedir`::
-  Specifies the directory that contains the instance's node directory.
-  The instance's files are stored in the instance's node directory. The
-  default is as-install``/nodes``.
-`--node`::
-  Specifies the node on which the instance resides. This option may be
-  omitted only if the directory that the `--nodedir` option specifies
-  contains only one node directory. Otherwise, this option is required.
 `--debug`::
 `-d`::
   Specifies whether the instance is started with
@@ -88,6 +85,14 @@ Possible values are as follows:
   be useful when troubleshooting startup issues. +
   The default value is `false`.
 
+`--node`::
+  Specifies the node on which the instance resides. This option may be
+  omitted only if the directory that the `--nodedir` option specifies
+  contains only one node directory. Otherwise, this option is required.
+`--nodedir`::
+  Specifies the directory that contains the instance's node directory.
+  The instance's files are stored in the instance's node directory. The
+  default is as-install``/nodes``.
 `--sync`::
   The type of synchronization between the DAS and the instance's files
   when the instance is started. +
@@ -130,6 +135,11 @@ cache, the subcommand fails and the instance cannot be restarted
 until it is resynchronized with the DAS.
 ====
 
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The instance status is unknown
+  in such case.
 `--verbose`::
 `-v`::
   Specifies whether detailed information about the instance is displayed

--- a/docs/reference-manual/src/main/asciidoc/stop-cluster.adoc
+++ b/docs/reference-manual/src/main/asciidoc/stop-cluster.adoc
@@ -17,11 +17,11 @@ Stops a {productName} cluster
 
 [source]
 ----
-asadmin [asadmin-options] stop-cluster [--help]
-[--verbose={false|true}]
-[--kill={false|true}]
-[--autohadboverride={true|false}]
-cluster-name
+asadmin stop-cluster
+[--help|-?]
+[--kill[=<kill(default:false)>]]
+[--timeout <timeout>]
+clustername
 ----
 
 === Description
@@ -64,11 +64,11 @@ asadmin-options::
     Each instance is killed. The subcommand uses functionality of the
     operating system to terminate each instance process.
 
-`--autohadboverride`::
-  Do not specify this option. This option is retained for compatibility
-  with earlier releases. If you specify this option, a syntax error does
-  not occur. Instead, the subcommand runs successfully and displays a
-  warning message that the option is ignored.
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The status of instances is
+  unknown in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/stop-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/stop-domain.adoc
@@ -17,10 +17,13 @@ Stops the Domain Administration Server of the specified domain
 
 [source]
 ----
-asadmin [asadmin-options] stop-domain [--help]
-[--domaindir domaindir]
-[--force={true|false}] [--kill={false|true}]
-[domain-name]
+asadmin stop-domain
+[--domaindir <domaindir>]
+[--force[=<force(default:true)>]]
+[--help|-?]
+[--kill[=<kill(default:false)>]]
+[--timeout <timeout>]
+[domain_name]
 ----
 
 === Description
@@ -45,11 +48,13 @@ asadmin-options::
 `--help`::
 `-?`::
   Displays the help text for the subcommand.
+
 `--domaindir`::
   Specifies the directory of the domain that is to be stopped. If
   specified, the path must be accessible in the file system. If not
   specified, the domain in the default as-install``/domains`` directory is
   stopped.
+
 `--force`::
   Specifies whether the domain is forcibly stopped immediately. +
   Possible values are as follows:
@@ -71,6 +76,13 @@ asadmin-options::
   `true`;;
     The domain is killed. The subcommand uses functionality of the
     operating system to terminate the domain process.
+
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The domain status is unknown
+  in such case.
+
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/stop-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/stop-instance.adoc
@@ -17,9 +17,12 @@ Stops a running {productName} instance
 
 [source]
 ----
-asadmin [asadmin-options] stop-instance [--help]
-[--force={false|true}] [--kill={false|true}]
-instance-name
+asadmin stop-instance
+[--force[=<force(default:true)>]]
+[--help|-?]
+[--kill[=<kill(default:false)>]]
+[--timeout <timeout>]
+instancename
 ----
 
 === Description
@@ -62,6 +65,12 @@ asadmin-options::
   `true`;;
     The instance is killed. The subcommand uses functionality of the
     operating system to terminate the instance process.
+
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The instance status is unknown
+  in such case.
 
 === Operands
 

--- a/docs/reference-manual/src/main/asciidoc/stop-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/stop-local-instance.adoc
@@ -17,10 +17,14 @@ Stops a {productName} instance on the machine where the subcommand is run
 
 [source]
 ----
-asadmin [asadmin-options] stop-local-instance [--help]
-[--nodedir node-dir] [--node node]
-[--force={true|false}] [--kill={false|true}]
-[instance-name]
+asadmin stop-local-instance
+[--force[=<force(default:true)>]]
+[--help|-?]
+[--kill[=<kill(default:false)>]]
+[--node <node>]
+[--nodedir <nodedir>]
+[--timeout <timeout>]
+[instance_name]
 ----
 
 === Description
@@ -51,14 +55,6 @@ asadmin-options::
 `--help`::
 `-?`::
   Displays the help text for the subcommand.
-`--nodedir`::
-  Specifies the directory that contains the instance's node directory.
-  The instance's files are stored in the instance's node directory. The
-  default is as-install``/nodes``.
-`--node`::
-  Specifies the node on which the instance resides. This option may be
-  omitted only if the directory that the `--nodedir` option specifies
-  contains only one node directory. Otherwise, this option is required.
 `--force`::
   Specifies whether the instance is forcibly stopped immediately. +
   Possible values are as follows:
@@ -80,6 +76,20 @@ asadmin-options::
   `true`;;
     The instance is killed. The subcommand uses functionality of the
     operating system to terminate the instance process.
+
+`--node`::
+  Specifies the node on which the instance resides. This option may be
+  omitted only if the directory that the `--nodedir` option specifies
+  contains only one node directory. Otherwise, this option is required.
+`--nodedir`::
+  Specifies the directory that contains the instance's node directory.
+  The instance's files are stored in the instance's node directory. The
+  default is as-install``/nodes``.
+`--timeout`::
+  Specifies timeout in seconds to evaluate the expected result.
+  If the timeout is exceeded, the command fails - however it does
+  not mean it did not make any changes. The instance status is unknown
+  in such case.
 
 === Operands
 

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLICommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,8 +53,10 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.glassfish.api.Param;
+import org.glassfish.api.ParamDefaultCalculator;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.api.admin.CommandModel;
 import org.glassfish.api.admin.CommandModel.ParamModel;
@@ -367,7 +370,7 @@ public abstract class CLICommand implements PostConstruct {
     public String getUsage() {
         String usage;
         if (commandModel != null && ok(usage = commandModel.getUsageText())) {
-            StringBuffer usageText = new StringBuffer();
+            StringBuilder usageText = new StringBuilder();
             usageText.append(strings.get("Usage", strings.get("Usage.brief", programOpts.getCommandName())));
             usageText.append(" ");
             usageText.append(usage);
@@ -382,90 +385,22 @@ public abstract class CLICommand implements PostConstruct {
         usageText.append(strings.get("Usage", strings.get("Usage.brief", programOpts.getCommandName())));
         usageText.append(" ");
         usageText.append(getName());
-        int len = usageText.length();
-        StringBuilder optText = new StringBuilder();
         String lsep = System.lineSeparator();
-        for (ParamModel opt : usageOptions()) {
-            optText.setLength(0);
-            final String optName = lc(opt.getName());
-            // "--terse" is part of asadmin utility options
-            if (optName.equals("terse")) {
+        // It is easier to find something if the options are sorted.
+        Collection<ParamModel> usageOptions = new ArrayList<>(usageOptions());
+        usageOptions.add(new NoValueModel("help", "?", true));
+        List<ParamModel> sorted = usageOptions.stream().sorted(new OptionComparator())
+            .collect(Collectors.toList());
+        for (ParamModel opt : sorted) {
+            String optText = toLine(opt);
+            if (optText == null) {
                 continue;
             }
-            // skip "hidden" options
-            if (optName.startsWith("_")) {
-                continue;
-            }
-            // do not want to display password as an option
-            if (opt.getParam().password()) {
-                continue;
-            }
-            // also do not want to display obsolete options
-            if (opt.getParam().obsolete()) {
-                continue;
-            }
-            // primary parameter is the operand, not an option
-            if (opt.getParam().primary()) {
-                continue;
-            }
-            boolean optional = opt.getParam().optional();
-            String defValue = opt.getParam().defaultValue();
-            if (optional) {
-                optText.append("[");
-            }
-            String sn = opt.getParam().shortName();
-            if (ok(sn)) {
-                optText.append('-').append(sn).append('|');
-            }
-            optText.append("--").append(optName);
-
-            if (opt.getType() == Boolean.class || opt.getType() == boolean.class) {
-                // canonicalize default value
-                if (ok(defValue) && Boolean.parseBoolean(defValue)) {
-                    defValue = "true";
-                } else {
-                    defValue = "false";
-                }
-                optText.append("[=<").append(optName);
-                optText.append(strings.get("Usage.default", defValue));
-                optText.append(">]");
-            } else { // STRING or FILE
-                if (ok(defValue)) {
-                    optText.append(" <").append(optName);
-                    optText.append(strings.get("Usage.default", defValue));
-                    optText.append('>');
-                } else {
-                    optText.append(" <").append(optName).append('>');
-                }
-            }
-            if (optional) {
-                optText.append("]");
-            }
-
-            if (len + 1 + optText.length() > 80) {
-                usageText.append(lsep).append('\t');
-                len = 8;
-            } else {
-                usageText.append(' ');
-                len++;
-            }
-            usageText.append(optText);
-            len += optText.length();
-        }
-
-        // add --help text
-        String helpText = "[-?|--help[=<help(default:false)>]]";
-        if (len + 1 + helpText.length() > 80) {
             usageText.append(lsep).append('\t');
-            len = 8;
-        } else {
-            usageText.append(' ');
-            len++;
+            usageText.append(optText);
         }
-        usageText.append(helpText);
-        len += helpText.length();
 
-        optText.setLength(0);
+        StringBuilder optText = new StringBuilder();
         ParamModel operandParam = getOperandModel();
         String opname = operandParam != null ? lc(operandParam.getName()) : null;
         if (!ok(opname)) {
@@ -492,15 +427,71 @@ public abstract class CLICommand implements PostConstruct {
                 }
             }
         }
-        if (len + 1 + optText.length() > 80) {
-            usageText.append(lsep).append('\t');
-            len = 8;
-        } else {
-            usageText.append(' ');
-            len++;
-        }
+        usageText.append(lsep).append('\t');
         usageText.append(optText);
         return usageText.toString();
+    }
+
+    private String toLine(ParamModel opt) {
+        final String optName = lc(opt.getName());
+        // "--terse" is part of asadmin utility options
+        if (optName.equals("terse")) {
+            return null;
+        }
+        // skip "hidden" options
+        if (optName.startsWith("_")) {
+            return null;
+        }
+        // do not want to display password as an option
+        if (opt.getParam().password()) {
+            return null;
+        }
+        // also do not want to display obsolete options
+        if (opt.getParam().obsolete()) {
+            return null;
+        }
+        // primary parameter is the operand, not an option
+        if (opt.getParam().primary()) {
+            return null;
+        }
+        StringBuilder optText = new StringBuilder();
+        boolean optional = opt.getParam().optional();
+        String defValue = opt.getParam().defaultValue();
+        if (optional) {
+            optText.append("[");
+        }
+        optText.append("--").append(optName);
+        String sn = opt.getParam().shortName();
+        if (ok(sn)) {
+            optText.append('|').append('-').append(sn);
+        }
+
+        if (opt.getType() == Boolean.class || opt.getType() == boolean.class) {
+            // canonicalize default value
+            if (ok(defValue) && Boolean.parseBoolean(defValue)) {
+                defValue = "true";
+            } else {
+                defValue = "false";
+            }
+            optText.append("[=<").append(optName);
+            optText.append(strings.get("Usage.default", defValue));
+            optText.append(">]");
+        } else if (opt.getType() == Void.class) {
+            // Don't add anything, value is always ignored.
+        } else {
+            // STRING or FILE
+            if (ok(defValue)) {
+                optText.append(" <").append(optName);
+                optText.append(strings.get("Usage.default", defValue));
+                optText.append('>');
+            } else {
+                optText.append(" <").append(optName).append('>');
+            }
+        }
+        if (optional) {
+            optText.append("]");
+        }
+        return optText.toString();
     }
 
     /**
@@ -613,7 +604,7 @@ public abstract class CLICommand implements PostConstruct {
             char c = value.charAt(i);
             if (c == '"' || c == '\\' || c == '\r' || c == '\n') {
                 // need to escape them and then quote the whole string
-                StringBuffer sb = new StringBuffer(len + 3);
+                StringBuilder sb = new StringBuilder(len + 3);
                 sb.append('"');
                 sb.append(value.substring(0, i));
                 int lastc = 0;
@@ -639,7 +630,7 @@ public abstract class CLICommand implements PostConstruct {
         }
 
         if (needQuoting) {
-            StringBuffer sb = new StringBuffer(len + 2);
+            StringBuilder sb = new StringBuilder(len + 2);
             sb.append('"').append(value).append('"');
             return sb.toString();
         } else {
@@ -1274,6 +1265,124 @@ public abstract class CLICommand implements PostConstruct {
             }
         } catch (IOException e) {
             throw new IllegalStateException("Could not parse resource file " + file, e);
+        }
+    }
+
+
+    /**
+     * options with short prefix should be before options without short prefix.
+     */
+    private static class OptionComparator implements Comparator<ParamModel> {
+
+        @Override
+        public int compare(ParamModel o1, ParamModel o2) {
+            return o1.getName().compareTo(o2.getName());
+        }
+    }
+
+
+    private static class NoValueModel extends ParamModel {
+        private final Param param;
+
+        NoValueModel(String name, String shortName, boolean optional) {
+            this.param = new Param() {
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return null;
+                }
+
+                @Override
+                public String shortName() {
+                    return shortName;
+                }
+
+                @Override
+                public char separator() {
+                    // no separator for no value
+                    return 0;
+                }
+
+                @Override
+                public boolean primary() {
+                    return false;
+                }
+
+                @Override
+                public boolean password() {
+                    return false;
+                }
+
+                @Override
+                public boolean optional() {
+                    return optional;
+                }
+
+                @Override
+                public boolean obsolete() {
+                    return false;
+                }
+
+                @Override
+                public String name() {
+                    return name;
+                }
+
+                @Override
+                public boolean multiple() {
+                    return false;
+                }
+
+                @Override
+                public String defaultValue() {
+                    return null;
+                }
+
+                @Override
+                public Class<? extends ParamDefaultCalculator> defaultCalculator() {
+                    return null;
+                }
+
+                @Override
+                public String alias() {
+                    return null;
+                }
+
+                @Override
+                public String acceptableValues() {
+                    return null;
+                }
+            };
+        }
+
+        @Override
+        public String getName() {
+            return param.name();
+        }
+
+        @Override
+        public Param getParam() {
+            return param;
+        }
+
+        @Override
+        public String getLocalizedDescription() {
+            return null;
+        }
+
+        @Override
+        public String getLocalizedPrompt() {
+            return null;
+        }
+
+        @Override
+        public String getLocalizedPromptAgain() {
+            return null;
+        }
+
+        @Override
+        public Class<Void> getType() {
+            return Void.class;
         }
     }
 }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLIConstants.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLIConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,12 @@
 package com.sun.enterprise.admin.cli;
 
 import java.lang.System.Logger.Level;
+import java.time.Duration;
+
+import org.glassfish.embeddable.GlassFishVariable;
+
+import static org.glassfish.embeddable.GlassFishVariable.TIMEOUT_START_SERVER;
+import static org.glassfish.embeddable.GlassFishVariable.TIMEOUT_STOP_SERVER;
 
 /**
  * Constants for use in this package and "sub" packages
@@ -29,7 +35,7 @@ public final class CLIConstants {
     public static final String DEFAULT_HOSTNAME = "localhost";
     public static final String EOL = System.lineSeparator();
 
-    public static final long WAIT_FOR_DAS_TIME_MS = getEnv("AS_START_TIMEOUT", 60_000L);
+    public static final Duration WAIT_FOR_DAS_TIME_MS = getEnv(TIMEOUT_START_SERVER, 60L);
     public static final int RESTART_NORMAL = 10;
     public static final int RESTART_DEBUG_ON = 11;
     public static final int RESTART_DEBUG_OFF = 12;
@@ -38,7 +44,7 @@ public final class CLIConstants {
     public static final int SUCCESS = 0;
     public static final int ERROR = 1;
     public static final int WARNING = 4;
-    public static final long DEATH_TIMEOUT_MS = getEnv("AS_STOP_TIMEOUT", 60_000);
+    public static final Duration DEATH_TIMEOUT_MS = getEnv(TIMEOUT_STOP_SERVER, 60L);
 
     public static final String K_ADMIN_PORT = "agent.adminPort";
     public static final String K_ADMIN_HOST = "agent.adminHost";
@@ -59,7 +65,7 @@ public final class CLIConstants {
     public static final String AGENT_DAS_IS_SECURE = "isDASSecure";
 
     public static final String NODEAGENT_DEFAULT_DAS_IS_SECURE = "false";
-    public static final String NODEAGENT_DEFAULT_DAS_PORT = String.valueOf(CLIConstants.DEFAULT_ADMIN_PORT);
+    public static final String NODEAGENT_DEFAULT_DAS_PORT = String.valueOf(DEFAULT_ADMIN_PORT);
     public static final String NODEAGENT_DEFAULT_HOST_ADDRESS = "0.0.0.0";
     public static final String NODEAGENT_JMX_DEFAULT_PROTOCOL = "rmi_jrmp";
     public static final int RESTART_CHECK_INTERVAL_MSEC = 10;
@@ -68,21 +74,24 @@ public final class CLIConstants {
         // no instances allowed!
     }
 
-    private static long getEnv(String name, long defaultValue) {
+    private static Duration getEnv(GlassFishVariable variable, long defaultValue) {
+        String name = variable.getEnvName();
         String value = System.getenv(name);
         if (value == null) {
-            return defaultValue;
+            return Duration.ofSeconds(defaultValue);
         }
         try {
-            long parsedValue = Long.parseLong(value);
+            int parsedValue = Integer.parseInt(value);
             if (parsedValue > 0L) {
-                return parsedValue;
+                return Duration.ofSeconds(parsedValue);
             }
-            System.getLogger(CLIConstants.class.getName()).log(Level.WARNING, "The value of the environment property {0} must be positive.", name);
-            return defaultValue;
+            System.getLogger(CLIConstants.class.getName()).log(Level.WARNING,
+                "The value of the environment property {0} must be positive.", name);
+            return Duration.ofSeconds(defaultValue);
         } catch (NumberFormatException e) {
-            System.getLogger(CLIConstants.class.getName()).log(Level.WARNING, "Environment property {0} is set to a value {1} which cannot be parsed to long.", name, value);
-            return defaultValue;
+            System.getLogger(CLIConstants.class.getName()).log(Level.WARNING,
+                "Environment property {0} is set to a value {1} which cannot be parsed to duration.", name, value);
+            return Duration.ofSeconds(defaultValue);
         }
     }
 }

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Server.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/serverbeans/Server.java
@@ -348,18 +348,10 @@ public interface Server extends ConfigBeanProxy, PropertyBag, Named, SystemPrope
     }
 
     /**
-     * This is NOT a reliable test. It just checks if ANYTHING has setup shop on the host and port.
-     * I wanted to run RemoteAdminCommand but that is (inexplicably) in admin/util -- and we would
-     * have a circular dependency.
+     * @return true if this server instance is listening on the admin port, false otherwise.
      */
-    default boolean isRunning() {
-        try {
-            ServerHelper helper = new ServerHelper(this, getConfig());
-            return helper.isRunning();
-        } catch (Exception e) {
-            // drop through...
-        }
-        return false;
+    default boolean isListeningOnAdminPort() {
+        return new ServerHelper(this, getConfig()).isListeningOnAdminPort();
     }
 
     @Service

--- a/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/util/ServerHelper.java
+++ b/nucleus/admin/config-api/src/main/java/com/sun/enterprise/config/util/ServerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -44,7 +44,7 @@ import static org.glassfish.embeddable.GlassFishVariable.HOST_NAME;
  *
  * @author Byron Nevins
  */
-public class ServerHelper {
+public final class ServerHelper {
 
     private final Server server;
     private final Config config;
@@ -114,13 +114,12 @@ public class ServerHelper {
     }
 
     // very simple generic check
-    public final boolean isRunning() {
+    public final boolean isListeningOnAdminPort() {
         try {
             return NetUtils.isRunning(getAdminHost(), getAdminPort());
         } catch (Exception e) {
-            // fall through
+            return false;
         }
-        return false;
     }
 
     public static NetworkListener getAdminListener(Config config) {

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalDomainCommand.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,7 +35,7 @@ import org.glassfish.api.admin.CommandValidationException;
  */
 public abstract class LocalDomainCommand extends LocalServerCommand {
     @Param(name = "domaindir", optional = true)
-    protected String domainDirParam = null;
+    protected String domainDirParam;
     // subclasses decide whether it's optional, required, or not allowed
     //@Param(name = "domain_name", primary = true, optional = true)
     private String userArgDomainName;
@@ -74,11 +75,10 @@ public abstract class LocalDomainCommand extends LocalServerCommand {
 
     protected final String getDomainName() {
         // can't just use "dd" since it may be half-baked right now!
-
-        if (dd != null && dd.isValid())
+        if (dd != null && dd.isValid()) {
             return dd.getDomainName();
-        else // too early!
-            return userArgDomainName; // might be and is ok to be null
+        }
+        return userArgDomainName; // might be and is ok to be null
     }
 
     /**
@@ -95,8 +95,9 @@ public abstract class LocalDomainCommand extends LocalServerCommand {
         try {
             File domainsDirFile = null;
 
-            if (ok(domainDirParam))
+            if (ok(domainDirParam)) {
                 domainsDirFile = new File(domainDirParam);
+            }
 
             dd = new DomainDirs(domainsDirFile, getDomainName());
             setServerDirs(dd.getServerDirs());

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -43,7 +43,6 @@ import org.glassfish.api.ActionReport.ExitCode;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.main.jdke.i18n.LocalStringsImpl;
 
-import static com.sun.enterprise.admin.cli.CLIConstants.DEATH_TIMEOUT_MS;
 import static com.sun.enterprise.admin.cli.CLIConstants.DEFAULT_ADMIN_PORT;
 import static com.sun.enterprise.admin.cli.CLIConstants.DEFAULT_HOSTNAME;
 import static com.sun.enterprise.admin.cli.ProgramOptions.PasswordLocation.LOCAL_PASSWORD;
@@ -332,14 +331,14 @@ public abstract class LocalServerCommand extends CLICommand {
      * @param oldPid
      * @param oldAdminAddress
      * @param newAdminAddress new admin endpoint - usually same as old, but it could change with restart.
+     * @param timeout can be null
      * @throws CommandException if we time out.
      */
     protected final void waitForRestart(final Long oldPid, final HostAndPort oldAdminAddress,
-        final HostAndPort newAdminAddress) throws CommandException {
-        logger.log(Level.FINEST, "waitForRestart(oldPid={0}, oldAdminAddress={1}, newAdminAddress={2})",
-            new Object[] {oldPid, oldAdminAddress, newAdminAddress});
+        final HostAndPort newAdminAddress, Duration timeout) throws CommandException {
+        logger.log(Level.FINEST, "waitForRestart(oldPid={0}, oldAdminAddress={1}, newAdminAddress={2}, timeout={3})",
+            new Object[] {oldPid, oldAdminAddress, newAdminAddress, timeout});
 
-        final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final boolean printDots = !programOpts.isTerse();
         final boolean stopped = oldPid == null || ProcessUtils.waitWhileIsAlive(oldPid, timeout, printDots);
         if (!stopped) {
@@ -367,7 +366,7 @@ public abstract class LocalServerCommand extends CLICommand {
             logger.log(Level.FINEST, "The server pid is {0}", newPid);
             return ProcessUtils.isAlive(newPid);
         };
-        if (!ProcessUtils.waitFor(signStart, Duration.ofMillis(CLIConstants.WAIT_FOR_DAS_TIME_MS), printDots)) {
+        if (!ProcessUtils.waitFor(signStart, timeout, printDots)) {
             throw new CommandException(I18N.get("restartDomain.noGFStart"));
         }
     }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
@@ -23,6 +23,7 @@ import com.sun.enterprise.util.HostAndPort;
 
 import jakarta.inject.Inject;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +33,9 @@ import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.main.jdke.i18n.LocalStringsImpl;
 import org.jvnet.hk2.annotations.Service;
+
+import static com.sun.enterprise.admin.cli.CLIConstants.DEATH_TIMEOUT_MS;
+import static com.sun.enterprise.admin.cli.CLIConstants.WAIT_FOR_DAS_TIME_MS;
 
 /**
  * THe restart-domain command. The local portion of this command is only used to block until:
@@ -51,13 +55,13 @@ import org.jvnet.hk2.annotations.Service;
 @Service(name = "restart-domain")
 @PerLookup
 public class RestartDomainCommand extends StopDomainCommand {
+    private static final LocalStringsImpl strings = new LocalStringsImpl(RestartDomainCommand.class);
 
     @Param(name = "debug", optional = true)
     private Boolean debug;
 
     @Inject
     private ServiceLocator habitat;
-    private static final LocalStringsImpl strings = new LocalStringsImpl(RestartDomainCommand.class);
 
     /**
      * Execute the restart-domain command.
@@ -73,14 +77,14 @@ public class RestartDomainCommand extends StopDomainCommand {
         final Long oldPid = getServerPid();
         final HostAndPort oldAdminAddress = getAdminAddress();
         final HostAndPort newAdminEndpoint = getAdminAddress("server");
-        RemoteCLICommand cmd = new RemoteCLICommand("restart-domain", programOpts, env);
+        final RemoteCLICommand cmd = new RemoteCLICommand("restart-domain", programOpts, env);
         if (debug == null) {
             cmd.executeAndReturnOutput("restart-domain");
         } else {
             cmd.executeAndReturnOutput("restart-domain", "--debug", debug.toString());
         }
 
-        waitForRestart(oldPid, oldAdminAddress, newAdminEndpoint);
+        waitForRestart(oldPid, oldAdminAddress, newAdminEndpoint, getRestartTimeout());
         logger.info(strings.get("restartDomain.success"));
     }
 
@@ -118,10 +122,31 @@ public class RestartDomainCommand extends StopDomainCommand {
             opts.add("--domaindir");
             opts.add(domainDirParam);
         }
+        opts.add("--timeout");
+        opts.add(Long.toString(getStartTimeout().toSeconds()));
         if (getDomainName() != null) {
             opts.add(getDomainName());
         }
 
         return cmd.execute(opts.toArray(String[]::new));
+    }
+
+    /**
+     * @return timeout for the start-domain command.
+     */
+    protected Duration getStartTimeout() {
+        final Duration parameter = getTimeout();
+        return parameter == null ? WAIT_FOR_DAS_TIME_MS : parameter;
+    }
+
+    /**
+     * @return timeout set as a parameter
+     */
+    private Duration getRestartTimeout() {
+        final Duration paramTimeout = getTimeout();
+        if (paramTimeout != null) {
+            return paramTimeout;
+        }
+        return WAIT_FOR_DAS_TIME_MS.plus(DEATH_TIMEOUT_MS).plusSeconds(5);
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerCommand.java
@@ -19,6 +19,8 @@ package com.sun.enterprise.admin.servermgmt.cli;
 import com.sun.enterprise.admin.launcher.GFLauncherException;
 import com.sun.enterprise.universal.xml.MiniXmlParserException;
 
+import java.time.Duration;
+
 import org.glassfish.api.admin.RuntimeType;
 
 /**
@@ -36,4 +38,11 @@ public interface StartServerCommand {
      */
     void createLauncher() throws GFLauncherException, MiniXmlParserException;
 
+    /**
+     * Timeout for the individual command.
+     * For example when is executed stop and start, both will have the same timeout.
+     *
+     * @return timeout for the command
+     */
+    Duration getTimeout();
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -39,9 +39,7 @@ import java.util.function.Supplier;
 import org.glassfish.api.admin.CommandException;
 import org.glassfish.main.jdke.i18n.LocalStringsImpl;
 
-import static com.sun.enterprise.admin.cli.CLIConstants.DEATH_TIMEOUT_MS;
 import static com.sun.enterprise.admin.cli.CLIConstants.MASTER_PASSWORD;
-import static com.sun.enterprise.admin.cli.CLIConstants.WAIT_FOR_DAS_TIME_MS;
 import static com.sun.enterprise.util.StringUtils.ok;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
@@ -69,14 +67,10 @@ public class StartServerHelper {
     private final ServerDirs serverDirs;
     private final String masterPassword;
     private final String serverOrDomainName;
-    private final int debugPort;
-
-    public StartServerHelper(boolean terse, ServerDirs serverDirs, GFLauncher launcher, String masterPassword) {
-        this(terse, serverDirs, launcher, masterPassword, false);
-    }
+    private final Duration timeout;
 
     public StartServerHelper(boolean terse, ServerDirs serverDirs, GFLauncher launcher, String masterPassword,
-            boolean debug) {
+        Duration timeout) {
         this.terse = terse;
         this.launcher = launcher;
         this.info = launcher.getInfo();
@@ -91,9 +85,7 @@ public class StartServerHelper {
         this.serverDirs = serverDirs;
         this.pidFile = serverDirs.getPidFile();
         this.masterPassword = masterPassword;
-
-        // it will be < 0 if both --debug is false and debug-enabled=false in jvm-config
-        this.debugPort = launcher.getDebugPort();
+        this.timeout = timeout;
     }
 
 
@@ -123,13 +115,12 @@ public class StartServerHelper {
             // Don't wait if the process died.
             return !glassFishProcess.isAlive();
         };
-        final Duration timeout = Duration.ofMillis(WAIT_FOR_DAS_TIME_MS);
         if (!ProcessUtils.waitFor(signOfFinishedStartup, timeout, !terse)) {
             final String msg;
             if (info.isDomain()) {
-                msg = I18N.get("serverNoStart", I18N.get("DAS"), info.getDomainName(), timeout.toSeconds());
+                msg = I18N.get("serverNoStart", I18N.get("DAS"), info.getDomainName(), timeout);
             } else {
-                msg = I18N.get("serverNoStart", I18N.get("INSTANCE"), info.getInstanceName(), timeout.toSeconds());
+                msg = I18N.get("serverNoStart", I18N.get("INSTANCE"), info.getInstanceName(), timeout);
             }
             throw new CommandException(msg);
         }
@@ -212,8 +203,8 @@ public class StartServerHelper {
             return;
         }
         LOG.log(DEBUG, "Waiting for death of the parent process with pid={0}", pid);
-        if (!ProcessUtils.waitWhileIsAlive(pid, Duration.ofMillis(DEATH_TIMEOUT_MS), false)) {
-            throw new CommandException(I18N.get("deathwait_timeout", DEATH_TIMEOUT_MS));
+        if (!ProcessUtils.waitWhileIsAlive(pid, timeout, false)) {
+            throw new CommandException(I18N.get("deathwait_timeout", timeout));
         }
         LOG.log(DEBUG, "Parent process with PID={0} is dead and all admin endpoints are free.", pid);
     }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StopDomainCommand.java
@@ -53,8 +53,17 @@ public class StopDomainCommand extends LocalDomainCommand {
     private Boolean force;
     @Param(optional = true, defaultValue = "false")
     private Boolean kill;
+    @Param(optional = true)
+    private Integer timeout;
 
     private HostAndPort addr;
+
+    /**
+     * @return timeout set as a parameter
+     */
+    protected Duration getTimeout() {
+        return timeout == null ?  null : Duration.ofSeconds(timeout);
+    }
 
     @Override
     protected void validate() throws CommandException {
@@ -142,7 +151,7 @@ public class StopDomainCommand extends LocalDomainCommand {
             if (isLocal()) {
                 try {
                     File prevPid = getServerDirs().getLastPidFile();
-                    ProcessUtils.kill(prevPid, Duration.ofMillis(DEATH_TIMEOUT_MS), !programOpts.isTerse());
+                    ProcessUtils.kill(prevPid, getStopTimeout(), !programOpts.isTerse());
                 } catch (KillNotPossibleException e) {
                     throw new CommandException(e.getMessage(), e);
                 }
@@ -169,8 +178,8 @@ public class StopDomainCommand extends LocalDomainCommand {
         // run the remote stop-domain command and throw away the output
         final RemoteCLICommand cmd = new RemoteCLICommand(getName(), programOpts, env);
         final Long oldPid = getServerPid();
-        final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final boolean printDots = !programOpts.isTerse();
+        final Duration stopTimeout = getStopTimeout();
         try {
             cmd.executeAndReturnOutput("stop-domain", "--force", force.toString());
             if (printDots) {
@@ -179,12 +188,12 @@ public class StopDomainCommand extends LocalDomainCommand {
             }
             final boolean dead;
             if (isLocal()) {
-                dead = oldPid == null || ProcessUtils.waitWhileIsAlive(oldPid, timeout, printDots);
+                dead = oldPid == null || ProcessUtils.waitWhileIsAlive(oldPid, stopTimeout, printDots);
             } else {
-                dead = ProcessUtils.waitWhileListening(addr, timeout, printDots);
+                dead = ProcessUtils.waitWhileListening(addr, stopTimeout, printDots);
             }
             if (!dead) {
-                throw new CommandException(Strings.get("StopDomain.DASNotDead", timeout.toSeconds()));
+                throw new CommandException(Strings.get("StopDomain.DASNotDead", stopTimeout.toSeconds()));
             }
         } catch (Exception e) {
             // The domain server may have died so fast we didn't have time to
@@ -193,7 +202,7 @@ public class StopDomainCommand extends LocalDomainCommand {
             if (kill && isLocal()) {
                 try {
                     File prevPid = getServerDirs().getLastPidFile();
-                    ProcessUtils.kill(prevPid, timeout, printDots);
+                    ProcessUtils.kill(prevPid, stopTimeout, printDots);
                     return;
                 } catch (Exception ex) {
                     e.addSuppressed(ex);
@@ -201,5 +210,10 @@ public class StopDomainCommand extends LocalDomainCommand {
             }
             throw e;
         }
+    }
+
+    private Duration getStopTimeout() {
+        final Duration parameter = getTimeout();
+        return parameter == null ? DEATH_TIMEOUT_MS : parameter;
     }
 }

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/restart-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/restart-domain.1
@@ -4,10 +4,14 @@ NAME
        restart-domain - restarts the DAS of the specified domain
 
 SYNOPSIS
-           restart-domain [--help] [--debug ={true|false}]
-           [--domaindir domaindir]
-           [--force={true|false}] [--kill={false|true}]
-           [domain-name]
+        restart-domain
+        [--debug[=<debug(default:false)>]]
+        [--domaindir <domaindir>]
+        [--force[=<force(default:true)>]]
+        [--help|-?]
+        [--kill[=<kill(default:false)>]]
+        [--timeout <timeout>]
+        [domain_name]
 
 DESCRIPTION
        The restart-domain subcommand stops and then restarts the domain
@@ -28,9 +32,6 @@ DESCRIPTION
        server.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
        --debug
            Specifies whether the domain is restarted with Java Platform
            Debugger Architecture (JPDA)
@@ -70,6 +71,9 @@ OPTIONS
                The subcommand waits until all threads that are associated with
                the domain are exited before stopping the domain.
 
+       --help, -?
+           Displays the help text for the subcommand.
+
        --kill
            Specifies whether the domain is killed before it is restarted by
            using functionality of the operating system to terminate the domain
@@ -84,6 +88,12 @@ OPTIONS
            true
                The domain is killed. The subcommand uses functionality of the
                operating system to terminate the domain process.
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The domain status is unknown
+            in such case.
 
 OPERANDS
        domain-name
@@ -113,4 +123,4 @@ SEE ALSO
        Java Platform Debugger Architecture (JPDA)
        (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
-Jakarta EE 10                         21 Aug 2017                restart-domain(1)
+Jakarta EE 10                         26 Jun 2025                restart-domain(1)

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1
@@ -1,14 +1,21 @@
 start-domain(1)           asadmin Utility Subcommands          start-domain(1)
 
 NAME
-       start-domain - starts the DAS of the specified domain
+       start-domain - starts the Domain Administration Server of the specified domain
 
 SYNOPSIS
-           start-domain [--help]
-           [--debug={true|false}] [--domaindir domain-dir]
-           [--dry-run={true|false}] [--upgrade={true|false}]
-           [--verbose={true|false}] [--watchdog={true|false}]
-           [domain-name]
+        start-domain
+        [--debug|-d[=<debug(default:false)>]]
+        [--domaindir <domaindir>]
+        [--drop-interrupted-commands[=<drop-interrupted-commands(default:false)>]]
+        [--dry-run|-n[=<dry-run(default:false)>]]
+        [--help|-?]
+        [--suspend|-s[=<suspend(default:false)>]]
+        [--timeout <timeout>]
+        [--upgrade[=<upgrade(default:false)>]]
+        [--verbose|-v[=<verbose(default:false)>]]
+        [--watchdog|-w[=<watchdog(default:false)>]]
+        [domain_name]
 
 DESCRIPTION
        The start-domain subcommand starts the domain administration server
@@ -52,9 +59,6 @@ DESCRIPTION
            +----------------------------------------+
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
        --debug, -d
            Specifies whether the domain is started with Java Platform Debugger
            Architecture (JPDA)
@@ -72,6 +76,16 @@ OPTIONS
            false
                The instance is started with JPDA debugging disabled (default).
 
+       --domaindir
+           The domain root directory, which contains the directory of the
+           domain that is to be restarted. If specified, the path must be
+           accessible in the file system. The default location of the domain
+           root directory is as-install/domains.
+
+       --drop-interrupted-commands
+           If you used --detach with commands supporting checkpoints, this
+           option specifies whether to drop the commands that were interrupted.
+
        --dry-run, -n
            Suppresses actual starting of the domain. Instead, start-domain
            displays the full java command that would be used to start the
@@ -80,11 +94,30 @@ OPTIONS
 
            The default value is false.
 
-       --domaindir
-           The domain root directory, which contains the directory of the
-           domain that is to be restarted. If specified, the path must be
-           accessible in the file system. The default location of the domain
-           root directory is as-install/domains.
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --suspend, -s
+           Specifies whether the domain is started with Java Platform Debugger
+           Architecture (JPDA) debugging enabled and suspends the newly started VM
+           before the main class loads.
+           When a debugger connects, it can send a JDWP command to resume the suspended VM.
+           With debugging enabled extra exceptions can be printed.
+
+           Possible values are as follows:
+
+          true
+              The instance is started with JPDA debugging enabled and a suspend policy
+              of `SUSPEND_ALL`. The port number for JPDA debugging is displayed.
+
+          false
+              The instance is started with JPDA debugging disabled (default).
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The domain status is unknown
+            in such case.
 
        --upgrade
            Specifies whether the configuration of the domain administration
@@ -183,4 +216,4 @@ SEE ALSO
        Java Platform Debugger Architecture (JPDA)
        (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
-Jakarta EE 10                         21 Aug 2017                  start-domain(1)
+Jakarta EE 10                         26 Jun 2025                  start-domain(1)

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/stop-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/stop-domain.1
@@ -5,9 +5,13 @@ NAME
        domain
 
 SYNOPSIS
-           stop-domain [--help] [--domaindir domaindir]
-           [--force={true|false}] [--kill={false|true}]
-           [domain-name]
+        stop-domain
+        [--domaindir <domaindir>]
+        [--force[=<force(default:true)>]]
+        [--help|-?]
+        [--kill[=<kill(default:false)>]]
+        [--timeout <timeout>]
+        [domain_name]
 
 DESCRIPTION
        The stop-domain subcommand stops the Domain Administration Server (DAS)
@@ -24,9 +28,6 @@ DESCRIPTION
        server.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
        --domaindir
            Specifies the directory of the domain that is to be stopped. If
            specified, the path must be accessible in the file system. If not
@@ -45,6 +46,9 @@ OPTIONS
                The subcommand waits until all threads that are associated with
                the domain are exited before stopping the domain.
 
+       --help, -?
+           Displays the help text for the subcommand.
+
        --kill
            Specifies whether the domain is killed by using functionality of
            the operating system to terminate the domain process.
@@ -58,6 +62,12 @@ OPTIONS
            true
                The domain is killed. The subcommand uses functionality of the
                operating system to terminate the domain process.
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The domain status is unknown
+            in such case.
 
 OPERANDS
        domain-name
@@ -85,4 +95,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Jakarta EE 10                         20 Dec 2010                   stop-domain(1)
+Jakarta EE 10                         26 Jun 2025                   stop-domain(1)

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ClusterCommandHelper.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/ClusterCommandHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -25,16 +25,17 @@ import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.v3.admin.adapter.AdminEndpointDecider;
 
+import java.lang.System.Logger;
+import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.ActionReport.ExitCode;
@@ -44,6 +45,12 @@ import org.glassfish.api.admin.CommandRunner;
 import org.glassfish.api.admin.CommandRunner.CommandInvocation;
 import org.glassfish.api.admin.ParameterMap;
 import org.glassfish.api.admin.ProgressStatus;
+import org.glassfish.embeddable.GlassFishVariable;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
 
 
 /*
@@ -57,13 +64,11 @@ import org.glassfish.api.admin.ProgressStatus;
  * @author Joe Di Pol
  */
 class ClusterCommandHelper {
-
-    private static final String NL = System.getProperty("line.separator");
+    private static final Logger LOG = System.getLogger(ClusterCommandHelper.class.getName());
+    private static final String NL = System.lineSeparator();
 
     private Domain domain;
-
     private CommandRunner runner;
-
     private ProgressStatus progress;
 
     /**
@@ -101,19 +106,15 @@ class ClusterCommandHelper {
             String  clusterName,
             AdminCommandContext context,
             boolean debug,
-            boolean verbose) throws CommandException {
+            boolean verbose,
+            Duration timeout) throws CommandException {
 
-        // When we started
-        final long startTime = System.currentTimeMillis();
-
-        Logger logger = context.getLogger();
         ActionReport report = context.getActionReport();
 
         // Get the cluster specified by clusterName
         Cluster cluster = domain.getClusterNamed(clusterName);
         if (cluster == null) {
-            String msg = Strings.get("cluster.command.unknownCluster",
-                    clusterName);
+            String msg = Strings.get("cluster.command.unknownCluster", clusterName);
             throw new CommandException(msg);
         }
 
@@ -123,18 +124,16 @@ class ClusterCommandHelper {
         // If the cluster is empty, say so
         if (targetServers == null || targetServers.isEmpty()) {
             report.setActionExitCode(ExitCode.SUCCESS);
-            report.setMessage(Strings.get("cluster.command.noInstances",
-                                            clusterName));
+            report.setMessage(Strings.get("cluster.command.noInstances", clusterName));
             return report;
         }
-        int nInstances = targetServers.size();
+        final int nInstances = targetServers.size();
 
         // We will save the name of the instances that worked and did
         // not work so we can summarize our results.
         StringBuilder failedServerNames = new StringBuilder();
         StringBuilder succeededServerNames = new StringBuilder();
         List<String> waitingForServerNames = new ArrayList<String>();
-        String msg;
         ReportResult reportResult = new ReportResult();
         boolean failureOccurred = false;
         progress = context.getProgressStatus();
@@ -144,41 +143,37 @@ class ClusterCommandHelper {
 
 
         // Optimize the oder of server instances to avoid clumping on nodes
-        if (logger.isLoggable(Level.FINE))
-            logger.fine(String.format("Original instance list %s",
-                serverListToString(targetServers)));
-        targetServers = optimizeServerListOrder(targetServers);
-
-        // Holds responses from the threads running the command
-        ArrayBlockingQueue<CommandRunnable> responseQueue =
-                    new ArrayBlockingQueue<CommandRunnable>(nInstances);
-
-        // Make the thread pool use the smaller of the number of instances
-        // or half the admin thread pool size.
-        int adminThreadPoolSize = getAdminThreadPoolSize(logger);
-        int threadPoolSize = Math.min(nInstances, adminThreadPoolSize / 2);
-        if (threadPoolSize < 1)
-            threadPoolSize = 1;
-
-        ExecutorService threadPool = Executors.newFixedThreadPool(threadPoolSize);
-
+        LOG.log(DEBUG, () -> "Instance list " + serverListToString(targetServers));
         if (map == null) {
             map = new ParameterMap();
         }
 
-        msg = String.format(
+        final ThreadFactory threadFactory = new ThreadFactory() {
+
+            private final AtomicInteger id = new AtomicInteger(0);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r,
+                    "ClusterCommandHelper-" + command + "-" + clusterName + "-" + id.incrementAndGet());
+                t.setDaemon(true);
+                return t;
+            }
+        };
+        int threadPoolSize = getAdminThreadPoolSize(LOG);
+        ExecutorService executor = Executors.newFixedThreadPool(threadPoolSize, threadFactory);
+
+        LOG.log(INFO, String.format(
             "Executing %s on %d instances using a thread pool of size %d: %s",
             command, nInstances, threadPoolSize,
-            serverListToString(targetServers));
-        logger.info(msg);
+            serverListToString(targetServers)));
 
-         msg = Strings.get("cluster.command.executing",
-                 command, Integer.toString(nInstances));
         progress.setTotalStepCount(nInstances);
-        progress.progress(msg);
+        progress.progress(Strings.get("cluster.command.executing", command, nInstances));
 
         // Loop through instance names, construct the command for each
         // instance name, and hand it off to the threadpool.
+        final ArrayBlockingQueue<CommandRunnable> responseQueue = new ArrayBlockingQueue<>(nInstances);
         for (Server server : targetServers) {
             String iname = server.getName();
             waitingForServerNames.add(iname);
@@ -190,59 +185,38 @@ class ClusterCommandHelper {
                 instanceParameterMap.set("debug", "true");
             }
 
-
             ActionReport instanceReport = runner.getActionReport("plain");
             instanceReport.setActionExitCode(ExitCode.SUCCESS);
-            CommandInvocation invocation = runner.getCommandInvocation(
-                        command, instanceReport, context.getSubject());
+            CommandInvocation invocation = runner.getCommandInvocation(command, instanceReport, context.getSubject());
             invocation.parameters(instanceParameterMap);
 
-            msg = command + " " + iname;
-            logger.info(msg);
+            String msg = command + " " + iname;
+            LOG.log(INFO, msg);
             if (verbose) {
                 output.append(msg).append(NL);
             }
 
             // Wrap the command invocation in a runnable and hand it off
             // to the thread pool
-            CommandRunnable cmdRunnable = new CommandRunnable(invocation,
-                    instanceReport, responseQueue);
-            cmdRunnable.setName(iname);
-            threadPool.execute(cmdRunnable);
+            CommandRunnable cmdRunnable = new CommandRunnable(iname, invocation, instanceReport, responseQueue);
+            CompletableFuture.runAsync(cmdRunnable, executor);
         }
 
-        if (logger.isLoggable(Level.FINE))
-            logger.fine(String.format(
-                "%s commands queued, waiting for responses", command));
-
-        // Make sure we don't wait longer than the admin read timeout. Set
-        // our limit to be 3 seconds less.
-        long adminTimeout = RemoteRestAdminCommand.getReadTimeout() - 3000;
-        if (adminTimeout <= 0) {
-            // This should never be the case
-            adminTimeout = 57 * 1000;
-        }
-        if (logger.isLoggable(Level.FINE))
-            logger.fine(String.format("Initial cluster command timeout: %d ms",
-                adminTimeout));
+        LOG.log(DEBUG, () -> "Started commands in parallel, waiting for responses...");
 
         // Now go get results from the response queue.
-        for (int n = 0; n < nInstances; n++) {
-            long timeLeft = adminTimeout - (System.currentTimeMillis() - startTime);
-            if (timeLeft < 0) {
-                timeLeft = 0;
-            }
+        final long deadline = computeDeadline(timeout);
+        for (int i = 0; i < nInstances; i++) {
+            final long timeLeft = deadline - System.currentTimeMillis();
             CommandRunnable cmdRunnable = null;
             try {
-                //cmdRunnable = responseQueue.take();
                 cmdRunnable = responseQueue.poll(timeLeft, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 // This thread has been interrupted. Abort
-                threadPool.shutdownNow();
-                msg = Strings.get("cluster.command.interrupted", clusterName,
-                        Integer.toString(n), Integer.toString(nInstances),
-                        command);
-                logger.warning(msg);
+                executor.shutdownNow();
+                String msg = Strings.get("cluster.command.interrupted", clusterName, i, Integer.toString(nInstances),
+                    command);
+                LOG.log(WARNING, msg);
                 output.append(msg).append(NL);
                 failureOccurred = true;
                 // Re-establish interrupted state on thread
@@ -257,20 +231,17 @@ class ClusterCommandHelper {
             String iname = cmdRunnable.getName();
             waitingForServerNames.remove(iname);
             ActionReport instanceReport = cmdRunnable.getActionReport();
-            if (logger.isLoggable(Level.FINE))
-                logger.fine(String.format(
-                    "Instance %d of %d (%s) has responded with %s",
-                    n+1, nInstances, iname, instanceReport.getActionExitCode()));
+            LOG.log(DEBUG, String.format("Instance %d of %d (%s) has responded with %s", i + 1, nInstances, iname,
+                instanceReport.getActionExitCode()));
             if (instanceReport.getActionExitCode() != ExitCode.SUCCESS) {
                 // Bummer, the command had an error. Log and save output
                 failureOccurred = true;
                 failedServerNames.append(iname).append(" ");
                 reportResult.failedServerNames.add(iname);
-                msg = iname + ": " + instanceReport.getMessage();
-                logger.severe(msg);
+                String msg = iname + ": " + instanceReport.getMessage();
+                LOG.log(ERROR, msg);
                 output.append(msg).append(NL);
-                msg = Strings.get("cluster.command.instancesFailed", command, iname);
-                progress.progress(1, msg);
+                progress.progress(1, Strings.get("cluster.command.instancesFailed", command, iname));
             } else {
                 // Command worked. Note that too.
                 succeededServerNames.append(iname).append(" ");
@@ -291,14 +262,12 @@ class ClusterCommandHelper {
         // Display summary of started servers if in verbose mode or we
         // had one or more failures.
         if (succeededServerNames.length() > 0 && (verbose || failureOccurred)) {
-            output.append(NL + Strings.get("cluster.command.instancesSucceeded",
-                    command, succeededServerNames));
+            output.append(NL).append(Strings.get("cluster.command.instancesSucceeded", command, succeededServerNames));
         }
 
         if (failureOccurred) {
             // Display summary of failed servers if we have any
-            output.append(NL + Strings.get("cluster.command.instancesFailed",
-                    command, failedServerNames));
+            output.append(NL).append(Strings.get("cluster.command.instancesFailed", command, failedServerNames));
             if (succeededServerNames.length() > 0) {
                 // At least one instance started. Warning.
                 report.setActionExitCode(ExitCode.WARNING);
@@ -310,9 +279,8 @@ class ClusterCommandHelper {
 
         // Check for server that did not respond
         if (!waitingForServerNames.isEmpty()) {
-            msg = Strings.get("cluster.command.instancesTimedOut",
-                    command, listToString(waitingForServerNames));
-            logger.warning(msg);
+            String msg = Strings.get("cluster.command.instancesTimedOut", command, listToString(waitingForServerNames));
+            LOG.log(WARNING, msg);
             if (output.length() > 0) {
                 output.append(NL);
             }
@@ -321,87 +289,47 @@ class ClusterCommandHelper {
         }
 
         report.setMessage(output.toString());
-        threadPool.shutdown();
+        executor.shutdown();
         return report;
+    }
+
+    /**
+     * @param timeout
+     * @return
+     */
+    private long computeDeadline(Duration timeoutParameter) {
+        // Make sure we don't wait longer than the admin read timeout.
+        // Set our limit to be 2 seconds less.
+        long adminTimeout = RemoteRestAdminCommand.getReadTimeout() - 2000;
+        final long timeout;
+        if (adminTimeout <= 0) {
+            timeout = timeoutParameter.toMillis();
+        } else if (timeoutParameter.toMillis() > adminTimeout) {
+            LOG.log(WARNING, "Cluster command timeout is greater than admin read timeout."
+                + " Using admin read timeout instead to prevent socket read timeouts.");
+            timeout = adminTimeout;
+        } else {
+            timeout = timeoutParameter.toMillis();
+        }
+        return System.currentTimeMillis() + timeout;
     }
 
     /**
      * Get the size of the admin threadpool
      */
     private int getAdminThreadPoolSize(Logger logger) {
-
-        final int DEFAULT_POOL_SIZE = 5;
-
-        // Get the DAS configuratoin
         Config config = domain.getConfigNamed("server-config");
-        if (config == null)
-            return DEFAULT_POOL_SIZE;
-
+        if (config == null) {
+            return 10;
+        }
         AdminEndpointDecider aed = new AdminEndpointDecider(config);
         return aed.getMaxThreadPoolSize();
-    }
-
-    /**
-     * Optimize the order of the list of servers. Basically we
-     * want the server list to be ordered such that we rotate over
-     * the nodes. For example we want: n1, n2, n3, n1, n2, n3
-     * not: n1, n1, n2, n2, n3, n3. This is to spread the load
-     * of operations across nodes.
-     *
-     * @param original a list of servers
-     * @return a list of servers with a more optimal order
-     */
-    List<Server> optimizeServerListOrder(List<Server> original) {
-
-        // Don't bother with all this if it's just two instances
-        if (original.size() < 3) {
-            return original;
-        }
-
-        // There must be a more efficient way to do this, but this is what
-        // we do. We first distribute all the server instances into a table
-        // that is indexed by node name. Then we snake over that table to
-        // create the final list.
-
-        // Key is the node name, value is the list of servers on that node
-        HashMap<String, List<Server>> serverTable =
-                new HashMap<String, List<Server>>();
-
-        // Distribute servers into serverTable
-        int count = 0;
-        for (Server server : original) {
-            String nodeName = server.getNodeRef();
-
-            List<Server> serverList = serverTable.get(nodeName);
-            if (serverList == null) {
-                serverList = new ArrayList<Server>();
-                serverTable.put(nodeName, serverList);
-            }
-            serverList.add(server);
-            count++;
-        }
-
-        // Now snake through server table moving server entries from the
-        // table to the final optimized list.
-        List<Server> optimized = new ArrayList<Server>(count);
-        Set<String> nodes = serverTable.keySet();
-        while (count > 0) {
-            for (String nodeName : nodes) {
-                List<Server> serverList = serverTable.get(nodeName);
-                if (! serverList.isEmpty()) {
-                    optimized.add(serverList.remove(0));
-                    count--;
-                }
-            }
-        }
-
-        return optimized;
     }
 
     private static String serverListToString(List<Server> servers) {
         StringBuilder sb = new StringBuilder();
         for (Server s : servers) {
-            sb.append(s.getNodeRef() + ":" + s.getName() + " ");
+            sb.append(s.getNodeRef()).append(':').append(s.getName()).append(' ');
         }
         return sb.toString().trim();
     }
@@ -409,13 +337,25 @@ class ClusterCommandHelper {
     private static String listToString(List<String> slist) {
         StringBuilder sb = new StringBuilder();
         for (String s : slist) {
-            sb.append(s + " ");
+            sb.append(s).append(' ');
         }
         return sb.toString().trim();
     }
 
+    static Duration getTimeout(Integer timeout, GlassFishVariable envVariable) {
+        if (timeout == null) {
+            String envValue = System.getenv(envVariable.getEnvName());
+            if (envValue == null) {
+                return Duration.ofSeconds(60);
+            }
+            return Duration.ofSeconds(Long.parseLong(envValue));
+        }
+        return Duration.ofSeconds(timeout);
+    }
+
+
     static public class ReportResult {
-        final public List<String> succeededServerNames = new ArrayList<String>();
-        final public List<String> failedServerNames = new ArrayList<String>();
+        final public List<String> succeededServerNames = new ArrayList<>();
+        final public List<String> failedServerNames = new ArrayList<>();
     }
 }

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/DeleteInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/DeleteInstanceCommand.java
@@ -113,7 +113,7 @@ public class DeleteInstanceCommand implements AdminCommand {
         instanceHost = instance.getAdminHost();
 
         // make sure instance is not running.
-        if (instance.isRunning()){
+        if (instance.isListeningOnAdminPort()){
             msg = Strings.get("instance.shutdown", instanceName);
             logger.warning(msg);
             report.setActionExitCode(ActionReport.ExitCode.FAILURE);
@@ -235,7 +235,7 @@ public class DeleteInstanceCommand implements AdminCommand {
         StringBuilder fullCommand = new StringBuilder();
 
         fullCommand.append("lib");
-        fullCommand.append(System.getProperty("file.separator"));
+        fullCommand.append(System.lineSeparator());
         fullCommand.append("nadmin ");
 
         for (String s : command) {

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/NodeUtils.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/NodeUtils.java
@@ -411,7 +411,7 @@ public class NodeUtils {
             int status = nr.runAdminCommandOnNode(node, output, command, context);
             if (status == 0) {
                 failure = false;
-                LOG.log(INFO, output.toString().trim());
+                LOG.log(INFO, "Output from the command execution on the node {0}:\n{1}", node.getName(), output);
             } else {
                 // Command ran, but didn't succeed. Log full information
                 msg2 = Strings.get("node.command.failed", nodeName, nodeHost, output.toString().trim(),

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopClusterCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -22,6 +22,7 @@ import com.sun.enterprise.config.serverbeans.Domain;
 
 import jakarta.inject.Inject;
 
+import java.time.Duration;
 import java.util.logging.Logger;
 
 import org.glassfish.api.ActionReport;
@@ -40,6 +41,9 @@ import org.glassfish.api.admin.RestParam;
 import org.glassfish.api.admin.ServerEnvironment;
 import org.glassfish.hk2.api.PerLookup;
 import org.jvnet.hk2.annotations.Service;
+
+import static com.sun.enterprise.v3.admin.cluster.ClusterCommandHelper.getTimeout;
+import static org.glassfish.embeddable.GlassFishVariable.TIMEOUT_STOP_SERVER;
 
 @I18n("stop.cluster.command")
 @Service(name="stop-cluster")
@@ -74,6 +78,9 @@ public class StopClusterCommand implements AdminCommand {
     @Param(optional = true, defaultValue = "false")
     private boolean verbose;
 
+    @Param(optional = true)
+    private Integer timeout;
+
     @Override
     public void execute(AdminCommandContext context) {
 
@@ -91,9 +98,7 @@ public class StopClusterCommand implements AdminCommand {
             return;
         }
 
-        ClusterCommandHelper clusterHelper = new ClusterCommandHelper(domain,
-                runner);
-
+        ClusterCommandHelper clusterHelper = new ClusterCommandHelper(domain, runner);
         ParameterMap map = null;
         if (kill) {
             map = new ParameterMap();
@@ -102,14 +107,13 @@ public class StopClusterCommand implements AdminCommand {
         try {
             // Run start-instance against each instance in the cluster
             String commandName = "stop-instance";
-            clusterHelper.runCommand(commandName, map, clusterName, context, false,
-                    verbose);
+            Duration cmdTimeout = getTimeout(timeout, TIMEOUT_STOP_SERVER);
+            clusterHelper.runCommand(commandName, map, clusterName, context, false, verbose, cmdTimeout);
         } catch (CommandException e) {
             String msg = e.getLocalizedMessage();
             logger.warning(msg);
             report.setActionExitCode(ExitCode.FAILURE);
             report.setMessage(msg);
-            return;
         }
     }
 }

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/restart-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/restart-instance.1
@@ -4,8 +4,10 @@ NAME
        restart-instance - restarts a running GlassFish Server instance
 
 SYNOPSIS
-           restart-instance [--help]
-           [--debug={false|true}] instance-name
+        restart-instance
+        [--debug <debug>]
+        [--timeout <timeout>]
+        instancename
 
 DESCRIPTION
        The restart-instance subcommand restarts a running GlassFish Server
@@ -58,9 +60,6 @@ DESCRIPTION
        This subcommand is supported in remote mode only.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
        --debug
            Specifies whether the instance is restarted with Java Platform
            Debugger Architecture (JPDA)
@@ -80,6 +79,15 @@ OPTIONS
 
            The default is the current setting of this option for the instance
            that is being restarted.
+
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The instance status is unknown
+            in such case.
 
 OPERANDS
        instance-name
@@ -114,4 +122,4 @@ SEE ALSO
        Java Platform Debugger Architecture (JPDA)
        (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
-Jakarta EE 10                         21 Aug 2017              restart-instance(1)
+Jakarta EE 10                         26 Jun 2025              restart-instance(1)

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-cluster.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-cluster.1
@@ -4,9 +4,12 @@ NAME
        start-cluster - starts a cluster
 
 SYNOPSIS
-           start-cluster [--help] 
-           [--debug={false|true}] [--autohadboverride={true|false}]
-           [--verbose={false|true}] cluster-name
+        start-cluster
+        [--debug[=<debug(default:false)>]]
+        [--help|-?]
+        [--timeout <timeout>]
+        [--verbose[=<verbose(default:false)>]]
+        clustername
 
 DESCRIPTION
        The start-cluster subcommand starts a cluster by starting all GlassFish
@@ -37,9 +40,6 @@ DESCRIPTION
        This subcommand is supported in remote mode only.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-       
        --debug
            Specifies whether each instance in the cluster is started with Java Platform
            Debugger Architecture (JPDA)
@@ -57,12 +57,14 @@ OPTIONS
            false
                Each instance is started with JPDA debugging disabled (default).
 
-       --autohadboverride
-           Do not specify this option. This option is retained for
-           compatibility with earlier releases. If you specify this option, a
-           syntax error does not occur. Instead, the subcommand runs
-           successfully and displays a warning message that the option is
-           ignored.
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The status of instances is
+            unknown in such case.
 
        --verbose
            Specifies whether additional status information is displayed when
@@ -108,4 +110,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Jakarta EE 10                         8 Dec 2011                  start-cluster(1)
+Jakarta EE 10                        26 Jun 2025                  start-cluster(1)

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-instance.1
@@ -4,9 +4,13 @@ NAME
        start-instance - starts a GlassFish Server instance
 
 SYNOPSIS
-           start-instance [--help]
-           [--debug={false|true}] [--sync={normal|full|none}]
-           instance-name
+        start-instance
+        [--debug[=<debug(default:false)>]]
+        [--help|-?]
+        [--sync <sync(default:normal)>]
+        [--timeout <timeout>]
+        instance_name
+
 
 DESCRIPTION
        The start-instance subcommand starts a GlassFish Server instance. This
@@ -35,9 +39,6 @@ DESCRIPTION
        This command is supported in remote mode only.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
        --debug
            Specifies whether the instance is started with Java Platform
            Debugger Architecture (JPDA)
@@ -54,6 +55,9 @@ OPTIONS
 
            false
                The instance is started with JPDA debugging disabled (default).
+
+       --help, -?
+           Displays the help text for the subcommand.
 
        --sync
            The type of synchronization between the DAS and the instance's
@@ -93,6 +97,12 @@ OPTIONS
                last synchronization. This type of synchronization might delay
                the startup of the instance while the DAS updates all files in
                the instance's directories.
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The instance status is unknown
+            in such case.
 
 OPERANDS
        instance-name
@@ -148,4 +158,4 @@ SEE ALSO
        Java Platform Debugger Architecture (JPDA)
        (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
-Jakarta EE 10                         21 Aug 2017                 start-instance(1)
+Jakarta EE 10                         26 Jun 2025                 start-instance(1)

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/stop-cluster.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/stop-cluster.1
@@ -4,11 +4,11 @@ NAME
        stop-cluster - stops a GlassFish Server cluster
 
 SYNOPSIS
-           stop-cluster [--help]
-           [--verbose={false|true}]
-           [--kill={false|true}]
-           [--autohadboverride={true|false}]
-           cluster-name
+        stop-cluster
+        [--help|-?]
+        [--kill[=<kill(default:false)>]]
+        [--timeout <timeout>]
+        clustername
 
 DESCRIPTION
        The stop-cluster subcommand stops a GlassFish Server cluster by
@@ -50,12 +50,11 @@ OPTIONS
                Each instance is killed. The subcommand uses functionality of
                the operating system to terminate each instance process.
 
-       --autohadboverride
-           Do not specify this option. This option is retained for
-           compatibility with earlier releases. If you specify this option, a
-           syntax error does not occur. Instead, the subcommand runs
-           successfully and displays a warning message that the option is
-           ignored.
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The status of instances is
+            unknown in such case.
 
 OPERANDS
        cluster-name
@@ -88,4 +87,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Jakarta EE 10                         16 Dec 2010                  stop-cluster(1)
+Jakarta EE 10                         26 Jun 2025                  stop-cluster(1)

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/stop-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/stop-instance.1
@@ -4,9 +4,12 @@ NAME
        stop-instance - stops a running GlassFish Server instance
 
 SYNOPSIS
-           stop-instance [--help]
-           [--force={false|true}] [--kill={false|true}]
-           instance-name
+        stop-instance
+        [--force[=<force(default:true)>]]
+        [--help|-?]
+        [--kill[=<kill(default:false)>]]
+        [--timeout <timeout>]
+        instancename
 
 DESCRIPTION
        The stop-instance subcommand stops a running GlassFish Server instance.
@@ -19,9 +22,6 @@ DESCRIPTION
        This command is supported in remote mode only.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
        --force
            Specifies whether the instance is forcibly stopped immediately.
 
@@ -33,6 +33,9 @@ OPTIONS
            false
                The subcommand waits until all threads that are associated with
                the instance are exited before stopping the instance.
+
+       --help, -?
+           Displays the help text for the subcommand.
 
        --kill
            Specifies whether the instance is killed by using functionality of
@@ -48,6 +51,12 @@ OPTIONS
            true
                The instance is killed. The subcommand uses functionality of
                the operating system to terminate the instance process.
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The instance status is unknown
+            in such case.
 
 OPERANDS
        instance-name
@@ -77,4 +86,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Jakarta EE 10                         16 Dec 2010                 stop-instance(1)
+Jakarta EE 10                         26 Jun 2025                 stop-instance(1)

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
@@ -28,6 +28,7 @@ import com.sun.enterprise.universal.xml.MiniXmlParserException;
 import com.sun.enterprise.util.ObjectAnalyzer;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +44,7 @@ import org.jvnet.hk2.annotations.Service;
 import static com.sun.enterprise.admin.cli.CLIConstants.RESTART_DEBUG_OFF;
 import static com.sun.enterprise.admin.cli.CLIConstants.RESTART_DEBUG_ON;
 import static com.sun.enterprise.admin.cli.CLIConstants.RESTART_NORMAL;
+import static com.sun.enterprise.admin.cli.CLIConstants.WAIT_FOR_DAS_TIME_MS;
 import static org.glassfish.main.jdke.props.SystemProperties.setProperty;
 
 /**
@@ -65,12 +67,11 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
     @Param(name = "dry-run", shortName = "n", optional = true, defaultValue = "false")
     private boolean dry_run;
 
+    @Param(optional = true)
+    private Integer timeout;
+
     private GFLauncherInfo info;
     private GFLauncher launcher;
-
-    // handled by superclass
-    //@Param(name = "instance_name", primary = true, optional = false)
-    //private String instanceName0;
 
     private StartServerHelper helper;
 
@@ -84,6 +85,14 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
         // we definitely do NOT want dirs created for this instance if
         // they don't exist!
         return false;
+    }
+
+    /**
+     * @return timeout for the command
+     */
+    @Override
+    public Duration getTimeout() {
+        return timeout == null ? WAIT_FOR_DAS_TIME_MS : Duration.ofSeconds(timeout);
     }
 
 
@@ -108,8 +117,7 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
             logger.info(Strings.get("Instance.nosync"));
         } else {
             if (!synchronizeInstance()) {
-                File domainXml =
-                    new File(new File(instanceDir, "config"), "domain.xml");
+                File domainXml = new File(new File(instanceDir, "config"), "domain.xml");
                 if (!domainXml.exists()) {
                     logger.info(Strings.get("Instance.nodomainxml"));
                     return ERROR;
@@ -119,21 +127,19 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
         }
 
         try {
-                 // createLauncher needs to go before the helper is created!!
+            // createLauncher needs to go before the helper is created!!
             createLauncher();
             final String mpv = getMasterPassword();
 
-            helper = new StartServerHelper(programOpts.isTerse(), getServerDirs(), launcher, mpv, debug);
+            helper = new StartServerHelper(programOpts.isTerse(), getServerDirs(), launcher, mpv, getTimeout());
 
             if (!helper.prepareForLaunch()) {
                 return ERROR;
             }
 
             if (dry_run) {
-                if (logger.isLoggable(Level.FINE)) {
-                    logger.fine(Strings.get("dry_run_msg"));
-                }
-                logger.info(getLauncher().getCommandLine().toString("\n"));
+                logger.log(Level.FINE, Strings.get("dry_run_msg"));
+                logger.log(Level.INFO, getLauncher().getCommandLine().toString("\n"));
                 return SUCCESS;
             }
 
@@ -205,7 +211,8 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
         args.addAll(Arrays.asList(programOpts.getProgramArguments()));
 
         // now the start-local-instance specific arguments
-        args.add(getName());    // the command name
+        // the command name
+        args.add(getName());
         args.add("--verbose=" + String.valueOf(verbose));
         args.add("--watchdog=" + String.valueOf(watchdog));
         args.add("--debug=" + String.valueOf(debug));
@@ -227,12 +234,8 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
             args.add(instanceName); // the operand
         }
 
-        if (logger.isLoggable(Level.FINER)) {
-            logger.finer("Respawn args: " + args.toString());
-        }
-        String[] a = new String[args.size()];
-        args.toArray(a);
-        return a;
+        logger.log(Level.FINER, "Respawn args: {0}", args);
+        return args.toArray(String[]::new);
     }
 
     private GFLauncher getLauncher() {
@@ -247,15 +250,15 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
     }
 
     private GFLauncherInfo getInfo() {
-        if(info == null) {
+        if (info == null) {
             throw new RuntimeException(Strings.get("internal.error", "GFLauncherInfo was not initialized"));
         }
-
-            return info;
+        return info;
     }
 
+
     private void setInfo(GFLauncherInfo inf) {
-            info = inf;
+        info = inf;
     }
 
     @Override

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StopLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StopLocalInstanceCommand.java
@@ -50,6 +50,8 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
     private String userArgInstanceName;
     @Param(optional = true, defaultValue = "false")
     private Boolean kill;
+    @Param(optional = true)
+    private Integer timeout;
 
 
     @Override
@@ -63,6 +65,13 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
         // we definitely do NOT want dirs created for this instance if
         // they don't exist!
         return false;
+    }
+
+    /**
+     * @return timeout set as a parameter
+     */
+    protected Duration getTimeout() {
+        return timeout == null ?  null : Duration.ofSeconds(timeout);
     }
 
     /**
@@ -111,7 +120,7 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
         if (kill) {
             try {
                 File lastPid = getServerDirs().getLastPidFile();
-                ProcessUtils.kill(lastPid, Duration.ofMillis(DEATH_TIMEOUT_MS), !programOpts.isTerse());
+                ProcessUtils.kill(lastPid, getStopTimeout(), !programOpts.isTerse());
             } catch (KillNotPossibleException e) {
                 logger.log(Level.SEVERE, e.getMessage(), e);
                 return -1;
@@ -152,7 +161,6 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
 
         final Long pid = getServerPid();
         final boolean printDots = !programOpts.isTerse();
-        final Duration timeout = Duration.ofMillis(DEATH_TIMEOUT_MS);
         final RemoteCLICommand cmd = new RemoteCLICommand("_stop-instance", programOpts, env);
         try {
             try {
@@ -172,9 +180,9 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
             if (printDots) {
                 System.out.print(Strings.get("StopInstance.waitForDeath") + " ");
             }
-            final boolean dead = pid == null || ProcessUtils.waitWhileIsAlive(pid, timeout, printDots);
+            final boolean dead = pid == null || ProcessUtils.waitWhileIsAlive(pid, getStopTimeout(), printDots);
             if (!dead) {
-                throw new CommandException(Strings.get("StopInstance.instanceNotDead", DEATH_TIMEOUT_MS / 1000));
+                throw new CommandException(Strings.get("StopInstance.instanceNotDead", getStopTimeout().toSeconds()));
             }
         } catch (Exception e) {
             // The server may have died so fast we didn't have time to
@@ -183,7 +191,7 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
             if (kill) {
                 try {
                     File prevPid = getServerDirs().getLastPidFile();
-                    ProcessUtils.kill(prevPid, timeout, printDots);
+                    ProcessUtils.kill(prevPid, getStopTimeout(), printDots);
                     return;
                 } catch (Exception ex) {
                     e.addSuppressed(ex);
@@ -191,5 +199,13 @@ public class StopLocalInstanceCommand extends LocalInstanceCommand {
             }
             throw e;
         }
+    }
+
+    /**
+     * @return timeout for the command
+     */
+    private Duration getStopTimeout() {
+        final Duration parameter = getTimeout();
+        return parameter == null ? DEATH_TIMEOUT_MS : parameter;
     }
 }

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/restart-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/restart-local-instance.1
@@ -5,11 +5,15 @@ NAME
        on the host where the subcommand is run
 
 SYNOPSIS
-           restart-local-instance [--help]
-           [--nodedir nodedir] [--node node]
-           [--debug={false|true}]
-           [--force={true|false}] [--kill={false|true}]
-           [instance-name]
+        restart-local-instance
+        [--debug[=<debug(default:false)>]]
+        [--force[=<force(default:true)>]]
+        [--help|-?]
+        [--kill[=<kill(default:false)>]]
+        [--node <node>]
+        [--nodedir <nodedir>]
+        [--timeout <timeout>]
+        [instance_name]
 
 DESCRIPTION
        The restart-local-instance subcommand restarts a GlassFish Server
@@ -57,20 +61,6 @@ DESCRIPTION
        instance with the DAS, this subcommand must be run in remote mode.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
-       --nodedir
-           Specifies the directory that contains the instance's node
-           directory. The instance's files are stored in the instance's node
-           directory. The default is as-install/nodes.
-
-       --node
-           Specifies the node on which the instance resides. This option may
-           be omitted only if the directory that the --nodedir option
-           specifies contains only one node directory. Otherwise, this option
-           is required.
-
        --debug
            Specifies whether the instance is restarted with Java Platform
            Debugger Architecture (JPDA)
@@ -105,6 +95,9 @@ OPTIONS
                The subcommand waits until all threads that are associated with
                the instance are exited before stopping the instance.
 
+       --help, -?
+           Displays the help text for the subcommand.
+
        --kill
            Specifies whether the instance is killed before it is restarted by
            using functionality of the operating system to terminate the
@@ -120,6 +113,23 @@ OPTIONS
            true
                The instance is killed. The subcommand uses functionality of
                the operating system to terminate the instance process.
+
+       --node
+           Specifies the node on which the instance resides. This option may
+           be omitted only if the directory that the --nodedir option
+           specifies contains only one node directory. Otherwise, this option
+           is required.
+
+       --nodedir
+           Specifies the directory that contains the instance's node
+           directory. The instance's files are stored in the instance's node
+           directory. The default is as-install/nodes.
+
+        --timeout
+           Specifies timeout in seconds to evaluate the expected result.
+           If the timeout is exceeded, the command fails - however it does
+           not mean it did not make any changes. The instance status is unknown
+           in such case.
 
 OPERANDS
        instance-name
@@ -152,4 +162,4 @@ SEE ALSO
        Java Platform Debugger Architecture (JPDA)
        (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
-Jakarta EE 10                   21 Aug 2017            restart-local-instance(1)
+Jakarta EE 10                   26 Jun 2026            restart-local-instance(1)

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/start-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/start-local-instance.1
@@ -5,12 +5,17 @@ NAME
        where the subcommand is run
 
 SYNOPSIS
-           start-local-instance [--help]
-           [--nodedir node-dir] [--node node]
-           [--debug={false|true}] [--dry-run={true|false}]
-           [--sync={normal|full|none}]
-           [--verbose={false|true}] [--watchdog={true|false}]
-           [instance-name]
+        start-local-instance
+        [--debug|-d[=<debug(default:false)>]]
+        [--dry-run|-n[=<dry-run(default:false)>]]
+        [--help|-?]
+        [--node <node>]
+        [--nodedir <nodedir>]
+        [--sync <sync(default:normal)>]
+        [--timeout <timeout>]
+        [--verbose|-v[=<verbose(default:false)>]]
+        [--watchdog|-w[=<watchdog(default:false)>]]
+        [instance_name]
 
 DESCRIPTION
        The start-local-instance subcommand starts a GlassFish Server instance
@@ -33,20 +38,6 @@ DESCRIPTION
        instance with the DAS, this subcommand must be run in remote mode.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
-       --nodedir
-           Specifies the directory that contains the instance's node
-           directory. The instance's files are stored in the instance's node
-           directory. The default is as-install/nodes.
-
-       --node
-           Specifies the node on which the instance resides. This option may
-           be omitted only if the directory that the --nodedir option
-           specifies contains only one node directory. Otherwise, this option
-           is required.
-
        --debug, -d
            Specifies whether the instance is started with Java Platform
            Debugger Architecture (JPDA)
@@ -71,6 +62,20 @@ OPTIONS
            command can be useful when troubleshooting startup issues.
 
            The default value is false.
+
+       --help, -?
+           Displays the help text for the subcommand.
+
+       --node
+           Specifies the node on which the instance resides. This option may
+           be omitted only if the directory that the --nodedir option
+           specifies contains only one node directory. Otherwise, this option
+           is required.
+
+       --nodedir
+           Specifies the directory that contains the instance's node
+           directory. The instance's files are stored in the instance's node
+           directory. The default is as-install/nodes.
 
        --sync
            The type of synchronization between the DAS and the instance's
@@ -124,6 +129,12 @@ OPTIONS
                    |instance cannot be restarted until it   |
                    |is resynchronized with the DAS.         |
                    +----------------------------------------+
+
+       --timeout
+            Specifies timeout in seconds to evaluate the expected result.
+            If the timeout is exceeded, the command fails - however it does
+            not mean it did not make any changes. The instance status is unknown
+            in such case.
 
        --verbose, -v
            Specifies whether detailed information about the instance is
@@ -205,4 +216,4 @@ SEE ALSO
        Java Platform Debugger Architecture (JPDA)
        (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
 
-Jakarta EE 10                         21 Aug 2017          start-local-instance(1)
+Jakarta EE 10                         26 Jun 2025          start-local-instance(1)

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/stop-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/stop-local-instance.1
@@ -5,10 +5,14 @@ NAME
        where the subcommand is run
 
 SYNOPSIS
-           stop-local-instance [--help]
-           [--nodedir node-dir] [--node node]
-           [--force={true|false}] [--kill={false|true}]
-           [instance-name]
+        stop-local-instance
+        [--force[=<force(default:true)>]]
+        [--help|-?]
+        [--kill[=<kill(default:false)>]]
+        [--node <node>]
+        [--nodedir <nodedir>]
+        [--timeout <timeout>]
+        [instance_name]
 
 DESCRIPTION
        The stop-local-instance subcommand stops a GlassFish Server instance on
@@ -29,20 +33,6 @@ DESCRIPTION
        This subcommand is supported in local mode.
 
 OPTIONS
-       --help, -?
-           Displays the help text for the subcommand.
-
-       --nodedir
-           Specifies the directory that contains the instance's node
-           directory. The instance's files are stored in the instance's node
-           directory. The default is as-install/nodes.
-
-       --node
-           Specifies the node on which the instance resides. This option may
-           be omitted only if the directory that the --nodedir option
-           specifies contains only one node directory. Otherwise, this option
-           is required.
-
        --force
            Specifies whether the instance is forcibly stopped immediately.
 
@@ -54,6 +44,9 @@ OPTIONS
            false
                The subcommand waits until all threads that are associated with
                the instance are exited before stopping the instance.
+
+       --help, -?
+           Displays the help text for the subcommand.
 
        --kill
            Specifies whether the instance is killed by using functionality of
@@ -69,6 +62,23 @@ OPTIONS
            true
                The instance is killed. The subcommand uses functionality of
                the operating system to terminate the instance process.
+
+       --node
+           Specifies the node on which the instance resides. This option may
+           be omitted only if the directory that the --nodedir option
+           specifies contains only one node directory. Otherwise, this option
+           is required.
+
+       --nodedir
+           Specifies the directory that contains the instance's node
+           directory. The instance's files are stored in the instance's node
+           directory. The default is as-install/nodes.
+
+       --timeout
+           Specifies timeout in seconds to evaluate the expected result.
+           If the timeout is exceeded, the command fails - however it does
+           not mean it did not make any changes. The instance status is unknown
+           in such case.
 
 OPERANDS
        instance-name
@@ -97,4 +107,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Jakarta EE 10                         11 Feb 2011           stop-local-instance(1)
+Jakarta EE 10                         26 Jun 2025           stop-local-instance(1)

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessManager.java
@@ -226,8 +226,10 @@ public final class ProcessManager {
         throws ProcessManagerException {
         if (textToWaitFor == null) {
             if (process.isAlive()) {
-                throw new ProcessManagerTimeoutException(
-                    "Process is still running, timeout " + timeoutInMillis + " ms exceeded.");
+                // Process.info().command() doesn't return too much on Windows and we know the command.
+                throw new ProcessManagerTimeoutException("Process with pid " + process.pid()
+                    + " is still running, timeout " + timeoutInMillis + " ms exceeded: "
+                    + process.info().commandLine().orElse(process.info().command().orElse("<unknown>")));
             }
             final int exitCode = process.exitValue();
             LOG.log(DEBUG, "Process finished with exit code {0}", exitCode);

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -232,7 +232,7 @@ public final class ProcessUtils {
 
     /**
      * @param sign logic defining what we are waiting for.
-     * @param timeout
+     * @param timeout can be null to wait indefinitely.
      * @param printDots print dot each second and new line in the end.
      * @return true if the sign returned true before timeout.
      */
@@ -241,8 +241,8 @@ public final class ProcessUtils {
         final DotPrinter dotPrinter = DotPrinter.startWaiting(printDots);
         final Instant start = Instant.now();
         try {
-            final Instant deadline = start.plus(timeout);
-            while (Instant.now().isBefore(deadline)) {
+            final Instant deadline = timeout == null ? null : start.plus(timeout);
+            while (deadline == null || Instant.now().isBefore(deadline)) {
                 if (sign.get()) {
                     return true;
                 }

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
@@ -52,7 +52,11 @@ public enum GlassFishVariable {
     /** Node agents directory */
     NODES_ROOT("AS_DEF_NODES_PATH", "com.sun.aas.agentRoot"),
     /** Install root parent, resolved from {@link #INSTANCE_ROOT}. */
-    PRODUCT_ROOT(null, "com.sun.aas.productRoot")
+    PRODUCT_ROOT(null, "com.sun.aas.productRoot"),
+    /** Default start server timeout in seconds */
+    TIMEOUT_START_SERVER("AS_START_TIMEOUT", null),
+    /** Default stop server timeout in seconds */
+    TIMEOUT_STOP_SERVER("AS_STOP_TIMEOUT", null),
     ;
 
     private final String envName;

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/MonitoringReporter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/MonitoringReporter.java
@@ -188,7 +188,7 @@ public class MonitoringReporter extends V2DottedNameSupport {
 
         List<Server> allServers = targetService.getAllInstances();
         for (Server server : allServers) {
-            if (server.isRunning()) {
+            if (server.isListeningOnAdminPort()) {
                 num++;
             }
         }
@@ -281,7 +281,7 @@ public class MonitoringReporter extends V2DottedNameSupport {
         String instanceListStr = "";
         i = 0;
         for (Server server : allServers) {
-            if (server.isRunning()) {
+            if (server.isListeningOnAdminPort()) {
                 if (i == 0) {
                     instanceListStr = server.getName();
                 } else {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/StopServer.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/StopServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -51,7 +51,7 @@ public class StopServer {
             // show up in the ServiceLocator.
             GlassFish gfKernel = serviceLocator.getService(GlassFish.class);
             while (gfKernel == null) {
-                Thread.yield();
+                Thread.onSpinWait();
                 gfKernel = serviceLocator.getService(GlassFish.class);
             }
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/LocalStrings.properties
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/commands/LocalStrings.properties
@@ -116,9 +116,11 @@ create.threadpool.deprecated.workqueues=Deprecated Syntax: --workqueues option i
 list.thread.pools.failed=List Thread Pools failed because of: {0}
 delete.threadpool.notexists=Thread Pool named {0} does not exist.
 delete.threadpool.failed=Delete Thread Pool failed because of: {0}
+
+user.not.authorized = User {0} not authorized to attach to job {1}
 attach.wrong.commandinstance.id=Job with id {0} does not exist.
 attach.finished=Command {0} executed with status {1}.
-user.not.authorized = User {0} not authorized to attach to job {1}
+attach.timeout=Waiting for job {0} timed out after {1} seconds.
 
 getPayload.wrong.commandinstance.id=Job with id {0} does not exist.
 getPayload.nopayload=Outbound payload does not exist.

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/attach.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/attach.1
@@ -5,8 +5,10 @@ NAME
        --detach or that contain progress information
 
 SYNOPSIS
-           attach  [--help]
-           job_id
+        attach
+        [--help|-?]
+        [--timeout <timeout>]
+        job_id
 
 DESCRIPTION
        The attach subcommand attaches to subcommands that were started using
@@ -24,6 +26,12 @@ DESCRIPTION
 OPTIONS
        --help, -?
            Displays the help text for the subcommand.
+
+       --timeout
+           Specifies timeout in seconds to evaluate the expected result.
+           If the timeout is exceeded, the command fails - however it does
+           not mean it did not make any changes. The job status is unknown
+           in such case.
 
 OPERANDS
        job_id
@@ -52,4 +60,4 @@ SEE ALSO
 
        asadmin(1M)
 
-Jakarta EE 10                         12 Jan 2013                        attach(1)
+Jakarta EE 10                         26 Jun 2025                        attach(1)


### PR DESCRIPTION
- The problem was that we had
  - timeout of the asadmin command
  - timeout of the asadmin start-domain, restart-domain, ...
- The test client timeout was just 5 seconds more than the internal asadmin, however just for the first start, not for all other in tests. Those used hard coded value which defined waiting just of the asadmin command.

The change
* added --timeout [seconds] parameter to some of commands
  * start-local-instance, start-instance, start-domain
  * stop...
  * restart-local-instance, restart-domain
* Using consistently defaults
  * env options, 60 s if not set
  * additional 5 seconds for restarts
* restarts
  * timeout parameter without changes
  * OR defaults = sum default for start, for stop, and 5 seconds.
  * if the server was already stopped, uses just start default as it uses also local command.

Possible failures:
Too short timeout - enough for stop, not enough to start, command fails. It doesn't mean server did not start, we don't know as we gave up. So I would use this with caution, however it is very flexible and easier than using shell variables. It is also easier on SSH nodes as sending env variables via SSH must be explicitly allowed.
```
/app/appservers/glassfish7/bin/asadmin restart-domain --timeout 1

Waiting finished after 392 ms.
Server instance is stopped, now we wait for the start on localhost:4848

Waiting finished after 1 000 ms.
Timed out waiting for the server to restart
Command restart-domain failed.
```
