### PR TITLE
Upgrade JNoSQL to 1.1.10. Move OSGi bundle to GlassFish

### DIFF
--- a/appserver/distributions/glassfish/pom.xml
+++ b/appserver/distributions/glassfish/pom.xml
@@ -102,7 +102,7 @@
                 </dependencies>
                 <executions>
                     <execution>
-                        <id>do stuff</id>
+                        <id>apply-patches</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>
@@ -116,16 +116,17 @@
                                     <attribute name="includes"/>
                                     <attribute name="destfile"/>
                                     <sequential>
-                                        <echo>PATCHING</echo>
+                                        <local name="destfile.filename"/>
+                                        <basename property="destfile.filename" file="@{destfile}"/>
+                                        <echo>${line.separator}PATCHING ${destfile.filename}${line.separator}</echo>
                                         <zip destfile="@{destfile}.tmp">
                                             <zipfileset src="@{destfile}" excludes="@{includes}"/>
                                         </zip>
                                         <move file="@{destfile}.tmp" tofile="@{destfile}" />
-                                        
-                                        <loadfile property="message" srcFile="@{basedir}/@{includes}"/>
-                                        
-                                        <echo>${message}</echo>
-                                        
+                                        <local name="includes.content"/>
+                                        <loadfile property="includes.content" srcFile="@{basedir}/@{includes}"/>
+                                        <echo>${line.separator}New contents of @{includes}:${line.separator}${line.separator}</echo>
+                                        <echo>${includes.content}</echo>
                                         <zip update="true" basedir="@{basedir}" includes="@{includes}" destfile="@{destfile}" />
                                     </sequential>
                                 </macrodef>

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -90,7 +90,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>do stuff</id>
+                        <id>apply-patches</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>run</goal>
@@ -102,10 +102,17 @@
                                     <attribute name="includes"/>
                                     <attribute name="destfile"/>
                                     <sequential>
+                                        <local name="destfile.filename"/>
+                                        <basename property="destfile.filename" file="@{destfile}"/>
+                                        <echo>${line.separator}PATCHING ${destfile.filename}${line.separator}</echo>
                                         <zip destfile="@{destfile}.tmp">
                                             <zipfileset src="@{destfile}" excludes="@{includes}"/>
                                         </zip>
                                         <move file="@{destfile}.tmp" tofile="@{destfile}" />
+                                        <local name="includes.content"/>
+                                        <loadfile property="includes.content" srcFile="@{basedir}/@{includes}"/>
+                                        <echo>${line.separator}New contents of @{includes}:${line.separator}${line.separator}</echo>
+                                        <echo>${includes.content}</echo>
                                         <zip update="true" basedir="@{basedir}" includes="@{includes}" destfile="@{destfile}" />
                                     </sequential>
                                 </macrodef>

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>org.glassfish.external</groupId>
             <artifactId>antlr</artifactId>
