### PR TITLE
Replaced references to release version with a variable

### DIFF
--- a/docs/add-on-component-development-guide/src/main/asciidoc/preface.adoc
+++ b/docs/add-on-component-development-guide/src/main/asciidoc/preface.adoc
@@ -26,7 +26,7 @@ program in the Java language.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -171,7 +171,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/add-on-component-development-guide/src/main/asciidoc/preface.adoc
+++ b/docs/add-on-component-development-guide/src/main/asciidoc/preface.adoc
@@ -26,7 +26,7 @@ program in the Java language.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -171,7 +171,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/administration-guide/src/main/asciidoc/asadmin-subcommands.adoc
+++ b/docs/administration-guide/src/main/asciidoc/asadmin-subcommands.adoc
@@ -9,7 +9,7 @@ prev=part-appendixes.adoc
 == A Subcommands for the `asadmin` Utility
 
 This appendix lists the `asadmin` subcommands that are included with
-this release of the {productName} 7 software.
+this release of the {productName} {productMajorVersion} software.
 
 * <<General Administration Subcommands>>
 * <<Batch Jobs Subcommands>>

--- a/docs/administration-guide/src/main/asciidoc/asadmin-subcommands.adoc
+++ b/docs/administration-guide/src/main/asciidoc/asadmin-subcommands.adoc
@@ -9,7 +9,7 @@ prev=part-appendixes.adoc
 == A Subcommands for the `asadmin` Utility
 
 This appendix lists the `asadmin` subcommands that are included with
-this release of the {productName} {productMajorVersion} software.
+this release of the {productName} {product-majorVersion} software.
 
 * <<General Administration Subcommands>>
 * <<Batch Jobs Subcommands>>

--- a/docs/administration-guide/src/main/asciidoc/connectors.adoc
+++ b/docs/administration-guide/src/main/asciidoc/connectors.adoc
@@ -9,7 +9,7 @@ prev=jdbc.adoc
 == 12 Administering EIS Connectivity
 
 This chapter provides information and procedures for administering
-connections to enterprise information system (EIS) data in the {productName} {productMajorVersion} environment by using the `asadmin` command-line utility.
+connections to enterprise information system (EIS) data in the {productName} {product-majorVersion} environment by using the `asadmin` command-line utility.
 
 
 [NOTE]

--- a/docs/administration-guide/src/main/asciidoc/connectors.adoc
+++ b/docs/administration-guide/src/main/asciidoc/connectors.adoc
@@ -9,7 +9,7 @@ prev=jdbc.adoc
 == 12 Administering EIS Connectivity
 
 This chapter provides information and procedures for administering
-connections to enterprise information system (EIS) data in the {productName} 7 environment by using the `asadmin` command-line utility.
+connections to enterprise information system (EIS) data in the {productName} {productMajorVersion} environment by using the `asadmin` command-line utility.
 
 
 [NOTE]

--- a/docs/administration-guide/src/main/asciidoc/domains.adoc
+++ b/docs/administration-guide/src/main/asciidoc/domains.adoc
@@ -1248,7 +1248,7 @@ typing `asadmin help uptime` at the command line.
 
 ==== To Switch a Domain to Another Supported Java Version
 
-{productName} 7 requires Java SE 11 as the underlying virtual
+{productName} {productMajorVersion} requires Java SE 11 as the underlying virtual
 machine for the Java platform (Java Virtual Machine or JVM machine).
 
 [NOTE]

--- a/docs/administration-guide/src/main/asciidoc/domains.adoc
+++ b/docs/administration-guide/src/main/asciidoc/domains.adoc
@@ -1248,7 +1248,7 @@ typing `asadmin help uptime` at the command line.
 
 ==== To Switch a Domain to Another Supported Java Version
 
-{productName} {productMajorVersion} requires Java SE 11 as the underlying virtual
+{productName} {product-majorVersion} requires Java SE 11 as the underlying virtual
 machine for the Java platform (Java Virtual Machine or JVM machine).
 
 [NOTE]

--- a/docs/administration-guide/src/main/asciidoc/general-administration.adoc
+++ b/docs/administration-guide/src/main/asciidoc/general-administration.adoc
@@ -9,7 +9,7 @@ prev=part-runtime-admin.adoc
 == 2 General Administration
 
 This chapter provides instructions for performing general administration
-tasks in the {productName} {productMajorVersion} environment by
+tasks in the {productName} {product-majorVersion} environment by
 using the `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/general-administration.adoc
+++ b/docs/administration-guide/src/main/asciidoc/general-administration.adoc
@@ -9,7 +9,7 @@ prev=part-runtime-admin.adoc
 == 2 General Administration
 
 This chapter provides instructions for performing general administration
-tasks in the {productName} 7 environment by
+tasks in the {productName} {productMajorVersion} environment by
 using the `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/http_https.adoc
+++ b/docs/administration-guide/src/main/asciidoc/http_https.adoc
@@ -9,7 +9,7 @@ prev=connectors.adoc
 == 13 Administering Internet Connectivity
 
 This chapter provides procedures for performing internet connectivity
-tasks in the {productName} 7 environment by
+tasks in the {productName} {productMajorVersion} environment by
 using the `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/http_https.adoc
+++ b/docs/administration-guide/src/main/asciidoc/http_https.adoc
@@ -9,7 +9,7 @@ prev=connectors.adoc
 == 13 Administering Internet Connectivity
 
 This chapter provides procedures for performing internet connectivity
-tasks in the {productName} {productMajorVersion} environment by
+tasks in the {productName} {product-majorVersion} environment by
 using the `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/jdbc.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jdbc.adoc
@@ -9,7 +9,7 @@ prev=part-res-and-svcs-admin.adoc
 == 11 Administering Database Connectivity
 
 This chapter provides procedures for performing database connectivity
-tasks in the {productName} 7 environment by
+tasks in the {productName} {productMajorVersion} environment by
 using the `asadmin` command-line utility.
 
 The following topics are addressed here:
@@ -983,7 +983,7 @@ typing `asadmin help delete-jdbc-resource` at the command line.
 
 ==== Enabling the `jdbc/__default` Resource in a Clustered Environment
 
-{productName} 7 includes a preconfigured JDBC resource with the
+{productName} {productMajorVersion} includes a preconfigured JDBC resource with the
 JNDI name `jdbc/__default`. This `jdbc/__default` resource is not
 enabled by default, so you need to explicitly enable it if you want to
 use it in a cluster.

--- a/docs/administration-guide/src/main/asciidoc/jdbc.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jdbc.adoc
@@ -9,7 +9,7 @@ prev=part-res-and-svcs-admin.adoc
 == 11 Administering Database Connectivity
 
 This chapter provides procedures for performing database connectivity
-tasks in the {productName} {productMajorVersion} environment by
+tasks in the {productName} {product-majorVersion} environment by
 using the `asadmin` command-line utility.
 
 The following topics are addressed here:
@@ -983,7 +983,7 @@ typing `asadmin help delete-jdbc-resource` at the command line.
 
 ==== Enabling the `jdbc/__default` Resource in a Clustered Environment
 
-{productName} {productMajorVersion} includes a preconfigured JDBC resource with the
+{productName} {product-majorVersion} includes a preconfigured JDBC resource with the
 JNDI name `jdbc/__default`. This `jdbc/__default` resource is not
 enabled by default, so you need to explicitly enable it if you want to
 use it in a cluster.

--- a/docs/administration-guide/src/main/asciidoc/jndi.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jndi.adoc
@@ -479,18 +479,18 @@ typing `asadmin help delete-jndi-resource` at the command line.
 
 ===== To Disable {productName} v2 Vendor-Specific JNDI Names
 
-The EJB 3.1 specification supported by {productName} {productMajorVersion} defines
+The EJB 3.1 specification supported by {productName} {product-majorVersion} defines
 portable EJB JNDI names. Because of this, there is less need to continue
 to use older vendor-specific JNDI names.
 
 By default, {productName} v2-specific JNDI names are applied
-automatically by {productName} {productMajorVersion} for backward compatibility.
+automatically by {productName} {product-majorVersion} for backward compatibility.
 However, this can lead to some ease-of-use issues. For example,
 deploying two different applications containing a Remote EJB component
 that exposes the same remote interface causes a conflict between the
 default JNDI names.
 
-The default handling of v2-specific JNDI names in {productName} {productMajorVersion}
+The default handling of v2-specific JNDI names in {productName} {product-majorVersion}
 can be managed with the `asadmin` command or with the
 `disable-nonportable-jndi-names` boolean property for the
 `ejb-container` element in `glassfish-ejb-jar.xml`.

--- a/docs/administration-guide/src/main/asciidoc/jndi.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jndi.adoc
@@ -479,18 +479,18 @@ typing `asadmin help delete-jndi-resource` at the command line.
 
 ===== To Disable {productName} v2 Vendor-Specific JNDI Names
 
-The EJB 3.1 specification supported by {productName} 7 defines
+The EJB 3.1 specification supported by {productName} {productMajorVersion} defines
 portable EJB JNDI names. Because of this, there is less need to continue
 to use older vendor-specific JNDI names.
 
 By default, {productName} v2-specific JNDI names are applied
-automatically by {productName} 7 for backward compatibility.
+automatically by {productName} {productMajorVersion} for backward compatibility.
 However, this can lead to some ease-of-use issues. For example,
 deploying two different applications containing a Remote EJB component
 that exposes the same remote interface causes a conflict between the
 default JNDI names.
 
-The default handling of v2-specific JNDI names in {productName} 7
+The default handling of v2-specific JNDI names in {productName} {productMajorVersion}
 can be managed with the `asadmin` command or with the
 `disable-nonportable-jndi-names` boolean property for the
 `ejb-container` element in `glassfish-ejb-jar.xml`.

--- a/docs/administration-guide/src/main/asciidoc/jvm.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jvm.adoc
@@ -10,7 +10,7 @@ prev=domains.adoc
 
 This chapter provides procedures for administering the Virtual Machine
 for the Java platform (Java Virtual Machine) or JVM machine) in the
-{productName} {productMajorVersion} environment by using the
+{productName} {product-majorVersion} environment by using the
 `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/jvm.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jvm.adoc
@@ -10,7 +10,7 @@ prev=domains.adoc
 
 This chapter provides procedures for administering the Virtual Machine
 for the Java platform (Java Virtual Machine) or JVM machine) in the
-{productName} 7 environment by using the
+{productName} {productMajorVersion} environment by using the
 `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/lifecycle-modules.adoc
+++ b/docs/administration-guide/src/main/asciidoc/lifecycle-modules.adoc
@@ -9,7 +9,7 @@ prev=monitoring.adoc
 == 9 Administering Life Cycle Modules
 
 This chapter provides procedures for administering life cycle modules in
-the {productName} {productMajorVersion} environment.
+the {productName} {product-majorVersion} environment.
 
 The following topics are addressed here:
 

--- a/docs/administration-guide/src/main/asciidoc/lifecycle-modules.adoc
+++ b/docs/administration-guide/src/main/asciidoc/lifecycle-modules.adoc
@@ -9,7 +9,7 @@ prev=monitoring.adoc
 == 9 Administering Life Cycle Modules
 
 This chapter provides procedures for administering life cycle modules in
-the {productName} 7 environment.
+the {productName} {productMajorVersion} environment.
 
 The following topics are addressed here:
 

--- a/docs/administration-guide/src/main/asciidoc/logging.adoc
+++ b/docs/administration-guide/src/main/asciidoc/logging.adoc
@@ -9,7 +9,7 @@ prev=webapps.html
 == 7 Administering the Logging Service
 
 This chapter provides instructions on how to configure logging and how
-to view log information in the {productName} {productMajorVersion} environment.
+to view log information in the {productName} {product-majorVersion} environment.
 
 The following topics are addressed here:
 

--- a/docs/administration-guide/src/main/asciidoc/logging.adoc
+++ b/docs/administration-guide/src/main/asciidoc/logging.adoc
@@ -9,7 +9,7 @@ prev=webapps.html
 == 7 Administering the Logging Service
 
 This chapter provides instructions on how to configure logging and how
-to view log information in the {productName} 7 environment.
+to view log information in the {productName} {productMajorVersion} environment.
 
 The following topics are addressed here:
 

--- a/docs/administration-guide/src/main/asciidoc/monitoring.adoc
+++ b/docs/administration-guide/src/main/asciidoc/monitoring.adoc
@@ -8,7 +8,7 @@ prev=logging.adoc
 [[administering-the-monitoring-service]]
 == 8 Administering the Monitoring Service
 
-This chapter explains how to monitor the {productName} 7 components and services by using the `asadmin` command-line
+This chapter explains how to monitor the {productName} {productMajorVersion} components and services by using the `asadmin` command-line
 utility. Instructions for configuring JConsole to monitor {productName} resources are also provided.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/monitoring.adoc
+++ b/docs/administration-guide/src/main/asciidoc/monitoring.adoc
@@ -8,7 +8,7 @@ prev=logging.adoc
 [[administering-the-monitoring-service]]
 == 8 Administering the Monitoring Service
 
-This chapter explains how to monitor the {productName} {productMajorVersion} components and services by using the `asadmin` command-line
+This chapter explains how to monitor the {productName} {product-majorVersion} components and services by using the `asadmin` command-line
 utility. Instructions for configuring JConsole to monitor {productName} resources are also provided.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/administration-guide/src/main/asciidoc/overview.adoc
@@ -46,7 +46,7 @@ administration values.
 
 [NOTE]
 ====
-For the zip bundle of {productName} {productMajorVersion}, the default administrator
+For the zip bundle of {productName} {product-majorVersion}, the default administrator
 login is `admin`, with no password, which means that no login is
 required.
 ====

--- a/docs/administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/administration-guide/src/main/asciidoc/overview.adoc
@@ -46,7 +46,7 @@ administration values.
 
 [NOTE]
 ====
-For the zip bundle of {productName} 7, the default administrator
+For the zip bundle of {productName} {productMajorVersion}, the default administrator
 login is `admin`, with no password, which means that no login is
 required.
 ====

--- a/docs/administration-guide/src/main/asciidoc/preface.adoc
+++ b/docs/administration-guide/src/main/asciidoc/preface.adoc
@@ -15,7 +15,7 @@ instructions for configuring and administering
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -159,7 +159,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/administration-guide/src/main/asciidoc/preface.adoc
+++ b/docs/administration-guide/src/main/asciidoc/preface.adoc
@@ -15,7 +15,7 @@ instructions for configuring and administering
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -159,7 +159,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/administration-guide/src/main/asciidoc/threadpools.adoc
+++ b/docs/administration-guide/src/main/asciidoc/threadpools.adoc
@@ -11,7 +11,7 @@ prev=jvm.html
 == 5 Administering Thread Pools
 
 This chapter provides procedures for administering thread pools in the
