### PR TITLE
Removed references to the Update Tool in docs

### DIFF
--- a/docs/add-on-component-development-guide/src/main/asciidoc/introduction.adoc
+++ b/docs/add-on-component-development-guide/src/main/asciidoc/introduction.adoc
@@ -246,9 +246,7 @@ Persistence Module].
 Packaging an add-on component enables the component to interact with the
 {productName} kernel in the same way as other components. Integrating
 a component with {productName} enables {productName} to discover
-the component at runtime. If an add-on component is an extension or
-update to existing installations of {productName}, deliver the
-component through Update Tool.
+the component at runtime.
 
 For more information, see
 xref:packaging-integrating-delivering.adoc#packaging-integrating-and-delivering-an-add-on-component[Packaging, Integrating,

--- a/docs/add-on-component-development-guide/src/main/asciidoc/packaging-integrating-delivering.adoc
+++ b/docs/add-on-component-development-guide/src/main/asciidoc/packaging-integrating-delivering.adoc
@@ -13,15 +13,12 @@ prev=session-persistence-modules.html
 Packaging an add-on component enables the component to interact with the
 {productName} kernel in the same way as other components. Integrating
 a component with {productName} enables {productName} to discover
-the component at runtime. If an add-on component is an extension or
-update to existing installations of {productName}, deliver the
-component through Update Tool.
+the component at runtime.
 
 The following topics are addressed here:
 
 * xref:#packaging-an-add-on-component[Packaging an Add-On Component]
 * xref:#integrating-an-add-on-component-with-glassfish-server[Integrating an Add-On Component With {productName}]
-* xref:#delivering-an-add-on-component-through-update-tool[Delivering an Add-On Component Through Update Tool]
 
 [[packaging-an-add-on-component]]
 
@@ -51,16 +48,6 @@ Integrating an add-on component with {productName} enables {productName} to
 discover the component at runtime. To integrate an add-on
 component with {productName}, ensure that the JAR file that contains
 the component is copied to or installed in the as-install``/modules/`` directory.
-
-[[delivering-an-add-on-component-through-update-tool]]
-
-=== Delivering an Add-On Component Through Update Tool
-
-If an add-on component is an extension or update to existing
-installations of {productName}, deliver the component through Update
-Tool. To deliver an add-on component through Update Tool, create an
-Image Packaging System (IPS) package to contain the component and add
-the package to a suitable IPS package repository.
 
 For information about how to create IPS packages, see the
 http://wikis.oracle.com/display/IpsBestPractices/[IPS best practices

--- a/docs/add-on-component-development-guide/src/main/asciidoc/packaging-integrating-delivering.adoc
+++ b/docs/add-on-component-development-guide/src/main/asciidoc/packaging-integrating-delivering.adoc
@@ -49,7 +49,4 @@ discover the component at runtime. To integrate an add-on
 component with {productName}, ensure that the JAR file that contains
 the component is copied to or installed in the as-install``/modules/`` directory.
 
-For information about how to create IPS packages, see the
-http://wikis.oracle.com/display/IpsBestPractices/[IPS best practices
-document] (`http://wikis.oracle.com/display/IpsBestPractices/`).
 

--- a/docs/application-development-guide/src/main/asciidoc/webservices.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/webservices.adoc
@@ -21,9 +21,8 @@ The following topics are addressed here:
 
 [NOTE]
 ====
-If you installed the Web Profile, web services are not supported unless
-the optional Metro Web Services Stack add-on component is downloaded
-from the Update Tool. Without the Metro add-on component, a servlet or
+If you installed the Web Profile, web services are not supported.
+Without the Metro add-on component, a servlet or
 EJB component cannot be a web service endpoint, and the
 `glassfish-web.xml` and `glassfish-ejb-jar.xml` elements related to web
 services are ignored.

--- a/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
@@ -2100,7 +2100,6 @@ nonembedded {productName} with these exceptions:
 
 * Installers
 * Administration Console
-* Update Tool
 * Apache Felix OSGi framework
 * The Maven plug-in for embedded {productName} does not support
 application clients.

--- a/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
+++ b/docs/quick-start-guide/src/main/asciidoc/basic-features.adoc
@@ -17,7 +17,6 @@ platform) applications and web technologies based on Java technology.
 * A lightweight and extensible core based on OSGi Alliance standards
 * A web container
 * An easy-to-use Administration Console for configuration and management
