### PR TITLE
Jakarta Data transactional interceptor plus fixes in class scanner

### DIFF
--- a/appserver/persistence/jnosql-integration/pom.xml
+++ b/appserver/persistence/jnosql-integration/pom.xml
@@ -29,6 +29,10 @@
     <packaging>glassfish-jar</packaging>
 
     <name>Eclipse JNoSQL Jakarta Persistence Integration</name>
+    
+    <properties>
+        <persistence.osgi.bundle.classpath>${project.build.directory}/dependencies/jnosql-jakarta-persistence-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-mapping-core-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-mapping-api-core-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-communication-core-${jnosql.version}.jar</persistence.osgi.bundle.classpath>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -75,6 +79,23 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-locator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- do not commit the jnosql-jakarta-persistence, it's only for IDE to find the dependency -->
+<!--        <dependency>
+            <groupId>org.eclipse.jnosql.mapping</groupId>
+            <artifactId>jnosql-jakarta-persistence</artifactId>
+            <version>1.1.8-SNAPSHOT</version>
+            <optional>true</optional>
+        </dependency>-->
     </dependencies>
 
     <build>
@@ -104,14 +125,44 @@
                             <outputProperty>compile.classpath</outputProperty>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>testclasspath</id>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>test</includeScope>
+                            <outputProperty>test.classpath</outputProperty>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-cp</arg>
+                                <arg>${test.classpath}${path.separator}${project.build.outputDirectory}${path.separator}${persistence.osgi.bundle.classpath}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-cli</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-cp</arg>
+                                <arg>${test.classpath}${path.separator}${project.build.outputDirectory}${path.separator}${persistence.osgi.bundle.classpath}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
                     <compilerArgs>
                         <arg>-cp</arg>
-                        <arg>${compile.classpath}${path.separator}${project.build.directory}/dependencies/jnosql-jakarta-persistence-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-mapping-core-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-mapping-api-core-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-communication-core-${jnosql.version}.jar</arg>
+                        <arg>${compile.classpath}${path.separator}${persistence.osgi.bundle.classpath}</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/appserver/persistence/jnosql-integration/pom.xml
+++ b/appserver/persistence/jnosql-integration/pom.xml
@@ -166,6 +166,18 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${project.build.directory}/dependencies/jnosql-jakarta-persistence-${jnosql.version}.jar</additionalClasspathElement>
+                        <additionalClasspathElement>${project.build.directory}/dependencies/jnosql-mapping-core-${jnosql.version}.jar</additionalClasspathElement>
+                        <additionalClasspathElement>${project.build.directory}/dependencies/jnosql-mapping-api-core-${jnosql.version}.jar</additionalClasspathElement>
+                        <additionalClasspathElement>${path.separator}${project.build.directory}/dependencies/jnosql-communication-core-${jnosql.version}.jar</additionalClasspathElement>
+                    </additionalClasspathElements>
+                </configuration>
+             </plugin>
 
             <!-- Creates the OSGi MANIFEST.MF file -->
             <plugin>

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/EntityValidator.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/EntityValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext;
+
+import jakarta.interceptor.InvocationContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jnosql.jakartapersistence.mapping.spi.MethodInterceptor;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@MethodInterceptor.SaveEntity
+public class EntityValidator implements MethodInterceptor {
+
+    @Override
+    public Object intercept(InvocationContext context) throws Exception {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+
+        final Set<ConstraintViolation<Object>> violations = new HashSet<>();
+        for (Object entity : context.getParameters()) {
+             violations.addAll(validator.validate(entity));
+        }
+        if (violations.isEmpty()) {
+            return context.proceed();
+        }
+        throw new ConstraintViolationException(violations);
+    }
+
+}

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
@@ -35,7 +35,9 @@ import java.util.logging.Logger;
 
 import org.eclipse.jnosql.jakartapersistence.communication.EntityManagerProvider;
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
+import org.eclipse.jnosql.jakartapersistence.mapping.EnsureTransactionInterceptor;
 import org.eclipse.jnosql.jakartapersistence.mapping.repository.AbstractRepositoryPersistenceBean;