-{productName} 7 environment by using the
+{productName} {productMajorVersion} environment by using the
 `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/threadpools.adoc
+++ b/docs/administration-guide/src/main/asciidoc/threadpools.adoc
@@ -11,7 +11,7 @@ prev=jvm.html
 == 5 Administering Thread Pools
 
 This chapter provides procedures for administering thread pools in the
-{productName} {productMajorVersion} environment by using the
+{productName} {product-majorVersion} environment by using the
 `asadmin` command-line utility.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/title.adoc
+++ b/docs/administration-guide/src/main/asciidoc/title.adoc
@@ -1,9 +1,9 @@
-title={productName} Administration Guide, Release 7
+title={productName} Administration Guide, Release {productMajorVersion}
 next=preface.adoc
 ~~~~~~
 
 
-= {productName} Administration Guide, Release 7
+= {productName} Administration Guide, Release {productMajorVersion}
 
 
 [[eclipse-glassfish-server]]
@@ -11,18 +11,18 @@ next=preface.adoc
 
 Administration Guide
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
-{productName} 7 Administration Guide provides
+{productName} {productMajorVersion} Administration Guide provides
 instructions for configuring and administering {productName}.
 
 [[sthref1]]
 
 '''''
 
-{productName} Administration Guide, Release 7
+{productName} Administration Guide, Release {productMajorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/administration-guide/src/main/asciidoc/title.adoc
+++ b/docs/administration-guide/src/main/asciidoc/title.adoc
@@ -1,9 +1,9 @@
-title={productName} Administration Guide, Release {productMajorVersion}
+title={productName} Administration Guide, Release {product-majorVersion}
 next=preface.adoc
 ~~~~~~
 
 
-= {productName} Administration Guide, Release {productMajorVersion}
+= {productName} Administration Guide, Release {product-majorVersion}
 
 
 [[eclipse-glassfish-server]]
@@ -11,18 +11,18 @@ next=preface.adoc
 
 Administration Guide
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
-{productName} {productMajorVersion} Administration Guide provides
+{productName} {product-majorVersion} Administration Guide provides
 instructions for configuring and administering {productName}.
 
 [[sthref1]]
 
 '''''
 
-{productName} Administration Guide, Release {productMajorVersion}
+{productName} Administration Guide, Release {product-majorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/administration-guide/src/main/asciidoc/webapps.adoc
+++ b/docs/administration-guide/src/main/asciidoc/webapps.adoc
@@ -9,7 +9,7 @@ prev=threadpools.adoc
 == 6 Administering Web Applications
 
 This chapter explains how to administer web applications in the
-{productName} {productMajorVersion} environment.
+{productName} {product-majorVersion} environment.
 
 The following topics are addressed here:
 
@@ -199,7 +199,7 @@ container with web servers such as Apache HTTP Server. By using
 
 You can also use `mod_jk` directly at the JSP/servlet engine for load
 balancing. For more information about configuring `mod_jk` and Apache
-HTTP Server for load balancing with {productName} {productMajorVersion} refer to
+HTTP Server for load balancing with {productName} {product-majorVersion} refer to
 "xref:ha-administration-guide.adoc#configuring-http-load-balancing[Configuring HTTP Load Balancing]" in {productName} High Availability Administration Guide.
 
 The following topics are addressed here:

--- a/docs/administration-guide/src/main/asciidoc/webapps.adoc
+++ b/docs/administration-guide/src/main/asciidoc/webapps.adoc
@@ -9,7 +9,7 @@ prev=threadpools.adoc
 == 6 Administering Web Applications
 
 This chapter explains how to administer web applications in the
-{productName} 7 environment.
+{productName} {productMajorVersion} environment.
 
 The following topics are addressed here:
 
@@ -199,7 +199,7 @@ container with web servers such as Apache HTTP Server. By using
 
 You can also use `mod_jk` directly at the JSP/servlet engine for load
 balancing. For more information about configuring `mod_jk` and Apache
-HTTP Server for load balancing with {productName} 7 refer to
+HTTP Server for load balancing with {productName} {productMajorVersion} refer to
 "xref:ha-administration-guide.adoc#configuring-http-load-balancing[Configuring HTTP Load Balancing]" in {productName} High Availability Administration Guide.
 
 The following topics are addressed here:

--- a/docs/application-deployment-guide/src/main/asciidoc/overview.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/overview.adoc
@@ -1,19 +1,19 @@
 type=page
 status=published
-title=Overview of {productName} {productMajorVersion} Application Deployment
+title=Overview of {productName} {product-majorVersion} Application Deployment
 next=deploying-applications.html
 prev=preface.html
 ~~~~~~
 
-= Overview of {productName} {productMajorVersion} Application Deployment
+= Overview of {productName} {product-majorVersion} Application Deployment
 
 [[gihxo]]
 
 
 [[overview-of-glassfish-server-open-source-edition-5.0-application-deployment]]
-== 1 Overview of {productName} {productMajorVersion} Application Deployment
+== 1 Overview of {productName} {product-majorVersion} Application Deployment
 
-{productName} {productMajorVersion} provides an environment for
+{productName} {product-majorVersion} provides an environment for
 developing and deploying Java applications and web services. {productName} applications include Java Platform, Enterprise Edition (Jakarta EE
 platform) standard features as well as features specific to {productName}. This guide explains the tools and processes used for deploying
 applications and modules in the {productName} environment. Only

--- a/docs/application-deployment-guide/src/main/asciidoc/overview.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/overview.adoc
@@ -1,19 +1,19 @@
 type=page
 status=published
-title=Overview of {productName} 7 Application Deployment
+title=Overview of {productName} {productMajorVersion} Application Deployment
 next=deploying-applications.html
 prev=preface.html
 ~~~~~~
 
-= Overview of {productName} 7 Application Deployment
+= Overview of {productName} {productMajorVersion} Application Deployment
 
 [[gihxo]]
 
 
 [[overview-of-glassfish-server-open-source-edition-5.0-application-deployment]]
-== 1 Overview of {productName} 7 Application Deployment
+== 1 Overview of {productName} {productMajorVersion} Application Deployment
 
-{productName} 7 provides an environment for
+{productName} {productMajorVersion} provides an environment for
 developing and deploying Java applications and web services. {productName} applications include Java Platform, Enterprise Edition (Jakarta EE
 platform) standard features as well as features specific to {productName}. This guide explains the tools and processes used for deploying
 applications and modules in the {productName} environment. Only

--- a/docs/application-deployment-guide/src/main/asciidoc/preface.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/preface.adoc
@@ -30,7 +30,7 @@ includes information about deployment descriptors.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -176,7 +176,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/application-deployment-guide/src/main/asciidoc/preface.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/preface.adoc
@@ -30,7 +30,7 @@ includes information about deployment descriptors.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -176,7 +176,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/application-development-guide/src/main/asciidoc/ejb.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/ejb.adoc
@@ -330,7 +330,7 @@ xref:reference-manual.adoc#GSRFM[{productName} Reference Manual].
 
 This procedure explains how to deploy an EJB timer to a cluster.
 
-By default, the {productName} {productMajorVersion} timer service points to the
+By default, the {productName} {product-majorVersion} timer service points to the
 preconfigured `jdbc/__TimerPool` resource, which uses an embedded Apache
 Derby database configuration that will not work in clustered
 environments.

--- a/docs/application-development-guide/src/main/asciidoc/ejb.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/ejb.adoc
@@ -330,7 +330,7 @@ xref:reference-manual.adoc#GSRFM[{productName} Reference Manual].
 
 This procedure explains how to deploy an EJB timer to a cluster.
 
-By default, the {productName} 7 timer service points to the
+By default, the {productName} {productMajorVersion} timer service points to the
 preconfigured `jdbc/__TimerPool` resource, which uses an embedded Apache
 Derby database configuration that will not work in clustered
 environments.

--- a/docs/application-development-guide/src/main/asciidoc/java-clients.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/java-clients.adoc
@@ -124,7 +124,7 @@ Start].
 
 ==== Application Client JAR File
 
-In {productName} {productMajorVersion}, the downloaded appclient JAR file is smaller
+In {productName} {product-majorVersion}, the downloaded appclient JAR file is smaller
 than in previous releases, with dependent classes in separate JAR files.
 When copying the downloaded appclient to another location, make sure to
 include the JAR files containing the dependent classes as well. You can

--- a/docs/application-development-guide/src/main/asciidoc/java-clients.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/java-clients.adoc
@@ -124,7 +124,7 @@ Start].
 
 ==== Application Client JAR File
 
-In {productName} 7, the downloaded appclient JAR file is smaller
+In {productName} {productMajorVersion}, the downloaded appclient JAR file is smaller
 than in previous releases, with dependent classes in separate JAR files.
 When copying the downloaded appclient to another location, make sure to
 include the JAR files containing the dependent classes as well. You can

--- a/docs/application-development-guide/src/main/asciidoc/jndi.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/jndi.adoc
@@ -79,7 +79,7 @@ have the same name.
 
 If an EJB component is a kind of session bean and it is deployed to any
 implementation supporting the EJB 3.1specification (for example,
-{productName} 7), it automatically has one or more portable JNDI
+{productName} {productMajorVersion}), it automatically has one or more portable JNDI
 names defined based on the syntax in the specification. Note that this
 is true of existing EJB 3.0 and 2.x applications that are deployed to an
 implementation supporting EJB 3.1. No code changes are required to the
@@ -147,18 +147,18 @@ name is `jdbc/Foo`.
 
 ==== Disabling {productName} V2 JNDI Names
 
-The EJB 3.1 specification supported by {productName} 7 defines
+The EJB 3.1 specification supported by {productName} {productMajorVersion} defines
 portable EJB JNDI names for session beans. Because of this, there is
 less need to continue to use older vendor-specific JNDI names.
 
 By default, {productName} V2-specific JNDI names are applied
-automatically by {productName} 7 for backward compatibility.
+automatically by {productName} {productMajorVersion} for backward compatibility.
 However, this can lead to some ease-of-use issues. For example,
 deploying two different applications containing a remote EJB component
 that exposes the same remote interface causes a conflict between the
 default JNDI names.
 
-The default handling of V2-specific JNDI names in {productName} 7
+The default handling of V2-specific JNDI names in {productName} {productMajorVersion}
 can be managed by using the `asadmin` command:
 
 [source]

--- a/docs/application-development-guide/src/main/asciidoc/jndi.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/jndi.adoc
@@ -79,7 +79,7 @@ have the same name.
 
 If an EJB component is a kind of session bean and it is deployed to any
 implementation supporting the EJB 3.1specification (for example,
-{productName} {productMajorVersion}), it automatically has one or more portable JNDI
+{productName} {product-majorVersion}), it automatically has one or more portable JNDI
 names defined based on the syntax in the specification. Note that this
 is true of existing EJB 3.0 and 2.x applications that are deployed to an
 implementation supporting EJB 3.1. No code changes are required to the
@@ -147,18 +147,18 @@ name is `jdbc/Foo`.
 
 ==== Disabling {productName} V2 JNDI Names
 
-The EJB 3.1 specification supported by {productName} {productMajorVersion} defines
+The EJB 3.1 specification supported by {productName} {product-majorVersion} defines
 portable EJB JNDI names for session beans. Because of this, there is
 less need to continue to use older vendor-specific JNDI names.
 
 By default, {productName} V2-specific JNDI names are applied
-automatically by {productName} {productMajorVersion} for backward compatibility.
+automatically by {productName} {product-majorVersion} for backward compatibility.
 However, this can lead to some ease-of-use issues. For example,
 deploying two different applications containing a remote EJB component
 that exposes the same remote interface causes a conflict between the
 default JNDI names.
 
-The default handling of V2-specific JNDI names in {productName} {productMajorVersion}
+The default handling of V2-specific JNDI names in {productName} {product-majorVersion}
 can be managed by using the `asadmin` command:
 
 [source]

--- a/docs/application-development-guide/src/main/asciidoc/preface.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/preface.adoc
@@ -34,7 +34,7 @@ and deploy Jakarta EE applications using {productName}s.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -179,7 +179,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/application-development-guide/src/main/asciidoc/preface.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/preface.adoc
@@ -34,7 +34,7 @@ and deploy Jakarta EE applications using {productName}s.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -179,7 +179,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/application-development-guide/src/main/asciidoc/securing-apps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/securing-apps.adoc
@@ -1025,11 +1025,11 @@ Persistence API by injecting or looking up an entity manager or entity
 manager factory, the EJB container sets this JVM option for you.
 
 You must grant additional permissions to CDI-enabled Jakarta EE
-applications that are deployed in a {productName} {productMajorVersion} domain or
+applications that are deployed in a {productName} {product-majorVersion} domain or
 cluster for which security manager is enabled. These additional
 permissions are not required when security manager is disabled.
 
-To deploy CDI-enabled Jakarta EE applications in a {productName} {productMajorVersion}
+To deploy CDI-enabled Jakarta EE applications in a {productName} {product-majorVersion}
 domain or cluster for which security manager is enabled, add the
 following permissions to the applications:
 

--- a/docs/application-development-guide/src/main/asciidoc/securing-apps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/securing-apps.adoc
@@ -1025,11 +1025,11 @@ Persistence API by injecting or looking up an entity manager or entity
 manager factory, the EJB container sets this JVM option for you.
 
 You must grant additional permissions to CDI-enabled Jakarta EE
-applications that are deployed in a {productName} 7 domain or
+applications that are deployed in a {productName} {productMajorVersion} domain or
 cluster for which security manager is enabled. These additional
 permissions are not required when security manager is disabled.
 
-To deploy CDI-enabled Jakarta EE applications in a {productName} 7
+To deploy CDI-enabled Jakarta EE applications in a {productName} {productMajorVersion}
 domain or cluster for which security manager is enabled, add the
 following permissions to the applications:
 

--- a/docs/deployment-planning-guide/src/main/asciidoc/preface.adoc
+++ b/docs/deployment-planning-guide/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ deployment of {productName}.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -46,7 +46,7 @@ The {productName} documentation set describes deployment planning and
 system installation. For an introduction to {productName}, refer to
 the books in the order in which they are listed in the following table.
 
-[width="100%",cols="<30%,<70%",options="header",]
+[width="100%",cols="<30%,<{productMajorVersion}0%",options="header",]
 |===
 |Book Title |Description
 |xref:release-notes.adoc#GSRLN[Release Notes] |Provides late-breaking information about
@@ -167,7 +167,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/deployment-planning-guide/src/main/asciidoc/preface.adoc
+++ b/docs/deployment-planning-guide/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ deployment of {productName}.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -46,7 +46,7 @@ The {productName} documentation set describes deployment planning and
 system installation. For an introduction to {productName}, refer to
 the books in the order in which they are listed in the following table.
 
-[width="100%",cols="<30%,<{productMajorVersion}0%",options="header",]
+[width="100%",cols="<30%,<{product-majorVersion}0%",options="header",]
 |===
 |Book Title |Description
 |xref:release-notes.adoc#GSRLN[Release Notes] |Provides late-breaking information about
@@ -167,7 +167,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
@@ -1,11 +1,11 @@
 type=page
 status=published
-title={productName} {productMajorVersion} Embedded Server Guide
+title={productName} {product-majorVersion} Embedded Server Guide
 prev=preface.html
 ~~~~~~
 
 [[GSESG]]
-== {productName} {productMajorVersion} Embedded Server Guide
+== {productName} {product-majorVersion} Embedded Server Guide
 
 This document explains how to run applications with embedded {productName} and to develop applications in which
 {productName} is embedded. This document is for software developers

--- a/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
@@ -1,11 +1,11 @@
 type=page
 status=published
-title={productName} 7 Embedded Server Guide
+title={productName} {productMajorVersion} Embedded Server Guide
 prev=preface.html
 ~~~~~~
 
 [[GSESG]]
-== {productName} 7 Embedded Server Guide
+== {productName} {productMajorVersion} Embedded Server Guide
 
 This document explains how to run applications with embedded {productName} and to develop applications in which
 {productName} is embedded. This document is for software developers

--- a/docs/embedded-server-guide/src/main/asciidoc/preface.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/preface.adoc
@@ -32,7 +32,7 @@ The ability to program in the Java language is assumed.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -177,7 +177,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/embedded-server-guide/src/main/asciidoc/preface.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/preface.adoc
@@ -32,7 +32,7 @@ The ability to program in the Java language is assumed.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -177,7 +177,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/embedded-server-guide/src/main/asciidoc/title.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/title.adoc
@@ -1,18 +1,18 @@
 type=page
 status=published
-title={productName} Embedded Server Guide, Release {productMajorVersion}
+title={productName} Embedded Server Guide, Release {product-majorVersion}
 next=preface.html
 prev=lot.html
 ~~~~~~
 
-= {productName} Embedded Server Guide, Release {productMajorVersion}
+= {productName} Embedded Server Guide, Release {product-majorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Embedded Server Guide
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
@@ -21,7 +21,7 @@ This document explains how to run applications in embedded {productName} and to 
 who are developing applications to run in embedded {productName}. The
 ability to program in the Java language is assumed.
 
-Note: The main thrust of the {productName} {productMajorVersion}
+Note: The main thrust of the {productName} {product-majorVersion}
 release is to provide an application server for developers to explore
 and begin exploiting the new and updated technologies in the Jakarta EE 10
 platform. Thus, the embedded server feature of {productName} was not
@@ -33,7 +33,7 @@ of the Jakarta EE 10 platform.
 
 '''''
 
-{productName} Embedded Server Guide, Release {productMajorVersion}
+{productName} Embedded Server Guide, Release {product-majorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/embedded-server-guide/src/main/asciidoc/title.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/title.adoc
@@ -1,18 +1,18 @@
 type=page
 status=published
-title={productName} Embedded Server Guide, Release 7
+title={productName} Embedded Server Guide, Release {productMajorVersion}
 next=preface.html
 prev=lot.html
 ~~~~~~
 
-= {productName} Embedded Server Guide, Release 7
+= {productName} Embedded Server Guide, Release {productMajorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Embedded Server Guide
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
@@ -21,7 +21,7 @@ This document explains how to run applications in embedded {productName} and to 
 who are developing applications to run in embedded {productName}. The
 ability to program in the Java language is assumed.
 
-Note: The main thrust of the {productName} 7
+Note: The main thrust of the {productName} {productMajorVersion}
 release is to provide an application server for developers to explore
 and begin exploiting the new and updated technologies in the Jakarta EE 10
 platform. Thus, the embedded server feature of {productName} was not
@@ -33,7 +33,7 @@ of the Jakarta EE 10 platform.
 
 '''''
 
-{productName} Embedded Server Guide, Release 7
+{productName} Embedded Server Guide, Release {productMajorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/error-messages-reference/src/main/asciidoc/preface.adoc
+++ b/docs/error-messages-reference/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ using {productName}.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -173,7 +173,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/error-messages-reference/src/main/asciidoc/preface.adoc
+++ b/docs/error-messages-reference/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ using {productName}.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -173,7 +173,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/ha-administration-guide/src/main/asciidoc/http-load-balancing.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/http-load-balancing.adoc
@@ -10,7 +10,7 @@ prev=named-configurations.html
 [[configuring-http-load-balancing]]
 == 7 Configuring HTTP Load Balancing
 
-This chapter describes how to configure HTTP load balancing on {productName} 7.
+This chapter describes how to configure HTTP load balancing on {productName} {productMajorVersion}.
 
 The following topics are addressed here:
 
@@ -56,7 +56,7 @@ HTTP Server and `mod_proxy_ajp`].
 
 ==== Configuring {productName} with Apache HTTP Server and `mod_jk`
 
-{productName} 7 can be configured for load balancing with Apache
+{productName} {productMajorVersion} can be configured for load balancing with Apache
 HTTP Server as a front end by enabling the Apache `mod_jk` connector
 module. To enable the `mod_jk` module in {productName}, set the
 {productName} `jk-enabled` `network-listener` attribute. You can also
@@ -192,7 +192,7 @@ worker.loadbalancer.balance_workers=worker1,worker2
 
 ==== Configuring {productName} with Apache HTTP Server and `mod_proxy_ajp`
 
-{productName} 7 can be configured for load balancing with Apache
+{productName} {productMajorVersion} can be configured for load balancing with Apache
 HTTP Server as a front end by enabling the Apache `mod_proxy_ajp`
 connector module. To enable the `mod_proxy_ajp` module in {productName}, set the {productName} `jk-enabled` `network-listener`
 attribute. You can also create `jk-connectors` under different

--- a/docs/ha-administration-guide/src/main/asciidoc/http-load-balancing.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/http-load-balancing.adoc
@@ -10,7 +10,7 @@ prev=named-configurations.html
 [[configuring-http-load-balancing]]
 == 7 Configuring HTTP Load Balancing
 
-This chapter describes how to configure HTTP load balancing on {productName} {productMajorVersion}.
+This chapter describes how to configure HTTP load balancing on {productName} {product-majorVersion}.
 
 The following topics are addressed here:
 
@@ -56,7 +56,7 @@ HTTP Server and `mod_proxy_ajp`].
 
 ==== Configuring {productName} with Apache HTTP Server and `mod_jk`
 
-{productName} {productMajorVersion} can be configured for load balancing with Apache
+{productName} {product-majorVersion} can be configured for load balancing with Apache
 HTTP Server as a front end by enabling the Apache `mod_jk` connector
 module. To enable the `mod_jk` module in {productName}, set the
 {productName} `jk-enabled` `network-listener` attribute. You can also
@@ -192,7 +192,7 @@ worker.loadbalancer.balance_workers=worker1,worker2
 
 ==== Configuring {productName} with Apache HTTP Server and `mod_proxy_ajp`
 
-{productName} {productMajorVersion} can be configured for load balancing with Apache
+{productName} {product-majorVersion} can be configured for load balancing with Apache
 HTTP Server as a front end by enabling the Apache `mod_proxy_ajp`
 connector module. To enable the `mod_proxy_ajp` module in {productName}, set the {productName} `jk-enabled` `network-listener`
 attribute. You can also create `jk-connectors` under different

--- a/docs/ha-administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/overview.adoc
@@ -10,7 +10,7 @@ prev=preface.html
 [[high-availability-in-glassfish-server]]
 == 1 High Availability in {productName}
 
-This chapter describes the high availability features in {productName} {productMajorVersion}.
+This chapter describes the high availability features in {productName} {product-majorVersion}.
 
 The following topics are addressed here:
 
@@ -44,7 +44,7 @@ minimum application downtime and enhanced transactional security.
 
 ==== Load Balancing With the Apache `mod_jk` or `mod_proxy_ajp` Module
 
-A common load balancing configuration for {productName} {productMajorVersion} is to use
+A common load balancing configuration for {productName} {product-majorVersion} is to use
 the Apache HTTP Server as the web server front-end, and the Apache
 `mod_jk` or `mod_proxy_ajp` module as the connector between the web
 server and {productName}. See
@@ -168,7 +168,7 @@ information. {productName} supports in-memory session replication on
 other servers in the cluster for maintaining HTTP session and stateful
 session bean data.
 
-In-memory session replication is implemented in {productName} {productMajorVersion} as
+In-memory session replication is implemented in {productName} {product-majorVersion} as
 an OSGi module. Internally, the replication module uses a consistent
 hash algorithm to pick a replica server instance within a cluster of
 instances. This allows the replication module to easily locate the

--- a/docs/ha-administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/overview.adoc
@@ -10,7 +10,7 @@ prev=preface.html
 [[high-availability-in-glassfish-server]]
 == 1 High Availability in {productName}
 
-This chapter describes the high availability features in {productName} 7.
+This chapter describes the high availability features in {productName} {productMajorVersion}.
 
 The following topics are addressed here:
 
@@ -44,7 +44,7 @@ minimum application downtime and enhanced transactional security.
 
 ==== Load Balancing With the Apache `mod_jk` or `mod_proxy_ajp` Module
 
-A common load balancing configuration for {productName} 7 is to use
+A common load balancing configuration for {productName} {productMajorVersion} is to use
 the Apache HTTP Server as the web server front-end, and the Apache
 `mod_jk` or `mod_proxy_ajp` module as the connector between the web
 server and {productName}. See
@@ -168,7 +168,7 @@ information. {productName} supports in-memory session replication on
 other servers in the cluster for maintaining HTTP session and stateful
 session bean data.
 
-In-memory session replication is implemented in {productName} 7 as
+In-memory session replication is implemented in {productName} {productMajorVersion} as
 an OSGi module. Internally, the replication module uses a consistent
 hash algorithm to pick a replica server instance within a cluster of
 instances. This allows the replication module to easily locate the

--- a/docs/ha-administration-guide/src/main/asciidoc/preface.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/preface.adoc
@@ -30,7 +30,7 @@ session persistence and failover.
 
 [NOTE]
 ====
-The main thrust of the {productName} 7 release
+The main thrust of the {productName} {productMajorVersion} release
 is to provide an application server for developers to explore and begin
 exploiting the new and updated technologies in the Jakarta EE 10 platform.
 Thus, the clustering, standalone instance and high availability features
@@ -44,7 +44,7 @@ This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation
 set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at `http://glassfish.java.net/`. The GlassFish
 project provides a structured process for developing the {productName} platform that makes the new features of the Jakarta EE platform
 available faster, while maintaining the most important feature of Java

--- a/docs/ha-administration-guide/src/main/asciidoc/preface.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/preface.adoc
@@ -30,7 +30,7 @@ session persistence and failover.
 
 [NOTE]
 ====
-The main thrust of the {productName} {productMajorVersion} release
+The main thrust of the {productName} {product-majorVersion} release
 is to provide an application server for developers to explore and begin
 exploiting the new and updated technologies in the Jakarta EE 10 platform.
 Thus, the clustering, standalone instance and high availability features
@@ -44,7 +44,7 @@ This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation
 set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at `http://glassfish.java.net/`. The GlassFish
 project provides a structured process for developing the {productName} platform that makes the new features of the Jakarta EE platform
 available faster, while maintaining the most important feature of Java

--- a/docs/ha-administration-guide/src/main/asciidoc/session-persistence-and-failover.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/session-persistence-and-failover.adoc
@@ -75,7 +75,7 @@ possible.
 +
 [NOTE]
 ====
-{productName} {productMajorVersion} does not support High Availability Database (HADB)
+{productName} {product-majorVersion} does not support High Availability Database (HADB)
 configurations. Instead, use in-memory replication, as described in
 xref:overview.adoc#high-availability-session-persistence[High Availability Session Persistence].
 ====
@@ -113,12 +113,12 @@ For information about how to disable these features, see the
 xref:application-deployment-guide.adoc#GSDPG[
 {productName} Application Deployment Guide].
 
-* {productName} {productMajorVersion} does not support High Availability Database
+* {productName} {product-majorVersion} does not support High Availability Database
 (HADB) configurations. Instead, use in-memory replication, as described
 in xref:overview.adoc#high-availability-session-persistence[High Availability Session Persistence].
 
 * You can only bind certain objects to distributed sessions that support
-failover. Contrary to the Servlet 2.4 specification, {productName} {productMajorVersion} does not throw an `IllegalArgumentException` if an object type not
+failover. Contrary to the Servlet 2.4 specification, {productName} {product-majorVersion} does not throw an `IllegalArgumentException` if an object type not
 supported for failover is bound into a distributed session.
 +
 You can bind the following objects into a distributed session that
@@ -346,7 +346,7 @@ the type of session persistence an application uses. It must be set to
 If you are using Memory Replication and your web application involves
 multiple client threads concurrently accessing the same session ID, then
 you may experience session loss even without any instance failure. The
-problem is that the {productName} {productMajorVersion} memory replication framework
+problem is that the {productName} {product-majorVersion} memory replication framework
 makes use of session versioning. This feature was designed with the more
 traditional HTTP request/response communication model in mind.
 
@@ -471,7 +471,7 @@ accessing the application.
 
 Built on top of Oracle Coherence, Coherence*Web is an HTTP session
 management module dedicated to managing session state in clustered
-environments. Starting with Coherence 3.7 and {productName} {productMajorVersion},
+environments. Starting with Coherence 3.7 and {productName} {product-majorVersion},
 there is a new feature of Coherence*Web called ActiveCache for
 GlassFish. ActiveCache for GlassFish provides Coherence*Web
 functionality in web applications deployed on {productName}s. Within

--- a/docs/ha-administration-guide/src/main/asciidoc/session-persistence-and-failover.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/session-persistence-and-failover.adoc
@@ -75,7 +75,7 @@ possible.
 +
 [NOTE]
 ====
-{productName} 7 does not support High Availability Database (HADB)
+{productName} {productMajorVersion} does not support High Availability Database (HADB)
 configurations. Instead, use in-memory replication, as described in
 xref:overview.adoc#high-availability-session-persistence[High Availability Session Persistence].
 ====
@@ -113,12 +113,12 @@ For information about how to disable these features, see the
 xref:application-deployment-guide.adoc#GSDPG[
 {productName} Application Deployment Guide].
 
-* {productName} 7 does not support High Availability Database
+* {productName} {productMajorVersion} does not support High Availability Database
 (HADB) configurations. Instead, use in-memory replication, as described
 in xref:overview.adoc#high-availability-session-persistence[High Availability Session Persistence].
 
 * You can only bind certain objects to distributed sessions that support
-failover. Contrary to the Servlet 2.4 specification, {productName} 7 does not throw an `IllegalArgumentException` if an object type not
+failover. Contrary to the Servlet 2.4 specification, {productName} {productMajorVersion} does not throw an `IllegalArgumentException` if an object type not
 supported for failover is bound into a distributed session.
 +
 You can bind the following objects into a distributed session that
@@ -346,7 +346,7 @@ the type of session persistence an application uses. It must be set to
 If you are using Memory Replication and your web application involves
 multiple client threads concurrently accessing the same session ID, then
 you may experience session loss even without any instance failure. The
-problem is that the {productName} 7 memory replication framework
+problem is that the {productName} {productMajorVersion} memory replication framework
 makes use of session versioning. This feature was designed with the more
 traditional HTTP request/response communication model in mind.
 
@@ -471,7 +471,7 @@ accessing the application.
 
 Built on top of Oracle Coherence, Coherence*Web is an HTTP session
 management module dedicated to managing session state in clustered
-environments. Starting with Coherence 3.7 and {productName} 7,
+environments. Starting with Coherence 3.7 and {productName} {productMajorVersion},
 there is a new feature of Coherence*Web called ActiveCache for
 GlassFish. ActiveCache for GlassFish provides Coherence*Web
 functionality in web applications deployed on {productName}s. Within

--- a/docs/installation-guide/src/main/asciidoc/installing.adoc
+++ b/docs/installation-guide/src/main/asciidoc/installing.adoc
@@ -1,32 +1,32 @@
 type=page
 status=published
-title=Installing {productName} {productMajorVersion}
+title=Installing {productName} {product-majorVersion}
 next=uninstalling.html
 prev=preface.html
 ~~~~~~
 
-= Installing {productName} {productMajorVersion}
+= Installing {productName} {product-majorVersion}
 
 [[ggssq]]
 
 
 [[installing-glassfish-server-5.0]]
-== 1 Installing {productName} {productMajorVersion}
+== 1 Installing {productName} {product-majorVersion}
 
-This chapter provides instructions for installing {productName} {productMajorVersion}
+This chapter provides instructions for installing {productName} {product-majorVersion}
 software on Linux, Mac OS X, and Windows systems.
 
 The following topics are addressed here:
 
 * xref:#installation-requirements[Installation Requirements]
-* xref:#GSING00023[Installation Files for {productName} {productMajorVersion}]
+* xref:#GSING00023[Installation Files for {productName} {product-majorVersion}]
 * xref:#installing-glassfish-server-from-a-zip-file[Installing {productName} From a ZIP File]
 
 [[installation-requirements]]
 
 === Installation Requirements
 
-Before installing {productName} {productMajorVersion}, ensure that
+Before installing {productName} {product-majorVersion}, ensure that
 your system meets the requirements listed in "xref:release-notes.adoc#hardware-and-software-requirements[Hardware
 and Software Requirements]" in {productName}
 Release Notes. If necessary, download and install the required JDK
@@ -563,7 +563,7 @@ either the MPL or the LGPL.
 
 [[GSING00023]][[installation-files-for-glassfish-server-5.0]]
 
-=== Installation Files for {productName} {productMajorVersion}
+=== Installation Files for {productName} {product-majorVersion}
 
 The following topics are addressed here:
 
@@ -576,7 +576,7 @@ The following topics are addressed here:
 
 ==== {productName} Download Locations
 
-Installation files for {productName} {productMajorVersion} are
+Installation files for {productName} {product-majorVersion} are
 available by download from the
 https://glassfish.org/download.html[{productName} Downloads]
 page.
@@ -605,7 +605,7 @@ in {productName} Release Notes.
 [[ghtqe]]
 
 
-Table 1-1 {productName} {productMajorVersion} Installation Methods
+Table 1-1 {productName} {product-majorVersion} Installation Methods
 
 [width="100%",cols="39%,61%",options="header",]
 |===
@@ -623,7 +623,7 @@ These two distributions are explained in the next section.
 ==== Choosing an Installation Method
 
 There are two general sets of questions you should consider when
-deciding which {productName} {productMajorVersion} installation method to use.
+deciding which {productName} {product-majorVersion} installation method to use.
 
 * xref:#zip-package[ZIP Package]
 * xref:#full-platform-or-web-profile-distribution[Full Platform or Web Profile Distribution]
@@ -749,7 +749,7 @@ CORBA v3.0 APIs are available in the Jakarta EE Web Profile.
 
 ==== {productName} ZIP Files
 
-The {productName} {productMajorVersion} multi-platform ZIP files
+The {productName} {product-majorVersion} multi-platform ZIP files
 are compatible with Solaris, Linux, Mac OS, UNIX, and Windows operating
 systems. See xref:#glassfish-server-download-locations[{productName} Download Locations] for a list
 of download locations.
@@ -784,7 +784,7 @@ glassfish-7.0.0-web.zip
 
 === Installing {productName} From a ZIP File
 
-This section describes how to install {productName} {productMajorVersion} using the multi-platform ZIP file. {productName} is
+This section describes how to install {productName} {product-majorVersion} using the multi-platform ZIP file. {productName} is
 installed by unzipping the file in the installation directory of your
 choice.
 
@@ -810,7 +810,7 @@ in {productName} Release Notes.
 
 Also see "xref:release-notes.adoc#GSRLN00253[Known Issues]" in {productName} Release Notes for known issues related to installation.
 
-1. Download the desired {productName} {productMajorVersion} ZIP file. +
+1. Download the desired {productName} {product-majorVersion} ZIP file. +
 See xref:#glassfish-server-download-locations[{productName} Download Locations] for a list of
 download locations. See xref:#gkbac[Table 1-3] for a list of available ZIP files.
 
@@ -835,8 +835,8 @@ glassfish-5.0.zip
 +
 Unzip using your favorite file compression utility.
 +
-{productName} {productMajorVersion} is extracted into a new `glassfish{productMajorVersion}` directory
-under your current directory. This `glassfish{productMajorVersion}` directory is referred to
+{productName} {product-majorVersion} is extracted into a new `glassfish{product-majorVersion}` directory
+under your current directory. This `glassfish{product-majorVersion}` directory is referred to
 throughout the {productName} documentation set as as-install-parent.
 
 4. Start {productName} using the instructions in the

--- a/docs/installation-guide/src/main/asciidoc/installing.adoc
+++ b/docs/installation-guide/src/main/asciidoc/installing.adoc
@@ -1,32 +1,32 @@
 type=page
 status=published
-title=Installing {productName} 7
+title=Installing {productName} {productMajorVersion}
 next=uninstalling.html
 prev=preface.html
 ~~~~~~
 
-= Installing {productName} 7
+= Installing {productName} {productMajorVersion}
 
 [[ggssq]]
 
 
 [[installing-glassfish-server-5.0]]
-== 1 Installing {productName} 7
+== 1 Installing {productName} {productMajorVersion}
 
-This chapter provides instructions for installing {productName} 7
+This chapter provides instructions for installing {productName} {productMajorVersion}
 software on Linux, Mac OS X, and Windows systems.
 
 The following topics are addressed here:
 
 * xref:#installation-requirements[Installation Requirements]
-* xref:#GSING00023[Installation Files for {productName} 7]
+* xref:#GSING00023[Installation Files for {productName} {productMajorVersion}]
 * xref:#installing-glassfish-server-from-a-zip-file[Installing {productName} From a ZIP File]
 
 [[installation-requirements]]
 
 === Installation Requirements
 
-Before installing {productName} 7, ensure that
+Before installing {productName} {productMajorVersion}, ensure that
 your system meets the requirements listed in "xref:release-notes.adoc#hardware-and-software-requirements[Hardware
 and Software Requirements]" in {productName}
 Release Notes. If necessary, download and install the required JDK
@@ -563,7 +563,7 @@ either the MPL or the LGPL.
 
 [[GSING00023]][[installation-files-for-glassfish-server-5.0]]
 
