### PR TITLE
More on Jakarta Data - respect provider, fix validation

### DIFF
--- a/appserver/persistence/jnosql-integration/pom.xml
+++ b/appserver/persistence/jnosql-integration/pom.xml
@@ -30,18 +30,18 @@
 
     <name>Eclipse JNoSQL Jakarta Persistence Integration</name>
     
-    <properties>
-        <persistence.osgi.bundle.classpath>${project.build.directory}/dependencies/jnosql-jakarta-persistence-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-mapping-core-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-mapping-api-core-${jnosql.version}.jar${path.separator}${project.build.directory}/dependencies/jnosql-communication-core-${jnosql.version}.jar</persistence.osgi.bundle.classpath>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
+
+        <!-- We use the shaded JAR for compilation and tests -->
         <dependency>
             <groupId>ee.omnifish</groupId>
             <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
+            <version>${jnosql.version}</version>
+            <classifier>shaded</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -49,6 +49,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>jakarta.data</groupId>
             <artifactId>jakarta.data-api</artifactId>
@@ -89,18 +90,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- do not commit the jnosql-jakarta-persistence, it's only for IDE to find the dependency -->
-<!--        <dependency>
-            <groupId>org.eclipse.jnosql.mapping</groupId>
-            <artifactId>jnosql-jakarta-persistence</artifactId>
-            <version>1.1.8-SNAPSHOT</version>
-            <optional>true</optional>
-        </dependency>-->
     </dependencies>
 
     <build>
         <plugins>
-            <!-- add JARs embedded in the OSGi bundle dependency to the compile classpath -->
+            <!-- unpack JARs embedded in the OSGi bundle dependency - they are referenced from system dependencies -->
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -115,69 +109,8 @@
                             <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>classpath</id>
-                        <goals>
-                            <goal>build-classpath</goal>
-                        </goals>
-                        <configuration>
-                            <includeScope>compile</includeScope>
-                            <outputProperty>compile.classpath</outputProperty>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>testclasspath</id>
-                        <goals>
-                            <goal>build-classpath</goal>
-                        </goals>
-                        <configuration>
-                            <includeScope>test</includeScope>
-                            <outputProperty>test.classpath</outputProperty>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <configuration>
-                            <compilerArgs>
-                                <arg>-cp</arg>
-                                <arg>${test.classpath}${path.separator}${project.build.outputDirectory}${path.separator}${persistence.osgi.bundle.classpath}</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-cli</id>
-                        <configuration>
-                            <compilerArgs>
-                                <arg>-cp</arg>
-                                <arg>${test.classpath}${path.separator}${project.build.outputDirectory}${path.separator}${persistence.osgi.bundle.classpath}</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-cp</arg>
-                        <arg>${compile.classpath}${path.separator}${persistence.osgi.bundle.classpath}</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <additionalClasspathElements>
-                        <additionalClasspathElement>${project.build.directory}/dependencies/jnosql-jakarta-persistence-${jnosql.version}.jar</additionalClasspathElement>
-                        <additionalClasspathElement>${project.build.directory}/dependencies/jnosql-mapping-core-${jnosql.version}.jar</additionalClasspathElement>
-                        <additionalClasspathElement>${project.build.directory}/dependencies/jnosql-mapping-api-core-${jnosql.version}.jar</additionalClasspathElement>
-                        <additionalClasspathElement>${path.separator}${project.build.directory}/dependencies/jnosql-communication-core-${jnosql.version}.jar</additionalClasspathElement>
-                    </additionalClasspathElements>
-                </configuration>
-             </plugin>
 
             <!-- Creates the OSGi MANIFEST.MF file -->
             <plugin>

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/EntityValidatorInterceptor.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/EntityValidatorInterceptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.jnosql.jakartapersistence.mapping.glassfishcontext;
+
+import jakarta.interceptor.InvocationContext;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.executable.ExecutableValidator;
+
+import java.util.Set;
+
+import org.eclipse.jnosql.jakartapersistence.mapping.spi.MethodInterceptor;
+
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class EntityValidatorInterceptor implements MethodInterceptor {
+
+    Validator validator = null;
+
+    @Override
+    public Object intercept(InvocationContext context) throws Exception {
+        final ExecutableValidator executablesValidator = getOrCreateValidator().forExecutables();
+
+        final Set<ConstraintViolation<Object>> parameterViolations = executablesValidator
+                .validateParameters(context.getTarget(), context.getMethod(), context.getParameters());
+
+        if (parameterViolations.isEmpty()) {
+            final Object returnValue = context.proceed();
+            final Set<ConstraintViolation<Object>> returnViolations = executablesValidator
+                    .validateReturnValue(context.getTarget(), context.getMethod(), returnValue);
+            if (returnViolations.isEmpty()) {
+                return returnValue;
+            }
+            throw new ConstraintViolationException(returnViolations);
+        }
+        throw new ConstraintViolationException(parameterViolations);
+    }
+
+    private Validator getOrCreateValidator() {
+        if (validator == null) {
+            synchronized (this) {
+                if (validator == null) {
+                    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+                    validator = factory.usingContext().getValidator();
+                }
+            }
+        }
+        return validator;
+    }
+
+}

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/GlassFishClassScanner.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/GlassFishClassScanner.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jnosql.jakartapersistence.JNoSQLJakartaPersistence;
 import org.eclipse.jnosql.mapping.metadata.ClassScanner;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.hk2.classmodel.reflect.AnnotationModel;