+import org.eclipse.jnosql.jakartapersistence.mapping.spi.RepositoryMethodInterceptor;
 import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.core.spi.AbstractBean;
 import org.eclipse.jnosql.mapping.metadata.ClassScanner;
@@ -107,15 +109,16 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
         }
 
         addBean(Converters.class, afterBeanDiscovery, beanManager)
-                .types(Converters.class)
                 .scope(ApplicationScoped.class);
 
         addBean(PersistenceDatabaseManager.class, afterBeanDiscovery, beanManager)
-                .types(PersistenceDatabaseManager.class)
                 .scope(ApplicationScoped.class);
 
         addBean(EntityManagerProvider.class, afterBeanDiscovery, beanManager)
-                .types(EntityManagerProvider.class)
+                .scope(ApplicationScoped.class);
+
+        addBean(EnsureTransactionInterceptor.class, afterBeanDiscovery, beanManager)
+                .types(RepositoryMethodInterceptor.class)
                 .scope(ApplicationScoped.class);
     }
 
@@ -152,6 +155,7 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
 
     private <T> BeanConfigurator<T> addBean(Class<T> beanClass, AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
         return afterBeanDiscovery.<T>addBean()
+                .types(beanClass)
                 .createWith(createBeanProducer(beanClass, beanManager))
                 .destroyWith(createBeanDestroyer(beanClass, beanManager));
     }

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
@@ -37,7 +37,7 @@ import org.eclipse.jnosql.jakartapersistence.communication.EntityManagerProvider
 import org.eclipse.jnosql.jakartapersistence.communication.PersistenceDatabaseManager;
 import org.eclipse.jnosql.jakartapersistence.mapping.EnsureTransactionInterceptor;
 import org.eclipse.jnosql.jakartapersistence.mapping.repository.AbstractRepositoryPersistenceBean;
-import org.eclipse.jnosql.jakartapersistence.mapping.spi.RepositoryMethodInterceptor;
+import org.eclipse.jnosql.jakartapersistence.mapping.spi.MethodInterceptor;
 import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.core.spi.AbstractBean;
 import org.eclipse.jnosql.mapping.metadata.ClassScanner;
@@ -89,6 +89,13 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
                 .types(EntitiesMetadata.class)
                 .scope(ApplicationScoped.class);
 
+        addBean(EntityValidator.class, afterBeanDiscovery, beanManager)
+                .types(MethodInterceptor.class)
+                .qualifiers(MethodInterceptor.SaveEntity.INSTANCE)
+                .alternative(true)
+                .priority(Interceptor.Priority.PLATFORM_BEFORE)
+                .scope(ApplicationScoped.class);
+
         defineJNoSqlBeans(afterBeanDiscovery, beanManager);
     }
 
@@ -118,7 +125,10 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
                 .scope(ApplicationScoped.class);
 
         addBean(EnsureTransactionInterceptor.class, afterBeanDiscovery, beanManager)