-=== Installation Files for {productName} 7
+=== Installation Files for {productName} {productMajorVersion}
 
 The following topics are addressed here:
 
@@ -576,7 +576,7 @@ The following topics are addressed here:
 
 ==== {productName} Download Locations
 
-Installation files for {productName} 7 are
+Installation files for {productName} {productMajorVersion} are
 available by download from the
 https://glassfish.org/download.html[{productName} Downloads]
 page.
@@ -605,7 +605,7 @@ in {productName} Release Notes.
 [[ghtqe]]
 
 
-Table 1-1 {productName} 7 Installation Methods
+Table 1-1 {productName} {productMajorVersion} Installation Methods
 
 [width="100%",cols="39%,61%",options="header",]
 |===
@@ -623,7 +623,7 @@ These two distributions are explained in the next section.
 ==== Choosing an Installation Method
 
 There are two general sets of questions you should consider when
-deciding which {productName} 7 installation method to use.
+deciding which {productName} {productMajorVersion} installation method to use.
 
 * xref:#zip-package[ZIP Package]
 * xref:#full-platform-or-web-profile-distribution[Full Platform or Web Profile Distribution]
@@ -749,7 +749,7 @@ CORBA v3.0 APIs are available in the Jakarta EE Web Profile.
 
 ==== {productName} ZIP Files
 
-The {productName} 7 multi-platform ZIP files
+The {productName} {productMajorVersion} multi-platform ZIP files
 are compatible with Solaris, Linux, Mac OS, UNIX, and Windows operating
 systems. See xref:#glassfish-server-download-locations[{productName} Download Locations] for a list
 of download locations.
@@ -784,7 +784,7 @@ glassfish-7.0.0-web.zip
 
 === Installing {productName} From a ZIP File
 
-This section describes how to install {productName} 7 using the multi-platform ZIP file. {productName} is
+This section describes how to install {productName} {productMajorVersion} using the multi-platform ZIP file. {productName} is
 installed by unzipping the file in the installation directory of your
 choice.
 
@@ -810,7 +810,7 @@ in {productName} Release Notes.
 
 Also see "xref:release-notes.adoc#GSRLN00253[Known Issues]" in {productName} Release Notes for known issues related to installation.
 
-1. Download the desired {productName} 7 ZIP file. +
+1. Download the desired {productName} {productMajorVersion} ZIP file. +
 See xref:#glassfish-server-download-locations[{productName} Download Locations] for a list of
 download locations. See xref:#gkbac[Table 1-3] for a list of available ZIP files.
 
@@ -835,8 +835,8 @@ glassfish-5.0.zip
 +
 Unzip using your favorite file compression utility.
 +
-{productName} 7 is extracted into a new `glassfish7` directory
-under your current directory. This `glassfish7` directory is referred to
+{productName} {productMajorVersion} is extracted into a new `glassfish{productMajorVersion}` directory
+under your current directory. This `glassfish{productMajorVersion}` directory is referred to
 throughout the {productName} documentation set as as-install-parent.
 
 4. Start {productName} using the instructions in the

--- a/docs/installation-guide/src/main/asciidoc/lot.adoc
+++ b/docs/installation-guide/src/main/asciidoc/lot.adoc
@@ -10,7 +10,7 @@ prev=toc.html
 [[list-of-tables]]
 == List of Tables
 
-* xref:installing.adoc#ghtqe[1-1 {productName} {productMajorVersion} Installation
+* xref:installing.adoc#ghtqe[1-1 {productName} {product-majorVersion} Installation
 Methods]
 * xref:installing.adoc#gkuap[1-2 {productName} Full Profile and Web
 Profile Features]

--- a/docs/installation-guide/src/main/asciidoc/lot.adoc
+++ b/docs/installation-guide/src/main/asciidoc/lot.adoc
@@ -10,7 +10,7 @@ prev=toc.html
 [[list-of-tables]]
 == List of Tables
 
-* xref:installing.adoc#ghtqe[1-1 {productName} 7 Installation
+* xref:installing.adoc#ghtqe[1-1 {productName} {productMajorVersion} Installation
 Methods]
 * xref:installing.adoc#gkuap[1-2 {productName} Full Profile and Web
 Profile Features]

--- a/docs/installation-guide/src/main/asciidoc/preface.adoc
+++ b/docs/installation-guide/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ This document contains instructions for installing and uninstalling
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -174,7 +174,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/installation-guide/src/main/asciidoc/preface.adoc
+++ b/docs/installation-guide/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ This document contains instructions for installing and uninstalling
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -174,7 +174,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/installation-guide/src/main/asciidoc/title.adoc
+++ b/docs/installation-guide/src/main/asciidoc/title.adoc
@@ -1,18 +1,18 @@
 type=page
 status=published
-title={productName} Installation Guide, Release {productMajorVersion}
+title={productName} Installation Guide, Release {product-majorVersion}
 next=preface.html
 prev=lot.html
 ~~~~~~
 
-= {productName} Installation Guide, Release {productMajorVersion}
+= {productName} Installation Guide, Release {product-majorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Installation Guide
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
@@ -23,7 +23,7 @@ This book contains instructions for installing and uninstalling
 
 '''''
 
-{productName} Installation Guide, Release {productMajorVersion}
+{productName} Installation Guide, Release {product-majorVersion}
 
 Copyright © 2010, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/installation-guide/src/main/asciidoc/title.adoc
+++ b/docs/installation-guide/src/main/asciidoc/title.adoc
@@ -1,18 +1,18 @@
 type=page
 status=published
-title={productName} Installation Guide, Release 7
+title={productName} Installation Guide, Release {productMajorVersion}
 next=preface.html
 prev=lot.html
 ~~~~~~
 
-= {productName} Installation Guide, Release 7
+= {productName} Installation Guide, Release {productMajorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Installation Guide
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
@@ -23,7 +23,7 @@ This book contains instructions for installing and uninstalling
 
 '''''
 
-{productName} Installation Guide, Release 7
+{productName} Installation Guide, Release {productMajorVersion}
 
 Copyright © 2010, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/installation-guide/src/main/asciidoc/uninstalling.adoc
+++ b/docs/installation-guide/src/main/asciidoc/uninstalling.adoc
@@ -1,6 +1,6 @@
 type=page
 status=published
-title=Uninstalling {productName} {productMajorVersion}
+title=Uninstalling {productName} {product-majorVersion}
 prev=installing.html
 ~~~~~~
 

--- a/docs/installation-guide/src/main/asciidoc/uninstalling.adoc
+++ b/docs/installation-guide/src/main/asciidoc/uninstalling.adoc
@@ -1,6 +1,6 @@
 type=page
 status=published
-title=Uninstalling {productName} 7
+title=Uninstalling {productName} {productMajorVersion}
 prev=installing.html
 ~~~~~~
 

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -174,24 +174,6 @@
             </plugin>
 
             <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.6.1</version>
-                    <executions>
-                        <execution>
-                            <id>parse-version</id>
-                            <goals>
-                                <goal>parse-version</goal>
-                            </goals>
-                            <phase>validate</phase>
-                            <configuration>
-                                <propertyPrefix>parsedVersion</propertyPrefix>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
@@ -210,6 +192,16 @@
                             </artifacts>
                         </configuration>
                     </execution>
+                        <execution>
+                            <id>parse-version</id>
+                            <goals>
+                                <goal>parse-version</goal>
+                            </goals>
+                            <phase>validate</phase>
+                            <configuration>
+                                <propertyPrefix>parsedVersion</propertyPrefix>
+                            </configuration>
+                        </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -41,7 +41,7 @@
         <html.rel.file.prefix></html.rel.file.prefix>
         <mq.docs.url>https://eclipse-ee4j.github.io/openmq/guides/</mq.docs.url>
         <bookDirectory>${project.build.directory}/book</bookDirectory>
-        <productMajorVersion>7</productMajorVersion>
+        <productMajorVersion>${parsedVersion.majorVersion}</productMajorVersion>
         <productCurrentVersion>${project.version}</productCurrentVersion>
     </properties>
 
@@ -172,6 +172,24 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.1</version>
+                    <executions>
+                        <execution>
+                            <id>parse-version</id>
+                            <goals>
+                                <goal>parse-version</goal>
+                            </goals>
+                            <phase>validate</phase>
+                            <configuration>
+                                <propertyPrefix>parsedVersion</propertyPrefix>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -41,6 +41,8 @@
         <html.rel.file.prefix></html.rel.file.prefix>
         <mq.docs.url>https://eclipse-ee4j.github.io/openmq/guides/</mq.docs.url>
         <bookDirectory>${project.build.directory}/book</bookDirectory>
+        <productMajorVersion>7</productMajorVersion>
+        <productCurrentVersion>${project.version}</productCurrentVersion>
     </properties>
 
     <build>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -41,8 +41,8 @@
         <html.rel.file.prefix></html.rel.file.prefix>
         <mq.docs.url>https://eclipse-ee4j.github.io/openmq/guides/</mq.docs.url>
         <bookDirectory>${project.build.directory}/book</bookDirectory>
-        <productMajorVersion>${parsedVersion.majorVersion}</productMajorVersion>
-        <productCurrentVersion>${project.version}</productCurrentVersion>
+        <productMajorVersion>${product.majorVersion}</productMajorVersion>
+        <product.currentVersion>${project.version}</product.currentVersion>
     </properties>
 
     <build>
@@ -174,6 +174,25 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <property name="productMajorVersion" value="${product.majorVersion}"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
@@ -199,7 +218,7 @@
                             </goals>
                             <phase>validate</phase>
                             <configuration>
-                                <propertyPrefix>parsedVersion</propertyPrefix>
+                                <propertyPrefix>product</propertyPrefix>
                             </configuration>
                         </execution>
                 </executions>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -41,7 +41,6 @@
         <html.rel.file.prefix></html.rel.file.prefix>
         <mq.docs.url>https://eclipse-ee4j.github.io/openmq/guides/</mq.docs.url>
         <bookDirectory>${project.build.directory}/book</bookDirectory>
-        <productMajorVersion>${product.majorVersion}</productMajorVersion>
         <product.currentVersion>${project.version}</product.currentVersion>
     </properties>
 

--- a/docs/performance-tuning-guide/src/main/asciidoc/overview.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/overview.adoc
@@ -28,7 +28,7 @@ The following topics are addressed here:
 
 === Process Overview
 
-The following table outlines the overall {productName} {productMajorVersion}
+The following table outlines the overall {productName} {product-majorVersion}
 administration process, and shows where performance tuning fits in the
 sequence.
 
@@ -256,13 +256,13 @@ Security]" in {productName} Security Guide.
 
 ==== High Availability Clustering, Load Balancing, and Failover
 
-{productName} {productMajorVersion} enables multiple {productName} instances to be
+{productName} {product-majorVersion} enables multiple {productName} instances to be
 clustered to provide high availability through failure protection,
 scalability, and load balancing.
 
 High availability applications and services provide their functionality
 continuously, regardless of hardware and software failures. To make such
-reliability possible, {productName} {productMajorVersion} provides mechanisms for
+reliability possible, {productName} {product-majorVersion} provides mechanisms for
 maintaining application state data between clustered {productName}
 instances. Application state data, such as HTTP session data, stateful
 EJB sessions, and dynamic cache information, is replicated in real time
@@ -282,7 +282,7 @@ high availability persistence tuning recommendations.
 See the xref:ha-administration-guide.adoc#GSHAG[{productName} High
 Availability Administration Guide] for complete information about
 configuring high availability clustering, load balancing, and failover
-features in {productName} {productMajorVersion}.
+features in {productName} {product-majorVersion}.
 
 [[hardware-resources]]
 

--- a/docs/performance-tuning-guide/src/main/asciidoc/overview.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/overview.adoc
@@ -28,7 +28,7 @@ The following topics are addressed here:
 
 === Process Overview
 
-The following table outlines the overall {productName} 7
+The following table outlines the overall {productName} {productMajorVersion}
 administration process, and shows where performance tuning fits in the
 sequence.
 
@@ -256,13 +256,13 @@ Security]" in {productName} Security Guide.
 
 ==== High Availability Clustering, Load Balancing, and Failover
 
-{productName} 7 enables multiple {productName} instances to be
+{productName} {productMajorVersion} enables multiple {productName} instances to be
 clustered to provide high availability through failure protection,
 scalability, and load balancing.
 
 High availability applications and services provide their functionality
 continuously, regardless of hardware and software failures. To make such
-reliability possible, {productName} 7 provides mechanisms for
+reliability possible, {productName} {productMajorVersion} provides mechanisms for
 maintaining application state data between clustered {productName}
 instances. Application state data, such as HTTP session data, stateful
 EJB sessions, and dynamic cache information, is replicated in real time
@@ -282,7 +282,7 @@ high availability persistence tuning recommendations.
 See the xref:ha-administration-guide.adoc#GSHAG[{productName} High
 Availability Administration Guide] for complete information about
 configuring high availability clustering, load balancing, and failover
-features in {productName} 7.
+features in {productName} {productMajorVersion}.
 
 [[hardware-resources]]
 

--- a/docs/performance-tuning-guide/src/main/asciidoc/preface.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/preface.adoc
@@ -24,12 +24,12 @@ Please see the Title page for additional license information.
 ====
 
 The Performance Tuning Guide describes how to get the best performance
-with {productName} 7.
+with {productName} {productMajorVersion}.
 
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at `http://glassfish.java.net/`. The GlassFish
 project provides a structured process for developing the {productName} platform that makes the new features of the Jakarta EE platform
 available faster, while maintaining the most important feature of Java

--- a/docs/performance-tuning-guide/src/main/asciidoc/preface.adoc
+++ b/docs/performance-tuning-guide/src/main/asciidoc/preface.adoc
@@ -24,12 +24,12 @@ Please see the Title page for additional license information.
 ====
 
 The Performance Tuning Guide describes how to get the best performance
-with {productName} {productMajorVersion}.
+with {productName} {product-majorVersion}.
 
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at `http://glassfish.java.net/`. The GlassFish
 project provides a structured process for developing the {productName} platform that makes the new features of the Jakarta EE platform
 available faster, while maintaining the most important feature of Java

--- a/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
@@ -12,7 +12,7 @@ prev=preface.html
 {productName} provides a server for the
 development and deployment of Java Platform, Enterprise Edition (Jakarta EE
 platform) applications and web technologies based on Java technology.
-{productName} 7 provides the following:
+{productName} {productMajorVersion} provides the following:
 
 * A lightweight and extensible core based on OSGi Alliance standards
 * A web container
@@ -36,14 +36,14 @@ The following topics are addressed here:
 
 === About This Quick Start Guide
 
-{productName} 7 Quick Start Guide demonstrates
+{productName} {productMajorVersion} Quick Start Guide demonstrates
 key features of the {productName} product and enables you to quickly
 learn the basics. Step-by-step procedures introduce you to product
 features and enable you to use them immediately.
 
 This guide assumes that you have already obtained and installed the
-{productName} 7 software. For more information about installing
-{productName} 7, see the
+{productName} {productMajorVersion} software. For more information about installing
+{productName} {productMajorVersion}, see the
 https://github.com/eclipse-ee4j/glassfishdocumentation[{productName} Installation Guide].
 
 Instructions and examples in this guide that apply to all supported
@@ -62,9 +62,9 @@ guide, see xref:#for-more-information[For More Information].
 To review additional details about this release before you begin using
 the software, see the xref:release-notes.adoc#GSRLN[{productName}
 Release Notes]. The Release Notes provide important information about
-the {productName} 7 release, including details about new features,
+the {productName} {productMajorVersion} release, including details about new features,
 information about known issues and possible workarounds, and tips for
-installing and working with {productName} 7 software.
+installing and working with {productName} {productMajorVersion} software.
 
 [[default-paths-and-file-names]]
 
@@ -706,7 +706,7 @@ RMI-IIOP Load Balancing and Failover]" in
 === For More Information
 
 Additional resources are available to help you learn more about
-{productName} 7 and related technologies.
+{productName} {productMajorVersion} and related technologies.
 
 The following resources are described here:
 

--- a/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
@@ -12,7 +12,7 @@ prev=preface.html
 {productName} provides a server for the
 development and deployment of Java Platform, Enterprise Edition (Jakarta EE
 platform) applications and web technologies based on Java technology.
-{productName} {productMajorVersion} provides the following:
+{productName} {product-majorVersion} provides the following:
 
 * A lightweight and extensible core based on OSGi Alliance standards
 * A web container
@@ -36,14 +36,14 @@ The following topics are addressed here:
 
 === About This Quick Start Guide
 
-{productName} {productMajorVersion} Quick Start Guide demonstrates
+{productName} {product-majorVersion} Quick Start Guide demonstrates
 key features of the {productName} product and enables you to quickly
 learn the basics. Step-by-step procedures introduce you to product
 features and enable you to use them immediately.
 
 This guide assumes that you have already obtained and installed the
-{productName} {productMajorVersion} software. For more information about installing
-{productName} {productMajorVersion}, see the
+{productName} {product-majorVersion} software. For more information about installing
+{productName} {product-majorVersion}, see the
 https://github.com/eclipse-ee4j/glassfishdocumentation[{productName} Installation Guide].
 
 Instructions and examples in this guide that apply to all supported
@@ -62,9 +62,9 @@ guide, see xref:#for-more-information[For More Information].
 To review additional details about this release before you begin using
 the software, see the xref:release-notes.adoc#GSRLN[{productName}
 Release Notes]. The Release Notes provide important information about
-the {productName} {productMajorVersion} release, including details about new features,
+the {productName} {product-majorVersion} release, including details about new features,
 information about known issues and possible workarounds, and tips for
-installing and working with {productName} {productMajorVersion} software.
+installing and working with {productName} {product-majorVersion} software.
 
 [[default-paths-and-file-names]]
 
@@ -706,7 +706,7 @@ RMI-IIOP Load Balancing and Failover]" in
 === For More Information
 
 Additional resources are available to help you learn more about
-{productName} {productMajorVersion} and related technologies.
+{productName} {product-majorVersion} and related technologies.
 
 The following resources are described here:
 

--- a/docs/quick-start-guide/src/main/asciidoc/preface.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/preface.adoc
@@ -33,7 +33,7 @@ This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation
 set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at `https://github.com/eclipse-ee4j/glassfish`. The
 GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE

--- a/docs/quick-start-guide/src/main/asciidoc/preface.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/preface.adoc
@@ -33,7 +33,7 @@ This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation
 set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at `https://github.com/eclipse-ee4j/glassfish`. The
 GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE

--- a/docs/quick-start-guide/src/main/asciidoc/title.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/title.adoc
@@ -1,31 +1,31 @@
 type=page
 status=published
-title={productName} Quick Start Guide, Release 7
+title={productName} Quick Start Guide, Release {productMajorVersion}
 next=preface.html
 prev=toc.html
 ~~~~~~
 