@@ -44,8 +45,6 @@ import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.deployment.Deployment;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
-
-import org.eclipse.jnosql.jakartapersistence.JNoSQLJakartaPersistence;
 
 /**
  *

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
@@ -89,9 +89,9 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
                 .types(EntitiesMetadata.class)
                 .scope(ApplicationScoped.class);
 
-        addBean(EntityValidator.class, afterBeanDiscovery, beanManager)
+        addBean(GlassFishRepositoryInterceptor.class, afterBeanDiscovery, beanManager)
                 .types(MethodInterceptor.class)
-                .qualifiers(MethodInterceptor.SaveEntity.INSTANCE)
+                .qualifiers(MethodInterceptor.Repository.INSTANCE)
                 .alternative(true)
                 .priority(Interceptor.Priority.PLATFORM_BEFORE)
                 .scope(ApplicationScoped.class);
@@ -125,8 +125,7 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
                 .scope(ApplicationScoped.class);
 
         addBean(EnsureTransactionInterceptor.class, afterBeanDiscovery, beanManager)
-                .types(MethodInterceptor.class)
-                .qualifiers(MethodInterceptor.Repository.INSTANCE)
+                .types(EnsureTransactionInterceptor.class)
                 .alternative(true)
                 .priority(Interceptor.Priority.PLATFORM_BEFORE)
                 .scope(ApplicationScoped.class);

--- a/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
+++ b/appserver/persistence/jnosql-integration/src/main/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/JakartaPersistenceIntegrationExtension.java
@@ -129,6 +129,9 @@ public class JakartaPersistenceIntegrationExtension implements Extension {
                 .alternative(true)
                 .priority(Interceptor.Priority.PLATFORM_BEFORE)
                 .scope(ApplicationScoped.class);
+
+        addBean(EnsureTransactionInterceptor.RunInGlobalTransaction.class, afterBeanDiscovery, beanManager)
+                .scope(ApplicationScoped.class);
     }
 
     private static Types getTypes() {

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -342,11 +342,6 @@
                 <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
                 <version>${jnosql.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.jnosql.mapping</groupId>
-                <artifactId>jnosql-mapping-api-core</artifactId>
-                <version>${jnosql.version}</version>
-            </dependency>
 
             <!-- Jakarta Persistence -->
             <dependency>

--- a/appserver/tests/tck/data/pom.xml
+++ b/appserver/tests/tck/data/pom.xml
@@ -128,6 +128,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -168,7 +177,6 @@
             <!-- Surefire plugin - Entrypoint for Junit5 -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependency>jakarta.data:jakarta.data-tck</dependency>
@@ -218,6 +226,26 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>in-global-transaction</id>
+            <!-- An alternative way of running the TCK with each test wrapped in a global transaction 
+                 (except those that don't support it) 
+            -->
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <systemPropertyVariables>
+                                    <org.glassfish.data.tck.global-transaction>true</org.glassfish.data.tck.global-transaction>
+                                </systemPropertyVariables>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
         <profile>
             <id>full</id>

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/JakartaPersistenceProcessor.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/arquillian/JakartaPersistenceProcessor.java
@@ -48,10 +48,12 @@ public class JakartaPersistenceProcessor implements ApplicationArchiveProcessor 
                           SignatureTest.class.getPackage(),
                           PluginAPI.class.getPackage(),
                           com.sun.tdk.signaturetest.core.Log.class.getPackage(),
-                          CommandLineParserException.class.getPackage())
-                      .add(
-                          new ClassLoaderAsset("META-INF/services/org.junit.jupiter.api.extension.Extension"),
+                          CommandLineParserException.class.getPackage());
+            if (Boolean.getBoolean("org.glassfish.data.tck.global-transaction")) {
+                 webArchive.add(new ClassLoaderAsset("META-INF/services/org.junit.jupiter.api.extension.Extension"),
                           "WEB-INF/classes/" + "META-INF/services/org.junit.jupiter.api.extension.Extension");
+
+            }
         }
     }
 

--- a/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/TransactionExtension.java
+++ b/appserver/tests/tck/data/src/test/java/org/glassfish/tck/data/junit5/TransactionExtension.java
@@ -27,30 +27,17 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 
 public class TransactionExtension implements InvocationInterceptor {
 
-    Set<String> targetTestMethodNames = Set.of(
-            "testThirdAndFourthSlicesOf5",
-            "testFirstSliceOf5",
-            "testOrderByHasPrecedenceOverPageRequestSorts",
-            "testStaticMetamodelAscendingSortsPreGenerated",
-            "testFinalSliceOfUpTo5",
-            "testThirdAndFourthPagesOf10",
-            "testSliceOfNothing",
-            "testFindPage",
-            "testPageOfNothing",
-            "testFirstPageOf10",
-            "testBeyondFinalSlice",
-            "testLiteralTrue",
-            "testFinalPageOfUpTo10",
-            "testStaticMetamodelAscendingSorts",
-            "testBeyondFinalPage"
-            );
+    Set<String> excludeTestMethodNames = Set.of(
+            "testVersionedInsertUpdateDelete", // gives timeouts in Derby when run in a global transaction
+            "testCommit", // creates UserTransaction transaction, cannot run in a global transaction
+            "testRollback"); // creates UserTransaction transaction, cannot run in a global transaction
 
     @Override
     public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (targetTestMethodNames.contains(invocationContext.getExecutable().getName())) {
-            CDI.current().select(TransactionalWrapper.class).get().proceed(invocation);
-        } else {
+        if (excludeTestMethodNames.contains(invocationContext.getExecutable().getName())) {
             invocation.proceed();
+        } else {
+            CDI.current().select(TransactionalWrapper.class).get().proceed(invocation);
         }
     }
 

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -96,6 +96,13 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
             <id>sonatype-oss-snapshots</id>
             <url>https://central.sonatype.com/repository/maven-snapshots</url>
             <releases>
@@ -103,6 +110,8 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
+                 <updatePolicy>always</updatePolicy>
+                 <checksumPolicy>fail</checksumPolicy>
             </snapshots>
         </repository>
     </repositories>


### PR DESCRIPTION
With this PR and the latest snapshot of the JNoSQL Jakarta Persistence driver ([at this commit](https://github.com/OmniFish-EE/jnosql-extensions-jakarta-data/commit/7f3f33eabf2b4550357e59edc213cf12e9b837b8)) pushed to Maven Central, GlassFish passes all 99 tests in the Jakarta Data TCK for Jakarta EE Platform.

In this PR:

- add provider check
- chained transaction and validation interceptors into a single repository interceptor
- fixed validation for parameters and added validation for results