### PR TITLE
Removed osgiversion-maven-plugin and  updated deploy plugin config

### DIFF
--- a/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
+++ b/nucleus/distributions/nucleus-common/src/main/resources/config/osgi.properties
@@ -35,7 +35,7 @@ Knopflerfish.system.packages=\
  org.osgi.service.condpermadmin;version=1.1
 
 org.osgi.framework.system.packages.extra=\
- org.glassfish.embeddable;org.glassfish.embeddable.spi;version=@project.osgi.version@
+ org.glassfish.embeddable;org.glassfish.embeddable.spi
 
 # NetBeans profiler packages exist in parent class loader
 org.osgi.framework.bootdelegation=org.netbeans.lib.profiler, org.netbeans.lib.profiler.*

--- a/nucleus/hk2-config-generator/pom.xml
+++ b/nucleus/hk2-config-generator/pom.xml
@@ -94,14 +94,13 @@
                     <instructions>
                         <Import-Package>*</Import-Package>
                         <_exportcontents>
-                            org.jvnet.hk2.config;version=${project.osgi.version},
-                            org.jvnet.hk2.config.api;version=${project.osgi.version},
-                            org.jvnet.hk2.config.provider;version=${project.osgi.version},
-                            org.jvnet.hk2.config.provider.internal;version=${project.osgi.version},
-                            org.jvnet.hk2.config.tiger;version=${project.osgi.version}
+                            org.jvnet.hk2.config,
+                            org.jvnet.hk2.config.api,
+                            org.jvnet.hk2.config.provider,
+                            org.jvnet.hk2.config.provider.internal,
+                            org.jvnet.hk2.config.tiger
                         </_exportcontents>
                         <_noimportjava>true</_noimportjava>
-                        <Specification-Version>${project.osgi.version}</Specification-Version>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>

--- a/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
+++ b/nucleus/osgi-platforms/felix/src/main/resources/config/osgi.properties
@@ -35,7 +35,7 @@ Knopflerfish.system.packages=\
  org.osgi.service.condpermadmin;version=1.1
 
 org.osgi.framework.system.packages.extra=\
- org.glassfish.embeddable;org.glassfish.embeddable.spi;version=@project.osgi.version@
+ org.glassfish.embeddable;org.glassfish.embeddable.spi
 
 # NetBeans profiler packages exist in parent class loader
 org.osgi.framework.bootdelegation=org.netbeans.lib.profiler, org.netbeans.lib.profiler.*

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -788,11 +788,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
-                    <artifactId>osgiversion-maven-plugin</artifactId>
-                    <version>${hk2.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.glassfish.hk2</groupId>
                     <artifactId>consolidatedbundle-maven-plugin</artifactId>
                     <version>${hk2.plugin.version}</version>
                 </plugin>
@@ -2044,26 +2039,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.glassfish.hk2</groupId>
-                <artifactId>osgiversion-maven-plugin</artifactId>
-                <!-- Since we don't want qualifier like b05 or SNAPSHOT to appear in package version attribute, we use the
-                following goal to populate a project property with an OSGi version which is equivalent to maven version without qualifier
-                and then use that property in osgi.bundle while exporting. -->
-                <configuration>
-                    <dropVersionComponent>qualifier</dropVersionComponent>
-                    <versionPropertyName>project.osgi.version</versionPropertyName>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>generate-osgi-version-property</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>compute-osgi-version</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1025,6 +1025,11 @@
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.3</version>
+                    <configuration>
+                        <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
+                        <skip>${deploy.skip}</skip>
+                        <deployAtEnd>true</deployAtEnd>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -2036,15 +2041,6 @@
                     <excludes>
                         <exclude>**/.ade_path/**</exclude>
                     </excludes>
-                </configuration>
-            </plugin>
-
-
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                    <skip>${deploy.skip}</skip>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Removed osgiversion-maven-plugin
    
- was a workaround for 1.2.3.SNAPSHOT versions generated by OSGi when we needed 1.2.3 instead.
- Now Felix maven plugin does that correctly and places where we still used the property did not need that.

Updated deploy plugin config

- Upload after build
- Moved to dependency management