-= {productName} Quick Start Guide, Release 7
+= {productName} Quick Start Guide, Release {productMajorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Quick Start Guide
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
 This book demonstrates key features of the {productName} product and
 enables you to quickly learn the basics. Step-by-step procedures
-introduce you to product features and {productName} 7 Quick Start Guide {productName} 7
+introduce you to product features and {productName} {productMajorVersion} Quick Start Guide {productName} {productMajorVersion}
 Quick Start Guide you to use them immediately.
 
 [[sthref1]]
 
 '''''
 
-{productName} Quick Start Guide, Release 7
+{productName} Quick Start Guide, Release {productMajorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/quick-start-guide/src/main/asciidoc/title.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/title.adoc
@@ -1,31 +1,31 @@
 type=page
 status=published
-title={productName} Quick Start Guide, Release {productMajorVersion}
+title={productName} Quick Start Guide, Release {product-majorVersion}
 next=preface.html
 prev=toc.html
 ~~~~~~
 
-= {productName} Quick Start Guide, Release {productMajorVersion}
+= {productName} Quick Start Guide, Release {product-majorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Quick Start Guide
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
 This book demonstrates key features of the {productName} product and
 enables you to quickly learn the basics. Step-by-step procedures
-introduce you to product features and {productName} {productMajorVersion} Quick Start Guide {productName} {productMajorVersion}
+introduce you to product features and {productName} {product-majorVersion} Quick Start Guide {productName} {product-majorVersion}
 Quick Start Guide you to use them immediately.
 
 [[sthref1]]
 
 '''''
 
-{productName} Quick Start Guide, Release {productMajorVersion}
+{productName} Quick Start Guide, Release {product-majorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/reference-manual/src/main/asciidoc/manvol1.adoc
+++ b/docs/reference-manual/src/main/asciidoc/manvol1.adoc
@@ -1,15 +1,15 @@
 type=page
 status=published
-title={productName} {productMajorVersion} asadmin Utility Subcommands
+title={productName} {product-majorVersion} asadmin Utility Subcommands
 next=add-library.html
 prev=preface.html
 ~~~~~~
 
-= {productName} {productMajorVersion} asadmin Utility Subcommands
+= {productName} {product-majorVersion} asadmin Utility Subcommands
 
 
 [[glassfish-server-open-source-edition-5.0-asadmin-utility-subcommands]]
-== 1 {productName} {productMajorVersion} asadmin Utility Subcommands
+== 1 {productName} {product-majorVersion} asadmin Utility Subcommands
 
 This section describes, in alphabetical order, the subcommands of the
 xref:asadmin.adoc#asadmin[`asadmin`(1M)] utility.

--- a/docs/reference-manual/src/main/asciidoc/manvol1.adoc
+++ b/docs/reference-manual/src/main/asciidoc/manvol1.adoc
@@ -1,15 +1,15 @@
 type=page
 status=published
-title={productName} 7 asadmin Utility Subcommands
+title={productName} {productMajorVersion} asadmin Utility Subcommands
 next=add-library.html
 prev=preface.html
 ~~~~~~
 
-= {productName} 7 asadmin Utility Subcommands
+= {productName} {productMajorVersion} asadmin Utility Subcommands
 
 
 [[glassfish-server-open-source-edition-5.0-asadmin-utility-subcommands]]
-== 1 {productName} 7 asadmin Utility Subcommands
+== 1 {productName} {productMajorVersion} asadmin Utility Subcommands
 
 This section describes, in alphabetical order, the subcommands of the
 xref:asadmin.adoc#asadmin[`asadmin`(1M)] utility.

--- a/docs/reference-manual/src/main/asciidoc/manvol1m.adoc
+++ b/docs/reference-manual/src/main/asciidoc/manvol1m.adoc
@@ -1,17 +1,17 @@
 type=page
 status=published
-title={productName} 7 Utility Commands
+title={productName} {productMajorVersion} Utility Commands
 next=appclient.html
 prev=version.html
 ~~~~~~
 
-= {productName} 7 Utility Commands
+= {productName} {productMajorVersion} Utility Commands
 
 [[sthref2356]]
 
 
 [[glassfish-server-open-source-edition-5.0-utility-commands]]
-== 2 {productName} 7 Utility Commands
+== 2 {productName} {productMajorVersion} Utility Commands
 
 This section describes {productName} utility commands.
 

--- a/docs/reference-manual/src/main/asciidoc/manvol1m.adoc
+++ b/docs/reference-manual/src/main/asciidoc/manvol1m.adoc
@@ -1,17 +1,17 @@
 type=page
 status=published
-title={productName} {productMajorVersion} Utility Commands
+title={productName} {product-majorVersion} Utility Commands
 next=appclient.html
 prev=version.html
 ~~~~~~
 
-= {productName} {productMajorVersion} Utility Commands
+= {productName} {product-majorVersion} Utility Commands
 
 [[sthref2356]]
 
 
 [[glassfish-server-open-source-edition-5.0-utility-commands]]
-== 2 {productName} {productMajorVersion} Utility Commands
+== 2 {productName} {product-majorVersion} Utility Commands
 
 This section describes {productName} utility commands.
 

--- a/docs/reference-manual/src/main/asciidoc/manvol5asc.adoc
+++ b/docs/reference-manual/src/main/asciidoc/manvol5asc.adoc
@@ -1,17 +1,17 @@
 type=page
 status=published
-title={productName} {productMajorVersion} {productName} Concepts
+title={productName} {product-majorVersion} {productName} Concepts
 next=application.html
 prev=package-appclient.html
 ~~~~~~
 
-= {productName} {productMajorVersion} {productName} Concepts
+= {productName} {product-majorVersion} {productName} Concepts
 
 [[sthref2391]]
 
 
 [[glassfish-server-open-source-edition-5.0-glassfish-server-concepts]]
-== 3 {productName} {productMajorVersion} {productName} Concepts
+== 3 {productName} {product-majorVersion} {productName} Concepts
 
 This section describes concepts that are related to {productName}
 administration.

--- a/docs/reference-manual/src/main/asciidoc/manvol5asc.adoc
+++ b/docs/reference-manual/src/main/asciidoc/manvol5asc.adoc
@@ -1,17 +1,17 @@
 type=page
 status=published
-title={productName} 7 {productName} Concepts
+title={productName} {productMajorVersion} {productName} Concepts
 next=application.html
 prev=package-appclient.html
 ~~~~~~
 
-= {productName} 7 {productName} Concepts
+= {productName} {productMajorVersion} {productName} Concepts
 
 [[sthref2391]]
 
 
 [[glassfish-server-open-source-edition-5.0-glassfish-server-concepts]]
-== 3 {productName} 7 {productName} Concepts
+== 3 {productName} {productMajorVersion} {productName} Concepts
 
 This section describes concepts that are related to {productName}
 administration.

--- a/docs/reference-manual/src/main/asciidoc/title.adoc
+++ b/docs/reference-manual/src/main/asciidoc/title.adoc
@@ -1,23 +1,23 @@
 type=page
 status=published
-title={productName} Reference Manual, Release {productMajorVersion}
+title={productName} Reference Manual, Release {product-majorVersion}
 next=preface.html
 prev=toc.html
 ~~~~~~
 
-= {productName} Reference Manual, Release {productMajorVersion}
+= {productName} Reference Manual, Release {product-majorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Reference Manual
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
 This reference manual describes administration commands and utility
-commands that are available with {productName} {productMajorVersion}.
+commands that are available with {productName} {product-majorVersion}.
 This reference manual also describes concepts that are related to
 {productName} administration.
 
@@ -32,7 +32,7 @@ This reference manual is for all users of {productName}.
 
 '''''
 
-{productName} Reference Manual, Release {productMajorVersion}
+{productName} Reference Manual, Release {product-majorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/reference-manual/src/main/asciidoc/title.adoc
+++ b/docs/reference-manual/src/main/asciidoc/title.adoc
@@ -1,23 +1,23 @@
 type=page
 status=published
-title={productName} Reference Manual, Release 7
+title={productName} Reference Manual, Release {productMajorVersion}
 next=preface.html
 prev=toc.html
 ~~~~~~
 
-= {productName} Reference Manual, Release 7
+= {productName} Reference Manual, Release {productMajorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Reference Manual
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
 This reference manual describes administration commands and utility
-commands that are available with {productName} 7.
+commands that are available with {productName} {productMajorVersion}.
 This reference manual also describes concepts that are related to
 {productName} administration.
 
@@ -32,7 +32,7 @@ This reference manual is for all users of {productName}.
 
 '''''
 
-{productName} Reference Manual, Release 7
+{productName} Reference Manual, Release {productMajorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/release-notes/src/main/asciidoc/preface.adoc
+++ b/docs/release-notes/src/main/asciidoc/preface.adoc
@@ -27,7 +27,7 @@ Please see the Title page for additional license information.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -172,7 +172,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/release-notes/src/main/asciidoc/preface.adoc
+++ b/docs/release-notes/src/main/asciidoc/preface.adoc
@@ -27,7 +27,7 @@ Please see the Title page for additional license information.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -172,7 +172,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -1,13 +1,13 @@
 type=page
 status=published
-title={productName} 7 Release Notes
+title={productName} {productMajorVersion} Release Notes
 prev=preface.html
 ~~~~~~
 
-= {productName} 7 Release Notes
+= {productName} {productMajorVersion} Release Notes
 
 [[GSRLN]]
-== 1 {productName} 7 Release Notes
+== 1 {productName} {productMajorVersion} Release Notes
 
 [CAUTION]
 ====
@@ -25,21 +25,21 @@ Jakarta EE technologies.
 For any issue or information on {productName},
 see the https://glassfish.org/.
 
-These Release Notes provide late-breaking information about {productName} 7
+These Release Notes provide late-breaking information about {productName} {productMajorVersion}
 software and documentation. These Release Notes include
 summaries of supported hardware, operating environments, and JDK and
 JDBC/RDBMS requirements. Also included are a summary of new product
-features in the 7 release, and descriptions and workarounds for known
+features in the {productMajorVersion} release, and descriptions and workarounds for known
 issues and limitations.
 
 Refer to this document prior to installing, configuring, or using
-{productName} 7 software. Consult this document periodically to
+{productName} {productMajorVersion} software. Consult this document periodically to
 view the most up-to-date product information.
 
 * xref:#revision-history["Revision History"]
-* xref:#whats-new-in-the-glassfish-server-release["What's New in the {productName} 7 Release?"]
+* xref:#whats-new-in-the-glassfish-server-release["What's New in the {productName} {productMajorVersion} Release?"]
 * xref:#hardware-and-software-requirements["Hardware and Software Requirements"]
-* xref:#GSRLN00253["Known Issues in {productName} 7"]
+* xref:#GSRLN00253["Known Issues in {productName} {productMajorVersion}"]
 * xref:#restrictions-and-deprecated-functionality["Restrictions and Deprecated Functionality"]
 * xref:#documentation-errata["Documentation Errata"]
 * xref:#features-available-only-in-the-full-platform["Features Available Only in the Full Platform"]
@@ -60,18 +60,18 @@ Table 1-1 Revision History
 [width="100%",options="header",]
 |===
 |Date |Description of Changes
-|September 2022 |{productName} 7.
+|September 2022 |{productName} {productMajorVersion}.
 |===
 
 
 [[whats-new-in-the-glassfish-server-release]]
 
-=== What's New in the {productName} 7 Release?
+=== What's New in the {productName} {productMajorVersion} Release?
 
 GlassFish is the Reference Implementation for Jakarta EE. Jakarta EE 10
 introduces ... To Be Done
 
-{productName} 7 includes the following new and updated Jakarta EE standards.
+{productName} {productMajorVersion} includes the following new and updated Jakarta EE standards.
 
 New Features
 
@@ -81,13 +81,13 @@ Updated
 
 * To Be Done
 
-For a complete list of the Jakarta EE technologies included in {productName} 7,
+For a complete list of the Jakarta EE technologies included in {productName} {productMajorVersion},
 see xref:#java-ee-standards-support[Jakarta EE Standards Support].
 
 
 [NOTE]
 ====
-The main thrust of the {productName} 7 release
+The main thrust of the {productName} {productMajorVersion} release
 is to provide an application server for developers to explore and begin
 exploiting the new and updated technologies in the Jakarta EE 10 platform.
 Thus, the following features of {productName} were not a focus of
@@ -107,7 +107,7 @@ properly with some of the new features added in support of the Jakarta EE 10 pla
 === Hardware and Software Requirements
 
 This section lists the requirements that must be met before installing
-{productName} Release 7 software.
+{productName} Release {productMajorVersion} software.
 
 The following topics are addressed here:
 
@@ -137,7 +137,7 @@ DAS or server instance have a minimum of 1 GB RAM.
 
 ==== Required Disk Space
 
-The download sizes for {productName} 7 vary depending on the
+The download sizes for {productName} {productMajorVersion} vary depending on the
 package you choose. The following are the approximate sizes of the ZIP
 packages for the Full and Web profiles:
 
@@ -145,7 +145,7 @@ packages for the Full and Web profiles:
 * Web `*.zip`: 64.9 MB (82.9 MB unzipped)
 
 The installation sizes will vary depending on your configuration, but
-the approximate amount of disk space used by {productName} 7 is as
+the approximate amount of disk space used by {productName} {productMajorVersion} is as
 follows:
 
 * Full: 138 MB
@@ -162,7 +162,7 @@ If these default port numbers are in use, the installation program
 assigns a randomly selected port number from the dynamic port range. The
 selected port number might not be the next available port number.
 
-Table 1-2 Default Port Assignments for {productName} 7
+Table 1-2 Default Port Assignments for {productName} {productMajorVersion}
 
 [width="100%",cols="63%,37%",options="header",]
 |===
@@ -275,7 +275,7 @@ configuration, as this has not been tested.
 
 ==== Message Queue Broker Requirements
 
-{productName} 7 is now bundled with Message Queue (MQ) Broker
+{productName} {productMajorVersion} is now bundled with Message Queue (MQ) Broker
 5.1.1. Refer to the
 https://github.com/eclipse-ee4j/glassfishdoc/5.1/mq-release-notes.pdf[`Open Message Queue Release Notes`]
 for complete information about MQ Broker requirements.
@@ -352,10 +352,10 @@ property in the in the as-install``/config/asenv.conf`` file.
 
 [[GSRLN00253]][[known-issues-in-glassfish-server-5.1]]
 
-=== Known Issues in {productName} 7
+=== Known Issues in {productName} {productMajorVersion}
 
 This section describes known issues and any available workarounds for
-{productName} 7 software.
+{productName} {productMajorVersion} software.
 
 The following topics are addressed here:
 
@@ -393,7 +393,7 @@ None
 ===== Description
 
 A new JVM option for deployment - deployment.resource.validation is
-introduced in {productName} 7. This property is set to True by
+introduced in {productName} {productMajorVersion}. This property is set to True by
 default so that each resource is validated during deployment time. This
 ensures that all resources are created beforehand. This property is
 applicable for administration server as well as instances when clusters
@@ -441,7 +441,7 @@ No workaround.
 
 ===== Description
 
-In the previous releases, Java DB was used as the database for {productName}s. With the release of {productName} 7, Apache Derby
+In the previous releases, Java DB was used as the database for {productName}s. With the release of {productName} {productMajorVersion}, Apache Derby
 10.13.1.1 has replaced Java DB as the database for {productName}s.
 
 [[workaround-3]]
@@ -455,7 +455,7 @@ No workaround.
 === Restrictions and Deprecated Functionality
 
 This section describes restrictions and deprecated functionality in
-{productName} 7.
+{productName} {productMajorVersion}.
 
 The following topics are addressed here:
 
@@ -468,7 +468,7 @@ The following topics are addressed here:
 [[asadmin-subcommands]]
 ==== `asadmin` Subcommands
 
-In {productName} 7, it is recommended that utility options of the
+In {productName} {productMajorVersion}, it is recommended that utility options of the
 `asadmin` command precede the subcommand. Utility options are options
 that control the behavior of the `asadmin` utility, as distinguished
 from subcommand options. Use of the following options after the
@@ -576,11 +576,11 @@ Replaced by an operand in the `list-custom-resources` subcommand and the
 
 ==== Applications That Use Apache Derby
 
-The directory location of Apache Derby in {productName} 7 has
+The directory location of Apache Derby in {productName} {productMajorVersion} has
 changed from its location in previous installations. Suppose that you
 have deployed applications that use Apache Derby databases in your
 previous server installation, and you upgrade your existing installation
-to {productName} 7. If you run the `asadmin start-database` command
+to {productName} {productMajorVersion}. If you run the `asadmin start-database` command
 and successfully start Apache Derby, you could run into problems while
 trying to run applications that were deployed on your previous server
 installation.
@@ -599,7 +599,7 @@ Derby. For example:
 ----
 asadmin start-database --dbhome c:\glassfish\databases
 ----
-2. After upgrade, start {productName} 7.
+2. After upgrade, start {productName} {productMajorVersion}.
 
 [[no-support-for-client-vm-on-windows-amd64]]
 
@@ -617,7 +617,7 @@ server instances use the Server VM by default.
 ==== Metro Reliable Messaging in `InOrder` Delivery Mode
 
 The Metro Reliable Messaging in `InOrder` Delivery mode has not been
-tested for high availability in {productName} 7. The feature may
+tested for high availability in {productName} {productMajorVersion}. The feature may
 work, but it has not been formally tested and is therefore not a
 supported feature.
 
@@ -625,7 +625,7 @@ supported feature.
 
 ==== No Support for Kerberos on AIX
 
-{productName} 7 does not support Kerberos on the AIX platform.
+{productName} {productMajorVersion} does not support Kerberos on the AIX platform.
 
 For the complete report about this issue, see
 https://github.com/javaee/glassfish/issues/16728[`Issue-16728`]
@@ -649,7 +649,7 @@ upgrade is not necessary.
 
 [NOTE]
 ====
-Upgrading may not work for {productName} 7
+Upgrading may not work for {productName} {productMajorVersion}
 ====
 
 
@@ -657,7 +657,7 @@ Upgrading may not work for {productName} 7
 
 === Features Available Only in the Full Platform
 
-The following features of {productName} 7 are available only in the
+The following features of {productName} {productMajorVersion} are available only in the
 Full Platform:
 
 * EJB features that make up the full EJB 3.2 API, such as remote EJB
@@ -681,14 +681,14 @@ related to web services are ignored.
 Connector modules that use only outbound communication features and
 work-management that does not involve inbound communication features are
 supported in the Web Profile. Other connector features are supported
-only in the {productName} 7 full platform.
+only in the {productName} {productMajorVersion} full platform.
 
 [[java-ee-standards-support]]
 
 === Jakarta EE Standards Support
 
 xref:#gjxcp[Table 1-4] lists the Jakarta EE standards implemented in
-{productName} 7. The table also indicates the distributions in
+{productName} {productMajorVersion}. The table also indicates the distributions in
 which the implementation of a standard is available.
 
 * X indicates that the implementation is available in the distribution.
@@ -697,11 +697,11 @@ distribution.
 
 [[gjxcp]]
 
-Table 1-4 Jakarta EE Standards Implementations in {productName} 7
+Table 1-4 Jakarta EE Standards Implementations in {productName} {productMajorVersion}
 
 [width="100%",cols="<48%,<10%,<10%,<10%",options="header",]
 |===
-|Jakarta EE Standard |Version |{productName} 7 Full Platform |{productName} 7 Web Profile
+|Jakarta EE Standard |Version |{productName} {productMajorVersion} Full Platform |{productName} {productMajorVersion} Web Profile
 
 |https://jakarta.ee/specifications/platform/10/[Jakarta EE Specification]
 |10
@@ -901,7 +901,7 @@ Table 1-4 Jakarta EE Standards Implementations in {productName} 7
 
 ^*^ Standalone Connector 1.7 Container only.
 
-Building on these standards, {productName} 7 provides a number of
+Building on these standards, {productName} {productMajorVersion} provides a number of
 extensions, including the following:
 
 * Ajax (asynchronous JavaScript and XML): Retrieves and displays new
@@ -917,7 +917,7 @@ extensions, including the following:
 
 === How to Report Problems and Provide Feedback
 
-If you have problems with {productName} 7, provide feedback through
+If you have problems with {productName} {productMajorVersion}, provide feedback through
 one of the following mechanisms:
 
 * https://javaee.groups.io/g/glassfish[{productName} forum]

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -1,13 +1,13 @@
 type=page
 status=published
-title={productName} {productMajorVersion} Release Notes
+title={productName} {product-majorVersion} Release Notes
 prev=preface.html
 ~~~~~~
 
-= {productName} {productMajorVersion} Release Notes
+= {productName} {product-majorVersion} Release Notes
 
 [[GSRLN]]
-== 1 {productName} {productMajorVersion} Release Notes
+== 1 {productName} {product-majorVersion} Release Notes
 
 [CAUTION]
 ====
@@ -25,21 +25,21 @@ Jakarta EE technologies.
 For any issue or information on {productName},
 see the https://glassfish.org/.
 
-These Release Notes provide late-breaking information about {productName} {productMajorVersion}
+These Release Notes provide late-breaking information about {productName} {product-majorVersion}
 software and documentation. These Release Notes include
 summaries of supported hardware, operating environments, and JDK and
 JDBC/RDBMS requirements. Also included are a summary of new product
-features in the {productMajorVersion} release, and descriptions and workarounds for known
+features in the {product-majorVersion} release, and descriptions and workarounds for known
 issues and limitations.
 
 Refer to this document prior to installing, configuring, or using
-{productName} {productMajorVersion} software. Consult this document periodically to
+{productName} {product-majorVersion} software. Consult this document periodically to
 view the most up-to-date product information.
 
 * xref:#revision-history["Revision History"]
-* xref:#whats-new-in-the-glassfish-server-release["What's New in the {productName} {productMajorVersion} Release?"]
+* xref:#whats-new-in-the-glassfish-server-release["What's New in the {productName} {product-majorVersion} Release?"]
 * xref:#hardware-and-software-requirements["Hardware and Software Requirements"]
-* xref:#GSRLN00253["Known Issues in {productName} {productMajorVersion}"]
+* xref:#GSRLN00253["Known Issues in {productName} {product-majorVersion}"]
 * xref:#restrictions-and-deprecated-functionality["Restrictions and Deprecated Functionality"]
 * xref:#documentation-errata["Documentation Errata"]
 * xref:#features-available-only-in-the-full-platform["Features Available Only in the Full Platform"]
@@ -60,18 +60,18 @@ Table 1-1 Revision History
 [width="100%",options="header",]
 |===
 |Date |Description of Changes
-|September 2022 |{productName} {productMajorVersion}.
+|September 2022 |{productName} {product-majorVersion}.
 |===
 
 
 [[whats-new-in-the-glassfish-server-release]]
 
-=== What's New in the {productName} {productMajorVersion} Release?
+=== What's New in the {productName} {product-majorVersion} Release?
 
 GlassFish is the Reference Implementation for Jakarta EE. Jakarta EE 10
 introduces ... To Be Done
 
-{productName} {productMajorVersion} includes the following new and updated Jakarta EE standards.
+{productName} {product-majorVersion} includes the following new and updated Jakarta EE standards.
 
 New Features
 
@@ -81,13 +81,13 @@ Updated
 
 * To Be Done
 
-For a complete list of the Jakarta EE technologies included in {productName} {productMajorVersion},
+For a complete list of the Jakarta EE technologies included in {productName} {product-majorVersion},
 see xref:#java-ee-standards-support[Jakarta EE Standards Support].
 
 
 [NOTE]
 ====
-The main thrust of the {productName} {productMajorVersion} release
+The main thrust of the {productName} {product-majorVersion} release
 is to provide an application server for developers to explore and begin
 exploiting the new and updated technologies in the Jakarta EE 10 platform.
 Thus, the following features of {productName} were not a focus of
@@ -107,7 +107,7 @@ properly with some of the new features added in support of the Jakarta EE 10 pla
 === Hardware and Software Requirements
 
 This section lists the requirements that must be met before installing
-{productName} Release {productMajorVersion} software.
+{productName} Release {product-majorVersion} software.
 
 The following topics are addressed here:
 
@@ -137,7 +137,7 @@ DAS or server instance have a minimum of 1 GB RAM.
 
 ==== Required Disk Space
 
-The download sizes for {productName} {productMajorVersion} vary depending on the
+The download sizes for {productName} {product-majorVersion} vary depending on the
 package you choose. The following are the approximate sizes of the ZIP
 packages for the Full and Web profiles:
 
@@ -145,7 +145,7 @@ packages for the Full and Web profiles:
 * Web `*.zip`: 64.9 MB (82.9 MB unzipped)
 
 The installation sizes will vary depending on your configuration, but
-the approximate amount of disk space used by {productName} {productMajorVersion} is as
+the approximate amount of disk space used by {productName} {product-majorVersion} is as
 follows:
 
 * Full: 138 MB
@@ -162,7 +162,7 @@ If these default port numbers are in use, the installation program
 assigns a randomly selected port number from the dynamic port range. The
 selected port number might not be the next available port number.
 
-Table 1-2 Default Port Assignments for {productName} {productMajorVersion}
+Table 1-2 Default Port Assignments for {productName} {product-majorVersion}
 
 [width="100%",cols="63%,37%",options="header",]
 |===
@@ -275,7 +275,7 @@ configuration, as this has not been tested.
 
 ==== Message Queue Broker Requirements
 
-{productName} {productMajorVersion} is now bundled with Message Queue (MQ) Broker
+{productName} {product-majorVersion} is now bundled with Message Queue (MQ) Broker
 5.1.1. Refer to the
 https://github.com/eclipse-ee4j/glassfishdoc/5.1/mq-release-notes.pdf[`Open Message Queue Release Notes`]
 for complete information about MQ Broker requirements.
@@ -352,10 +352,10 @@ property in the in the as-install``/config/asenv.conf`` file.
 
 [[GSRLN00253]][[known-issues-in-glassfish-server-5.1]]
 
-=== Known Issues in {productName} {productMajorVersion}
+=== Known Issues in {productName} {product-majorVersion}
 
 This section describes known issues and any available workarounds for
-{productName} {productMajorVersion} software.
+{productName} {product-majorVersion} software.
 
 The following topics are addressed here:
 
@@ -393,7 +393,7 @@ None
 ===== Description
 
 A new JVM option for deployment - deployment.resource.validation is
-introduced in {productName} {productMajorVersion}. This property is set to True by
+introduced in {productName} {product-majorVersion}. This property is set to True by
 default so that each resource is validated during deployment time. This
 ensures that all resources are created beforehand. This property is
 applicable for administration server as well as instances when clusters
@@ -441,7 +441,7 @@ No workaround.
 
 ===== Description
 
-In the previous releases, Java DB was used as the database for {productName}s. With the release of {productName} {productMajorVersion}, Apache Derby
+In the previous releases, Java DB was used as the database for {productName}s. With the release of {productName} {product-majorVersion}, Apache Derby
 10.13.1.1 has replaced Java DB as the database for {productName}s.
 
 [[workaround-3]]
@@ -455,7 +455,7 @@ No workaround.
 === Restrictions and Deprecated Functionality
 
 This section describes restrictions and deprecated functionality in
-{productName} {productMajorVersion}.
+{productName} {product-majorVersion}.
 
 The following topics are addressed here:
 
@@ -468,7 +468,7 @@ The following topics are addressed here:
 [[asadmin-subcommands]]
 ==== `asadmin` Subcommands
 
-In {productName} {productMajorVersion}, it is recommended that utility options of the
+In {productName} {product-majorVersion}, it is recommended that utility options of the
 `asadmin` command precede the subcommand. Utility options are options
 that control the behavior of the `asadmin` utility, as distinguished
 from subcommand options. Use of the following options after the
@@ -576,11 +576,11 @@ Replaced by an operand in the `list-custom-resources` subcommand and the
 
 ==== Applications That Use Apache Derby
 
-The directory location of Apache Derby in {productName} {productMajorVersion} has
+The directory location of Apache Derby in {productName} {product-majorVersion} has
 changed from its location in previous installations. Suppose that you
 have deployed applications that use Apache Derby databases in your
 previous server installation, and you upgrade your existing installation
-to {productName} {productMajorVersion}. If you run the `asadmin start-database` command
+to {productName} {product-majorVersion}. If you run the `asadmin start-database` command
 and successfully start Apache Derby, you could run into problems while
 trying to run applications that were deployed on your previous server
 installation.
@@ -599,7 +599,7 @@ Derby. For example:
 ----
 asadmin start-database --dbhome c:\glassfish\databases
 ----
-2. After upgrade, start {productName} {productMajorVersion}.
+2. After upgrade, start {productName} {product-majorVersion}.
 
 [[no-support-for-client-vm-on-windows-amd64]]
 
@@ -617,7 +617,7 @@ server instances use the Server VM by default.
 ==== Metro Reliable Messaging in `InOrder` Delivery Mode
 
 The Metro Reliable Messaging in `InOrder` Delivery mode has not been
-tested for high availability in {productName} {productMajorVersion}. The feature may
+tested for high availability in {productName} {product-majorVersion}. The feature may
 work, but it has not been formally tested and is therefore not a
 supported feature.
 
@@ -625,7 +625,7 @@ supported feature.
 
 ==== No Support for Kerberos on AIX
 
-{productName} {productMajorVersion} does not support Kerberos on the AIX platform.
+{productName} {product-majorVersion} does not support Kerberos on the AIX platform.
 
 For the complete report about this issue, see
 https://github.com/javaee/glassfish/issues/16728[`Issue-16728`]
@@ -649,7 +649,7 @@ upgrade is not necessary.
 
 [NOTE]
 ====
-Upgrading may not work for {productName} {productMajorVersion}
+Upgrading may not work for {productName} {product-majorVersion}
 ====
 
 
@@ -657,7 +657,7 @@ Upgrading may not work for {productName} {productMajorVersion}
 
 === Features Available Only in the Full Platform
 
-The following features of {productName} {productMajorVersion} are available only in the
+The following features of {productName} {product-majorVersion} are available only in the
 Full Platform:
 
 * EJB features that make up the full EJB 3.2 API, such as remote EJB
@@ -681,14 +681,14 @@ related to web services are ignored.
 Connector modules that use only outbound communication features and
 work-management that does not involve inbound communication features are
 supported in the Web Profile. Other connector features are supported
-only in the {productName} {productMajorVersion} full platform.
+only in the {productName} {product-majorVersion} full platform.
 
 [[java-ee-standards-support]]
 
 === Jakarta EE Standards Support
 
 xref:#gjxcp[Table 1-4] lists the Jakarta EE standards implemented in
-{productName} {productMajorVersion}. The table also indicates the distributions in
+{productName} {product-majorVersion}. The table also indicates the distributions in
 which the implementation of a standard is available.
 
 * X indicates that the implementation is available in the distribution.
@@ -697,11 +697,11 @@ distribution.
 
 [[gjxcp]]
 
-Table 1-4 Jakarta EE Standards Implementations in {productName} {productMajorVersion}
+Table 1-4 Jakarta EE Standards Implementations in {productName} {product-majorVersion}
 
 [width="100%",cols="<48%,<10%,<10%,<10%",options="header",]
 |===
-|Jakarta EE Standard |Version |{productName} {productMajorVersion} Full Platform |{productName} {productMajorVersion} Web Profile
+|Jakarta EE Standard |Version |{productName} {product-majorVersion} Full Platform |{productName} {product-majorVersion} Web Profile
 
 |https://jakarta.ee/specifications/platform/10/[Jakarta EE Specification]
 |10
@@ -901,7 +901,7 @@ Table 1-4 Jakarta EE Standards Implementations in {productName} {productMajorVer
 
 ^*^ Standalone Connector 1.7 Container only.
 
-Building on these standards, {productName} {productMajorVersion} provides a number of
+Building on these standards, {productName} {product-majorVersion} provides a number of
 extensions, including the following:
 
 * Ajax (asynchronous JavaScript and XML): Retrieves and displays new
@@ -917,7 +917,7 @@ extensions, including the following:
 
 === How to Report Problems and Provide Feedback
 
-If you have problems with {productName} {productMajorVersion}, provide feedback through
+If you have problems with {productName} {product-majorVersion}, provide feedback through
 one of the following mechanisms:
 
 * https://javaee.groups.io/g/glassfish[{productName} forum]

--- a/docs/release-notes/src/main/asciidoc/title.adoc
+++ b/docs/release-notes/src/main/asciidoc/title.adoc
@@ -1,31 +1,31 @@
 type=page
 status=published
-title={productName} Release Notes, Release 7
+title={productName} Release Notes, Release {productMajorVersion}
 next=preface.html
 prev=toc.html
 ~~~~~~
 
-= {productName} Release Notes, Release 7
+= {productName} Release Notes, Release {productMajorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Release Notes
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
-These Release Notes provide late-breaking information about {productName} 7
+These Release Notes provide late-breaking information about {productName} {productMajorVersion}
 software and documentation. Also included are a summary of
-new product features in the 7 release, and descriptions and
+new product features in the {productMajorVersion} release, and descriptions and
 workarounds for known issues and limitations.
 
 [[sthref1]]
 
 '''''
 
-{productName} Release Notes, Release 7
+{productName} Release Notes, Release {productMajorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/release-notes/src/main/asciidoc/title.adoc
+++ b/docs/release-notes/src/main/asciidoc/title.adoc
@@ -1,31 +1,31 @@
 type=page
 status=published
-title={productName} Release Notes, Release {productMajorVersion}
+title={productName} Release Notes, Release {product-majorVersion}
 next=preface.html
 prev=toc.html
 ~~~~~~
 
-= {productName} Release Notes, Release {productMajorVersion}
+= {productName} Release Notes, Release {product-majorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Release Notes
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
-These Release Notes provide late-breaking information about {productName} {productMajorVersion}
+These Release Notes provide late-breaking information about {productName} {product-majorVersion}
 software and documentation. Also included are a summary of
-new product features in the {productMajorVersion} release, and descriptions and
+new product features in the {product-majorVersion} release, and descriptions and
 workarounds for known issues and limitations.
 
 [[sthref1]]
 
 '''''
 
-{productName} Release Notes, Release {productMajorVersion}
+{productName} Release Notes, Release {product-majorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/security-guide/src/main/asciidoc/preface.adoc
+++ b/docs/security-guide/src/main/asciidoc/preface.adoc
@@ -30,7 +30,7 @@ instructions for configuring and administering {productName} security.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -176,7 +176,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/security-guide/src/main/asciidoc/preface.adoc
+++ b/docs/security-guide/src/main/asciidoc/preface.adoc
@@ -30,7 +30,7 @@ instructions for configuring and administering {productName} security.
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -176,7 +176,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/security-guide/src/main/asciidoc/system-security.adoc
+++ b/docs/security-guide/src/main/asciidoc/system-security.adoc
@@ -873,7 +873,7 @@ environment.
 
 ===== Custom Authentication of Client Certificate in SSL Mutual Authentication
 
-Release {productMajorVersion} of {productName} extends the Certificate realm to allow
+Release {product-majorVersion} of {productName} extends the Certificate realm to allow
 custom authentication and group assignment based on the client
 certificate received as part of SSL mutual (two-way) authentication.
 
@@ -1268,7 +1268,7 @@ passwords are not echoed to the display.
 
 [NOTE]
 ====
-For the zip bundle of {productName} {productMajorVersion}, the default administrator
+For the zip bundle of {productName} {product-majorVersion}, the default administrator
 login is `admin`, with no password, which means that no login is
 required. For {productName}, you are prompted to provide a
 password for the `admin` user when you start the domain for the first
@@ -1672,7 +1672,7 @@ Command delete-audit-module executed successfully.
 
 === Administering JSSE Certificates
 
-In the developer profile, the {productName} {productMajorVersion} uses the JSSE format
+In the developer profile, the {productName} {product-majorVersion} uses the JSSE format
 on the server side to manage certificates and key stores. In all
 profiles, the client side (appclient or stand-alone) uses the JSSE
 format.

--- a/docs/security-guide/src/main/asciidoc/system-security.adoc
+++ b/docs/security-guide/src/main/asciidoc/system-security.adoc
@@ -873,7 +873,7 @@ environment.
 
 ===== Custom Authentication of Client Certificate in SSL Mutual Authentication
 
-Release 7 of {productName} extends the Certificate realm to allow
+Release {productMajorVersion} of {productName} extends the Certificate realm to allow
 custom authentication and group assignment based on the client
 certificate received as part of SSL mutual (two-way) authentication.
 
@@ -1268,7 +1268,7 @@ passwords are not echoed to the display.
 
 [NOTE]
 ====
-For the zip bundle of {productName} 7, the default administrator
+For the zip bundle of {productName} {productMajorVersion}, the default administrator
 login is `admin`, with no password, which means that no login is
 required. For {productName}, you are prompted to provide a
 password for the `admin` user when you start the domain for the first
@@ -1672,7 +1672,7 @@ Command delete-audit-module executed successfully.
 
 === Administering JSSE Certificates
 
-In the developer profile, the {productName} 7 uses the JSSE format
+In the developer profile, the {productName} {productMajorVersion} uses the JSSE format
 on the server side to manage certificates and key stores. In all
 profiles, the client side (appclient or stand-alone) uses the JSSE
 format.

--- a/docs/troubleshooting-guide/src/main/asciidoc/preface.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ This guide describes common problems that you might encounter when using
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -174,7 +174,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/troubleshooting-guide/src/main/asciidoc/preface.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/preface.adoc
@@ -29,7 +29,7 @@ This guide describes common problems that you might encounter when using
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -174,7 +174,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/troubleshooting-guide/src/main/asciidoc/specific-issues.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/specific-issues.adoc
@@ -10,7 +10,7 @@ prev=overview.html
 [[specific-issues]]
 == 2 Specific Issues
 
-This chapter lists problems that you might encounter when using {productName} 7. The following topics are addressed:
+This chapter lists problems that you might encounter when using {productName} {productMajorVersion}. The following topics are addressed:
 
 * xref:#cannot-access-local-server-httplocalhost8080[Cannot Access Local Server (`http://localhost:8080`)]
 * xref:#cannot-access-remote-server[Cannot Access Remote Server]

--- a/docs/troubleshooting-guide/src/main/asciidoc/specific-issues.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/specific-issues.adoc
@@ -10,7 +10,7 @@ prev=overview.html
 [[specific-issues]]
 == 2 Specific Issues
 
-This chapter lists problems that you might encounter when using {productName} {productMajorVersion}. The following topics are addressed:
+This chapter lists problems that you might encounter when using {productName} {product-majorVersion}. The following topics are addressed:
 
 * xref:#cannot-access-local-server-httplocalhost8080[Cannot Access Local Server (`http://localhost:8080`)]
 * xref:#cannot-access-remote-server[Cannot Access Remote Server]

--- a/docs/upgrade-guide/src/main/asciidoc/preface.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/preface.adoc
@@ -20,7 +20,7 @@ and applications that are to be migrated.
 
 [NOTE]
 ====
-The main thrust of the {productName} 7 release
+The main thrust of the {productName} {productMajorVersion} release
 is to provide an application server for developers to explore and begin
 exploiting the new and updated technologies in the Jakarta EE 10 platform.
 Thus, the upgrade feature of {productName} was not a focus of this
@@ -31,7 +31,7 @@ properly with some of the new features added in support of the Jakarta EE 10 pla
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} 7 is developed through the GlassFish project
+{productName} {productMajorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -176,7 +176,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} 7, including Jakarta EE
+* The API specification for {productName} {productMajorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/upgrade-guide/src/main/asciidoc/preface.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/preface.adoc
@@ -20,7 +20,7 @@ and applications that are to be migrated.
 
 [NOTE]
 ====
-The main thrust of the {productName} {productMajorVersion} release
+The main thrust of the {productName} {product-majorVersion} release
 is to provide an application server for developers to explore and begin
 exploiting the new and updated technologies in the Jakarta EE 10 platform.
 Thus, the upgrade feature of {productName} was not a focus of this
@@ -31,7 +31,7 @@ properly with some of the new features added in support of the Jakarta EE 10 pla
 This preface contains information about and conventions for the entire
 {productName} ({productName}) documentation set.
 
-{productName} {productMajorVersion} is developed through the GlassFish project
+{productName} {product-majorVersion} is developed through the GlassFish project
 open-source community at https://github.com/eclipse-ee4j/glassfish.
 The GlassFish project provides a structured process for developing the
 {productName} platform that makes the new features of the Jakarta EE
@@ -176,7 +176,7 @@ Javadoc tool reference documentation for packages that are provided with
 * The Jakarta EE specifications and API specification is
 located at https://jakarta.ee/specifications/.
 
-* The API specification for {productName} {productMajorVersion}, including Jakarta EE
+* The API specification for {productName} {product-majorVersion}, including Jakarta EE
 platform packages and nonplatform packages that are specific to the
 {productName} product, is located at
 https://glassfish.org/docs/.

--- a/docs/upgrade-guide/src/main/asciidoc/title.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/title.adoc
@@ -1,31 +1,31 @@
 type=page
 status=published
-title={productName} Upgrade Guide, Release {productMajorVersion}
+title={productName} Upgrade Guide, Release {product-majorVersion}
 next=preface.html
 prev=lot.html
 ~~~~~~
 
-= {productName} Upgrade Guide, Release {productMajorVersion}
+= {productName} Upgrade Guide, Release {product-majorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Upgrade Guide
 
-Release {productMajorVersion}
+Release {product-majorVersion}
 
 Contributed 2018 - 2024
 
-This guide explains how to upgrade to {productName} {productMajorVersion}
+This guide explains how to upgrade to {productName} {product-majorVersion}
 from previous {productName} and Sun GlassFish Enterprise
 Server product releases. Also included in this guide are instructions
 for upgrading configuration data and Jakarta EE applications from
 binary-compatible earlier versions of this software to work with
-{productName} {productMajorVersion}. Finally, this guide describes
+{productName} {product-majorVersion}. Finally, this guide describes
 compatibility issues that affect data and applications that are to be
 migrated.
 
-Note: The main thrust of the {productName} {productMajorVersion}
+Note: The main thrust of the {productName} {product-majorVersion}
 release is to provide an application server for developers to explore
 and begin exploiting the new and updated technologies in the Jakarta EE 10
 platform. Thus, the upgrade feature of {productName} was not a focus
@@ -37,7 +37,7 @@ Jakarta EE 10 platform.
 
 '''''
 
-{productName} Upgrade Guide, Release {productMajorVersion}
+{productName} Upgrade Guide, Release {product-majorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/upgrade-guide/src/main/asciidoc/title.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/title.adoc
@@ -1,31 +1,31 @@
 type=page
 status=published
-title={productName} Upgrade Guide, Release 7
+title={productName} Upgrade Guide, Release {productMajorVersion}
 next=preface.html
 prev=lot.html
 ~~~~~~
 
-= {productName} Upgrade Guide, Release 7
+= {productName} Upgrade Guide, Release {productMajorVersion}
 
 [[eclipse-glassfish-server]]
 == {productName}
 
 Upgrade Guide
 
-Release 7
+Release {productMajorVersion}
 
 Contributed 2018 - 2024
 
-This guide explains how to upgrade to {productName} 7
+This guide explains how to upgrade to {productName} {productMajorVersion}
 from previous {productName} and Sun GlassFish Enterprise
 Server product releases. Also included in this guide are instructions
 for upgrading configuration data and Jakarta EE applications from
 binary-compatible earlier versions of this software to work with
-{productName} 7. Finally, this guide describes
+{productName} {productMajorVersion}. Finally, this guide describes
 compatibility issues that affect data and applications that are to be
 migrated.
 
-Note: The main thrust of the {productName} 7
+Note: The main thrust of the {productName} {productMajorVersion}
 release is to provide an application server for developers to explore
 and begin exploiting the new and updated technologies in the Jakarta EE 10
 platform. Thus, the upgrade feature of {productName} was not a focus
@@ -37,7 +37,7 @@ Jakarta EE 10 platform.
 
 '''''
 
-{productName} Upgrade Guide, Release 7
+{productName} Upgrade Guide, Release {productMajorVersion}
 
 Copyright © 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/upgrade-guide/src/main/asciidoc/upgrade-compatibility-issues.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/upgrade-compatibility-issues.adoc
@@ -10,15 +10,15 @@ prev=preface.html
 [[glassfish-server-upgrade-compatibility-issues]]
 == 1 {productName} Upgrade Compatibility Issues
 
-This section describes some compatibility issues between {productName} 7 and earlier product releases. This section also describes
+This section describes some compatibility issues between {productName} {productMajorVersion} and earlier product releases. This section also describes
 some compatibility issues that affect Java applications that run on
-earlier product releases with which {productName} 7 is
-binary-compatible. When you upgrade to {productName} 7, you must
+earlier product releases with which {productName} {productMajorVersion} is
+binary-compatible. When you upgrade to {productName} {productMajorVersion}, you must
 address these issues.
 
 The following topics are addressed here:
 
-* xref:#binary-compatible-releases-for-glassfish-server[Binary-Compatible Releases For {productName} 7]
+* xref:#binary-compatible-releases-for-glassfish-server[Binary-Compatible Releases For {productName} {productMajorVersion}]
 * xref:#new-default-installation-directory[New Default Installation Directory]
 * xref:#changes-to-group-management-service-settings[Changes to Group Management Service Settings]
 * xref:#application-client-interoperability[Application Client Interoperability]
@@ -32,9 +32,9 @@ The following topics are addressed here:
 
 [[binary-compatible-releases-for-glassfish-server]]
 
-=== Binary-Compatible Releases For {productName} 7
+=== Binary-Compatible Releases For {productName} {productMajorVersion}
 
-{productName} 7 is NOT binary-compatible with the earlier releases of the software:
+{productName} {productMajorVersion} is NOT binary-compatible with the earlier releases of the software:
 
 * Sun GlassFish Enterprise Server v2.1.1 (Enterprise and Developer Profiles)
 * Sun GlassFish Enterprise Server v3
@@ -45,7 +45,7 @@ The following topics are addressed here:
 * GlassFish Server Open Source Edition 5.x
 * Eclipse GlassFish 6.x
 
-Java applications that run on these releases also work on {productName} 7 except for the compatibility issues that
+Java applications that run on these releases also work on {productName} {productMajorVersion} except for the compatibility issues that
 are listed in the remainder of this chapter.
 
 
@@ -54,7 +54,7 @@ are listed in the remainder of this chapter.
 The compatibility issues that are listed in the remainder of this
 chapter do not affect Java applications that run on Sun GlassFish
 Enterprise Server v3 and {productName} 3.0.1. The differences between
-{productName} 7 and the Enterprise Server v3 releases do not affect
+{productName} {productMajorVersion} and the Enterprise Server v3 releases do not affect
 applications and data.
 ====
 
@@ -63,7 +63,7 @@ applications and data.
 
 === New Default Installation Directory
 
-The default {productName} 7 installation directories are as follows:
+The default {productName} {productMajorVersion} installation directories are as follows:
 
 Solaris, Linux, and Mac OS X systems::
 [source]
@@ -120,13 +120,13 @@ access to EJB JAR files or other JAR files in the EAR file unless they
 use a `Class-Path` header in the manifest file, or unless references use
 the standard Java SE mechanisms (extensions, for example), or use the
 Jakarta EE `library-directory` mechanism. Deployed Jakarta EE 5 applications
-that are upgraded to {productName} 7 will have the `compatibility`
-property set to `v2` and will run without change on {productName} 7.
+that are upgraded to {productName} {productMajorVersion} will have the `compatibility`
+property set to `v2` and will run without change on {productName} {productMajorVersion}.
 You may, however, want to consider modifying the applications to
 conform to Jakarta EE 6 requirements.
 
 If your upgrade includes a deployed application with an application
-client, you will need to retrieve the client stubs using {productName} 7 in order to run the client. Use the
+client, you will need to retrieve the client stubs using {productName} {productMajorVersion} in order to run the client. Use the
 `asadmin get-client-stubs` command.
 
 If you try to run the application client before retrieving the client
@@ -139,13 +139,13 @@ Invalid or corrupt jarfile jar-file-name
 
 If you commonly distribute application clients to remote systems from
 which users will run them, you must not only retrieve the client stubs,
-but you must also run the `package-appclient` utility for {productName} 7 to upgrade the {productName} system files. This utility
+but you must also run the `package-appclient` utility for {productName} {productMajorVersion} to upgrade the {productName} system files. This utility
 creates a JAR file, which you can then expand on the remote systems.
 
 Application clients use EJBs, web services, or other enterprise
 components that are in the application server (on the server side). The
 application client and the application server must use the same version
-and implementation of the RMI-IIOP protocol. {productName} 7 does
+and implementation of the RMI-IIOP protocol. {productName} {productMajorVersion} does
 not support communication between different versions of the protocol
 implementation. You cannot run application clients with one version of
 the application server runtime with a server that has a different
@@ -163,7 +163,7 @@ clients and servers synchronized and using the same runtime.
 
 === Node Agent Support
 
-{productName} 7 does not support node agents. When updating from
+{productName} {productMajorVersion} does not support node agents. When updating from
 installations of earlier product versions in which node agents were
 configured, the cluster definitions will be migrated, but the clustered
 instances themselves must be manually re-created. See
@@ -174,9 +174,9 @@ Agent Configurations] for more information.
 
 === HADB and `hadbm` Command Support
 
-{productName} 7 does not support HADB or the `hadbm` management command.
+{productName} {productMajorVersion} does not support HADB or the `hadbm` management command.
 
-Instead of HADB, {productName} 7 supports high availability
+Instead of HADB, {productName} {productMajorVersion} supports high availability
 clustering by means of in-memory session state replication and
 ActiveCache for GlassFish.
 See "xref:ha-administration-guide.adoc#high-availability-in-glassfish-server[
@@ -200,7 +200,7 @@ xref:reference-manual.adoc#GSRFM[{productName} Reference Manual].
 
 ==== Deprecated `asadmin` Subcommands
 
-In {productName} 7, it is recommended that utility options of the
+In {productName} {productMajorVersion}, it is recommended that utility options of the
 `asadmin` command precede the subcommand. Utility options are options
 that control the behavior of the `asadmin` utility, as distinguished
 from subcommand options. Use of the following options after the
@@ -334,10 +334,10 @@ Replaced by an operand in the `list-custom-resources` subcommand and the
 
 === Applications That Use Java DB
 
-The directory location of Java DB in {productName} 7 has changed
+The directory location of Java DB in {productName} {productMajorVersion} has changed
 from its location in previous installations. Suppose that you have
 deployed applications that use Java DB databases in your previous server
-installation, and you upgrade your existing installation to {productName} 7. If you run the `asadmin start-database` command and
+installation, and you upgrade your existing installation to {productName} {productMajorVersion}. If you run the `asadmin start-database` command and
 successfully start Java DB, you could run into problems while trying to
 run applications that were deployed on your previous server
 installation.
@@ -356,19 +356,19 @@ For example:
 ----
 asadmin start-database --dbhome c:\glassfish\databases
 ----
-2. After upgrade, start {productName} 7.
+2. After upgrade, start {productName} {productMajorVersion}.
 
 [[applications-that-use-persistence]]
 
 === Applications That Use Persistence
 
-{productName} 7 and 3.0.1, and Sun GlassFish Enterprise Server v3
+{productName} {productMajorVersion} and 3.0.1, and Sun GlassFish Enterprise Server v3
 use the persistence provider EclipseLink, while earlier versions used
 TopLink Essentials.
 
 An application that uses the container to create an `EntityManager` or
 `EntityManagerFactory` and that used Toplink Essentials as its provider
-will work in {productName} 7. The container creates an
+will work in {productName} {productMajorVersion}. The container creates an
 `EntityManager` if the application uses the `@PersistenceContext`
 annotation to inject an `EntityManager`, as in the following example:
 
@@ -390,7 +390,7 @@ EntityManagerFactory emf;
 EntityManager em = emf.createEntityManager();
 ----
 
-When the application is loaded, {productName} 7 will translate the
+When the application is loaded, {productName} {productMajorVersion} will translate the
 provider to EclipseLink and will also translate `toplink.*` properties
 in the `persistence.xml` to corresponding EclipseLink properties. (The
 actual `persistence.xml` file remains unchanged.)
@@ -423,14 +423,14 @@ the code to cast to `org.eclipse.persistence.*`. You can use the package
 renamer tool described on the
 http://wiki.eclipse.org/EclipseLink/Examples/MigratingFromOracleTopLink#Rename_Packages[
 Eclipse wiki]
-to do this. This tool is not provided with {productName} 7,
+to do this. This tool is not provided with {productName} {productMajorVersion},
 however, so you must obtain it from the EclipseLink project download site.
 
 [[http-service-to-network-service-changes]]
 
 === HTTP Service to Network Service Changes
 
-In {productName} 7, most HTTP Service settings are defined in the
+In {productName} {productMajorVersion}, most HTTP Service settings are defined in the
 Network Service configuration that was introduced in Sun GlassFish
 Enterprise Server v3.
 
@@ -446,7 +446,7 @@ The changes are described in the following sections.
 ==== Changes to Dotted Names
 
 The dotted name hierarchy for the HTTP Service configuration in
-{productName} 7 is shown below. Elements that are no longer
+{productName} {productMajorVersion} is shown below. Elements that are no longer
 supported are `request-processing`, `keep-alive`, `connection-pool`,
 `http-protocol`, `http-file-cache`, and `http-listener`. During the
 upgrade process, these discontinued elements are remapped to the new
@@ -473,7 +473,7 @@ config
         thread-pool
 ----
 
-The dotted name hierarchy for the {productName} 7 Network Service
+The dotted name hierarchy for the {productName} {productMajorVersion} Network Service
 and HTTP Service configurations is shown below. The `network-config`
 element and all its children are new except for `ssl`.
 
@@ -507,7 +507,7 @@ config
 ----
 
 The following example compares the commands for setting a listener port
-for Sun GlassFish Enterprise Server v3 and {productName} 7. Note
+for Sun GlassFish Enterprise Server v3 and {productName} {productMajorVersion}. Note
 that the configuration for Enterprise Server v3 also applies to all
 earlier Enterprise Server 2.x releases.
 
@@ -517,7 +517,7 @@ earlier Enterprise Server 2.x releases.
 ----
 asadmin set server-config.http-service.http-listener.http-1.listenerport=4321
 ----
-* Command for {productName} 7:
+* Command for {productName} {productMajorVersion}:
 +
 [source]
 ----
@@ -546,7 +546,7 @@ options of this commands are unchanged.
 ==== Remapping of HTTP Service Attributes and Properties
 
 The following tables describe how attributes and properties in the HTTP
-Service configuration for {productName} 7 are remapped to
+Service configuration for {productName} {productMajorVersion} are remapped to
 attributes in the Network Service configuration for older product
 releases. If you use a configuration from a Sun GlassFish Enterprise
 Server v2 or v3 release, this remapping happens automatically and then
@@ -1064,8 +1064,8 @@ xref:#gipfn[Table 1-4], xref:#gipev[Table 1-6], and xref:#gipdo[Table
 
 === NSS Cryptographic Token Support
 
-{productName} 7 does not support Network Security Services (NSS)
-cryptographic tokens. When upgrading to {productName} 7 from
+{productName} {productMajorVersion} does not support Network Security Services (NSS)
+cryptographic tokens. When upgrading to {productName} {productMajorVersion} from
 Enterprise Server v2.x, additional manual configuration steps must be
 performed. These steps are explained later in this guide, in
 xref:upgrading-legacy-installation.adoc#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading Installations

--- a/docs/upgrade-guide/src/main/asciidoc/upgrade-compatibility-issues.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/upgrade-compatibility-issues.adoc
@@ -10,15 +10,15 @@ prev=preface.html
 [[glassfish-server-upgrade-compatibility-issues]]
 == 1 {productName} Upgrade Compatibility Issues
 
-This section describes some compatibility issues between {productName} {productMajorVersion} and earlier product releases. This section also describes
+This section describes some compatibility issues between {productName} {product-majorVersion} and earlier product releases. This section also describes
 some compatibility issues that affect Java applications that run on
-earlier product releases with which {productName} {productMajorVersion} is
-binary-compatible. When you upgrade to {productName} {productMajorVersion}, you must
+earlier product releases with which {productName} {product-majorVersion} is
+binary-compatible. When you upgrade to {productName} {product-majorVersion}, you must
 address these issues.
 
 The following topics are addressed here:
 
-* xref:#binary-compatible-releases-for-glassfish-server[Binary-Compatible Releases For {productName} {productMajorVersion}]
+* xref:#binary-compatible-releases-for-glassfish-server[Binary-Compatible Releases For {productName} {product-majorVersion}]
 * xref:#new-default-installation-directory[New Default Installation Directory]
 * xref:#changes-to-group-management-service-settings[Changes to Group Management Service Settings]
 * xref:#application-client-interoperability[Application Client Interoperability]
@@ -32,9 +32,9 @@ The following topics are addressed here:
 
 [[binary-compatible-releases-for-glassfish-server]]
 
-=== Binary-Compatible Releases For {productName} {productMajorVersion}
+=== Binary-Compatible Releases For {productName} {product-majorVersion}
 
-{productName} {productMajorVersion} is NOT binary-compatible with the earlier releases of the software:
+{productName} {product-majorVersion} is NOT binary-compatible with the earlier releases of the software:
 
 * Sun GlassFish Enterprise Server v2.1.1 (Enterprise and Developer Profiles)
 * Sun GlassFish Enterprise Server v3
@@ -45,7 +45,7 @@ The following topics are addressed here:
 * GlassFish Server Open Source Edition 5.x
 * Eclipse GlassFish 6.x
 
-Java applications that run on these releases also work on {productName} {productMajorVersion} except for the compatibility issues that
+Java applications that run on these releases also work on {productName} {product-majorVersion} except for the compatibility issues that
 are listed in the remainder of this chapter.
 
 
@@ -54,7 +54,7 @@ are listed in the remainder of this chapter.
 The compatibility issues that are listed in the remainder of this
 chapter do not affect Java applications that run on Sun GlassFish
 Enterprise Server v3 and {productName} 3.0.1. The differences between
-{productName} {productMajorVersion} and the Enterprise Server v3 releases do not affect
+{productName} {product-majorVersion} and the Enterprise Server v3 releases do not affect
 applications and data.
 ====
 
@@ -63,7 +63,7 @@ applications and data.
 
 === New Default Installation Directory
 
-The default {productName} {productMajorVersion} installation directories are as follows:
+The default {productName} {product-majorVersion} installation directories are as follows:
 
 Solaris, Linux, and Mac OS X systems::
 [source]
@@ -120,13 +120,13 @@ access to EJB JAR files or other JAR files in the EAR file unless they
 use a `Class-Path` header in the manifest file, or unless references use
 the standard Java SE mechanisms (extensions, for example), or use the
 Jakarta EE `library-directory` mechanism. Deployed Jakarta EE 5 applications
-that are upgraded to {productName} {productMajorVersion} will have the `compatibility`
-property set to `v2` and will run without change on {productName} {productMajorVersion}.
+that are upgraded to {productName} {product-majorVersion} will have the `compatibility`
+property set to `v2` and will run without change on {productName} {product-majorVersion}.
 You may, however, want to consider modifying the applications to
 conform to Jakarta EE 6 requirements.
 
 If your upgrade includes a deployed application with an application
-client, you will need to retrieve the client stubs using {productName} {productMajorVersion} in order to run the client. Use the
+client, you will need to retrieve the client stubs using {productName} {product-majorVersion} in order to run the client. Use the
 `asadmin get-client-stubs` command.
 
 If you try to run the application client before retrieving the client
@@ -139,13 +139,13 @@ Invalid or corrupt jarfile jar-file-name
 
 If you commonly distribute application clients to remote systems from
 which users will run them, you must not only retrieve the client stubs,
-but you must also run the `package-appclient` utility for {productName} {productMajorVersion} to upgrade the {productName} system files. This utility
+but you must also run the `package-appclient` utility for {productName} {product-majorVersion} to upgrade the {productName} system files. This utility
 creates a JAR file, which you can then expand on the remote systems.
 
 Application clients use EJBs, web services, or other enterprise
 components that are in the application server (on the server side). The
 application client and the application server must use the same version
-and implementation of the RMI-IIOP protocol. {productName} {productMajorVersion} does
+and implementation of the RMI-IIOP protocol. {productName} {product-majorVersion} does
 not support communication between different versions of the protocol
 implementation. You cannot run application clients with one version of
 the application server runtime with a server that has a different
@@ -163,7 +163,7 @@ clients and servers synchronized and using the same runtime.
 
 === Node Agent Support
 
-{productName} {productMajorVersion} does not support node agents. When updating from
+{productName} {product-majorVersion} does not support node agents. When updating from
 installations of earlier product versions in which node agents were
 configured, the cluster definitions will be migrated, but the clustered
 instances themselves must be manually re-created. See
@@ -174,9 +174,9 @@ Agent Configurations] for more information.
 
 === HADB and `hadbm` Command Support
 
-{productName} {productMajorVersion} does not support HADB or the `hadbm` management command.
+{productName} {product-majorVersion} does not support HADB or the `hadbm` management command.
 
-Instead of HADB, {productName} {productMajorVersion} supports high availability
+Instead of HADB, {productName} {product-majorVersion} supports high availability
 clustering by means of in-memory session state replication and
 ActiveCache for GlassFish.
 See "xref:ha-administration-guide.adoc#high-availability-in-glassfish-server[
@@ -200,7 +200,7 @@ xref:reference-manual.adoc#GSRFM[{productName} Reference Manual].
 
 ==== Deprecated `asadmin` Subcommands
 
-In {productName} {productMajorVersion}, it is recommended that utility options of the
+In {productName} {product-majorVersion}, it is recommended that utility options of the
 `asadmin` command precede the subcommand. Utility options are options
 that control the behavior of the `asadmin` utility, as distinguished
 from subcommand options. Use of the following options after the
@@ -334,10 +334,10 @@ Replaced by an operand in the `list-custom-resources` subcommand and the
 
 === Applications That Use Java DB
 
-The directory location of Java DB in {productName} {productMajorVersion} has changed
+The directory location of Java DB in {productName} {product-majorVersion} has changed
 from its location in previous installations. Suppose that you have
 deployed applications that use Java DB databases in your previous server
-installation, and you upgrade your existing installation to {productName} {productMajorVersion}. If you run the `asadmin start-database` command and
+installation, and you upgrade your existing installation to {productName} {product-majorVersion}. If you run the `asadmin start-database` command and
 successfully start Java DB, you could run into problems while trying to
 run applications that were deployed on your previous server
 installation.
@@ -356,19 +356,19 @@ For example:
 ----
 asadmin start-database --dbhome c:\glassfish\databases
 ----
-2. After upgrade, start {productName} {productMajorVersion}.
+2. After upgrade, start {productName} {product-majorVersion}.
 
 [[applications-that-use-persistence]]
 
 === Applications That Use Persistence
 
-{productName} {productMajorVersion} and 3.0.1, and Sun GlassFish Enterprise Server v3
+{productName} {product-majorVersion} and 3.0.1, and Sun GlassFish Enterprise Server v3
 use the persistence provider EclipseLink, while earlier versions used
 TopLink Essentials.
 
 An application that uses the container to create an `EntityManager` or
 `EntityManagerFactory` and that used Toplink Essentials as its provider
-will work in {productName} {productMajorVersion}. The container creates an
+will work in {productName} {product-majorVersion}. The container creates an
 `EntityManager` if the application uses the `@PersistenceContext`
 annotation to inject an `EntityManager`, as in the following example:
 
@@ -390,7 +390,7 @@ EntityManagerFactory emf;
 EntityManager em = emf.createEntityManager();
 ----
 
-When the application is loaded, {productName} {productMajorVersion} will translate the
+When the application is loaded, {productName} {product-majorVersion} will translate the
 provider to EclipseLink and will also translate `toplink.*` properties
 in the `persistence.xml` to corresponding EclipseLink properties. (The
 actual `persistence.xml` file remains unchanged.)
@@ -423,14 +423,14 @@ the code to cast to `org.eclipse.persistence.*`. You can use the package
 renamer tool described on the
 http://wiki.eclipse.org/EclipseLink/Examples/MigratingFromOracleTopLink#Rename_Packages[
 Eclipse wiki]
-to do this. This tool is not provided with {productName} {productMajorVersion},
+to do this. This tool is not provided with {productName} {product-majorVersion},
 however, so you must obtain it from the EclipseLink project download site.
 
 [[http-service-to-network-service-changes]]
 
 === HTTP Service to Network Service Changes
 
-In {productName} {productMajorVersion}, most HTTP Service settings are defined in the
+In {productName} {product-majorVersion}, most HTTP Service settings are defined in the
 Network Service configuration that was introduced in Sun GlassFish
 Enterprise Server v3.
 
@@ -446,7 +446,7 @@ The changes are described in the following sections.
 ==== Changes to Dotted Names
 
 The dotted name hierarchy for the HTTP Service configuration in
-{productName} {productMajorVersion} is shown below. Elements that are no longer
+{productName} {product-majorVersion} is shown below. Elements that are no longer
 supported are `request-processing`, `keep-alive`, `connection-pool`,
 `http-protocol`, `http-file-cache`, and `http-listener`. During the
 upgrade process, these discontinued elements are remapped to the new
@@ -473,7 +473,7 @@ config
         thread-pool
 ----
 
-The dotted name hierarchy for the {productName} {productMajorVersion} Network Service
+The dotted name hierarchy for the {productName} {product-majorVersion} Network Service
 and HTTP Service configurations is shown below. The `network-config`
 element and all its children are new except for `ssl`.
 
@@ -507,7 +507,7 @@ config
 ----
 
 The following example compares the commands for setting a listener port
-for Sun GlassFish Enterprise Server v3 and {productName} {productMajorVersion}. Note
+for Sun GlassFish Enterprise Server v3 and {productName} {product-majorVersion}. Note
 that the configuration for Enterprise Server v3 also applies to all
 earlier Enterprise Server 2.x releases.
 
@@ -517,7 +517,7 @@ earlier Enterprise Server 2.x releases.
 ----
 asadmin set server-config.http-service.http-listener.http-1.listenerport=4321
 ----
-* Command for {productName} {productMajorVersion}:
+* Command for {productName} {product-majorVersion}:
 +
 [source]
 ----
@@ -546,7 +546,7 @@ options of this commands are unchanged.
 ==== Remapping of HTTP Service Attributes and Properties
 
 The following tables describe how attributes and properties in the HTTP
-Service configuration for {productName} {productMajorVersion} are remapped to
+Service configuration for {productName} {product-majorVersion} are remapped to
 attributes in the Network Service configuration for older product
 releases. If you use a configuration from a Sun GlassFish Enterprise
 Server v2 or v3 release, this remapping happens automatically and then
@@ -1064,8 +1064,8 @@ xref:#gipfn[Table 1-4], xref:#gipev[Table 1-6], and xref:#gipdo[Table
 
 === NSS Cryptographic Token Support
 
-{productName} {productMajorVersion} does not support Network Security Services (NSS)
-cryptographic tokens. When upgrading to {productName} {productMajorVersion} from
+{productName} {product-majorVersion} does not support Network Security Services (NSS)
+cryptographic tokens. When upgrading to {productName} {product-majorVersion} from
 Enterprise Server v2.x, additional manual configuration steps must be
 performed. These steps are explained later in this guide, in
 xref:upgrading-legacy-installation.adoc#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading Installations

--- a/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
@@ -14,14 +14,14 @@ prev=upgrade-compatibility-issues.html
 This chapter is obsoleted and must be revided.
 ====
 
-The Upgrade Tool that is bundled with {productName} 7 replicates
+The Upgrade Tool that is bundled with {productName} {productMajorVersion} replicates
 the configuration of a previously installed server in the target
 installation. The Upgrade Tool assists in upgrading the configuration
 and applications from an earlier version of the Application Server or
-{productName} to {productName} 7.
+{productName} to {productName} {productMajorVersion}.
 
 In addition to Upgrade Tool, there are three Update Center tools that
-can be used to perform an in-place upgrade to {productName} 7 from
+can be used to perform an in-place upgrade to {productName} {productMajorVersion} from
 {productName} 3.1.1, 3.1, 3.0.1, and Enterprise Server v3. These
 three Update Center tools are:
 
@@ -33,7 +33,7 @@ Upgrade Tool and the three Update Center tools are explained later in
 this chapter.
 
 To view a list of the older versions from which you can upgrade, see
-xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} 7].
+xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}].
 
 The following topics are addressed here:
 
