### PR TITLE
Addded TCK security and updated arquillian glassfish container

### DIFF
--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -38,8 +38,6 @@
         <faces.tck.version>4.0.3</faces.tck.version>
         <tck.root>${project.build.directory}</tck.root>
         <tck.parentPomFile>${tck.root}/faces-tck-${faces.tck.version}/tck/pom.xml</tck.parentPomFile>
-        <maven.executable>${maven.home}/bin/mvn</maven.executable>
-        <maven.settings.xml>${user.home}/.m2/settings.xml</maven.settings.xml>
     </properties>
 
     <dependencyManagement>

--- a/appserver/tests/tck/pom.xml
+++ b/appserver/tests/tck/pom.xml
@@ -49,6 +49,7 @@
         <module>pages_tags</module>
         <module>pages_debugging</module>
         <module>servlet</module>
+        <module>security</module>
         <module>authentication</module>
         <module>authorization</module>
         <module>cdi</module>
@@ -61,6 +62,9 @@
     </modules>
 
     <properties>
+        <maven.executable>${maven.home}/bin/mvn${file.executable.suffix}</maven.executable>
+        <maven.settings.xml>${user.home}/.m2/settings.xml</maven.settings.xml>
+
         <glassfish.version>${project.version}</glassfish.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.directoryName>glassfish7</glassfish.directoryName>
@@ -80,7 +84,7 @@
         <port.orb.ssl>13820</port.orb.ssl>
         <port.harness.log>12000</port.harness.log>
 
-        <omnifish.arquillian.version>2.0.0</omnifish.arquillian.version>
+        <omnifish.arquillian.version>2.1.0</omnifish.arquillian.version>
     </properties>
 
     <dependencyManagement>

--- a/appserver/tests/tck/security/pom.xml
+++ b/appserver/tests/tck/security/pom.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.tests.tck</groupId>
+        <artifactId>tck</artifactId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>glassfish-external-tck-security</artifactId>
+    <packaging>pom</packaging>
+
+    <name>TCK: Security</name>
+
+    <properties>
+        <tck.home>${project.build.directory}/security-tck-3.0.3/tck</tck.home>
+        <tck.old.glassfish.home>${tck.home}/old-tck/run/target/glassfish7</tck.old.glassfish.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.tests.tck</groupId>
+            <artifactId>jakarta-security-tck</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <skip>${skipITs}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>unpack-glassfish</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>glassfish</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-tck</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>jakarta-security-tck</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${maven.executable}</executable>
+                            <arguments>
+                                <argument>-B</argument>
+                                <argument>-e</argument>
+                                <argument>-s</argument>
+                                <argument>${maven.settings.xml}</argument>
+                                <argument>-f</argument>
+                                <argument>${tck.home}/pom.xml</argument>
+                                <argument>clean</argument>
+                                <argument>install</argument>
+                                <argument>-Pglassfish-ci-managed</argument>
+                                <argument>-Dglassfish.home=${glassfish.home}</argument>
+                                <argument>-Dglassfish.version=${glassfish.version}</argument>
+                                <argument>-Dglassfish.arquillian.version=${omnifish.arquillian.version}</argument>
+                                <argument>-DtrustStore.suffix=p12</argument>
+                            </arguments>
+                            <commandlineArgs>${tck.args}</commandlineArgs>
+                        </configuration>
+                    </execution>
+                    <!-- TCK old doesn't properly stop -->
+                    <execution>
+                        <id>stop-domain</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${glassfish.home}/bin/asadmin</executable>
+                            <arguments>
+                                <argument>stop-domain</argument>
+                                <argument>--kill</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-database</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>${tck.old.glassfish.home}/bin/asadmin</executable>
+                            <arguments>
+                                <argument>stop-database</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>print-warning</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>/bin/echo</executable>
+                            <arguments>
+                                <argument>
+                                WARNING: This TCK leaves few processes running, we tried out best, but you probably will have to stop them manually: GlassFish, LDAP, Derby.
+                                </argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/tests/tck/tck-download/jakarta-security-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-security-tck/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.main.tests.tck</groupId>
+        <artifactId>tck-download</artifactId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta-security-tck</artifactId>
+    <packaging>pom</packaging>
+    <name>TCK: Install Jakarta Security TCK</name>
+
+    <properties>
+        <tck.artifactFileName>jakarta-security-tck-3.0.3.zip</tck.artifactFileName>
+        <tck.artifactUrl>https://download.eclipse.org/security/jakartaee10/staged/eftl/${tck.artifactFileName}</tck.artifactUrl>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.download-maven-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-tck</id>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-tck</id>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/tests/tck/tck-download/pom.xml
+++ b/appserver/tests/tck/tck-download/pom.xml
@@ -47,6 +47,7 @@
         <module>jakarta-pages-tck</module>
         <module>jakarta-pages-tags-tck</module>
         <module>jakarta-pages-debugging-tck</module>
+        <module>jakarta-security-tck</module>
         <module>jakarta-servlet-tck</module>
         <module>jakarta-authentication-tck</module>
         <module>jakarta-authorization-tck</module>


### PR DESCRIPTION
Depends on the release of Security TCK 3.0.3 as with 3.0.2 it would need much more work (filtering pom, resolving problems with Tomcat).

See
* https://github.com/jakartaee/security/pull/352
* https://github.com/jakartaee/security/pull/351
* https://github.com/jakartaee/security/pull/350
* https://github.com/jakartaee/security/pull/349

With the locally built TCK:
```
mvn clean install -Ptck -pl :glassfish-external-tck-security
```
<img width="649" height="760" alt="image" src="https://github.com/user-attachments/assets/c2b7b668-0694-4e54-b565-ac9e2c8ef181" />
