### PR TITLE
Fixed detached commands mistake + Jenkinsfile changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,6 @@ spec:
       S1AS_HOME = "${WORKSPACE}/glassfish7/glassfish"
       APS_HOME = "${WORKSPACE}/appserver/tests/appserv-tests"
       TEST_RUN_LOG = "${WORKSPACE}/tests-run.log"
-      GF_INTERNAL_ENV = credentials('gf-internal-env')
       PORT_ADMIN=4848
       PORT_HTTP=8080
       PORT_HTTPS=8181

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ def dumpSysInfo() {
    ps -e -o start,etime,pid,rss,drs,command || true
    lscpu || true
    cat /proc/meminfo || true
+   ulimit -a || true
    """
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,10 +147,10 @@ spec:
     resources:
       limits:
         memory: "8Gi"
-        cpu: "6000m"
+        cpu: "5500m"
       requests:
         memory: "8Gi"
-        cpu: "6000m"
+        cpu: "5500m"
   volumes:
   - name: "jenkins-home"
     emptyDir:

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/DetachAttachITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/DetachAttachITest.java
@@ -57,7 +57,7 @@ public class DetachAttachITest {
     @Test
     public void uptimePeriodically() throws Exception {
         final Set<String> ids = new HashSet<>();
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < 10; i++) {
             LOG.log(INFO, "detachAndAttachUptimePeriodically: round {0}", i);
             final String id;
             {

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/JobTestExtension.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/JobTestExtension.java
@@ -95,7 +95,7 @@ public class JobTestExtension implements BeforeAllCallback, AfterAllCallback {
      */
     public static void waitForJobCleanup(long cleanupPeriod) {
         //  the configured period plus reserve time
-        final long maxEnd = System.currentTimeMillis() + cleanupPeriod * 1000L + 1000L;
+        final long maxEnd = System.currentTimeMillis() + cleanupPeriod * 1000L + 10000L;
         while (true) {
             AsadminResult result = ASADMIN.exec("list-jobs");
             assertThat(result, asadminOK());
@@ -114,7 +114,7 @@ public class JobTestExtension implements BeforeAllCallback, AfterAllCallback {
      */
     public static void waitForAllJobCompleted(long timeout) {
         //  the configured period plus reserve time
-        final long maxEnd = System.currentTimeMillis() + timeout * 1000L;
+        final long maxEnd = System.currentTimeMillis() + timeout * 10000L;
         while (true) {
             AsadminResult result = ASADMIN.exec("list-jobs");
             assertThat(result, asadminOK());

--- a/appserver/tests/gftest.sh
+++ b/appserver/tests/gftest.sh
@@ -18,7 +18,7 @@
 run_test() {
     local testid=${1}
     local found=false
-    
+
     for runtest in `find . -name run_test\.sh`; do
         for id in `${runtest} list_test_ids`; do
             if [[ "${id}" = "${testid}" ]]; then
@@ -34,7 +34,7 @@ run_test() {
             break
         fi
     done
-    
+
     if [[ "${found}" = false ]]; then
         echo Invalid Test Id.
         exit 1
@@ -42,14 +42,6 @@ run_test() {
 }
 
 if [ ! -z "${JENKINS_HOME}" ] ; then
-
-  # inject internal environment
-  readonly GF_INTERNAL_ENV_SH=$(mktemp -t XXXgf-internal-env)
-  if [ ! -z "${GF_INTERNAL_ENV}" ] ; then
-    echo "${GF_INTERNAL_ENV}" | base64 -d > ${GF_INTERNAL_ENV_SH}
-    . ${GF_INTERNAL_ENV_SH}
-    export MAVEN_OPTS="${MAVEN_OPTS} ${ANT_OPTS}"
-  fi
   export WSIMPORT_OPTS="${ANT_OPTS}"
 
   # setup the local repository

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateCommandDeleteResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateCommandDeleteResource.java
@@ -88,7 +88,7 @@ public class TemplateCommandDeleteResource extends TemplateExecCommand {
                     "Unable to parse the input entity. Please check the syntax.");
             throw new WebApplicationException(ResourceUtil.getResponse(400, /*parsing error*/ errorMessage, requestHeaders, uriInfo));
         }
-        return executeCommandAsSse(preprocessData(data));
+        return executeSseCommand(preprocessData(data));
     }
 
     //    //Handle POST request without any entity(input).

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateCommandGetResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateCommandGetResource.java
@@ -53,7 +53,7 @@ public class TemplateCommandGetResource extends TemplateExecCommand {
     @GET
     @Produces(SseFeature.SERVER_SENT_EVENTS + ";qs=0.5")
     public Response processSseGet() {
-        return executeCommandAsSse(prepareParameters());
+        return executeSseCommand(prepareParameters());
     }
 
     private ParameterMap prepareParameters() {

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateCommandPostResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateCommandPostResource.java
@@ -122,7 +122,7 @@ public class TemplateCommandPostResource extends TemplateExecCommand {
                     "Unable to parse the input entity. Please check the syntax.");
             throw new WebApplicationException(ResourceUtil.getResponse(400, /*parsing error*/ errorMessage, requestHeaders, uriInfo));
         }
-        return super.executeCommandAsSse(preprocessData(data));
+        return super.executeSseCommand(preprocessData(data));
     }
 
     @POST

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/DetachedSseAdminCommandInvoker.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/DetachedSseAdminCommandInvoker.java
@@ -18,6 +18,10 @@ package org.glassfish.admin.rest.utils;
 
 import com.sun.enterprise.v3.admin.AdminCommandJob;
 import com.sun.enterprise.v3.admin.AsyncAdminCommandInvoker;
+import com.sun.enterprise.v3.common.ActionReporter;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
 
 import java.lang.System.Logger;
 
@@ -31,33 +35,39 @@ import static java.lang.System.Logger.Level.TRACE;
  * Starts the job, creates the {@link SseEventOutput} and writes the {@link ActionReport} containing
  * the job id as a message. Then ends.
  */
-public class DetachedSseAdminCommandInvoker extends AsyncAdminCommandInvoker<SseEventOutput> {
+public class DetachedSseAdminCommandInvoker extends AsyncAdminCommandInvoker<Response> {
     private static final Logger LOG = System.getLogger(DetachedSseAdminCommandInvoker.class.getName());
 
-    public DetachedSseAdminCommandInvoker(CommandInvocation<AdminCommandJob> commandInvocation) {
-        super(commandInvocation);
-    }
+    private final ActionReporter report;
+    private final ResponseBuilder builder;
 
+    public DetachedSseAdminCommandInvoker(ActionReporter idReport, CommandInvocation<AdminCommandJob> invocation, ResponseBuilder builder) {
+        super(invocation);
+        this.report = idReport;
+        this.builder = builder;
+    }
 
     /**
      * Starts the job, creates the {@link SseEventOutput} and writes the {@link ActionReport}
-     * containing
-     * the job id as a message. Then ends.
+     * containing the job id as a message. Then ends.
      */
     @Override
-    public SseEventOutput start() {
+    public Response start() {
         final AdminCommandJob job = getJob();
-        LOG.log(TRACE, "Job parameters: {0}, this: {1}", job.getParameters(), this);
-        final SseEventOutput eventOutput = new SseEventOutput(job);
-        LOG.log(TRACE, "Writing the job id. {0}", this);
-        final ActionReport report = job.getActionReport();
         report.setMessage(job.getId());
         report.setActionExitCode(ExitCode.SUCCESS);
-        // No other writes to the report or event output until we close.
-        report.lock();
-        eventOutput.write();
+        final Response response = createResponse(job);
+        LOG.log(TRACE, "Job parameters: {0}, this: {1}", job.getParameters(), this);
         startJob();
         LOG.log(TRACE, "Detached job started, leaving. {0}", this);
-        return eventOutput;
+        return response;
+    }
+
+    private Response createResponse(AdminCommandJob job) {
+        try (SseEventOutput eventOutput = new SseEventOutput(job)) {
+            LOG.log(TRACE, "Writing the job id. {0}", this);
+            eventOutput.write();
+            return builder.entity(eventOutput).build();
+        }
     }
 }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/SseEventOutput.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/SseEventOutput.java
@@ -79,9 +79,6 @@ public class SseEventOutput extends EventOutput {
             // and usually does when he receives the COMPLETED state.
             // The close() call does flush and may fail then.
             LOG.log(TRACE, "Failed to close the event output.", ex);
-        } finally {
-            // When we close, we abandon the lock so other threads can continue
-            job.getActionReport().unlock();
         }
     }
 }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminCommandJob.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminCommandJob.java
@@ -23,7 +23,6 @@ import com.sun.enterprise.v3.admin.CheckpointHelper.CheckpointFilename;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.io.Serializable;
 import java.lang.System.Logger;
 import java.util.List;
 import java.util.Objects;
@@ -53,7 +52,7 @@ import static java.lang.System.Logger.Level.WARNING;
  * @author Martin Mares
  * @author Bhakti Mehta
  */
-public final class AdminCommandJob implements Job, Serializable {
+public final class AdminCommandJob implements Job {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = System.getLogger(AdminCommandJob.class.getName());

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -81,14 +81,10 @@
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
 
-        <!-- Jakarta Web Services -->
-
         <!-- Jakarta XML Web Services -->
         <jakarta.xml.ws-api.version>4.0.2</jakarta.xml.ws-api.version>
 
-        <!-- Jakarta SOAP (with Attachments)
-       <jakarta.xml.soap-api.version>3.0.0-RC2</jakarta.xml.soap-api.version>
-        -->
+        <!-- Jakarta SOAP (with Attachments) -->
         <webservices.version>4.0.4</webservices.version>
 
         <!-- Jakarta Inject -->
@@ -119,9 +115,7 @@
         <jakarta.authorization-api.version>2.1.0</jakarta.authorization-api.version>
         <jakarta.authentication-api.version>3.0.0</jakarta.authentication-api.version>
 
-
         <!-- GlassFish Components -->
-
         <grizzly.version>4.0.2</grizzly.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
 
@@ -135,9 +129,7 @@
         <logging-annotation-processor.version>1.10</logging-annotation-processor.version>
         <command.security.maven.plugin.isFailureFatal>true</command.security.maven.plugin.isFailureFatal>
 
-
         <!-- 3rd party dependencies -->
-
         <commons-io.version>2.18.0</commons-io.version>
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
@@ -167,8 +159,12 @@
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>
+
         <!-- Overrides the value from parent and enables the one we generate. -->
         <project.build.outputTimestamp>2025-04-22T16:51:49Z</project.build.outputTimestamp>
+
+        <!-- Show to developers by default -->
+        <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
 
         <maven.test.jvmoptions.add-opens>--add-opens java.base/java.lang=ALL-UNNAMED</maven.test.jvmoptions.add-opens>
         <maven.test.jvmoptions.memory.sizes>-Xss512k -Xms256m -Xmx1g -XX:MaxDirectMemorySize=512m</maven.test.jvmoptions.memory.sizes>
@@ -948,7 +944,7 @@
                         <suppressionsLocation>org/glassfish/qa/config/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         <skip>${checkstyle.skip}</skip>
-                        <consoleOutput>true</consoleOutput>
+                        <consoleOutput>${checkstyle.consoleOutput}</consoleOutput>
                         <logViolationsToConsole>true</logViolationsToConsole>
                         <excludes>**/generated-sources/**/*, **/module-info.java</excludes>
                         <includes>**/*admin,**/*.adoc,**/*.bat,**/*.java,**/*.sh,**/*.xml</includes>
@@ -2097,21 +2093,11 @@
 
     <profiles>
         <profile>
-            <id>mac</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../Classes/classes.jar</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools-jar</artifactId>
-                    <version>1</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../Classes/classes.jar</systemPath>
-                </dependency>
-            </dependencies>
+            <id>ci</id>
+            <properties>
+                <!-- Limit unuseful noise on CI while developers should see it -->
+                <checkstyle.consoleOutput>false</checkstyle.consoleOutput>
+            </properties>
         </profile>
         <profile>
             <id>oss-release</id>
@@ -2271,6 +2257,23 @@
             </build>
         </profile>
 
+        <profile>
+            <id>mac</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../Classes/classes.jar</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools-jar</artifactId>
+                    <version>1</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../Classes/classes.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>windows</id>
             <activation>


### PR DESCRIPTION
Fixes #25575 
As we still struggle with Jenkins today, I am joining two commits in one PR as a critical update.

* Jenkinsfile
  * Reducing logs on CI as large logs may be one of causes of our issues with Jenkins together with some Jenkins features.
  * Added df -h executed after the build.
* In #25592 I left one mistake which caused the old behavior; despite the command was set to be detached, the `SseAdminCommandInvoker` was used instead of `DetachedSseAdminCommandInvoker`. The first then continues sending "news" from the command, the first writes the command id and stops listening.