### PR TITLE
Fixes scattered web archive processing

### DIFF
--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/embed/impl/ScatteredWebArchivist.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/embed/impl/ScatteredWebArchivist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -101,7 +101,7 @@ public class ScatteredWebArchivist extends WebArchivist {
             Enumeration<String> fileEntries = descriptor.getArchiveFileEntries(archiveFile);
             while (fileEntries.hasMoreElements()) {
                 String entry = fileEntries.nextElement();
-                if (entry.endsWith(".class")) {
+                if (entry.startsWith("WEB-INF/classes/") && entry.endsWith(".class")) {
                     try {
                         elements.add(classLoader.loadClass(toClassName(entry)));
                     } catch (ClassNotFoundException e) {
@@ -113,8 +113,7 @@ public class ScatteredWebArchivist extends WebArchivist {
 
 
         @Override
-        protected void process(File archiveFile, WebBundleDescriptorImpl descriptor, ClassLoader classLoader)
-            throws IOException {
+        protected void process(File archiveFile, WebBundleDescriptorImpl descriptor, ClassLoader classLoader) {
         }
 
 


### PR DESCRIPTION
This fix removes a lot of the classloading exceptions from the Embedded GlassFish tests.
