### PR TITLE
Fix cleanup on deployment error

### DIFF
--- a/appserver/common/container-common/pom.xml
+++ b/appserver/common/container-common/pom.xml
@@ -151,4 +151,14 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
@@ -426,9 +426,7 @@ public class ComponentEnvManagerImpl implements ComponentEnvManager {
     private void unregisterAllEjbs(Application application) {
         application.getEjbDescriptors().stream()
                 .map(this::getComponentEnvId)
-                .forEach(componentEnvId -> {
-                    compId2Env.remove(componentEnvId);
-        });
+                .forEach(compId2Env::remove);
     }
 
     private void undeployAllDescriptors(JndiNameEnvironment env) {

--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
@@ -379,19 +379,19 @@ public class ComponentEnvManagerImpl implements ComponentEnvManager {
     }
 
     @Override
-    public void unbindFromComponentNamespace(JndiNameEnvironment JndiEnvironment) throws NamingException {
+    public void unbindFromComponentNamespace(JndiNameEnvironment jndiEnvironment) throws NamingException {
         // undeploy all descriptors
-        undeployAllDescriptors(JndiEnvironment);
+        undeployAllDescriptors(jndiEnvironment);
 
         // Unpublish any global entries exported by this environment
         Collection<JNDIBinding> globalBindings = new ArrayList<>();
-        addJNDIBindings(JndiEnvironment, ScopeType.GLOBAL, globalBindings);
+        addJNDIBindings(jndiEnvironment, ScopeType.GLOBAL, globalBindings);
 
         for (JNDIBinding globalBinding : globalBindings) {
             namingManager.unpublishObject(globalBinding.getName());
         }
 
-        Application app = getApplicationFromEnv(JndiEnvironment);
+        Application app = getApplicationFromEnv(jndiEnvironment);
 
         // undeploy data-sources & mail-sessions exposed by app-client descriptors.
         Set<ApplicationClientDescriptor> appClientDescriptors = app.getBundleDescriptors(ApplicationClientDescriptor.class);
@@ -399,9 +399,9 @@ public class ComponentEnvManagerImpl implements ComponentEnvManager {
             undeployAllDescriptors(appClientDescriptor);
         }
 
-        if (!(JndiEnvironment instanceof ApplicationClientDescriptor) && (app.getBundleDescriptors(ApplicationClientDescriptor.class).size() > 0)) {
+        if (!(jndiEnvironment instanceof ApplicationClientDescriptor) && (app.getBundleDescriptors(ApplicationClientDescriptor.class).size() > 0)) {
             Collection<JNDIBinding> appBindings = new ArrayList<>();
-            addJNDIBindings(JndiEnvironment, ScopeType.APP, appBindings);
+            addJNDIBindings(jndiEnvironment, ScopeType.APP, appBindings);
             for (JNDIBinding appBinding : appBindings) {
                 namingManager.unpublishObject(
                     componentNamingUtil.composeInternalGlobalJavaAppName(app.getAppName(), appBinding.getName()));
@@ -409,14 +409,14 @@ public class ComponentEnvManagerImpl implements ComponentEnvManager {
             }
         }
 
-        if (JndiEnvironment instanceof Application) {
-            Application application = (Application)JndiEnvironment;
+        if (jndiEnvironment instanceof Application) {
+            Application application = (Application)jndiEnvironment;
             final String applicationName = getApplicationName(application);
             namingManager.unbindAppObjects(applicationName);
             unregisterAllEjbs(application);
         } else {
             // Unbind anything in the component namespace
-            String componentEnvId = getComponentEnvId(JndiEnvironment);
+            String componentEnvId = getComponentEnvId(jndiEnvironment);
             namingManager.unbindComponentObjects(componentEnvId);
             this.unregister(componentEnvId);
         }

--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/ComponentEnvManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -410,7 +410,10 @@ public class ComponentEnvManagerImpl implements ComponentEnvManager {
         }
 
         if (JndiEnvironment instanceof Application) {
-            namingManager.unbindAppObjects(getApplicationName(JndiEnvironment));
+            Application application = (Application)JndiEnvironment;
+            final String applicationName = getApplicationName(application);
+            namingManager.unbindAppObjects(applicationName);
+            unregisterAllEjbs(application);
         } else {
             // Unbind anything in the component namespace
             String componentEnvId = getComponentEnvId(JndiEnvironment);
@@ -418,6 +421,14 @@ public class ComponentEnvManagerImpl implements ComponentEnvManager {
             this.unregister(componentEnvId);
         }
 
+    }
+
+    private void unregisterAllEjbs(Application application) {
+        application.getEjbDescriptors().stream()
+                .map(this::getComponentEnvId)
+                .forEach(componentEnvId -> {
+                    compId2Env.remove(componentEnvId);
+        });
     }
 
     private void undeployAllDescriptors(JndiNameEnvironment env) {

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/AsadminResultMatcher.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/AsadminResultMatcher.java
@@ -18,8 +18,7 @@ package org.glassfish.main.itest.tools.asadmin;
 import org.hamcrest.CustomTypeSafeMatcher;
 
 /**
- * Matcher checking that {@link Asadmin} command succeeded. Prints it's output
- * otherwise.
+ * Matcher checking that {@link Asadmin} command succeeded. Prints its output otherwise.
  *
  * @author David Matejcek
  */
@@ -35,8 +34,7 @@ public class AsadminResultMatcher extends CustomTypeSafeMatcher<AsadminResult> {
     }
 
     /**
-     * @return matcher checking that {@link Asadmin} command succeeded. Prints
-     * it's output otherwise.
+     * @return matcher checking that {@link Asadmin} command succeeded. Prints it's output otherwise.
      */
     public static CustomTypeSafeMatcher<AsadminResult> asadminOK() {
         return new AsadminResultMatcher();
@@ -56,7 +54,7 @@ public class AsadminResultMatcher extends CustomTypeSafeMatcher<AsadminResult> {
         private String expectedErrorMessage;
 
         private AsadminFailedMatcher(String expectedErrorMessage) {
-            super("asadmin succeeded");
+            super("asadmin failed in an expected way");
             this.expectedErrorMessage = expectedErrorMessage;
         }
 

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/AsadminResultMatcher.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/AsadminResultMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022,2025 Eclipse Foundation and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,14 +13,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 package org.glassfish.main.itest.tools.asadmin;
 
 import org.hamcrest.CustomTypeSafeMatcher;
 
-
 /**
- * Matcher checking that {@link Asadmin} command succeeded. Prints it's output otherwise.
+ * Matcher checking that {@link Asadmin} command succeeded. Prints it's output
+ * otherwise.
  *
  * @author David Matejcek
  */
@@ -30,17 +29,41 @@ public class AsadminResultMatcher extends CustomTypeSafeMatcher<AsadminResult> {
         super("asadmin succeeded");
     }
 
-
     @Override
     protected boolean matchesSafely(AsadminResult item) {
         return !item.isError();
     }
 
+    /**
+     * @return matcher checking that {@link Asadmin} command succeeded. Prints
+     * it's output otherwise.
+     */
+    public static CustomTypeSafeMatcher<AsadminResult> asadminOK() {
+        return new AsadminResultMatcher();
+    }
 
     /**
-     * @return matcher checking that {@link Asadmin} command succeeded. Prints it's output otherwise.
+     * Returns true if the command failed and contains the specified message in stderr
+     * @param expectedErrorMessage A message that should appear in the stderr to match this error
+     * @return matcher checking that {@link Asadmin} command failed.
      */
-    public static AsadminResultMatcher asadminOK() {
-        return new AsadminResultMatcher();
+    public static CustomTypeSafeMatcher<AsadminResult> asadminError(String expectedErrorMessage) {
+        return new AsadminFailedMatcher(expectedErrorMessage);
+    }
+
+    private static class AsadminFailedMatcher extends CustomTypeSafeMatcher<AsadminResult> {
+
+        private String expectedErrorMessage;
+
+        private AsadminFailedMatcher(String expectedErrorMessage) {
+            super("asadmin succeeded");
+            this.expectedErrorMessage = expectedErrorMessage;
+        }
+
+        @Override
+        protected boolean matchesSafely(AsadminResult item) {
+            return item.isError() && item.getStdErr().contains(expectedErrorMessage);
+        }
+
     }
 }

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -29,13 +29,17 @@
 
     <artifactId>application-tests</artifactId>
     <name>GlassFish Application Tests</name>
+    
+    <properties>
+        <glassfish.version>${project.version}</glassfish.version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.glassfish.main.distributions</groupId>
             <artifactId>glassfish</artifactId>
             <type>zip</type>
-            <version>${project.version}</version>
+            <version>${glassfish.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -197,6 +201,7 @@
                             <includeArtifactIds>glassfish</includeArtifactIds>
                             <excludeTransitive>true</excludeTransitive>
                             <outputDirectory>${project.build.directory}</outputDirectory>
+                            <verbose>true</verbose>
                         </configuration>
                     </execution>
                 </executions>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/deploy/BeanFailingDeployment.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/deploy/BeanFailingDeployment.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.deploy;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.ws.rs.Path;
+
+@Path("/")
+@Singleton
+@Startup
+public class BeanFailingDeployment {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @PostConstruct
+    public void startup() {
+        if (!em.getEntityManagerFactory().isOpen()) {
+            throw new RuntimeException("EMF should be open");
+        }
+        throw new RuntimeException("Expected deployment error");
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/deploy/BeanNotFailingDeployment.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/deploy/BeanNotFailingDeployment.java
@@ -35,7 +35,7 @@ public class BeanNotFailingDeployment {
     @PostConstruct
     public void startup() {
         if (!em.getEntityManagerFactory().isOpen()) {
-            throw new RuntimeException("EM should be open");
+            throw new RuntimeException("EntityManagerFactory should be open");
         }
     }
 }

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/deploy/BeanNotFailingDeployment.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/deploy/BeanNotFailingDeployment.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.deploy;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.ejb.Singleton;
+import jakarta.ejb.Startup;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Singleton
+@Startup
+public class BeanNotFailingDeployment {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @PostConstruct
+    public void startup() {
+        if (!em.getEntityManagerFactory().isOpen()) {
+            throw new RuntimeException("EM should be open");
+        }
+    }
+}

--- a/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/deploy/afterfailed/persistence.xml
+++ b/appserver/tests/application/src/main/resources/org/glassfish/main/test/app/deploy/afterfailed/persistence.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+    version="3.0"
+>
+    <persistence-unit name="default" transaction-type="JTA">
+    </persistence-unit>
+</persistence>

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/deploy/afterfailed/DeployAfterFailedDeploymentTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/deploy/afterfailed/DeployAfterFailedDeploymentTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.deploy.afterfailed;
+
+import java.io.File;
+
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.test.app.deploy.BeanFailingDeployment;
+import org.glassfish.main.test.app.deploy.BeanNotFailingDeployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.UnknownExtensionTypeException;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getAsadmin;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminError;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DeployAfterFailedDeploymentTest {
+
+    private static final System.Logger LOG = System.getLogger(DeployAfterFailedDeploymentTest.class.getName());
+
+    private static final Package TEST_PACKAGE = DeployAfterFailedDeploymentTest.class.getPackage();
+    private static final String FAILING_APP_NAME = DeployAfterFailedDeploymentTest.class.getSimpleName() + "FailingApp";
+    private static final String OK_APP_NAME = DeployAfterFailedDeploymentTest.class.getSimpleName() + "OKApp";
+
+    private static final Asadmin ASADMIN = getAsadmin();
+
+    @TempDir
+    private static File tempDir;
+    private static File failingAppWarFile;
+    private static File okAppWarFile;
+
+    @BeforeAll
+    public static void prepareDeployment() {
+        failingAppWarFile = prepareFailingApp();
+        okAppWarFile = prepareOkApp();
+    }
+
+    private static File prepareFailingApp() throws IllegalArgumentException, UnknownExtensionTypeException {
+        WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
+                .addClass(BeanFailingDeployment.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource(TEST_PACKAGE, "persistence.xml", "META-INF/persistence.xml");
+        LOG.log(INFO, webArchive.toString(true));
+        File warFile = new File(tempDir, FAILING_APP_NAME + ".war");
+        webArchive.as(ZipExporter.class).exportTo(warFile, true);
+        return warFile;
+    }
+
+    private static File prepareOkApp() {
+        WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
+                .addClass(BeanNotFailingDeployment.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource(TEST_PACKAGE, "persistence.xml", "META-INF/persistence.xml");
+        LOG.log(INFO, webArchive.toString(true));
+        File warFile = new File(tempDir, OK_APP_NAME + ".war");
+        webArchive.as(ZipExporter.class).exportTo(warFile, true);
+        return warFile;
+    }
+
+    /**
+     * This test verifies that the JNDI environment is cleaned up for the application context in case of failed deployment.
+     * It used to happen that after a failed deployment, JNDI environment for the app name and context root stayed in memory,
+     * with an entity manager factory that was closed after failed deployment.
+     * A new deployment of the same app would pick up the previous JNDI environment and would attempt
+     * to use the already closed entity manager factory, until server restarted.
+     */
+    @Test
+    public void testDeployFailedAppAndThenFixedAppWithSameNameAndContextRoot() {
+        assertThat(ASADMIN.exec("deploy", "--name", OK_APP_NAME, "--contextroot", "/", failingAppWarFile.getAbsolutePath()), asadminError("Initialization failed for Singleton BeanFailingDeployment"));
+        assertThat(ASADMIN.exec("deploy", "--name", OK_APP_NAME, "--contextroot", "/", okAppWarFile.getAbsolutePath()), asadminOK());
+        assertThat(ASADMIN.exec("undeploy", OK_APP_NAME), asadminOK());
+    }
+
+}


### PR DESCRIPTION
Before this, JNDI bindings were not cleaned up for all EJBs, leaking information to future deployments of the same name. If an app didn't deploy successfully and was deployed later, JNDI bindings remained from the previous failed deployment instead of being initialized from scratch. I saw an issue that EntityManagerFactory was closed because of a failed deployment, and then it was reused for the next deployment, leading to a closed EMF assigned to a newly deployed app. 

The cause for this was that the JNDI bindings were removed only after they were unregistered the same number of times as they were registered. During failed deployment, they were not unregistered in some cases, and an old JNDI reference was kept in the map. The fix removes all the bindings once again during application unregistration.