@@ -57,7 +57,7 @@ The following topics are addressed here:
 * xref:#upgrade-paths[Upgrade Paths]
 * xref:#upgrade-terminology[Upgrade Terminology]
 * xref:#summary-of-upgrade-tools-and-procedures[Summary of Upgrade Tools and Procedures]
-* xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} 7]
+* xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}]
 * xref:#GSUPG00063[Upgrading From Version 8.x or Older Product Releases]
 * xref:#upgrading-glassfish-server-inside-a-closed-network[Upgrading {productName} Inside a Closed Network]
 
@@ -65,7 +65,7 @@ The following topics are addressed here:
 
 ==== Upgrade Paths
 
-There are two general paths you can use when upgrading to {productName} 7:
+There are two general paths you can use when upgrading to {productName} {productMajorVersion}:
 
 Side-by-Side::
   A side-by-side upgrade means that the new {productName} release is
@@ -73,10 +73,10 @@ Side-by-Side::
   upgrading. +
   In this scenario, you perform the following steps:
 
-  1.  Perform a basic installation of {productName} 7 in a location
+  1.  Perform a basic installation of {productName} {productMajorVersion} in a location
   other than the one being used for the older product.
   2.  Use Upgrade Tool to migrate the old configurations and
-  applications to the new {productName} 7 directories.
+  applications to the new {productName} {productMajorVersion} directories.
   3.  Test the new {productName} installation to make sure everything
   is working properly.
   4.  When you are satisfied that the new installation works properly,