-                .types(RepositoryMethodInterceptor.class)
+                .types(MethodInterceptor.class)
+                .qualifiers(MethodInterceptor.Repository.INSTANCE)
+                .alternative(true)
+                .priority(Interceptor.Priority.PLATFORM_BEFORE)
                 .scope(ApplicationScoped.class);
     }
 

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/GlassFishClassScannerTest.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/GlassFishClassScannerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext;
+
+
+
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Repository;
+import jakarta.persistence.Entity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.glassfish.hk2.classmodel.reflect.ParsingContext;
+import org.glassfish.hk2.classmodel.reflect.Types;
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories.CombinedRepository;
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories.MyBasicRepository;
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories.MyCrudRepository;
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories.MyDataRepository;
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories.NoInterfaceRepository;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class GlassFishClassScannerTest {
+
+    public GlassFishClassScannerTest() {
+    }
+
+    @Test
+    public void testVariousRepositories() throws URISyntaxException, IOException, InterruptedException {
+
+        Set<Class<?>> allClasses = new HashSet<>();
+        Set<Class<?>> normalRepositories = new HashSet<>();
+
+        final Set<Class<?>> apiClasses = Set.of(DataRepository.class, BasicRepository.class, CrudRepository.class,
+                Entity.class, Repository.class);
+        allClasses.addAll(apiClasses);
+
+        final Set<Class<?>> otherTestClasses = Set.of(MyEntity.class);
+        allClasses.addAll(otherTestClasses);
+
+        final Set<Class<?>> standardRepositories = Set.of(
+                MyDataRepository.class, MyBasicRepository.class, MyCrudRepository.class);
+        allClasses.addAll(standardRepositories);
+        normalRepositories.addAll(standardRepositories);
+
+        final Set<Class<?>> combinedRepositories = Set.of(CombinedRepository.class);
+        allClasses.addAll(combinedRepositories);
+        normalRepositories.addAll(combinedRepositories);
+
+        final Set<Class<?>> customRepositories = new HashSet<>();
+        customRepositories.addAll(Set.of(NoInterfaceRepository.class));
+        customRepositories.addAll(combinedRepositories);
+        allClasses.addAll(customRepositories);
+
+        Types types = parseClasses(allClasses);
+
+        final GlassFishClassScanner scanner = new GlassFishClassScanner(types);
+
+        final Set<Class<?>> repositoriesStandardResult = scanner.repositoriesStandard();
+        assertTrue(repositoriesStandardResult.equals(standardRepositories), "Standard repositories: " + repositoriesStandardResult);
+        final Set<Class<?>> customRepositoriesResult = scanner.customRepositories();
+        assertTrue(customRepositoriesResult.equals(customRepositories), "Custom repositories: " + customRepositoriesResult);
+        final Set<Class<?>> repositoriesResult = scanner.repositories();
+        assertTrue(repositoriesResult.equals(normalRepositories), "Repositories: " + repositoriesResult);
+    }
+
+    public static Types parseClasses(Collection<Class<?>> classes) throws IOException {
+        ParsingContext context = new ParsingContext.Builder().build();
+
+        for (Class<?> clazz : classes) {
+            // Get the bytecode
+            String classPath = "/" + clazz.getName().replace('.', '/') + ".class";
+            InputStream classBytes = clazz.getResourceAsStream(classPath);
+
+            if (classBytes == null) {
+                throw new IOException("Could not find bytecode for " + clazz.getName());
+            }
+
+            try {
+                // Parse it
+                ClassReader classReader = new ClassReader(classBytes);
+                URI classUri = URI.create("test://memory/" + clazz.getSimpleName() + ".class");
+
+                classReader.accept(
+                        context.getClassVisitor(classUri, clazz.getSimpleName() + ".class", true),
+                        ClassReader.SKIP_DEBUG
+                );
+
+            } finally {
+                classBytes.close();
+            }
+        }
+
+        // Return the parsed type
+        return context.getTypes();
+
+    }
+}

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/MyEntity.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/MyEntity.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Entity
+public class MyEntity {
+
+    @Id
+    long id;
+}

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/CombinedRepository.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/CombinedRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories;
+
+import jakarta.data.repository.Repository;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Repository
+public interface CombinedRepository extends MyCrudRepository {
+
+}

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/MyBasicRepository.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/MyBasicRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories;
+
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
+
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.MyEntity;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Repository
+public interface MyBasicRepository extends BasicRepository<MyEntity, Long>{
+
+}

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/MyCrudRepository.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/MyCrudRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.MyEntity;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Repository
+public interface MyCrudRepository extends CrudRepository<MyEntity, Long>{
+
+}

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/MyDataRepository.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/MyDataRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Repository;
+
+import org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.MyEntity;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Repository
+public interface MyDataRepository extends DataRepository<MyEntity, Long> {
+
+}

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/NoInterfaceRepository.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/repositories/NoInterfaceRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext.repositories;
+
+import jakarta.data.repository.Repository;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Repository
+public interface NoInterfaceRepository {
+
+}

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -116,7 +116,7 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-        <eclipselink.version>5.0.0-B07</eclipselink.version>
+        <eclipselink.version>5.0.0-B09</eclipselink.version>
         <eclipselink.asm.version>9.8.0</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->