-* Update Tool connectivity for updates and add-on components
 * Support for high availability clustering and load balancing
 
 The following topics are addressed here:

--- a/docs/reference-manual/src/main/asciidoc/deploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploy.adoc
@@ -88,10 +88,10 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
-  `--verify`::
-    If set to true and the required verifier packages are installed from
-    the Update Tool, the syntax and semantics of the deployment descriptor
-    is verified. Default is `false`.
+`--verify`::
+  If set to true and the required verifier packages are installed from
+  the Update Tool, the syntax and semantics of the deployment descriptor
+  is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/deploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploy.adoc
@@ -22,7 +22,6 @@ asadmin [asadmin-options] deploy [--help]
 [--virtualservers virtual_servers]
 [--contextroot context_root]
 [--precompilejsp={false|true}]
-[--verify={false|true}]
 [--name component_name]
 [--upload={true|false}]
 [--retrieve local_dirpath]
@@ -88,10 +87,6 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
-`--verify`::
-  If set to true and the required verifier packages are installed from
-  the Update Tool, the syntax and semantics of the deployment descriptor
-  is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/deploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploy.adoc
@@ -89,8 +89,8 @@ asadmin-options::
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
 `--verify`::
-  If set to true and the required verifier packages are installed from
-  the Update Tool, the syntax and semantics of the deployment descriptor
+  If set to true and the required verifier packages are installed,
+  the syntax and semantics of the deployment descriptor
   is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +

--- a/docs/reference-manual/src/main/asciidoc/deploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploy.adoc
@@ -22,6 +22,7 @@ asadmin [asadmin-options] deploy [--help]
 [--virtualservers virtual_servers]
 [--contextroot context_root]
 [--precompilejsp={false|true}]
+[--verify={false|true}]
 [--name component_name]
 [--upload={true|false}]
 [--retrieve local_dirpath]
@@ -87,6 +88,10 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
+  `--verify`::
+    If set to true and the required verifier packages are installed from
+    the Update Tool, the syntax and semantics of the deployment descriptor
+    is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/deploydir.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploydir.adoc
@@ -21,7 +21,6 @@ asadmin [asadmin-options] deploydir [--help]
 [--force={false|true}]
 [--virtualservers virtual_servers]
 [--contextroot context_root]
-[--verify={false|true}]
 [--precompilejsp={false|true}]
 [--name component-name]
 [--retrieve local_dirpath]
@@ -102,10 +101,6 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
-`--verify`::
-  If set to true and the required verifier packages are installed from
-  the Update Tool, the syntax and semantics of the deployment descriptor
-  is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/deploydir.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploydir.adoc
@@ -102,10 +102,10 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
-  `--verify`::
-    If set to true and the required verifier packages are installed from
-    the Update Tool, the syntax and semantics of the deployment descriptor
-    is verified. Default is `false`.
+`--verify`::
+  If set to true and the required verifier packages are installed from
+  the Update Tool, the syntax and semantics of the deployment descriptor
+  is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/deploydir.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploydir.adoc
@@ -21,6 +21,7 @@ asadmin [asadmin-options] deploydir [--help]
 [--force={false|true}]
 [--virtualservers virtual_servers]
 [--contextroot context_root]
+[--verify={false|true}]
 [--precompilejsp={false|true}]
 [--name component-name]
 [--retrieve local_dirpath]
@@ -101,6 +102,10 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
+  `--verify`::
+    If set to true and the required verifier packages are installed from
+    the Update Tool, the syntax and semantics of the deployment descriptor
+    is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/deploydir.adoc
+++ b/docs/reference-manual/src/main/asciidoc/deploydir.adoc
@@ -103,8 +103,8 @@ asadmin-options::
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
 `--verify`::
-  If set to true and the required verifier packages are installed from
-  the Update Tool, the syntax and semantics of the deployment descriptor
+  If set to true and the required verifier packages are installed,
+  the syntax and semantics of the deployment descriptor
   is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +

--- a/docs/reference-manual/src/main/asciidoc/redeploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/redeploy.adoc
@@ -32,7 +32,6 @@ asadmin [asadmin-options] redeploy [--help]
 [--generatermistubs={false|true}]
 [--contextroot context_root]
 [--precompilejsp={true|false}]
-[--verify={false|true}]
 [--virtualservers virtual_servers]
 [--availabilityenabled={false|true}]
 [--asyncreplication={true|false}]