@@ -94,7 +94,7 @@ In-Place::
   installation. +
 In this scenario, you simply use Update Tool, the `pkg` utility, or
   the Update Notifier in your old installation to overwrite the old
-  installation with the new {productName} 7 product. +
+  installation with the new {productName} {productMajorVersion} product. +
   Performing an in-place upgrade is easier than performing a
   side-by-side upgrade, but you lose the ability to switch back and
   forth between the old and new installations. There is also no way to
@@ -133,8 +133,8 @@ Master Password::
 
 ==== Summary of Upgrade Tools and Procedures
 
-There are several tools you can use to upgrade from an earlier {productName} or Enterprise Server installation to {productName} 7. The
-general procedures for upgrading to {productName} 7 vary depending
+There are several tools you can use to upgrade from an earlier {productName} or Enterprise Server installation to {productName} {productMajorVersion}. The
+general procedures for upgrading to {productName} {productMajorVersion} vary depending
 on which tool you use and the product version from which you are upgrading.
 
 The following topics are addressed here:
@@ -149,7 +149,7 @@ The following topics are addressed here:
 
 ===== Summary of Tools for Performing an Upgrade
 
-There are several tools you can use to perform an upgrade to {productName} 7 are described below.
+There are several tools you can use to perform an upgrade to {productName} {productMajorVersion} are described below.
 
 * xref:#upgrade-tool[Upgrade Tool]
 * xref:#update-tool-and-the-pkg-utility[Update Tool and the `pkg` Utility]
@@ -161,19 +161,19 @@ Upgrade Tool
 
 The {productName} Upgrade Tool is tended solely for performing
 side-by-side upgrades from any compatible older product version to
-{productName} 7.
+{productName} {productMajorVersion}.
 
 Upgrade Tool provides a number of features that aid in the migration of
-older configurations and applications to a new {productName} 7
+older configurations and applications to a new {productName} {productMajorVersion}
 installation. These features are described in more detail in
 xref:#upgrade-tool-functionality[Upgrade Tool Functionality].
 
-In {productName} 7 Upgrade Tool is installed in the
+In {productName} {productMajorVersion} Upgrade Tool is installed in the
 as-install``/bin`` directory.
 
 [NOTE]
 ====
-Upgrade Tool is the only tool you can use when upgrading to {productName} 7 from product versions prior to {productName} 3.0.1 or
+Upgrade Tool is the only tool you can use when upgrading to {productName} {productMajorVersion} from product versions prior to {productName} 3.0.1 or
 Enterprise Server v3.
 ====
 
@@ -193,15 +193,15 @@ such as OSGi Admin Console.
 
 The command-line counterpart to Update Tool is the `pkg` utility. While
 the `pkg` utility does not provide exactly the same set of features as
-Update Tool, for the purposes of upgrading to {productName} 7, the
+Update Tool, for the purposes of upgrading to {productName} {productMajorVersion}, the
 `pkg` utility and Update Tool feature sets are almost identical.
 
 In addition to day-to-day maintenance tasks, Update Tool and the `pkg`
 utility can be used to perform an in-place upgrade of an entire
 {productName} 3.0.1 or Enterprise Server v3 installation to the
-{productName} 7 or later release.
+{productName} {productMajorVersion} or later release.
 
-In {productName} 7 Update Tool is installed in the
+In {productName} {productMajorVersion} Update Tool is installed in the
 as-install-parent``/bin`` directory.
 
 [NOTE]
@@ -229,7 +229,7 @@ Software Update tool to upgrade from product releases prior 3.0.1 and
 v3.
 
 The Software Update Notifier is distributed as a configuration option
-during {productName} 7, 3.0.1, and Enterprise Server v3
+during {productName} {productMajorVersion}, 3.0.1, and Enterprise Server v3
 installation. If installed and enabled, the Software Update Notifier
 monitors your installation and pops up a notification balloon when
 updates or upgrades are available for your product.
@@ -244,20 +244,20 @@ the Update Notifier, refer to the Update Tool online help.
 ===== Summary of Procedure for Upgrading With Upgrade Tool
 
 The general procedure for using Upgrade Tool to perform an upgrade to
-{productName} 7 from any compatible older version of {productName} or Enterprise Server comprises the following steps:
+{productName} {productMajorVersion} from any compatible older version of {productName} or Enterprise Server comprises the following steps:
 
-1. Download {productName} 7 and perform a Standard Installation,
+1. Download {productName} {productMajorVersion} and perform a Standard Installation,
 as described in "xref:installation-guide.adoc#GSING00007[
 To Install {productName} Using the Self-Extracting File]"
 in {productName} Installation Guide.
 2. Copy any custom or third-party libraries from the older installation
-to their corresponding locations in the new {productName} 7
+to their corresponding locations in the new {productName} {productMajorVersion}
 installation directories. Note that you should only copy custom or
 third-party libraries here. Do not copy an libraries from the actual
 domain that will be upgraded.
-3. Run the `asupgrade` command from the new {productName} 7
+3. Run the `asupgrade` command from the new {productName} {productMajorVersion}
 as-install``/bin`` directory.
-4. Start the new {productName} 7 DAS with the
+4. Start the new {productName} {productMajorVersion} DAS with the
 `asadmin start-domain` subcommand.
 
 This procedure is described in more detail in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a
@@ -268,14 +268,14 @@ Side-By-Side Upgrade With Upgrade Tool].
 ===== Summary of Procedure for Upgrading With Update Tool
 
 The general procedure for using Update Tool to perform an upgrade to
-{productName} 7 from {productName} 3.0.1 or Enterprise Server v3
+{productName} {productMajorVersion} from {productName} 3.0.1 or Enterprise Server v3
 comprises the following steps:
 
 1. Manually stop all server instances and the domain.
 2. Launch Update Tool by using the as-install-parent`/bin/updatetool`
 command in the older product directory.
 3. In Update Tool, select and install the latest {productName}
-product release. This updates your server to the 7 release.
+product release. This updates your server to the {productMajorVersion} release.
 4. Upgrade the domain by running the `asadmin start-domain --upgrade`
 subcommand. This performs the upgrade and then shuts down the DAS.
 5. Restart the DAS normally with the with the `asadmin start-domain`
@@ -289,7 +289,7 @@ Using the Update Tool GUI].
 ===== Summary of Procedure for Upgrading With the Software Update Notifier
 
 The general procedure for using the Software Update Notifier to perform
-an upgrade to {productName} 7 from {productName}3.0.1 or
+an upgrade to {productName} {productMajorVersion} from {productName}3.0.1 or
 Enterprise Server v3 comprises the following steps:
 
 1. Wait for the Software Update Notifier to pop up a notification
@@ -297,7 +297,7 @@ balloon informing you that updates are available.
 2. Click the balloon prompt to launch the Software Update GUI.
 3. Manually stop all server instances and the domain.
 4. Use the Software Update GUI to perform the upgrade. This updates
-your server to the 7 release.
+your server to the {productMajorVersion} release.
 5. Upgrade the domain by running the `asadmin start-domain --upgrade`
 subcommand. This performs the upgrade and then shuts down the DAS.
 6. Restart the upgraded DAS normally with the with the
@@ -311,12 +311,12 @@ Using the Software Update Notifier].
 ===== Summary of Procedure for Upgrading With the `pkg` Utility
 
 The general procedure for using the `pkg` utility to perform an upgrade
-to {productName} 7 from {productName}3.0.1 or Enterprise Server
+to {productName} {productMajorVersion} from {productName}3.0.1 or Enterprise Server
 v3 comprises the following steps:
 
 1. Manually stop all server instances and the domain.
 2. Run the as-install-parent`/bin/pkg` command with the desired options
-in the older product directory. This updates your server to the 7
+in the older product directory. This updates your server to the {productMajorVersion}
 release.
 3. Upgrade the domain by running the `asadmin start-domain --upgrade`
 subcommand. This performs the upgrade and then shuts down the DAS.
@@ -328,9 +328,9 @@ From the Command Line Using the `pkg` Utility].
 
 [[supported-releases-for-upgrade-to-glassfish-server-7]]
 
-==== Supported Releases for Upgrade to {productName} 7
+==== Supported Releases for Upgrade to {productName} {productMajorVersion}
 
-Upgrades to {productName} 7 are supported from the following
+Upgrades to {productName} {productMajorVersion} are supported from the following
 earlier {productName} product releases:
 
 * Sun GlassFish Enterprise Server v2.1.1
@@ -343,19 +343,19 @@ earlier {productName} product releases:
 
 ==== Upgrading From Version 8.x or Older Product Releases
 
-It is not possible to upgrade to {productName} 7 directly from Sun
+It is not possible to upgrade to {productName} {productMajorVersion} directly from Sun
 GlassFish Enterprise Server 8.x or older product releases.
 
 To upgrade from a product release that is older than any of those listed
-in xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} 7],
+in xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}],
 you must first upgrade your older product release to one of the releases
-that are supported for upgrade to {productName} 7.
+that are supported for upgrade to {productName} {productMajorVersion}.
 
 For example, to upgrade from any Enterprise Server 8.x release, you
 first need to upgrade that older release to Enterprise Server 2.1.1.
 That is, your upgrade path would be as follows:
 
-Enterprise Server 8.x⇒Enterprise Server 2.1.1⇒{productName} 7
+Enterprise Server 8.x⇒Enterprise Server 2.1.1⇒{productName} {productMajorVersion}
 
 Sun GlassFish Enterprise Server 2.1.1 is available for download from the
 http://glassfish.java.net/public/downloadsindex.html[GlassFish Community
@@ -367,7 +367,7 @@ GlassFish Enterprise Server 2.1.1 Upgrade Guide]
 
 After upgrading your older Enterprise Server installation to Enterprise
 Server 2.1.1, you can proceed normally with the instructions in this
-guide to complete the upgrade to {productName} 7.
+guide to complete the upgrade to {productName} {productMajorVersion}.
 
 [[upgrading-glassfish-server-inside-a-closed-network]]
 
@@ -384,7 +384,7 @@ in {productName} Administration Guide.
 === Performing a Side-By-Side Upgrade With Upgrade Tool
 
 This section explains how to use Upgrade Tool to perform a side-by-side
-upgrade to {productName} 7 from any compatible older product release.
+upgrade to {productName} {productMajorVersion} from any compatible older product release.
 
 The following topics are addressed here:
 
@@ -441,9 +441,9 @@ Additional Upgrade Tool functions are explained in the following sections:
 
 Application archives (EAR files) and component archives (JAR, WAR, and
 RAR files) that are deployed in the source server do not require any
-modification to run on {productName} 7.
-Components that may have incompatibilities are deployed on {productName} 7 with the `compatibility` property set to `v2` and will run
-without change on {productName} 7. You may, however, want to
+modification to run on {productName} {productMajorVersion}.
+Components that may have incompatibilities are deployed on {productName} {productMajorVersion} with the `compatibility` property set to `v2` and will run
+without change on {productName} {productMajorVersion}. You may, however, want to
 consider modifying the applications to conform to Jakarta EE 6 requirements.
 
 The Jakarta EE 6 platform specification imposes stricter requirements than
@@ -470,7 +470,7 @@ attempt to reconfigure the incorrect configurations.
 ===== Upgrade of Clusters
 
 When upgrading from a clustered configuration, the older cluster
-information is retained in a new `domain.xml` file in the {productName} 7 installation directories. However, it is still necessary to
+information is retained in a new `domain.xml` file in the {productName} {productMajorVersion} installation directories. However, it is still necessary to
 manually re-create the server instances that are contained in the
 clusters. This procedure is explained in xref:#upgrading-clusters-and-node-agent-configurations[Upgrading Clusters
 and Node Agent Configurations].
@@ -499,15 +499,15 @@ Command version executed successfully.
 ==== To Upgrade From the Command Line Using Upgrade Tool
 
 This procedure explains how to use the Upgrade Tool command line to
-upgrade to {productName} 7 from any supported older product release.
-See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} 7] for a list of supported releases.
+upgrade to {productName} {productMajorVersion} from any supported older product release.
+See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}] for a list of supported releases.
 
 Before You Begin
 
 Ensure that the domains on the source server from which you are
 upgrading are stopped before proceeding.
 
-1. Download and install {productName} 7 using the Typical
+1. Download and install {productName} {productMajorVersion} using the Typical
 Installation path. +
 See "xref:installation-guide.adoc#GSING00025[
 Installing {productName} From a Self-Extracting Bundle]"
@@ -525,7 +525,7 @@ as-install``/lib`` directory.
 +
 [NOTE]
 ====
-Use the Upgrade Tool that is located in the target {productName} 7
+Use the Upgrade Tool that is located in the target {productName} {productMajorVersion}
 installation, not the older source installation.
 ====
 +
@@ -585,7 +585,7 @@ If there are any `SEVERE` or `WARNING` messages in the `server.log`
 file, the upgrade output will say
 `"Possible error encountered during upgrade. See server log after upgrade process completes."`
 
-6. Start the upgraded {productName} 7 domain.
+6. Start the upgraded {productName} {productMajorVersion} domain.
 +
 [source]
 ----
@@ -596,7 +596,7 @@ used in the older server.
 +
 [NOTE]
 ====
-{productName} 7 does not support NSS authentication. If you are
+{productName} {productMajorVersion} does not support NSS authentication. If you are
 upgrading from a Enterprise Profile configuration that uses NSS
 authentication, follow the procedure in xref:#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading
 Installations That Use NSS Cryptographic Tokens].
@@ -611,7 +611,7 @@ Example 2-1 Using the `asupgrade` Command Line
 
 The following example shows how to use the `asupgrade` command-line
 utility in non-interactive mode to upgrade an existing Sun GlassFish
-Enterprise Server v2.1 installation to {productName} 7. The
+Enterprise Server v2.1 installation to {productName} {productMajorVersion}. The
 following command should be entered on a single line.
 
 [source]
@@ -647,7 +647,7 @@ short form, the long form, and a description of each option.
 
 |`-t` target-domains-directory
 |`--target` target-domains-directory
-|The desired domain-root-dir directory in the {productName} 7 target
+|The desired domain-root-dir directory in the {productName} {productMajorVersion} target
 installation; default is as-install``/domains``
 
 |`-f` password-file
@@ -659,9 +659,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir``/docroot/index.html`` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} 7 file
+the upgrade. You may want to copy the default {productName} {productMajorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} 7 installation.
+{productName} {productMajorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -672,15 +672,15 @@ click the Help button on the Administration Console.
 ==== To Upgrade Using the Upgrade Tool Wizard
 
 This procedure explains how to use the graphical Upgrade Tool Wizard to
-upgrade to {productName} 7 from any supported older product release.
-See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} 7] for a list of supported releases.
+upgrade to {productName} {productMajorVersion} from any supported older product release.
+See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}] for a list of supported releases.
 
 Before You Begin
 
 Ensure that the source domains from which you are upgrading are stopped
 before proceeding.
 
