### PR TITLE
Providing default SSLContextProvider

### DIFF
--- a/appserver/web/jersey-ejb-component-provider/src/main/java/org/glassfish/jersey/gf/ejb/internal/GlassFishSslContextProvider.java
+++ b/appserver/web/jersey-ejb-component-provider/src/main/java/org/glassfish/jersey/gf/ejb/internal/GlassFishSslContextProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+
+package org.glassfish.jersey.gf.ejb.internal;
+
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+
+import org.glassfish.jersey.client.spi.DefaultSslContextProvider;
+
+/**
+ * Default SSL context provider for REST clients used from GlassFish.
+ */
+public class GlassFishSslContextProvider implements DefaultSslContextProvider {
+
+    @Override
+    public SSLContext getDefaultSslContext() {
+        try {
+            // See SSLUtils.getSSLContext() - it sets the default SSLContext.
+            return SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to obtain default SSLContext!", e);
+        }
+    }
+}

--- a/appserver/web/jersey-ejb-component-provider/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.DefaultSslContextProvider
+++ b/appserver/web/jersey-ejb-component-provider/src/main/resources/META-INF/services/org.glassfish.jersey.client.spi.DefaultSslContextProvider
@@ -1,0 +1,1 @@
+org.glassfish.jersey.gf.ejb.internal.GlassFishSslContextProvider

--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -1612,6 +1612,10 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
             // myfaces-api uses jakarta.faces packages
             return !useMyFaces;
         }
+        if (name.startsWith("META-INF/services/org.glassfish.jersey.client.spi.DefaultSslContextProvider")) {
+            // Jersey Client uses GF cacerts and keystore by default
+            return true;
+        }
         if (DELEGATED_RESOURCE_PATHS.stream().anyMatch(name::startsWith)) {
             return true;
         }


### PR DESCRIPTION
- Originally Jersey REST client depended on JVM options, so we had to set the truststore password to the JVM option. Now we don't do that.
- Note that user can always configure own provider. If it is not set, Jersey constructs own default made of system properties - but we already have it loaded.
- This change should make also some tests a bit faster as we don't load the truststore for every test class. The same applies for users.
- Fixes Security TCK after recent changes around truststore