--- a/appserver/tests/tck/data/pom.xml
+++ b/appserver/tests/tck/data/pom.xml
@@ -121,8 +121,8 @@
             <artifactId>arquillian-junit5-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.omnifaces.arquillian</groupId>
-            <artifactId>arquillian-glassfish-server-managed</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -170,9 +170,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.3</version>
                 <configuration>
-                    <dependenciesToScan>
-                        <dependency>jakarta.data:jakarta.data-tck</dependency>
-                    </dependenciesToScan>
                     <groups><![CDATA[web & persistence]]></groups>
                     
                     <!-- If running back-to-back tests at different levels
@@ -202,10 +199,24 @@
 
     <profiles>
         <profile>
-            <id>full</id>
+            <id>full-managed</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
+                <groups>platform,tck-javatest</groups>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.omnifaces.arquillian</groupId>
+                    <artifactId>arquillian-glassfish-server-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>full</id>
             <properties>
                 <glassfish-artifact-id>glassfish</glassfish-artifact-id>
                 <groups>platform,tck-javatest</groups>
@@ -218,6 +229,26 @@
                 <groups>web,tck-javatest</groups>
             </properties>
         </profile>
-
+        <profile>
+            <id>arquillian-managed</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.omnifaces.arquillian</groupId>
+                    <artifactId>arquillian-glassfish-server-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>arquillian-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.omnifaces.arquillian</groupId>
+                    <artifactId>arquillian-glassfish-server-remote</artifactId>
+                    <scope>test</scope>
+                    <version>1.8</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/appserver/tests/tck/data/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/appserver/tests/tck/data/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,1 @@
-org.glassfish.tck.data.ArquillianExtension
+org.glassfish.tck.data.arquillian.ArquillianExtension

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlCDITests.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlCDITests.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data;
+
+import org.glassfish.tck.data.junit5.TransactionExtension;
+
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import ee.jakarta.tck.data.core.cdi.CDITests;
+
+@ExtendWith(value = TransactionExtension.class)
+public class JNoSqlCDITests extends CDITests {
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlEntityTests.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlEntityTests.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data;
+
+import org.glassfish.tck.data.junit5.TransactionExtension;
+
+import ee.jakarta.tck.data.standalone.entity.EntityTests;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(value = TransactionExtension.class)
+public class JNoSqlEntityTests extends EntityTests {
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlPersistenceEntityTests.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlPersistenceEntityTests.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data;
+
+import org.glassfish.tck.data.junit5.TransactionExtension;
+
+import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+@ExtendWith(value = TransactionExtension.class)
+public class JNoSqlPersistenceEntityTests extends PersistenceEntityTests {
+
+    /**
+     * This test expects running outside of a global transaction. It should be
+     * executed in {@link JNoSqlPersistenceEntityTestsNoGlobalTx}
+     */
+    @Override
+    @Disabled
+    public void testVersionedInsertUpdateDelete() {
+        super.testVersionedInsertUpdateDelete();
+    }
+
+    /**
+     * This test expects running outside of a global transaction. It should be
+     * executed in {@link JNoSqlPersistenceEntityTestsNoGlobalTx}
+     */
+    @Override
+    @Disabled
+    public void testMultipleInsertUpdateDelete() {
+        super.testMultipleInsertUpdateDelete();
+    }
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlPersistenceEntityTestsNoGlobalTx.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlPersistenceEntityTestsNoGlobalTx.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data;
+
+import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
+
+import org.glassfish.tck.data.junit5.RunOnly;
+import org.glassfish.tck.data.junit5.RunOnlyCondition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+/**
+ * This is a group of PersistenceEntityTests tests that must run outside of a global transaction,
+ * otherwise the test scenario doesn't make sense and would always fail. The rest of the tests
+ * are executed in {@link JNoSqlPersistenceEntityTests}, with global transactions created with
+ * {@link TransactionExtension}
+ *
+ * @author ondro
+ */
+@ExtendWith(RunOnlyCondition.class)
+public class JNoSqlPersistenceEntityTestsNoGlobalTx extends PersistenceEntityTests {
+
+    @Override
+    @RunOnly
+    @Test
+    public void testVersionedInsertUpdateDelete() {
+        super.testVersionedInsertUpdateDelete();
+    }
+
+    @Override
+    @RunOnly
+    @Test
+    public void testMultipleInsertUpdateDelete() {
+        super.testMultipleInsertUpdateDelete();
+    }
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlSignatureTests.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlSignatureTests.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data;
+
+
+import ee.jakarta.tck.data.standalone.signature.SignatureTests;
+
+public class JNoSqlSignatureTests extends SignatureTests {
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlValidationTests.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlValidationTests.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data;
+
+import org.glassfish.tck.data.junit5.TransactionExtension;
+
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import ee.jakarta.tck.data.web.validation.ValidationTests;
+
+@ExtendWith(value = TransactionExtension.class)
+public class JNoSqlValidationTests extends ValidationTests {
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlValidationTests.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/JNoSqlValidationTests.java
@@ -14,14 +14,9 @@
  */
 package org.glassfish.tck.data;
 
-import org.glassfish.tck.data.junit5.TransactionExtension;
-
-
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import ee.jakarta.tck.data.web.validation.ValidationTests;
 
-@ExtendWith(value = TransactionExtension.class)
+// Tests here are not designed to run in a global transaction, we don't add the TransactionExtensions
 public class JNoSqlValidationTests extends ValidationTests {
 
 }

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/ArquillianExtension.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/ArquillianExtension.java
@@ -16,7 +16,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.glassfish.tck.data;
+package org.glassfish.tck.data.arquillian;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.core.spi.LoadableExtension;

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/JakartaPersistenceProcessor.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/JakartaPersistenceProcessor.java
@@ -15,14 +15,20 @@
  */
 package org.glassfish.tck.data.arquillian;
 
+import com.sun.tdk.signaturetest.SignatureTest;
+import com.sun.tdk.signaturetest.plugin.PluginAPI;
+import com.sun.tdk.signaturetest.util.CommandLineParserException;
+
 import org.glassfish.tck.data.junit5.TransactionExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import ee.jakarta.tck.data.core.cdi.CDITests;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber;
+import ee.jakarta.tck.data.framework.signature.DataSignatureTestRunner;
 import ee.jakarta.tck.data.standalone.entity.EntityTests;
 import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
 import ee.jakarta.tck.data.standalone.signature.SignatureTests;
@@ -45,7 +51,23 @@ public class JakartaPersistenceProcessor implements ApplicationArchiveProcessor 
                     PersistenceEntityTests.class.getPackage(),
                     CDITests.class.getPackage(),
                     EntityTests.class.getPackage(),
-                    SignatureTests.class.getPackage());
+                    SignatureTests.class.getPackage(),
+                    DataSignatureTestRunner.class.getPackage());
+            webArchive.addPackages(true,
+                    SignatureTest.class.getPackage(),
+                    PluginAPI.class.getPackage(),
+                    com.sun.tdk.signaturetest.core.Log.class.getPackage(),
+                    CommandLineParserException.class.getPackage());
+            String[] resourceFiles = {
+                "jakarta.data.sig_17",
+                "jakarta.data.sig_21",
+                "sig-test-pkg-list.txt",
+                "sig-test.map"
+            };
+            for (String resourceFile : resourceFiles) {
+                String directory = DataSignatureTestRunner.class.getPackageName().replace(".", "/");
+                webArchive.add(new ClassLoaderAsset(directory + "/" + resourceFile), "WEB-INF/classes/" + directory + "/" + resourceFile);
+            }
         }
     }
 

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/JakartaPersistenceProcessor.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/JakartaPersistenceProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tck.data.arquillian;
+
+import org.glassfish.tck.data.junit5.TransactionExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import ee.jakarta.tck.data.core.cdi.CDITests;
+import ee.jakarta.tck.data.framework.read.only.NaturalNumber;
+import ee.jakarta.tck.data.standalone.entity.EntityTests;
+import ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests;
+import ee.jakarta.tck.data.standalone.signature.SignatureTests;
+import ee.jakarta.tck.data.web.validation.ValidationTests;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class JakartaPersistenceProcessor implements ApplicationArchiveProcessor {
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if(archive instanceof WebArchive webArchive) {
+            webArchive.addAsWebInfResource(getClass().getClassLoader().getResource("persistence.xml"), "classes/META-INF/persistence.xml");
+            webArchive.addPackages(false,
+                    TransactionExtension.class.getPackage(),
+                    NaturalNumber.class.getPackage(),
+                    ValidationTests.class.getPackage(),
+                    PersistenceEntityTests.class.getPackage(),
+                    CDITests.class.getPackage(),
+                    EntityTests.class.getPackage(),
+                    SignatureTests.class.getPackage());
+        }
+    }
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/RunOnly.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/RunOnly.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.glassfish.tck.data.junit5;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RunOnly {}
+

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/RunOnlyCondition.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/RunOnlyCondition.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ *
+ *  Contributors:
+ *
+ *  Ondro Mihalyi
+ */
+package org.glassfish.tck.data.junit5;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class RunOnlyCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<Method> method = context.getTestMethod();
+        if (method.isPresent()) {
+            boolean hasRunOnly = method.map(m -> m.isAnnotationPresent(RunOnly.class)).orElse(false);
+
+            if (!hasRunOnly) {
+                return ConditionEvaluationResult.disabled("Disabled: not marked with @RunOnly");
+            }
+        }
+
+        return ConditionEvaluationResult.enabled("Enabled");
+    }
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/TransactionExtension.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/TransactionExtension.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Ondro Mihalyi
+ */
+package org.glassfish.tck.data.junit5;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+public class TransactionExtension implements InvocationInterceptor {
+
+    @Override
+    public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+        CDI.current().select(TransactionalWrapper.class).get().proceed(invocation);
+    }
+
+}

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/TransactionalWrapper.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/TransactionalWrapper.java
@@ -13,24 +13,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package org.glassfish.tck.data;
+package org.glassfish.tck.data.junit5;
 