-1. Download and install {productName} 7 using the Typical Installation path. +
+1. Download and install {productName} {productMajorVersion} using the Typical Installation path. +
 See "xref:installation-guide.adoc#GSING00025[
 Installing {productName} From a Self-Extracting Bundle]"
 in {productName} Installation Guide for instructions.
@@ -697,7 +697,7 @@ operating environment.
 +
 [NOTE]
 ====
-Use the Upgrade Tool that is located in the target {productName} 7
+Use the Upgrade Tool that is located in the target {productName} {productMajorVersion}
 installation, not the older source installation.
 ====
 +
@@ -728,11 +728,11 @@ click Browse. +
 For example, you might type `c:\glassfish\domains\domain1`.
 
 5. In the Target Domains Root Directory field, type the location of the
-{productName} 7 installation to which to transfer the
+{productName} {productMajorVersion} installation to which to transfer the
 configuration, or click Browse. +
 The default is the full path name of the `domains` directory of your
-{productName} 7 installation (for example,
-`c:\glassfish7\glassfish\domains`).
+{productName} {productMajorVersion} installation (for example,
+`c:\glassfish{productMajorVersion}\glassfish\domains`).
 
 6. Provide the master password of the source application server. +
 The domain will be upgraded using these credentials. If you do not
@@ -740,7 +740,7 @@ specify a password here, the default master password is used.
 +
 [NOTE]
 ====
-{productName} 7 does not support NSS authentication. If you are
+{productName} {productMajorVersion} does not support NSS authentication. If you are
 upgrading from a Enterprise Profile configuration that uses NSS
 authentication, follow the procedure in xref:#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading
 Installations That Use NSS Cryptographic Tokens].
@@ -771,7 +771,7 @@ file, the upgrade output will say
 9. Click Finish to exit the Upgrade Tool when the upgrade process is
 complete.
 
-10. Start the upgraded {productName} 7 domain.
+10. Start the upgraded {productName} {productMajorVersion} domain.
 +
 [source]
 ----
@@ -788,9 +788,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir`/docroot/index.html` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} 7 file
+the upgrade. You may want to copy the default {productName} {productMajorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} 7 installation.
+{productName} {productMajorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -801,7 +801,7 @@ click the Help button on the Administration Console.
 === Performing an In-Place Upgrade With the Update Center Tools
 
 This section explains how to use the three Update Center tools to
-perform an in-place upgrade to {productName} 7 from {productName} 3.0.1 or Enterprise Server v3. Specifically, the three tools
+perform an in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1 or Enterprise Server v3. Specifically, the three tools
 explained in this section are:
 
 * Update Tool
@@ -829,7 +829,7 @@ The following topics are addressed here:
 ==== Update Center Tool Procedures
 
 Unlike when using Upgrade Tool, when you use the Update Tool, the
-Software Update Notifier, or the `pkg` utility to perform a {productName} 7 upgrade, the older source server directories are overwritten
+Software Update Notifier, or the `pkg` utility to perform a {productName} {productMajorVersion} upgrade, the older source server directories are overwritten
 with the new target server directories, and the existing configuration
 and deployed applications are reused in the updated installation.
 
@@ -848,7 +848,7 @@ following ways:
 ==== To Upgrade Using the Update Tool GUI
 
 This procedure explains how to use the graphical Update Tool to perform
-an in-place upgrade to {productName} 7 from {productName} 3.0.1
+an in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1
 or Enterprise Server v3. Note that it is not possible to use this
 procedure with any other product releases.
 
@@ -888,9 +888,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir``/docroot/index.html`` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} 7 file
+the upgrade. You may want to copy the default {productName} {productMajorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} 7 installation.
+{productName} {productMajorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -901,7 +901,7 @@ click the Help button on the Administration Console.
 ==== To Upgrade Using the Software Update Notifier
 
 This procedure explains how to use the Software Update Notifier to
-perform an in-place upgrade to {productName} 7 from {productName} 3.0.1 or Enterprise Server v3. Note that it is not possible to
+perform an in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1 or Enterprise Server v3. Note that it is not possible to
 use this procedure with any other product releases.
 
 Before You Begin
@@ -923,7 +923,7 @@ balloon informing you that updates are available.
 
 4. Using the Software Update GUI, select the items you want to upgrade
 and start the installation. +
-Ensure that {productName} 7 is one of the items you select for
+Ensure that {productName} {productMajorVersion} is one of the items you select for
 upgrade. This upgrades the server and selected components to the latest
 available versions.
 
@@ -948,9 +948,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir`/docroot/index.html` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} 7 file
+the upgrade. You may want to copy the default {productName} {productMajorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} 7 installation.
+{productName} {productMajorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -961,7 +961,7 @@ click the Help button on the Administration Console.
 ==== To Upgrade From the Command Line Using the `pkg` Utility
 
 This procedure explains how to use the `pkg` utility to perform an
-in-place upgrade to {productName} 7 from {productName} 3.0.1 or
+in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1 or
 Enterprise Server v3. Note that it is not possible to use this procedure
 with any other product releases.
 
@@ -971,7 +971,7 @@ upgrading are stopped before proceeding.
 2. In a command shell for your operating environment, navigate to the
 as-install-parent``/bin`` directory.
 
-3. Use the `pkg image-update` command to update your entire {productName} 3.0.1 or Enterprise Server v3 installation to {productName} 7.
+3. Use the `pkg image-update` command to update your entire {productName} 3.0.1 or Enterprise Server v3 installation to {productName} {productMajorVersion}.
 +
 [source]
 ----
@@ -998,9 +998,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir`/docroot/index.html` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} 7 file
+the upgrade. You may want to copy the default {productName} {productMajorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} 7 installation.
+{productName} {productMajorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -1011,7 +1011,7 @@ click the Help button on the Administration Console.
 === Upgrading Installations That Use NSS Cryptographic Tokens
 
 {productName} v2.x EE (Enterprise Edition) uses Network Security
-Services (NSS) for cryptographic software tokens. {productName} 7
+Services (NSS) for cryptographic software tokens. {productName} {productMajorVersion}
 does not support NSS, so when performing an upgrade from v2.x EE to 7
 additional manual configuration steps must be performed.
 
@@ -1026,30 +1026,30 @@ The following topics are addressed here:
 ==== To Prepare for the Upgrade
 
 This procedure explains how to prepare for modifying an NSS-based
-{productName} 2.x installation when upgrading to {productName} 7.
+{productName} 2.x installation when upgrading to {productName} {productMajorVersion}.
 
-1. Download and install {productName} 7 using the Typical Installation path. +
-Ensure that you install the new {productName} 7 product in a
+1. Download and install {productName} {productMajorVersion} using the Typical Installation path. +
+Ensure that you install the new {productName} {productMajorVersion} product in a
 directory that is different than the one used for the older installation
 from which you are upgrading. +
 See "xref:installation-guide.adoc#GSING00025[
 Installing {productName} From a Self-Extracting Bundle]"
 in {productName} Installation Guide for instructions.
 
-2. Rename the new {productName} 7 domain-dir (the default is
+2. Rename the new {productName} {productMajorVersion} domain-dir (the default is
 as-install``/domains/domain1``) to a name of your choice. +
-In this procedure, `31domain` is used for the renamed {productName} 7 domain.
+In this procedure, `31domain` is used for the renamed {productName} {productMajorVersion} domain.
 
-3. Copy the older source domain to be upgraded to the new {productName} 7 as-install``/domains`` directory. +
+3. Copy the older source domain to be upgraded to the new {productName} {productMajorVersion} as-install``/domains`` directory. +
 In this procedure, `domain1` is used for the older source domain that is
-copied to the new {productName} 7 installation.
+copied to the new {productName} {productMajorVersion} installation.
 +
 [NOTE]
 ====
 The remaining steps in this procedure are performed on the copy of your
 source domain that you created in this step, rather than on your
 original source domain. It is strongly recommended that you perform the
-{productName} 7 upgrade on a copy of your old domain rather than on
+{productName} {productMajorVersion} upgrade on a copy of your old domain rather than on
 the original.
 ====
 
@@ -1085,7 +1085,7 @@ password used in the `./31domain`.
 -Dcom.sun.appserv.nss.db=${com.sun.aas.instanceRoot}/config
 ----
 
-6. Upgrade `./domain1` by starting the DAS in the new {productName} 7
+6. Upgrade `./domain1` by starting the DAS in the new {productName} {productMajorVersion}
 installation with the `--upgrade` option.
 +
 [source]
@@ -1106,14 +1106,14 @@ as-install/bin/asadmin start-domain domain1
 
 These instructions explain the post-upgrade configuration steps that
 must be performed when upgrading from an NSS-based installation to
-{productName} 7.
+{productName} {productMajorVersion}.
 
 Before You Begin
 
 Before proceeding with this procedure, complete the procedure explained
 in xref:#to-prepare-for-the-upgrade[To Prepare for the Upgrade].
 
-1. Start the {productName} 7 domain, if it is not already running,
+1. Start the {productName} {productMajorVersion} domain, if it is not already running,
 and open the {productName} Admin Console in a browser window. +
 The default URL is `https://localhost:4848` +
 As part of the xref:#to-prepare-for-the-upgrade[To Prepare for the Upgrade] procedure, the
@@ -1144,7 +1144,7 @@ keytool -storepasswd -new v2-master-password \
 
 4. Take note of all the `KeyEntries` that exist in your NSS database.
 +
-These entries must be migrated to the `keystore.jks` in the {productName} 7 domain. The following command can be used to list all the
+These entries must be migrated to the `keystore.jks` in the {productName} {productMajorVersion} domain. The following command can be used to list all the
 `KeyEntries` in the NSS database:
 +
 [source]
@@ -1259,7 +1259,7 @@ NSS-PKCS11, then the v2.x EE-to-7 upgrade solution is to directly
 configure the Hardware Token as a PKCS11 token using the JDK-JSSE
 supported mechanisms for configuring PKCS#11 tokens.
 
-1. Set the `javax.net.ssl.keyStoreType` `jvm-options` in {productName} 7 to PKCS11.
+1. Set the `javax.net.ssl.keyStoreType` `jvm-options` in {productName} {productMajorVersion} to PKCS11.
 +
 [source,xml]
 ----
@@ -1302,18 +1302,18 @@ Ensure that the following two `jvm-options` are set in the `domain.xml` file:
 
 This section explains additional steps you need to perform when
 upgrading cluster and node agent configurations from Application Server
-or Enterprise Server to {productName} 7.
+or Enterprise Server to {productName} {productMajorVersion}.
 
-{productName} 7 does not support node agents. As part of the
+{productName} {productMajorVersion} does not support node agents. As part of the
 upgrade process, any node agent elements in the older source
 configuration are transformed into `CONFIG` node elements in the
 `domain.xml` file for the upgraded DAS. If the source node agent
-configuration is incompatible with your {productName} 7
+configuration is incompatible with your {productName} {productMajorVersion}
 installation, you must correct the node configuration on the upgraded DAS.
 
 In addition, although the source cluster configuration is retained in
 the `domain.xml` file for the upgraded DAS, it is still necessary to
-install {productName} 7 on each node host and manually re-create
+install {productName} {productMajorVersion} on each node host and manually re-create
 the server instances that are contained in the clusters.
 
 The following topics are addressed here:
@@ -1327,13 +1327,13 @@ The following topics are addressed here:
 ==== Overview of Cluster and Node Agent Upgrade Procedures
 
 The general steps for upgrading a cluster and node agent configuration
-so it will work in {productName} 7 are as follows:
+so it will work in {productName} {productMajorVersion} are as follows:
 
 1. Perform a side-by-side upgrade of the DAS. This procedure is
 described in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a Side-By-Side Upgrade With Upgrade Tool].
 
-2. Perform new (not upgrade) {productName} 7 installations on each
-node host. {productName} 7 installation instructions are provided
+2. Perform new (not upgrade) {productName} {productMajorVersion} installations on each
+node host. {productName} {productMajorVersion} installation instructions are provided
 in the xref:installation-guide.adoc#GSING[
 {productName} Installation Guide].
 
@@ -1341,7 +1341,7 @@ in the xref:installation-guide.adoc#GSING[
 This procedure is described in xref:#to-correct-the-configuration-of-a-node-after-an-upgrade[To Correct the Configuration
 of a Node After an Upgrade].
 
-4. Re-create the clusters and server instances on each {productName} 7 node host.
+4. Re-create the clusters and server instances on each {productName} {productMajorVersion} node host.
 This procedure is described in xref:#to-re-create-a-cluster[To Re-Create a Cluster].
 
 [[to-correct-the-configuration-of-a-node-after-an-upgrade]]
@@ -1372,7 +1372,7 @@ might not meet your requirements for the upgraded installation of {productName}:
 * The parent of the base installation directory of the {productName}
 software on the host, for example, `/export/glassfish7`. +
 The default is the parent of the default base installation directory of
-the {productName} 7 software on the DAS host. If the {productName} software is installed under a different directory on the node
+the {productName} {productMajorVersion} software on the DAS host. If the {productName} software is installed under a different directory on the node
 host, you must update the node's configuration to specify the correct directory.
 
 * The directory that will contain the {productName} instances that
@@ -1406,7 +1406,7 @@ Setting Up SSH for Centralized Administration]" in
 * If you are upgrading from an Enterprise Profile configuration that
 uses NSS authentication, ensure that the procedure in
 xref:#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading Installations That Use NSS Cryptographic Tokens]
-has been performed. {productName} 7 does not support NSS authentication.
+has been performed. {productName} {productMajorVersion} does not support NSS authentication.
 
 1. Ensure that the DAS is running. +
 Remote subcommands require a running server.
@@ -1467,7 +1467,7 @@ Command update-node-config executed successfully.
 Next Steps
 
 Re-create the cluster configuration from the older source installation
-in the new {productName} 7 installation in as explained in
+in the new {productName} {productMajorVersion} installation in as explained in
 xref:#to-re-create-a-cluster[To Re-Create a Cluster].
 
 See Also
@@ -1485,15 +1485,15 @@ in {productName} High Availability Administration Guide
 ==== To Re-Create a Cluster
 
 This procedure explains how to re-create a clustered {productName} or
-Enterprise Server configuration for {productName} 7.
+Enterprise Server configuration for {productName} {productMajorVersion}.
 
 Before proceeding with these instructions, ensure that you have
 completed the following procedures:
 --
-* Perform the standard upgrade to {productName} 7 on the DAS, as
+* Perform the standard upgrade to {productName} {productMajorVersion} on the DAS, as
 described in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a Side-By-Side Upgrade With Upgrade Tool].
 
-* Perform a new (not upgrade) installation of {productName} 7 on
+* Perform a new (not upgrade) installation of {productName} {productMajorVersion} on
 each node host. See the xref:installation-guide.adoc#GSING[
 {productName} Installation Guide] for instructions.
 
@@ -1554,7 +1554,7 @@ xref:#to-correct-the-configuration-of-a-node-after-an-upgrade[To Correct the Con
 
 4. After creating the instances, manually copy the instance-dir``/imq``
 directory for each instance from the older source installation to the
-target {productName} 7 installation.
+target {productName} {productMajorVersion} installation.
 
 5. If necessary, start the cluster. +
 For example:
@@ -1592,7 +1592,7 @@ host2$ asadmin --host dashost create-local-instance --node na2 --cluster cluster
 === Correcting Potential Upgrade Problems
 
 This section addresses issues that can occur during an upgrade to
-{productName} 7.
+{productName} {productMajorVersion}.
 
 The following topics are addressed here:
 
@@ -1605,7 +1605,7 @@ The following topics are addressed here:
 ==== Cluster Profile Security Setting
 
 When upgrading a clustered domain configuration from Application Server
-9.1 or Enterprise Server v2 to {productName} 7, you may encounter
+9.1 or Enterprise Server v2 to {productName} {productMajorVersion}, you may encounter
 problems if the `admin-service` element in the DAS `domain.xml` file
 sets both of the following attributes:
 

--- a/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
@@ -14,14 +14,14 @@ prev=upgrade-compatibility-issues.html
 This chapter is obsoleted and must be revided.
 ====
 
-The Upgrade Tool that is bundled with {productName} {productMajorVersion} replicates
+The Upgrade Tool that is bundled with {productName} {product-majorVersion} replicates
 the configuration of a previously installed server in the target
 installation. The Upgrade Tool assists in upgrading the configuration
 and applications from an earlier version of the Application Server or
-{productName} to {productName} {productMajorVersion}.
+{productName} to {productName} {product-majorVersion}.
 
 In addition to Upgrade Tool, there are three Update Center tools that
-can be used to perform an in-place upgrade to {productName} {productMajorVersion} from
+can be used to perform an in-place upgrade to {productName} {product-majorVersion} from
 {productName} 3.1.1, 3.1, 3.0.1, and Enterprise Server v3. These
 three Update Center tools are:
 
@@ -33,7 +33,7 @@ Upgrade Tool and the three Update Center tools are explained later in
 this chapter.
 
 To view a list of the older versions from which you can upgrade, see
-xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}].
+xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {product-majorVersion}].
 
 The following topics are addressed here:
 
@@ -57,7 +57,7 @@ The following topics are addressed here:
 * xref:#upgrade-paths[Upgrade Paths]
 * xref:#upgrade-terminology[Upgrade Terminology]
 * xref:#summary-of-upgrade-tools-and-procedures[Summary of Upgrade Tools and Procedures]
-* xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}]
+* xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {product-majorVersion}]
 * xref:#GSUPG00063[Upgrading From Version 8.x or Older Product Releases]
 * xref:#upgrading-glassfish-server-inside-a-closed-network[Upgrading {productName} Inside a Closed Network]
 
@@ -65,7 +65,7 @@ The following topics are addressed here:
 
 ==== Upgrade Paths
 
-There are two general paths you can use when upgrading to {productName} {productMajorVersion}:
+There are two general paths you can use when upgrading to {productName} {product-majorVersion}:
 
 Side-by-Side::
   A side-by-side upgrade means that the new {productName} release is
@@ -73,10 +73,10 @@ Side-by-Side::
   upgrading. +
   In this scenario, you perform the following steps:
 
-  1.  Perform a basic installation of {productName} {productMajorVersion} in a location
+  1.  Perform a basic installation of {productName} {product-majorVersion} in a location
   other than the one being used for the older product.
   2.  Use Upgrade Tool to migrate the old configurations and
-  applications to the new {productName} {productMajorVersion} directories.
+  applications to the new {productName} {product-majorVersion} directories.
   3.  Test the new {productName} installation to make sure everything
   is working properly.
   4.  When you are satisfied that the new installation works properly,
@@ -94,7 +94,7 @@ In-Place::
   installation. +
 In this scenario, you simply use Update Tool, the `pkg` utility, or
   the Update Notifier in your old installation to overwrite the old
-  installation with the new {productName} {productMajorVersion} product. +
+  installation with the new {productName} {product-majorVersion} product. +
   Performing an in-place upgrade is easier than performing a
   side-by-side upgrade, but you lose the ability to switch back and
   forth between the old and new installations. There is also no way to
@@ -133,8 +133,8 @@ Master Password::
 
 ==== Summary of Upgrade Tools and Procedures
 
-There are several tools you can use to upgrade from an earlier {productName} or Enterprise Server installation to {productName} {productMajorVersion}. The
-general procedures for upgrading to {productName} {productMajorVersion} vary depending
+There are several tools you can use to upgrade from an earlier {productName} or Enterprise Server installation to {productName} {product-majorVersion}. The
+general procedures for upgrading to {productName} {product-majorVersion} vary depending
 on which tool you use and the product version from which you are upgrading.
 
 The following topics are addressed here:
@@ -149,7 +149,7 @@ The following topics are addressed here:
 
 ===== Summary of Tools for Performing an Upgrade
 
-There are several tools you can use to perform an upgrade to {productName} {productMajorVersion} are described below.
+There are several tools you can use to perform an upgrade to {productName} {product-majorVersion} are described below.
 
 * xref:#upgrade-tool[Upgrade Tool]
 * xref:#update-tool-and-the-pkg-utility[Update Tool and the `pkg` Utility]
@@ -161,19 +161,19 @@ Upgrade Tool
 
 The {productName} Upgrade Tool is tended solely for performing
 side-by-side upgrades from any compatible older product version to
-{productName} {productMajorVersion}.
+{productName} {product-majorVersion}.
 
 Upgrade Tool provides a number of features that aid in the migration of
-older configurations and applications to a new {productName} {productMajorVersion}
+older configurations and applications to a new {productName} {product-majorVersion}
 installation. These features are described in more detail in
 xref:#upgrade-tool-functionality[Upgrade Tool Functionality].
 
-In {productName} {productMajorVersion} Upgrade Tool is installed in the
+In {productName} {product-majorVersion} Upgrade Tool is installed in the
 as-install``/bin`` directory.
 
 [NOTE]
 ====
-Upgrade Tool is the only tool you can use when upgrading to {productName} {productMajorVersion} from product versions prior to {productName} 3.0.1 or
+Upgrade Tool is the only tool you can use when upgrading to {productName} {product-majorVersion} from product versions prior to {productName} 3.0.1 or
 Enterprise Server v3.
 ====
 
@@ -193,15 +193,15 @@ such as OSGi Admin Console.
 
 The command-line counterpart to Update Tool is the `pkg` utility. While
 the `pkg` utility does not provide exactly the same set of features as
-Update Tool, for the purposes of upgrading to {productName} {productMajorVersion}, the
+Update Tool, for the purposes of upgrading to {productName} {product-majorVersion}, the
 `pkg` utility and Update Tool feature sets are almost identical.
 
 In addition to day-to-day maintenance tasks, Update Tool and the `pkg`
 utility can be used to perform an in-place upgrade of an entire
 {productName} 3.0.1 or Enterprise Server v3 installation to the
-{productName} {productMajorVersion} or later release.
+{productName} {product-majorVersion} or later release.
 
-In {productName} {productMajorVersion} Update Tool is installed in the
+In {productName} {product-majorVersion} Update Tool is installed in the
 as-install-parent``/bin`` directory.
 
 [NOTE]
@@ -229,7 +229,7 @@ Software Update tool to upgrade from product releases prior 3.0.1 and
 v3.
 
 The Software Update Notifier is distributed as a configuration option
-during {productName} {productMajorVersion}, 3.0.1, and Enterprise Server v3
+during {productName} {product-majorVersion}, 3.0.1, and Enterprise Server v3
 installation. If installed and enabled, the Software Update Notifier
 monitors your installation and pops up a notification balloon when
 updates or upgrades are available for your product.
@@ -244,20 +244,20 @@ the Update Notifier, refer to the Update Tool online help.
 ===== Summary of Procedure for Upgrading With Upgrade Tool
 
 The general procedure for using Upgrade Tool to perform an upgrade to
-{productName} {productMajorVersion} from any compatible older version of {productName} or Enterprise Server comprises the following steps:
+{productName} {product-majorVersion} from any compatible older version of {productName} or Enterprise Server comprises the following steps:
 
-1. Download {productName} {productMajorVersion} and perform a Standard Installation,
+1. Download {productName} {product-majorVersion} and perform a Standard Installation,
 as described in "xref:installation-guide.adoc#GSING00007[
 To Install {productName} Using the Self-Extracting File]"
 in {productName} Installation Guide.
 2. Copy any custom or third-party libraries from the older installation
-to their corresponding locations in the new {productName} {productMajorVersion}
+to their corresponding locations in the new {productName} {product-majorVersion}
 installation directories. Note that you should only copy custom or
 third-party libraries here. Do not copy an libraries from the actual
 domain that will be upgraded.
-3. Run the `asupgrade` command from the new {productName} {productMajorVersion}
+3. Run the `asupgrade` command from the new {productName} {product-majorVersion}
 as-install``/bin`` directory.
-4. Start the new {productName} {productMajorVersion} DAS with the
+4. Start the new {productName} {product-majorVersion} DAS with the
 `asadmin start-domain` subcommand.
 
 This procedure is described in more detail in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a
@@ -268,14 +268,14 @@ Side-By-Side Upgrade With Upgrade Tool].
 ===== Summary of Procedure for Upgrading With Update Tool
 
 The general procedure for using Update Tool to perform an upgrade to
-{productName} {productMajorVersion} from {productName} 3.0.1 or Enterprise Server v3
+{productName} {product-majorVersion} from {productName} 3.0.1 or Enterprise Server v3
 comprises the following steps:
 
 1. Manually stop all server instances and the domain.
 2. Launch Update Tool by using the as-install-parent`/bin/updatetool`
 command in the older product directory.
 3. In Update Tool, select and install the latest {productName}
-product release. This updates your server to the {productMajorVersion} release.
+product release. This updates your server to the {product-majorVersion} release.
 4. Upgrade the domain by running the `asadmin start-domain --upgrade`
 subcommand. This performs the upgrade and then shuts down the DAS.
 5. Restart the DAS normally with the with the `asadmin start-domain`
@@ -289,7 +289,7 @@ Using the Update Tool GUI].
 ===== Summary of Procedure for Upgrading With the Software Update Notifier
 
 The general procedure for using the Software Update Notifier to perform
-an upgrade to {productName} {productMajorVersion} from {productName}3.0.1 or
+an upgrade to {productName} {product-majorVersion} from {productName}3.0.1 or
 Enterprise Server v3 comprises the following steps:
 
 1. Wait for the Software Update Notifier to pop up a notification
@@ -297,7 +297,7 @@ balloon informing you that updates are available.
 2. Click the balloon prompt to launch the Software Update GUI.
 3. Manually stop all server instances and the domain.
 4. Use the Software Update GUI to perform the upgrade. This updates