@@ -75,10 +74,6 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
-`--verify`::
-  If set to true and the required verifier packages are installed from
-  the Update Tool, the syntax and semantics of the deployment descriptor
-  is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/redeploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/redeploy.adoc
@@ -75,10 +75,10 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
-  `--verify`::
-    If set to true and the required verifier packages are installed from
-    the Update Tool, the syntax and semantics of the deployment descriptor
-    is verified. Default is `false`.
+`--verify`::
+  If set to true and the required verifier packages are installed from
+  the Update Tool, the syntax and semantics of the deployment descriptor
+  is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/reference-manual/src/main/asciidoc/redeploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/redeploy.adoc
@@ -76,8 +76,8 @@ asadmin-options::
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
 `--verify`::
-  If set to true and the required verifier packages are installed from
-  the Update Tool, the syntax and semantics of the deployment descriptor
+  If set to true and the required verifier packages are installed,
+  the syntax and semantics of the deployment descriptor
   is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +

--- a/docs/reference-manual/src/main/asciidoc/redeploy.adoc
+++ b/docs/reference-manual/src/main/asciidoc/redeploy.adoc
@@ -32,6 +32,7 @@ asadmin [asadmin-options] redeploy [--help]
 [--generatermistubs={false|true}]
 [--contextroot context_root]
 [--precompilejsp={true|false}]
+[--verify={false|true}]
 [--virtualservers virtual_servers]
 [--availabilityenabled={false|true}]
 [--asyncreplication={true|false}]
@@ -74,6 +75,10 @@ asadmin-options::
   By default this option does not allow the JSP to be precompiled during
   deployment. Instead, JSPs are compiled during runtime. Default is
   `false`.
+  `--verify`::
+    If set to true and the required verifier packages are installed from
+    the Update Tool, the syntax and semantics of the deployment descriptor
+    is verified. Default is `false`.
 `--name`::
   Name of the deployable component. +
   The name can include an optional version identifier, which follows the

--- a/docs/troubleshooting-guide/src/main/asciidoc/faqs.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/faqs.adoc
@@ -21,7 +21,6 @@ This chapter contains the following:
 * xref:#eclipse-faqs[Eclipse FAQs]
 * xref:#extensibility-faqs[Extensibility FAQs]
 * xref:#java-persistence-faqs[Java Persistence FAQs]
-* xref:#update-tool-faqs[Update Tool FAQs]
 
 [[administration-faqs]]
 
@@ -116,63 +115,3 @@ See "xref:add-on-component-development-guide.adoc#extending-the-administration-c
 
 See "xref:application-development-guide.adoc#restrictions-and-optimizations[Restrictions and Optimizations]" in {productName} Application Development Guide.
 
-[[update-tool-faqs]]
-
-=== Update Tool FAQs
-
-[[how-do-i-use-update-tool-to-extend-my-glassfish-server-installation]]
-
-==== How Do I Use Update Tool to Extend My {productName} Installation?
-
-Enterprise Server provides an administrative tool called Update Tool
-that enables you to install updates and add-on components to your
-existing Enterprise Server installation.
-
-Update Tool can be accessed as a standalone graphical tool from the
-command line (using the `updatetool` command from
-as-install-parent``/bin``), or as a browser-based graphical tool from the
-Administration Console (using the Update Tool node). For more
-information about Update Tool, see "xref:administration-guide.adoc#GSADG00701[Update Tool]" in
-{productName} Administration Guide.
-
-[NOTE]
-====
-To update or remove installed components, you must use the standalone
-graphical Update Tool, not the Administration Console Update Tool.
-====
-
-A command-line interface is also available for Update Tool. This
-interface uses the `pkg` command and enables you to perform most of the
-tasks provided by the standalone graphical version. For more information
-about the `pkg` command, see "xref:administration-guide.adoc#GSADG00014[Extending and Updating
-{productName}]" in {productName}
-Administration Guide.
-
-[NOTE]
-====
-Update Tool differs from Upgrade Tool, which is used to migrate the
-configuration and deployed applications from an earlier version of
-{productName} to the current version. For more information about
-Upgrade Tool and upgrading, see the xref:upgrade-guide.adoc#GSUPG[{productName} Upgrade Guide].
-====
-
-[[how-do-i-turn-off-the-notifier]]
-
-==== How Do I Turn Off the Notifier?
-
-Update Tool provides automatic notifications of available updates after
-installation. These notifications can be turned off if desired.
-
-[[to-turn-off-the-notifier]]
-
-===== To Turn Off the Notifier
-
-1. Launch the standalone graphical tool using the `updatetool` command:
-+
-[source]
-----
-as-install-parent/bin/updatetool
-----
-2. Click Preferences.
-3. Click the Updates tab.
-4. Deselect Automatically Check for Updates and click OK.

