### PR TITLE
Load `GlassFishRoleMapper` before installing the system-wide Exousia policy

### DIFF
--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/PolicyLoader.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/PolicyLoader.java
@@ -132,13 +132,7 @@ public class PolicyLoader {
                     policy = loadPolicy(javaPolicyClassName);
                 }
 
-                // TODO: causing ClassCircularity error when SM ON and
-                // deployment use library feature and ApplibClassLoader
-                // it is likely a problem caused by the way classloading is done
-                // in this case.
-                if (System.getSecurityManager() == null) {
-                    policy.refresh();
-                }
+                policy.refresh();
 
                 try {
                     Policy.setPolicy(policy);


### PR DESCRIPTION
* This closes #25552.

Consider two threads `AutoDeployer` and `FelixStartLevel`. 

`AutoDeployer` thread starts deploying the application and eventually installs the Exousia policy:

```java
try {
    Policy.setPolicy(policy);
} catch (UnsupportedOperationException e) {
    Class<?> authorizationServiceClass = Class.forName("org.glassfish.exousia.AuthorizationService");

    Method setPolicyMethod = authorizationServiceClass.getMethod("setPolicy", Policy.class);
    setPolicyMethod.invoke(null, policy);
}

// TODO: causing ClassCircularity error when SM ON and
// deployment use library feature and ApplibClassLoader
// it is likely a problem caused by the way classloading is done
// in this case.
if (System.getSecurityManager() == null) {
       policy.refresh();
}
```

Let the `FelixStartLevel` thread tries to activate some bundle after `Policy.setPolicy()` method but before `policy.refresh()`. The role mapper has not yet been loaded and the `FelixStartLevel` thread is trying to load it with wrong context classloader (the System classloader). This give us an error at the hk2 descriptor validation stage:

```
2025-06-12 12:22:40.997 ERROR [FelixStartLevel] [GlassFish] Initializer failure: java.lang.ClassNotFoundException: com.sun.enterprise.security.ee.web.integration.GlassfishRoleMapper:
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at org.glassfish.exousia.modules.locked.SimplePolicyConfiguration.<clinit>(SimplePolicyConfiguration.java:94)
	at org.glassfish.exousia.modules.locked.SimplePolicyProvider.doImplies(SimplePolicyProvider.java:159)
	at org.glassfish.exousia.modules.locked.SimplePolicyProvider.implies(SimplePolicyProvider.java:150)
	at java.base/java.security.ProtectionDomain.implies(ProtectionDomain.java:325)
	at java.base/java.security.ProtectionDomain.impliesWithAltFilePerm(ProtectionDomain.java:357)
	at java.base/java.security.AccessControlContext.checkPermission(AccessControlContext.java:463)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:1068)
	at org.glassfish.security.services.common.SecurityAccessValidator.checkPerm(SecurityAccessValidator.java:256)
	at org.glassfish.security.services.common.SecurityAccessValidator.validateLookup(SecurityAccessValidator.java:164)
	at org.glassfish.security.services.common.SecurityAccessValidator.validate(SecurityAccessValidator.java:59)
	at org.jvnet.hk2.internal.ServiceLocatorImpl.callValidate(ServiceLocatorImpl.java:230)
```

Now we loads the `GlassFishRoleMapper` before installing the Exousia `SimplePolicyProvider` as a system-wide policy.