### PR TITLE
Improve Data TCK Runner to add a default persistence unit

### DIFF
--- a/appserver/tests/tck/data/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/appserver/tests/tck/data/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.glassfish.tck.data.ArquillianExtension

--- a/appserver/tests/tck/data/src/main/resources/persistence.xml
+++ b/appserver/tests/tck/data/src/main/resources/persistence.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2025 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Ondro Mihalyi
+  ~
+  -->
+<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+  <persistence-unit name="testPersistenceUnit" transaction-type="JTA">
+    <class>ee.jakarta.tck.data.core.cdi.Person</class>
+    <class>ee.jakarta.tck.data.framework.read.only.AsciiCharacter</class>
+    <class>ee.jakarta.tck.data.framework.read.only.NaturalNumber</class>
+    <class>ee.jakarta.tck.data.standalone.entity.Box</class>
+    <class>ee.jakarta.tck.data.standalone.entity.Coordinate</class>
+    <class>ee.jakarta.tck.data.standalone.persistence.Product</class>
+    <class>ee.jakarta.tck.data.web.validation.Rectangle</class>
+    <exclude-unlisted-classes>true</exclude-unlisted-classes>
+    <properties>
+      <!-- EclipseLink specific properties -->
+      <property name="eclipselink.orm.throw.exceptions" value="true"/>
+      <property name="eclipselink.target-database" value="Derby"/>
+      <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+<!--      <property name="eclipselink.debug" value="ALL"/>
+      <property name="eclipselink.logging.level" value="FINEST"/>
+      <property name="eclipselink.logging.level.sql" value="FINEST"/>
+      <property name="eclipselink.logging.level.cache" value="FINEST"/>-->
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/ArquillianExtension.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/ArquillianExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.glassfish.tck.data;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.core.spi.LoadableExtension.ExtensionBuilder;
+
+public class ArquillianExtension implements LoadableExtension {
+
+    public static final String PROPERTY_PREFIX = "arquillian.extensions.jakarta.batch.";
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ApplicationArchiveProcessor.class, JakartaPersistenceProcessor.class);
+    }
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JakartaPersistenceProcessor.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JakartaPersistenceProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tck.data;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class JakartaPersistenceProcessor implements ApplicationArchiveProcessor {
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if(archive instanceof WebArchive webArchive) {
+            webArchive.addAsWebInfResource(getClass().getClassLoader().getResource("persistence.xml"), "classes/META-INF/persistence.xml");
+        }
+    }
+
+}

--- a/appserver/tests/tck/data/src/test/resources/arquillian.xml
+++ b/appserver/tests/tck/data/src/test/resources/arquillian.xml
@@ -1,0 +1,18 @@
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian  https://www.jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    <defaultProtocol type="Servlet 6.0"/>
+
+    <engine>
+        <!--<property name="deploymentExportPath">target/</property>-->
+    </engine>
+
+    <container qualifier="http" default="true">
+        <configuration>
+            <property name="httpsPortAsDefault">false</property>
+<!--                <property name="suspend">true</property>-->
+            <property name="enableDerby">true</property>
+        </configuration>
+    </container>
+
+</arquillian>


### PR DESCRIPTION
Some way to define the default persistence unit is needed. This PR adds persistence.xml do all test apps to do it. Alternatively, we would need to add a producer for the default EM to each test app. 

Or enhance GF to create a default PU based on the default DS if none is defined. The solution in the PR works well, we can consider it later to improve dev experience for new projects or prototypes.