--- a/docs/troubleshooting-guide/src/main/asciidoc/specific-issues.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/specific-issues.adoc
@@ -665,38 +665,6 @@ inability to stop the domain.
 
 === Issues Related to Installation
 
-[[installation-hangs-during-update-tool-configuration]]
-
-==== Installation Hangs During Update Tool Configuration
-
-[[description-16]]
-
-===== Description
-
-Installation hangs more than five minutes during Update Tool configuration.
-
-[[solution-13]]
-
-===== Solution
-
-Cancel the installation and run the installation program again, but this
-time deselect the Install Update Tool check box. Update Tool can be
-installed later from as-install``/bin/``. For more information about
-Update Tool, see "xref:administration-guide.adoc#GSADG00701[Update Tool]"
-in {productName} Administration Guide. For general information about
-{productName}installation, see the xref:installation-guide.adoc#GSING[
-{productName} Installation Guide].
-
-
-[NOTE]
-====
-Update Tool differs from Upgrade Tool, which is used to migrate the
-configuration and deployed applications from an earlier version of
-{productName} to the current version.
-For more information about Upgrade Tool and upgrading, see the
-xref:upgrade-guide.adoc#GSUPG[{productName} Upgrade Guide].
-====
-
 
 [[glassfish-server-components-not-removed-during-uninstallation]]
 

--- a/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
@@ -20,12 +20,11 @@ installation. The Upgrade Tool assists in upgrading the configuration
 and applications from an earlier version of the Application Server or
 {productName} to {productName} {product-majorVersion}.
 
-In addition to Upgrade Tool, there are three Update Center tools that
+In addition to Upgrade Tool, there are two Update Center tools that
 can be used to perform an in-place upgrade to {productName} {product-majorVersion} from
 {productName} 3.1.1, 3.1, 3.0.1, and Enterprise Server v3. These
-three Update Center tools are:
+two Update Center tools are:
 
-* Update Tool
 * Software Update Notifier
 * The `pkg` command-line utility
 
@@ -92,7 +91,7 @@ In-Place::
   installed directly over and into the same directory as the previous
   product release. The existing configuration is reused in the updated
   installation. +
-In this scenario, you simply use Update Tool, the `pkg` utility, or
+In this scenario, you simply use the `pkg` utility or
   the Update Notifier in your old installation to overwrite the old
   installation with the new {productName} {product-majorVersion} product. +
   Performing an in-place upgrade is easier than performing a
@@ -141,7 +140,6 @@ The following topics are addressed here:
 
 * xref:#summary-of-tools-for-performing-an-upgrade[Summary of Tools for Performing an Upgrade]
 * xref:#summary-of-procedure-for-upgrading-with-upgrade-tool[Summary of Procedure for Upgrading With Upgrade Tool]
-* xref:#summary-of-procedure-for-upgrading-with-update-tool[Summary of Procedure for Upgrading With Update Tool]
 * xref:#summary-of-procedure-for-upgrading-with-the-software-update-notifier[Summary of Procedure for Upgrading With the Software Update Notifier]
 * xref:#summary-of-procedure-for-upgrading-with-the-pkg-utility[Summary of Procedure for Upgrading With the `pkg` Utility]
 
@@ -152,7 +150,6 @@ The following topics are addressed here:
 There are several tools you can use to perform an upgrade to {productName} {product-majorVersion} are described below.
 
 * xref:#upgrade-tool[Upgrade Tool]
-* xref:#update-tool-and-the-pkg-utility[Update Tool and the `pkg` Utility]
 * xref:#software-update-notifier[Software Update Notifier]
 
 [[upgrade-tool]]
@@ -181,52 +178,14 @@ See xref:#summary-of-procedure-for-upgrading-with-upgrade-tool[Summary of Proced
 for an overview of the general procedure for performing an upgrade with
 Upgrade Tool.
 