-your server to the {productMajorVersion} release.
+your server to the {product-majorVersion} release.
 5. Upgrade the domain by running the `asadmin start-domain --upgrade`
 subcommand. This performs the upgrade and then shuts down the DAS.
 6. Restart the upgraded DAS normally with the with the
@@ -311,12 +311,12 @@ Using the Software Update Notifier].
 ===== Summary of Procedure for Upgrading With the `pkg` Utility
 
 The general procedure for using the `pkg` utility to perform an upgrade
-to {productName} {productMajorVersion} from {productName}3.0.1 or Enterprise Server
+to {productName} {product-majorVersion} from {productName}3.0.1 or Enterprise Server
 v3 comprises the following steps:
 
 1. Manually stop all server instances and the domain.
 2. Run the as-install-parent`/bin/pkg` command with the desired options
-in the older product directory. This updates your server to the {productMajorVersion}
+in the older product directory. This updates your server to the {product-majorVersion}
 release.
 3. Upgrade the domain by running the `asadmin start-domain --upgrade`
 subcommand. This performs the upgrade and then shuts down the DAS.
@@ -328,9 +328,9 @@ From the Command Line Using the `pkg` Utility].
 
 [[supported-releases-for-upgrade-to-glassfish-server-7]]
 
-==== Supported Releases for Upgrade to {productName} {productMajorVersion}
+==== Supported Releases for Upgrade to {productName} {product-majorVersion}
 
-Upgrades to {productName} {productMajorVersion} are supported from the following
+Upgrades to {productName} {product-majorVersion} are supported from the following
 earlier {productName} product releases:
 
 * Sun GlassFish Enterprise Server v2.1.1
@@ -343,19 +343,19 @@ earlier {productName} product releases:
 
 ==== Upgrading From Version 8.x or Older Product Releases
 
-It is not possible to upgrade to {productName} {productMajorVersion} directly from Sun
+It is not possible to upgrade to {productName} {product-majorVersion} directly from Sun
 GlassFish Enterprise Server 8.x or older product releases.
 
 To upgrade from a product release that is older than any of those listed
-in xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}],
+in xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {product-majorVersion}],
 you must first upgrade your older product release to one of the releases
-that are supported for upgrade to {productName} {productMajorVersion}.
+that are supported for upgrade to {productName} {product-majorVersion}.
 
 For example, to upgrade from any Enterprise Server 8.x release, you
 first need to upgrade that older release to Enterprise Server 2.1.1.
 That is, your upgrade path would be as follows:
 
-Enterprise Server 8.x⇒Enterprise Server 2.1.1⇒{productName} {productMajorVersion}
+Enterprise Server 8.x⇒Enterprise Server 2.1.1⇒{productName} {product-majorVersion}
 
 Sun GlassFish Enterprise Server 2.1.1 is available for download from the
 http://glassfish.java.net/public/downloadsindex.html[GlassFish Community
@@ -367,7 +367,7 @@ GlassFish Enterprise Server 2.1.1 Upgrade Guide]
 
 After upgrading your older Enterprise Server installation to Enterprise
 Server 2.1.1, you can proceed normally with the instructions in this
-guide to complete the upgrade to {productName} {productMajorVersion}.
+guide to complete the upgrade to {productName} {product-majorVersion}.
 
 [[upgrading-glassfish-server-inside-a-closed-network]]
 
@@ -384,7 +384,7 @@ in {productName} Administration Guide.
 === Performing a Side-By-Side Upgrade With Upgrade Tool
 
 This section explains how to use Upgrade Tool to perform a side-by-side
-upgrade to {productName} {productMajorVersion} from any compatible older product release.
+upgrade to {productName} {product-majorVersion} from any compatible older product release.
 
 The following topics are addressed here:
 
@@ -441,9 +441,9 @@ Additional Upgrade Tool functions are explained in the following sections:
 
 Application archives (EAR files) and component archives (JAR, WAR, and
 RAR files) that are deployed in the source server do not require any
-modification to run on {productName} {productMajorVersion}.
-Components that may have incompatibilities are deployed on {productName} {productMajorVersion} with the `compatibility` property set to `v2` and will run
-without change on {productName} {productMajorVersion}. You may, however, want to
+modification to run on {productName} {product-majorVersion}.
+Components that may have incompatibilities are deployed on {productName} {product-majorVersion} with the `compatibility` property set to `v2` and will run
+without change on {productName} {product-majorVersion}. You may, however, want to
 consider modifying the applications to conform to Jakarta EE 6 requirements.
 
 The Jakarta EE 6 platform specification imposes stricter requirements than
@@ -470,7 +470,7 @@ attempt to reconfigure the incorrect configurations.
 ===== Upgrade of Clusters
 
 When upgrading from a clustered configuration, the older cluster
-information is retained in a new `domain.xml` file in the {productName} {productMajorVersion} installation directories. However, it is still necessary to
+information is retained in a new `domain.xml` file in the {productName} {product-majorVersion} installation directories. However, it is still necessary to
 manually re-create the server instances that are contained in the
 clusters. This procedure is explained in xref:#upgrading-clusters-and-node-agent-configurations[Upgrading Clusters
 and Node Agent Configurations].
@@ -499,15 +499,15 @@ Command version executed successfully.
 ==== To Upgrade From the Command Line Using Upgrade Tool
 
 This procedure explains how to use the Upgrade Tool command line to
-upgrade to {productName} {productMajorVersion} from any supported older product release.
-See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}] for a list of supported releases.
+upgrade to {productName} {product-majorVersion} from any supported older product release.
+See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {product-majorVersion}] for a list of supported releases.
 
 Before You Begin
 
 Ensure that the domains on the source server from which you are
 upgrading are stopped before proceeding.
 
-1. Download and install {productName} {productMajorVersion} using the Typical
+1. Download and install {productName} {product-majorVersion} using the Typical
 Installation path. +
 See "xref:installation-guide.adoc#GSING00025[
 Installing {productName} From a Self-Extracting Bundle]"
@@ -525,7 +525,7 @@ as-install``/lib`` directory.
 +
 [NOTE]
 ====
-Use the Upgrade Tool that is located in the target {productName} {productMajorVersion}
+Use the Upgrade Tool that is located in the target {productName} {product-majorVersion}
 installation, not the older source installation.
 ====
 +
@@ -585,7 +585,7 @@ If there are any `SEVERE` or `WARNING` messages in the `server.log`
 file, the upgrade output will say
 `"Possible error encountered during upgrade. See server log after upgrade process completes."`
 
-6. Start the upgraded {productName} {productMajorVersion} domain.
+6. Start the upgraded {productName} {product-majorVersion} domain.
 +
 [source]
 ----
@@ -596,7 +596,7 @@ used in the older server.
 +
 [NOTE]
 ====
-{productName} {productMajorVersion} does not support NSS authentication. If you are
+{productName} {product-majorVersion} does not support NSS authentication. If you are
 upgrading from a Enterprise Profile configuration that uses NSS
 authentication, follow the procedure in xref:#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading
 Installations That Use NSS Cryptographic Tokens].
@@ -611,7 +611,7 @@ Example 2-1 Using the `asupgrade` Command Line
 
 The following example shows how to use the `asupgrade` command-line
 utility in non-interactive mode to upgrade an existing Sun GlassFish
-Enterprise Server v2.1 installation to {productName} {productMajorVersion}. The
+Enterprise Server v2.1 installation to {productName} {product-majorVersion}. The
 following command should be entered on a single line.
 
 [source]
@@ -647,7 +647,7 @@ short form, the long form, and a description of each option.
 
 |`-t` target-domains-directory
 |`--target` target-domains-directory
-|The desired domain-root-dir directory in the {productName} {productMajorVersion} target
+|The desired domain-root-dir directory in the {productName} {product-majorVersion} target
 installation; default is as-install``/domains``
 
 |`-f` password-file
@@ -659,9 +659,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir``/docroot/index.html`` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} {productMajorVersion} file
+the upgrade. You may want to copy the default {productName} {product-majorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} {productMajorVersion} installation.
+{productName} {product-majorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -672,15 +672,15 @@ click the Help button on the Administration Console.
 ==== To Upgrade Using the Upgrade Tool Wizard
 
 This procedure explains how to use the graphical Upgrade Tool Wizard to
-upgrade to {productName} {productMajorVersion} from any supported older product release.
-See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {productMajorVersion}] for a list of supported releases.
+upgrade to {productName} {product-majorVersion} from any supported older product release.
+See xref:#supported-releases-for-upgrade-to-glassfish-server-7[Supported Releases for Upgrade to {productName} {product-majorVersion}] for a list of supported releases.
 
 Before You Begin
 
 Ensure that the source domains from which you are upgrading are stopped
 before proceeding.
 
-1. Download and install {productName} {productMajorVersion} using the Typical Installation path. +
+1. Download and install {productName} {product-majorVersion} using the Typical Installation path. +
 See "xref:installation-guide.adoc#GSING00025[
 Installing {productName} From a Self-Extracting Bundle]"
 in {productName} Installation Guide for instructions.
@@ -697,7 +697,7 @@ operating environment.
 +
 [NOTE]
 ====
-Use the Upgrade Tool that is located in the target {productName} {productMajorVersion}
+Use the Upgrade Tool that is located in the target {productName} {product-majorVersion}
 installation, not the older source installation.
 ====
 +
@@ -728,11 +728,11 @@ click Browse. +
 For example, you might type `c:\glassfish\domains\domain1`.
 
 5. In the Target Domains Root Directory field, type the location of the
-{productName} {productMajorVersion} installation to which to transfer the
+{productName} {product-majorVersion} installation to which to transfer the
 configuration, or click Browse. +
 The default is the full path name of the `domains` directory of your
-{productName} {productMajorVersion} installation (for example,
-`c:\glassfish{productMajorVersion}\glassfish\domains`).
+{productName} {product-majorVersion} installation (for example,
+`c:\glassfish{product-majorVersion}\glassfish\domains`).
 
 6. Provide the master password of the source application server. +
 The domain will be upgraded using these credentials. If you do not
@@ -740,7 +740,7 @@ specify a password here, the default master password is used.
 +
 [NOTE]
 ====
-{productName} {productMajorVersion} does not support NSS authentication. If you are
+{productName} {product-majorVersion} does not support NSS authentication. If you are
 upgrading from a Enterprise Profile configuration that uses NSS
 authentication, follow the procedure in xref:#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading
 Installations That Use NSS Cryptographic Tokens].
@@ -771,7 +771,7 @@ file, the upgrade output will say
 9. Click Finish to exit the Upgrade Tool when the upgrade process is
 complete.
 
-10. Start the upgraded {productName} {productMajorVersion} domain.
+10. Start the upgraded {productName} {product-majorVersion} domain.
 +
 [source]
 ----
@@ -788,9 +788,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir`/docroot/index.html` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} {productMajorVersion} file
+the upgrade. You may want to copy the default {productName} {product-majorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} {productMajorVersion} installation.
+{productName} {product-majorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -801,7 +801,7 @@ click the Help button on the Administration Console.
 === Performing an In-Place Upgrade With the Update Center Tools
 
 This section explains how to use the three Update Center tools to
-perform an in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1 or Enterprise Server v3. Specifically, the three tools
+perform an in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1 or Enterprise Server v3. Specifically, the three tools
 explained in this section are:
 
 * Update Tool
@@ -829,7 +829,7 @@ The following topics are addressed here:
 ==== Update Center Tool Procedures
 
 Unlike when using Upgrade Tool, when you use the Update Tool, the
-Software Update Notifier, or the `pkg` utility to perform a {productName} {productMajorVersion} upgrade, the older source server directories are overwritten
+Software Update Notifier, or the `pkg` utility to perform a {productName} {product-majorVersion} upgrade, the older source server directories are overwritten
 with the new target server directories, and the existing configuration
 and deployed applications are reused in the updated installation.
 
@@ -848,7 +848,7 @@ following ways:
 ==== To Upgrade Using the Update Tool GUI
 
 This procedure explains how to use the graphical Update Tool to perform
-an in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1
+an in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1
 or Enterprise Server v3. Note that it is not possible to use this
 procedure with any other product releases.
 
@@ -888,9 +888,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir``/docroot/index.html`` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} {productMajorVersion} file
+the upgrade. You may want to copy the default {productName} {product-majorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} {productMajorVersion} installation.
+{productName} {product-majorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -901,7 +901,7 @@ click the Help button on the Administration Console.
 ==== To Upgrade Using the Software Update Notifier
 
 This procedure explains how to use the Software Update Notifier to
-perform an in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1 or Enterprise Server v3. Note that it is not possible to
+perform an in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1 or Enterprise Server v3. Note that it is not possible to
 use this procedure with any other product releases.
 
 Before You Begin
@@ -923,7 +923,7 @@ balloon informing you that updates are available.
 
 4. Using the Software Update GUI, select the items you want to upgrade
 and start the installation. +
-Ensure that {productName} {productMajorVersion} is one of the items you select for
+Ensure that {productName} {product-majorVersion} is one of the items you select for
 upgrade. This upgrades the server and selected components to the latest
 available versions.
 
@@ -948,9 +948,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir`/docroot/index.html` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} {productMajorVersion} file
+the upgrade. You may want to copy the default {productName} {product-majorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} {productMajorVersion} installation.
+{productName} {product-majorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -961,7 +961,7 @@ click the Help button on the Administration Console.
 ==== To Upgrade From the Command Line Using the `pkg` Utility
 
 This procedure explains how to use the `pkg` utility to perform an
-in-place upgrade to {productName} {productMajorVersion} from {productName} 3.0.1 or
+in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1 or
 Enterprise Server v3. Note that it is not possible to use this procedure
 with any other product releases.
 
@@ -971,7 +971,7 @@ upgrading are stopped before proceeding.
 2. In a command shell for your operating environment, navigate to the
 as-install-parent``/bin`` directory.
 
-3. Use the `pkg image-update` command to update your entire {productName} 3.0.1 or Enterprise Server v3 installation to {productName} {productMajorVersion}.
+3. Use the `pkg image-update` command to update your entire {productName} 3.0.1 or Enterprise Server v3 installation to {productName} {product-majorVersion}.
 +
 [source]
 ----
@@ -998,9 +998,9 @@ Next Steps
 
 * Browse to the URL `http://localhost:8080` to view the
 domain-dir`/docroot/index.html` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} {productMajorVersion} file
+the upgrade. You may want to copy the default {productName} {product-majorVersion} file
 from the `domain1.original/docroot` directory and customize it for your
-{productName} {productMajorVersion} installation.
+{productName} {product-majorVersion} installation.
 * To register your installation of {productName} from the
 Administration Console, select the Registration item from the Common
 Tasks page. For step-by-step instructions on the registration process,
@@ -1011,7 +1011,7 @@ click the Help button on the Administration Console.
 === Upgrading Installations That Use NSS Cryptographic Tokens
 
 {productName} v2.x EE (Enterprise Edition) uses Network Security
-Services (NSS) for cryptographic software tokens. {productName} {productMajorVersion}
+Services (NSS) for cryptographic software tokens. {productName} {product-majorVersion}
 does not support NSS, so when performing an upgrade from v2.x EE to 7
 additional manual configuration steps must be performed.
 
@@ -1026,30 +1026,30 @@ The following topics are addressed here:
 ==== To Prepare for the Upgrade
 
 This procedure explains how to prepare for modifying an NSS-based
-{productName} 2.x installation when upgrading to {productName} {productMajorVersion}.
+{productName} 2.x installation when upgrading to {productName} {product-majorVersion}.
 
-1. Download and install {productName} {productMajorVersion} using the Typical Installation path. +
-Ensure that you install the new {productName} {productMajorVersion} product in a
+1. Download and install {productName} {product-majorVersion} using the Typical Installation path. +
+Ensure that you install the new {productName} {product-majorVersion} product in a
 directory that is different than the one used for the older installation
 from which you are upgrading. +
 See "xref:installation-guide.adoc#GSING00025[
 Installing {productName} From a Self-Extracting Bundle]"
 in {productName} Installation Guide for instructions.
 
-2. Rename the new {productName} {productMajorVersion} domain-dir (the default is
+2. Rename the new {productName} {product-majorVersion} domain-dir (the default is
 as-install``/domains/domain1``) to a name of your choice. +
-In this procedure, `31domain` is used for the renamed {productName} {productMajorVersion} domain.
+In this procedure, `31domain` is used for the renamed {productName} {product-majorVersion} domain.
 
-3. Copy the older source domain to be upgraded to the new {productName} {productMajorVersion} as-install``/domains`` directory. +
+3. Copy the older source domain to be upgraded to the new {productName} {product-majorVersion} as-install``/domains`` directory. +
 In this procedure, `domain1` is used for the older source domain that is
-copied to the new {productName} {productMajorVersion} installation.
+copied to the new {productName} {product-majorVersion} installation.
 +
 [NOTE]
 ====
 The remaining steps in this procedure are performed on the copy of your
 source domain that you created in this step, rather than on your
 original source domain. It is strongly recommended that you perform the
-{productName} {productMajorVersion} upgrade on a copy of your old domain rather than on
+{productName} {product-majorVersion} upgrade on a copy of your old domain rather than on
 the original.
 ====
 
@@ -1085,7 +1085,7 @@ password used in the `./31domain`.
 -Dcom.sun.appserv.nss.db=${com.sun.aas.instanceRoot}/config
 ----
 
-6. Upgrade `./domain1` by starting the DAS in the new {productName} {productMajorVersion}
+6. Upgrade `./domain1` by starting the DAS in the new {productName} {product-majorVersion}
 installation with the `--upgrade` option.
 +
 [source]
@@ -1106,14 +1106,14 @@ as-install/bin/asadmin start-domain domain1
 
 These instructions explain the post-upgrade configuration steps that
 must be performed when upgrading from an NSS-based installation to
-{productName} {productMajorVersion}.
+{productName} {product-majorVersion}.
 
 Before You Begin
 
 Before proceeding with this procedure, complete the procedure explained
 in xref:#to-prepare-for-the-upgrade[To Prepare for the Upgrade].
 
-1. Start the {productName} {productMajorVersion} domain, if it is not already running,
+1. Start the {productName} {product-majorVersion} domain, if it is not already running,
 and open the {productName} Admin Console in a browser window. +
 The default URL is `https://localhost:4848` +
 As part of the xref:#to-prepare-for-the-upgrade[To Prepare for the Upgrade] procedure, the
@@ -1144,7 +1144,7 @@ keytool -storepasswd -new v2-master-password \
 
 4. Take note of all the `KeyEntries` that exist in your NSS database.
 +
-These entries must be migrated to the `keystore.jks` in the {productName} {productMajorVersion} domain. The following command can be used to list all the
+These entries must be migrated to the `keystore.jks` in the {productName} {product-majorVersion} domain. The following command can be used to list all the
 `KeyEntries` in the NSS database:
 +
 [source]
@@ -1259,7 +1259,7 @@ NSS-PKCS11, then the v2.x EE-to-7 upgrade solution is to directly
 configure the Hardware Token as a PKCS11 token using the JDK-JSSE
 supported mechanisms for configuring PKCS#11 tokens.
 
-1. Set the `javax.net.ssl.keyStoreType` `jvm-options` in {productName} {productMajorVersion} to PKCS11.
+1. Set the `javax.net.ssl.keyStoreType` `jvm-options` in {productName} {product-majorVersion} to PKCS11.
 +
 [source,xml]
 ----
@@ -1302,18 +1302,18 @@ Ensure that the following two `jvm-options` are set in the `domain.xml` file:
 
 This section explains additional steps you need to perform when
 upgrading cluster and node agent configurations from Application Server
-or Enterprise Server to {productName} {productMajorVersion}.
+or Enterprise Server to {productName} {product-majorVersion}.
 
-{productName} {productMajorVersion} does not support node agents. As part of the
+{productName} {product-majorVersion} does not support node agents. As part of the
 upgrade process, any node agent elements in the older source
 configuration are transformed into `CONFIG` node elements in the
 `domain.xml` file for the upgraded DAS. If the source node agent
-configuration is incompatible with your {productName} {productMajorVersion}
+configuration is incompatible with your {productName} {product-majorVersion}
 installation, you must correct the node configuration on the upgraded DAS.
 
 In addition, although the source cluster configuration is retained in
 the `domain.xml` file for the upgraded DAS, it is still necessary to
-install {productName} {productMajorVersion} on each node host and manually re-create
+install {productName} {product-majorVersion} on each node host and manually re-create
 the server instances that are contained in the clusters.
 
 The following topics are addressed here:
@@ -1327,13 +1327,13 @@ The following topics are addressed here:
 ==== Overview of Cluster and Node Agent Upgrade Procedures
 
 The general steps for upgrading a cluster and node agent configuration
-so it will work in {productName} {productMajorVersion} are as follows:
+so it will work in {productName} {product-majorVersion} are as follows:
 
 1. Perform a side-by-side upgrade of the DAS. This procedure is
 described in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a Side-By-Side Upgrade With Upgrade Tool].
 
-2. Perform new (not upgrade) {productName} {productMajorVersion} installations on each
-node host. {productName} {productMajorVersion} installation instructions are provided
+2. Perform new (not upgrade) {productName} {product-majorVersion} installations on each
+node host. {productName} {product-majorVersion} installation instructions are provided
 in the xref:installation-guide.adoc#GSING[
 {productName} Installation Guide].
 
@@ -1341,7 +1341,7 @@ in the xref:installation-guide.adoc#GSING[
 This procedure is described in xref:#to-correct-the-configuration-of-a-node-after-an-upgrade[To Correct the Configuration
 of a Node After an Upgrade].
 
-4. Re-create the clusters and server instances on each {productName} {productMajorVersion} node host.
+4. Re-create the clusters and server instances on each {productName} {product-majorVersion} node host.
 This procedure is described in xref:#to-re-create-a-cluster[To Re-Create a Cluster].
 
 [[to-correct-the-configuration-of-a-node-after-an-upgrade]]
@@ -1372,7 +1372,7 @@ might not meet your requirements for the upgraded installation of {productName}:
 * The parent of the base installation directory of the {productName}
 software on the host, for example, `/export/glassfish7`. +
 The default is the parent of the default base installation directory of
-the {productName} {productMajorVersion} software on the DAS host. If the {productName} software is installed under a different directory on the node
+the {productName} {product-majorVersion} software on the DAS host. If the {productName} software is installed under a different directory on the node
 host, you must update the node's configuration to specify the correct directory.
 
 * The directory that will contain the {productName} instances that
@@ -1406,7 +1406,7 @@ Setting Up SSH for Centralized Administration]" in
 * If you are upgrading from an Enterprise Profile configuration that
 uses NSS authentication, ensure that the procedure in
 xref:#upgrading-installations-that-use-nss-cryptographic-tokens[Upgrading Installations That Use NSS Cryptographic Tokens]
-has been performed. {productName} {productMajorVersion} does not support NSS authentication.
+has been performed. {productName} {product-majorVersion} does not support NSS authentication.
 
 1. Ensure that the DAS is running. +
 Remote subcommands require a running server.
@@ -1467,7 +1467,7 @@ Command update-node-config executed successfully.
 Next Steps
 
 Re-create the cluster configuration from the older source installation
-in the new {productName} {productMajorVersion} installation in as explained in
+in the new {productName} {product-majorVersion} installation in as explained in
 xref:#to-re-create-a-cluster[To Re-Create a Cluster].
 
 See Also
@@ -1485,15 +1485,15 @@ in {productName} High Availability Administration Guide
 ==== To Re-Create a Cluster
 
 This procedure explains how to re-create a clustered {productName} or
-Enterprise Server configuration for {productName} {productMajorVersion}.
+Enterprise Server configuration for {productName} {product-majorVersion}.
 
 Before proceeding with these instructions, ensure that you have
 completed the following procedures:
 --
-* Perform the standard upgrade to {productName} {productMajorVersion} on the DAS, as
+* Perform the standard upgrade to {productName} {product-majorVersion} on the DAS, as
 described in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a Side-By-Side Upgrade With Upgrade Tool].
 
-* Perform a new (not upgrade) installation of {productName} {productMajorVersion} on
+* Perform a new (not upgrade) installation of {productName} {product-majorVersion} on
 each node host. See the xref:installation-guide.adoc#GSING[
 {productName} Installation Guide] for instructions.
 
@@ -1554,7 +1554,7 @@ xref:#to-correct-the-configuration-of-a-node-after-an-upgrade[To Correct the Con
 
 4. After creating the instances, manually copy the instance-dir``/imq``
 directory for each instance from the older source installation to the
-target {productName} {productMajorVersion} installation.
+target {productName} {product-majorVersion} installation.
 
 5. If necessary, start the cluster. +
 For example:
@@ -1592,7 +1592,7 @@ host2$ asadmin --host dashost create-local-instance --node na2 --cluster cluster
 === Correcting Potential Upgrade Problems
 
 This section addresses issues that can occur during an upgrade to
-{productName} {productMajorVersion}.
+{productName} {product-majorVersion}.
 
 The following topics are addressed here:
 
@@ -1605,7 +1605,7 @@ The following topics are addressed here:
 ==== Cluster Profile Security Setting
 
 When upgrading a clustered domain configuration from Application Server
-9.1 or Enterprise Server v2 to {productName} {productMajorVersion}, you may encounter
+9.1 or Enterprise Server v2 to {productName} {product-majorVersion}, you may encounter
 problems if the `admin-service` element in the DAS `domain.xml` file
 sets both of the following attributes:
 


### PR DESCRIPTION
This PR:

- Introduces new variable names, i.e,  `<productMajorVersion>7</productMajorVersion>`
`<productCurrentVersion>${project.version}</productCurrentVersion>`

- Updates all the adoc documentation files with a variable  `{productMajorVersion}` which currently points to `version 7`, which is expected to change every after the release of a new GlassFish release.

- Fixes <https://github.com/eclipse-ee4j/glassfish/issues/25389>