-            <version>${antlr.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.glassfish.external</groupId>
             <artifactId>antlr</artifactId>
-            <version>${antlr.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/appserver/featuresets/glassfish/pom.xml
+++ b/appserver/featuresets/glassfish/pom.xml
@@ -292,7 +292,6 @@
         <dependency>
             <groupId>org.glassfish.external</groupId>
             <artifactId>antlr</artifactId>
-            <version>${antlr.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>ee.omnifish</groupId>
              <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
-            <version>1.1.8-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -43,17 +43,6 @@
         </dependency>
 
 
-        <dependency>
-            <groupId>ee.omnifish</groupId>
-             <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Jakarta Faces -->
        <dependency>
            <groupId>org.glassfish</groupId>
@@ -1457,12 +1446,29 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-       </dependency>
-       <!-- TMP -->
-       <dependency>
-            <groupId>io.github.classgraph</groupId>
-            <artifactId>classgraph</artifactId>
-            <version>4.8.179</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.main.persistence</groupId>
+            <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Jakarta Persistence -->

--- a/appserver/persistence/cmp/support-ejb/pom.xml
+++ b/appserver/persistence/cmp/support-ejb/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.glassfish.external</groupId>
             <artifactId>antlr</artifactId>
-            <version>${antlr.version}</version>
         </dependency>
         <dependency><!-- We depend on repackaged antlr, but antlr-maven-plugin checks for this dependency to be present -->
             <groupId>antlr</groupId>

--- a/appserver/persistence/cmp/support-sqlstore/pom.xml
+++ b/appserver/persistence/cmp/support-sqlstore/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.glassfish.external</groupId>
             <artifactId>antlr</artifactId>
-            <version>${antlr.version}</version>
         </dependency>
         <dependency><!-- We depend on repackaged antlr, but antlr-maven-plugin checks for this dependency to be present -->
             <groupId>antlr</groupId>

--- a/appserver/persistence/jnosql-integration/pom.xml
+++ b/appserver/persistence/jnosql-integration/pom.xml
@@ -35,21 +35,21 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
-
-        <!-- We use the shaded JAR for compilation and tests -->
         <dependency>
-            <groupId>ee.omnifish</groupId>
-            <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
+            <groupId>org.eclipse.jnosql.mapping</groupId>
+            <artifactId>jnosql-jakarta-persistence</artifactId>
             <version>${jnosql.version}</version>
-            <classifier>shaded</classifier>
             <exclusions>
                 <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-jakarta-persistence-scanner</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>jakarta.data</groupId>
             <artifactId>jakarta.data-api</artifactId>

--- a/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/GlassFishClassScannerTest.java
+++ b/appserver/persistence/jnosql-integration/src/test/java/org/glassfish/main/jnosql/jakartapersistence/mapping/glassfishcontext/GlassFishClassScannerTest.java
@@ -21,14 +21,20 @@ import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.persistence.Entity;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 import org.glassfish.hk2.classmodel.reflect.ParsingContext;
@@ -81,7 +87,8 @@ public class GlassFishClassScannerTest {
 
         Types types = parseClasses(allClasses);
 
-        final GlassFishClassScanner scanner = new GlassFishClassScanner(types);
+        configureCDI(types);
+        final GlassFishClassScanner scanner = new GlassFishClassScanner();
 
         final Set<Class<?>> repositoriesStandardResult = scanner.repositoriesStandard();
         assertTrue(repositoriesStandardResult.equals(standardRepositories), "Standard repositories: " + repositoriesStandardResult);
@@ -89,6 +96,23 @@ public class GlassFishClassScannerTest {
         assertTrue(customRepositoriesResult.equals(customRepositories), "Custom repositories: " + customRepositoriesResult);
         final Set<Class<?>> repositoriesResult = scanner.repositories();
         assertTrue(repositoriesResult.equals(normalRepositories), "Repositories: " + repositoriesResult);
+    }
+
+    private void configureCDI(Types types) {
+        CDI.setCDIProvider(() -> new MockCDI() {
+            @Override
+            public <U> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+                return new MockInstance<U>() {
+                    @Override
+                    public U get() {
+                        if (subtype.isAssignableFrom(ApplicationContext.class)) {
+                            return subtype.cast(new ApplicationContext(types));
+                        }
+                        throw new UnsupportedOperationException("Not supported yet.");
+                    }
+                };
+            }
+        });
     }
 
     public static Types parseClasses(Collection<Class<?>> classes) throws IOException {
@@ -120,6 +144,119 @@ public class GlassFishClassScannerTest {
 
         // Return the parsed type
         return context.getTypes();
+
+    }
+
+    static class MockCDI extends CDI<Object> {
+
+        @Override
+        public BeanManager getBeanManager() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Instance<Object> select(Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public <U> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public <U> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean isUnsatisfied() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void destroy(Object instance) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Handle<Object> getHandle() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Iterable<? extends Handle<Object>> handles() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Object get() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+    }
+
+    static class MockInstance<T> implements Instance<T> {
+
+        @Override
+        public Instance<T> select(Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean isUnsatisfied() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean isAmbiguous() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void destroy(T instance) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Handle<T> getHandle() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Iterable<? extends Handle<T>> handles() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public T get() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
 
     }
 }

--- a/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/pom.xml
+++ b/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/pom.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~
+~  Copyright (c) 2025 Contributors to the Eclipse Foundation
+~   All rights reserved. This program and the accompanying materials
+~   are made available under the terms of the Eclipse Public License v1.0
+~   and Apache License v2.0 which accompanies this distribution.
+~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~
+~   You may elect to redistribute this code under either of these licenses.
+~
+~   Contributors:
+~
+~   Ondro Mihalyi
+~   Arjan Tijms
+~
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.persistence</groupId>
+        <artifactId>persistence</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>jnosql-jakarta-persistence-osgi-bundle</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Eclipse JNoSQL Jakarta Persistence Driver OSGi bundle</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jnosql.mapping</groupId>
+            <artifactId>jnosql-jakarta-persistence</artifactId>
+            <version>${jnosql.version}</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-jakarta-persistence-scanner</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jnosql.mapping</groupId>
+                    <artifactId>jnosql-mapping-reflection</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- Creates the OSGi MANIFEST.MF file -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <_noimportjava>true</_noimportjava>
+                        <_runee>JavaSE-17</_runee>
+                        <!-- <Automatic-Module-Name>org.eclipse.jnosql.jakartapersistence</Automatic-Module-Name> -->
+                        <Extension-Name>org.eclipse.jnosql.jakartapersistence</Extension-Name>
+
+                        <Bundle-SymbolicName>org.eclipse.jnosql.jakartapersistence</Bundle-SymbolicName>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Bundle-Name>Jakarta Data Implementation ${project.version}</Bundle-Name>
+                        <Bundle-Description>Eclipse Jakarta Data Implementation (jakarta.data/1.0) ${project.version}</Bundle-Description>
+
+                        <Specification-Title>Jakarta Data</Specification-Title>
+                        <Specification-Version>1.0</Specification-Version>
+                        <Specification-Vendor>Eclipse Foundation</Specification-Vendor>
+
+                        <Implementation-Title>JNoSQL Jakarta Persistence</Implementation-Title>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Implementation-Vendor>Eclipse</Implementation-Vendor>
+                        <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
+
+                        <Import-Package>
+                            !org.eclipse.jnosql.mapping.reflection.*,
+                            *
+                        </Import-Package>
+                        <!-- TODO: import antlr runtime instead of bundling it -->
+                        <Embed-Dependency>
+                            !jakarta.data-api.*,
+                            !jakarta.persistence-api.*,
+                            !jakarta.validation-api.*,
+                            !jnosql-mapping-reflection,
+                            !classgraph,
+                            *;scope=compile|runtime
+                        </Embed-Dependency>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <Export-Package>org.eclipse.jnosql.jakartapersistence.communication,*</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <!-- Unpack source JARs from dependencies -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-sources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>sources</classifier>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                            <outputDirectory>${project.build.directory}/dependency-sources</outputDirectory>
+                            <includes>**/*.java</includes>
+                            <includeGroupIds>org.eclipse.jnosql.mapping,
+                                org.eclipse.jnosql.communication,
+                                ee.omnifish</includeGroupIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-sources-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>${basedir}/src/assembly/sources.xml</descriptor>
+                            </descriptors>
+                            <attach>true</attach>
+                            <finalName>${project.build.finalName}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/pom.xml
+++ b/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/pom.xml
@@ -84,11 +84,12 @@
                             !org.eclipse.jnosql.mapping.reflection.*,
                             *
                         </Import-Package>
-                        <!-- TODO: import antlr runtime instead of bundling it -->
                         <Embed-Dependency>
                             !jakarta.data-api.*,
                             !jakarta.persistence-api.*,
                             !jakarta.validation-api.*,
+                            !jakarta.nosql-api.*,
+                            !antlr4-runtime.*,
                             !jnosql-mapping-reflection,
                             !classgraph,
                             *;scope=compile|runtime

--- a/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/src/assembly/sources.xml
+++ b/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/src/assembly/sources.xml
@@ -1,0 +1,37 @@
+<!--
+~
+~  Copyright (c) 2025 Contributors to the Eclipse Foundation
+~   All rights reserved. This program and the accompanying materials
+~   are made available under the terms of the Eclipse Public License v1.0
+~   and Apache License v2.0 which accompanies this distribution.
+~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+~
+~   You may elect to redistribute this code under either of these licenses.
+~
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+    <id>sources</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/src/main/java</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*.java</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency-sources</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*.java</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.core.repository.RepositoryReturn
+++ b/appserver/persistence/jnosql-jakarta-persistence-osgi-bundle/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.core.repository.RepositoryReturn
@@ -1,0 +1,9 @@
+org.eclipse.jnosql.mapping.core.repository.returns.InstanceRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.ListRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.OptionalRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.PageRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.QueueRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.SetRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.SortedSetRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.StreamRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.ArrayRepositoryReturn

--- a/appserver/persistence/pom.xml
+++ b/appserver/persistence/pom.xml
@@ -36,6 +36,7 @@
         <module>common</module>
         <module>oracle-jdbc-driver-packages</module>
         <module>gf-jpa-connector</module>
+        <module>jnosql-jakarta-persistence-osgi-bundle</module>
         <module>jnosql-integration</module>
         <module>jpa-container</module>
         <module>eclipselink-wrapper</module>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -112,7 +112,7 @@
         <!-- Jakarta Data / NoSQL -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
         <jakarta.nosql-api.version>1.0.1</jakarta.nosql-api.version>
-        <jnosql.version>1.1.10-SNAPSHOT</jnosql.version>
+        <jnosql.version>1.1.10</jnosql.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -112,7 +112,7 @@
         <!-- Jakarta Data / NoSQL -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
         <jakarta.nosql-api.version>1.0.1</jakarta.nosql-api.version>
-        <jnosql.version>1.1.8-SNAPSHOT</jnosql.version>
+        <jnosql.version>1.1.10-SNAPSHOT</jnosql.version>
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -141,7 +141,9 @@
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.8</asm.version>
         <jsch.version>2.27.2</jsch.version>
-        <antlr.version>2.7.8</antlr.version>
+        <antlr2.version>2.7.7</antlr2.version>
+        <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
+        <antlr4.version>4.13.2</antlr4.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.19.2</jackson.version>
@@ -654,7 +656,17 @@
             <dependency>
                 <groupId>antlr</groupId>
                 <artifactId>antlr</artifactId>
-                <version>2.7.7</version>
+                <version>${antlr2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.external</groupId>
+                <artifactId>antlr</artifactId>
+                <version>${antlr2-repackaged.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-runtime</artifactId>
+                <version>${antlr4.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jvnet.mimepull</groupId>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -110,7 +110,6 @@
             </releases>
             <snapshots>
                 <enabled>true</enabled>
-                 <updatePolicy>always</updatePolicy>
                  <checksumPolicy>fail</checksumPolicy>
             </snapshots>
         </repository>
@@ -169,4 +168,24 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>ci</id>
+            <repositories>
+                <repository>
+                    <id>sonatype-oss-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>fail</checksumPolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
In synch with the current 1.1.x branch in github.com/eclipse-jnosql/jnosql and github.com/eclipse-jnosql/jnosql-extensions repositories, waiting for release of JNoSQL 1.1.10