-[[update-tool-and-the-pkg-utility]]
-
-Update Tool and the `pkg` Utility
-
-The {productName} Update Tool is a graphical utility that is
-typically used for the day-to-day maintenance of {productName}
-components and additional features. For example, Update Tool can be used
-to update {productName} components or install additional features
-such as OSGi Admin Console.
-
-The command-line counterpart to Update Tool is the `pkg` utility. While
-the `pkg` utility does not provide exactly the same set of features as
-Update Tool, for the purposes of upgrading to {productName} {product-majorVersion}, the
-`pkg` utility and Update Tool feature sets are almost identical.
-
-In addition to day-to-day maintenance tasks, Update Tool and the `pkg`
-utility can be used to perform an in-place upgrade of an entire
-{productName} 3.0.1 or Enterprise Server v3 installation to the
-{productName} {product-majorVersion} or later release.
-
-In {productName} {product-majorVersion} Update Tool is installed in the
-as-install-parent``/bin`` directory.
-
-[NOTE]
-====
-It is not possible to use Update Tool to upgrade from {productName}
-or Enterprise Server versions prior to 3x. For these older versions, you
-must use the Upgrade Tool, described in xref:#upgrade-tool[Upgrade Tool].
-====
-
-See xref:#summary-of-procedure-for-upgrading-with-update-tool[Summary of Procedure for Upgrading With Update Tool] for
-an overview of the general procedure for performing an upgrade with
-Update Tool. For more information about Update Tool in general, see
-"xref:administration-guide.adoc#GSADG00701[Update Tool]"
-in {productName} Administration Guide.
-
 [[software-update-notifier]]
 
 Software Update Notifier
 
-The {productName} Software Update Notifier is similar to Update Tool
-and the `pkg` utility in that it enables you to perform an in-place
-upgrade from {productName} 3.1.1, 3.1, 3.0.1, or Enterprise Server
-v3. As with Update Tool and the `pkg` utility, you cannot use the
-Software Update tool to upgrade from product releases prior 3.0.1 and
-v3.
+The {productName} Software Update Notifier enables you to perform
+an in-place upgrade from {productName} 3.1.1, 3.1, 3.0.1, or
+Enterprise Server v3. But you cannot use the Software Update Notifier
+to upgrade from product releases prior 3.0.1 and v3.
 
 The Software Update Notifier is distributed as a configuration option
 during {productName} {product-majorVersion}, 3.0.1, and Enterprise Server v3
@@ -262,27 +221,6 @@ as-install``/bin`` directory.
 
 This procedure is described in more detail in xref:#performing-a-side-by-side-upgrade-with-upgrade-tool[Performing a
 Side-By-Side Upgrade With Upgrade Tool].
-
-[[summary-of-procedure-for-upgrading-with-update-tool]]
-
-===== Summary of Procedure for Upgrading With Update Tool
-
-The general procedure for using Update Tool to perform an upgrade to
-{productName} {product-majorVersion} from {productName} 3.0.1 or Enterprise Server v3
-comprises the following steps:
-
-1. Manually stop all server instances and the domain.
-2. Launch Update Tool by using the as-install-parent`/bin/updatetool`
-command in the older product directory.
-3. In Update Tool, select and install the latest {productName}
-product release. This updates your server to the {product-majorVersion} release.
-4. Upgrade the domain by running the `asadmin start-domain --upgrade`
-subcommand. This performs the upgrade and then shuts down the DAS.
-5. Restart the DAS normally with the with the `asadmin start-domain`
-subcommand.
-
-This procedure is described in more detail in xref:#to-upgrade-using-the-update-tool-gui[To Upgrade
-Using the Update Tool GUI].
 
 [[summary-of-procedure-for-upgrading-with-the-software-update-notifier]]
 
@@ -800,11 +738,10 @@ click the Help button on the Administration Console.
 
 === Performing an In-Place Upgrade With the Update Center Tools
 
-This section explains how to use the three Update Center tools to
-perform an in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1 or Enterprise Server v3. Specifically, the three tools
+This section explains how to use the two Update Center tools to
+perform an in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1 or Enterprise Server v3. Specifically, the two tools
 explained in this section are:
 
-* Update Tool
 * Software Update Notifier
 * The `pkg` command-line utility
 
@@ -820,7 +757,6 @@ Upgrade With Upgrade Tool].
 The following topics are addressed here:
 
 * xref:#update-center-tool-procedures[Update Center Tool Procedures]
