### PR TITLE
Fix #25617 Monitoring data become unavailable after updating configuration

### DIFF
--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/FlashlightProbeClientMediator.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/FlashlightProbeClientMediator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -135,8 +136,8 @@ public class FlashlightProbeClientMediator
             ProbeClientMethodHandleImpl hi = new ProbeClientMethodHandleImpl(invoker.getId(), invoker, probe);
             pcms.add(hi);
 
-            if (probe.addInvoker(invoker))
-                probesRequiringClassTransformation.add(probe);
+            probe.addInvoker(invoker);
+            probesRequiringClassTransformation.add(probe);
         }
     }
 
@@ -155,8 +156,8 @@ public class FlashlightProbeClientMediator
             ProbeClientMethodHandleImpl hi = new ProbeClientMethodHandleImpl(invoker.getId(), invoker, probe);
             pcms.add(hi);
 
-            if (probe.addInvoker(invoker))
-                probesRequiringClassTransformation.add(probe);
+            probe.addInvoker(invoker);
+            probesRequiringClassTransformation.add(probe);
 
             if (listener == null)
                 listener = probe.getDTraceProviderImpl();    // all the probes in propro have the same "listener"

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/impl/client/ProbeProviderClassFileTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -132,10 +132,12 @@ public class ProbeProviderClassFileTransformer implements ClassFileTransformer {
 
     synchronized void addProbe(FlashlightProbe probe) throws NoSuchMethodException {
         Method m = getMethod(probe);
-        probes.put(probe.getProviderJavaMethodName() + "::" + Type.getMethodDescriptor(m), probe);
+        FlashlightProbe existingProbe = probes.put(probe.getProviderJavaMethodName() + "::" + Type.getMethodDescriptor(m), probe);
 
         // probes can be added piecemeal after the initial transformation is done, flagging when probes are added to detect that
-        allProbesTransformed = false;
+        if (existingProbe == null || existingProbe != probe) {
+            allProbesTransformed = false;
+        }
     }
 
     final synchronized void transform() {

--- a/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/provider/FlashlightProbe.java
+++ b/nucleus/flashlight/framework/src/main/java/org/glassfish/flashlight/provider/FlashlightProbe.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -98,9 +99,7 @@ public class FlashlightProbe
         }
     }
 
-    public synchronized boolean addInvoker(ProbeClientInvoker invoker) {
-            boolean isFirst = (invokers.isEmpty() && firstTransform);
-
+    public synchronized void addInvoker(ProbeClientInvoker invoker) {
         if(invokers.putIfAbsent(invoker.getId(), invoker) != null) {
             if (logger.isLoggable(Level.FINE))
                 logger.fine("Adding an invoker that already exists: " + invoker.getId() +  "  &&&&&&&&&&");
@@ -113,10 +112,8 @@ public class FlashlightProbe
             logger.fine("Total invokers = " + invokers.size());
         }
         listenerEnabled.set(true);
-        firstTransform = false;
 
         initInvokerList();
-        return isFirst;
     }
 
     public synchronized boolean removeInvoker(ProbeClientInvoker invoker) {
@@ -401,7 +398,6 @@ public class FlashlightProbe
     private Method  dtraceMethod;
     private boolean hasSelf;
     private boolean hidden;
-    private boolean firstTransform = true;
     private ConcurrentMap<Integer, ProbeClientInvoker> invokers = new ConcurrentHashMap<Integer, ProbeClientInvoker>();
     private static final Logger logger = FlashlightLoggerInfo.getLogger();
     public final static LocalStringManagerImpl localStrings =


### PR DESCRIPTION
Fixes #25617.

The cause of the issue is that probe classes are not transformed after their untransformation triggered by configuration updates.
The `firstTransform` flag in `FlashlightProbe`, which is never reset by untransformation, is blocking the transformation.

This can be fixed by utilizing the existing `allProbesTransformed` flag in `ProbeProviderClassFileTransformer` for controlling transformation.
This flag is properly reset by untransformation.