-import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
-import org.jboss.arquillian.test.spi.TestClass;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.extension.InvocationInterceptor;
 
 /**
  *
  * @author Ondro Mihalyi
  */
-public class JakartaPersistenceProcessor implements ApplicationArchiveProcessor {
-
-    @Override
-    public void process(Archive<?> archive, TestClass testClass) {
-        if(archive instanceof WebArchive webArchive) {
-            webArchive.addAsWebInfResource(getClass().getClassLoader().getResource("persistence.xml"), "classes/META-INF/persistence.xml");
-        }
+@ApplicationScoped
+@Transactional
+public class TransactionalWrapper {
+    void proceed(InvocationInterceptor.Invocation<Void> invocation) throws Throwable {
+        invocation.proceed();
     }
-
 }


### PR DESCRIPTION
This depends on a new snapshot release of the Jakarta Data JPA driver with this commit: https://github.com/OmniFish-EE/jnosql-extensions-jakarta-data/commit/f5b957b7fb5f10c59b15f8074a2c0fccfe6af91c.

Runs repository method in a new transaction if no transaction is active. Basically adds @Transactional interceptor on all methods of repository beans. For non-JTA EMs, it wraps the method calls into a transaction created using the EM.

Required to pass some any TCK test for which we don't/can't create a global transaction (a few TCK tests expect there's no global Tx and that each repository method runs in its own transaction, others can run with a global transaction but also pass when a transaction is created for each repository method call).