-* xref:#to-upgrade-using-the-update-tool-gui[To Upgrade Using the Update Tool GUI]
 * xref:#to-upgrade-using-the-software-update-notifier[To Upgrade Using the Software Update Notifier]
 * xref:#to-upgrade-from-the-command-line-using-the-pkg-utility[To Upgrade From the Command Line Using the `pkg` Utility]
 
@@ -828,8 +764,8 @@ The following topics are addressed here:
 
 ==== Update Center Tool Procedures
 
-Unlike when using Upgrade Tool, when you use the Update Tool, the
-Software Update Notifier, or the `pkg` utility to perform a {productName} {product-majorVersion} upgrade, the older source server directories are overwritten
+Unlike when using Upgrade Tool, when you use the
+Software Update Notifier or the `pkg` utility to perform a {productName} {product-majorVersion} upgrade, the older source server directories are overwritten
 with the new target server directories, and the existing configuration
 and deployed applications are reused in the updated installation.
 
@@ -839,62 +775,10 @@ and writer permissions for the server installation directories.
 You can perform an upgrade using the Update Center tools in the
 following ways:
 
-* xref:#to-upgrade-using-the-update-tool-gui[To Upgrade Using the Update Tool GUI]
 * xref:#to-upgrade-using-the-software-update-notifier[To Upgrade Using the Software Update Notifier]
 * xref:#to-upgrade-from-the-command-line-using-the-pkg-utility[To Upgrade From the Command Line Using the `pkg` Utility]
 
-[[to-upgrade-using-the-update-tool-gui]]
 
-==== To Upgrade Using the Update Tool GUI
-
-This procedure explains how to use the graphical Update Tool to perform
-an in-place upgrade to {productName} {product-majorVersion} from {productName} 3.0.1
-or Enterprise Server v3. Note that it is not possible to use this
-procedure with any other product releases.
-
-1. Ensure that all domains on the source server from which you are
-upgrading are stopped before proceeding.
-
-2. In a command shell for your operating environment, navigate to the
-as-install-parent``/bin`` directory.
-
-3. Use the `updatetool` command to start the Update Tool GUI. +
-The Update Tool main window is displayed.
-
-4. Click on Available Updates.
-
-5. Select all items in the Available Updates list, and then click the
-Install button in the toolbar at the top of the Update Tool main window. +
-When the upgrade is complete, exit Update Tool.
-
-6. Upgrade the domain by starting the DAS with the `--upgrade` option.
-+
-[source]
-----
-as-install/bin/asadmin start-domain --upgrade domain-name
-----
-This upgrades the domain and then shuts down the DAS.
-
-7. Start the DAS normally.
-+
-[source]
-----
-as-install/bin/asadmin start-domain domain-name
-----
-
-
-
-Next Steps
-
-* Browse to the URL `http://localhost:8080` to view the
-domain-dir``/docroot/index.html`` file. This file is brought over during
-the upgrade. You may want to copy the default {productName} {product-majorVersion} file
-from the `domain1.original/docroot` directory and customize it for your
-{productName} {product-majorVersion} installation.
-* To register your installation of {productName} from the
-Administration Console, select the Registration item from the Common
-Tasks page. For step-by-step instructions on the registration process,
-click the Help button on the Administration Console.
 
 [[to-upgrade-using-the-software-update-notifier]]
 

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
@@ -76,8 +76,8 @@ OPTIONS
            Default is false.
 
        --verify
-           If set to true and the required verifier packages are installed
-           from the Update Tool, the syntax and semantics of the deployment
+           If set to true and the required verifier packages are installed,
+           the syntax and semantics of the deployment
            descriptor is verified. Default is false.
 
        --name

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
@@ -9,7 +9,6 @@ SYNOPSIS
            [--virtualservers virtual_servers]
            [--contextroot context_root]
            [--precompilejsp={false|true}]
-           [--verify={false|true}]
            [--name component_name]
            [--upload={true|false}]
            [--retrieve local_dirpath]
@@ -74,11 +73,6 @@ OPTIONS
            By default this option does not allow the JSP to be precompiled
            during deployment. Instead, JSPs are compiled during runtime.
            Default is false.
-
-       --verify
-           If set to true and the required verifier packages are installed
-           from the Update Tool, the syntax and semantics of the deployment
-           descriptor is verified. Default is false.
 
        --name
            Name of the deployable component.

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploy.1
@@ -9,6 +9,7 @@ SYNOPSIS
            [--virtualservers virtual_servers]
            [--contextroot context_root]
            [--precompilejsp={false|true}]
+           [--verify={false|true}]
            [--name component_name]
            [--upload={true|false}]
            [--retrieve local_dirpath]
@@ -73,6 +74,11 @@ OPTIONS
            By default this option does not allow the JSP to be precompiled
            during deployment. Instead, JSPs are compiled during runtime.
            Default is false.
+
+       --verify
+           If set to true and the required verifier packages are installed
+           from the Update Tool, the syntax and semantics of the deployment
+           descriptor is verified. Default is false.
 
        --name
            Name of the deployable component.

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
@@ -8,7 +8,6 @@ SYNOPSIS
            [--force={false|true}]
            [--virtualservers virtual_servers]
            [--contextroot context_root]
-           [--verify={false|true}]
            [--precompilejsp={false|true}]
            [--name component-name]
            [--retrieve local_dirpath]
@@ -90,11 +89,6 @@ OPTIONS
            By default this option does not allow the JSP to be precompiled
            during deployment. Instead, JSPs are compiled during runtime.
            Default is false.
-
-       --verify
-           If set to true and the required verifier packages are installed
-           from the Update Tool, the syntax and semantics of the deployment
-           descriptor is verified. Default is false.
 
        --name
            Name of the deployable component.

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
@@ -9,6 +9,7 @@ SYNOPSIS
            [--virtualservers virtual_servers]
            [--contextroot context_root]
            [--precompilejsp={false|true}]
+           [--verify={false|true}]
            [--name component-name]
            [--retrieve local_dirpath]
            [--uniquetablenames={true|false}]
@@ -90,6 +91,10 @@ OPTIONS
            during deployment. Instead, JSPs are compiled during runtime.
            Default is false.
 
+       --verify
+           If set to true and the required verifier packages are installed
+           from the Update Tool, the syntax and semantics of the deployment
+           descriptor is verified. Default is false.
        --name
            Name of the deployable component.
 

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/deploydir.1
@@ -92,8 +92,8 @@ OPTIONS
            Default is false.
 
        --verify
-           If set to true and the required verifier packages are installed
-           from the Update Tool, the syntax and semantics of the deployment
+           If set to true and the required verifier packages are installed,
+           the syntax and semantics of the deployment
            descriptor is verified. Default is false.
        --name
            Name of the deployable component.

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
@@ -19,6 +19,7 @@ SYNOPSIS
            [--generatermistubs={false|true}]
            [--contextroot context_root]
            [--precompilejsp={true|false}]
+           [--verify={false|true}]
            [--virtualservers virtual_servers]
            [--availabilityenabled={false|true}]
            [--asyncreplication={true|false}]
@@ -58,6 +59,11 @@ OPTIONS
            By default this option does not allow the JSP to be precompiled
            during deployment. Instead, JSPs are compiled during runtime.
            Default is false.
+
+       --verify
+           If set to true and the required verifier packages are installed
+           from the Update Tool, the syntax and semantics of the deployment
+           descriptor is verified. Default is false.
 
        --name
            Name of the deployable component.

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
@@ -61,8 +61,8 @@ OPTIONS
            Default is false.
 
        --verify
-           If set to true and the required verifier packages are installed
-           from the Update Tool, the syntax and semantics of the deployment
+           If set to true and the required verifier packages are installed,
+           the syntax and semantics of the deployment
            descriptor is verified. Default is false.
 
        --name

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/redeploy.1
@@ -19,7 +19,6 @@ SYNOPSIS
            [--generatermistubs={false|true}]
            [--contextroot context_root]
            [--precompilejsp={true|false}]
-           [--verify={false|true}]
            [--virtualservers virtual_servers]
            [--availabilityenabled={false|true}]
            [--asyncreplication={true|false}]
@@ -59,11 +58,6 @@ OPTIONS
            By default this option does not allow the JSP to be precompiled
            during deployment. Instead, JSPs are compiled during runtime.
            Default is false.
-
-       --verify
-           If set to true and the required verifier packages are installed
-           from the Update Tool, the syntax and semantics of the deployment
-           descriptor is verified. Default is false.
 
        --name
            Name of the deployable component.


### PR DESCRIPTION
In this PR, the Update tool is removed from the docs since it doesn't exist in Eclipse GlassFish anymore.

Fixes <https://github.com/eclipse-ee4j/glassfish/issues/24304>