### PR TITLE
Fixed appclient classpath

### DIFF
--- a/appserver/appclient/client/acc-standalone/pom.xml
+++ b/appserver/appclient/client/acc-standalone/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${project.version}</version>

--- a/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/CLIBootstrap.java
+++ b/appserver/appclient/client/acc-standalone/src/main/java/org/glassfish/appclient/client/acc/agent/CLIBootstrap.java
@@ -32,6 +32,7 @@ import org.glassfish.embeddable.client.ApplicationClientCLIEncoding;
 import org.glassfish.embeddable.client.UserError;
 
 import static java.lang.System.arraycopy;
+import static org.glassfish.appclient.client.acc.agent.ClassPathUtils.getClassPathForGfClient;
 import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
 import static org.glassfish.embeddable.GlassFishVariable.JAVA_HOME;
 
@@ -289,6 +290,10 @@ public class CLIBootstrap {
         command.append(' ').append("--module-path ").append(quote(gfBootstrapLibs.toString()));
         command.append(' ').append("--add-modules ALL-MODULE-PATH");
         command.append(' ').append("--add-opens=java.base/java.lang=ALL-UNNAMED");
+        if (userVMArgs.evJVMValuedOptions.values.isEmpty()) {
+            // Even to print help we need this jar on classpath
+            command.append(' ').append("-cp ").append(gfInfo.agentJarPath());
+        }
         command.append(' ').append("-Xshare:off");
         command.append(' ').append(SYSPROP_SYSTEM_CLASS_LOADER).append("org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader");
         command.append(' ').append("-D").append(INSTALL_ROOT.getSystemPropertyName()).append('=').append(quote(gfInfo.home().getAbsolutePath()));
@@ -754,8 +759,7 @@ public class CLIBootstrap {
             // Make sure there is a next item and that it
             if (args[slot].charAt(0) != '-') {
                 values.add("-classpath");
-                values.add(gfInfo.agentJarPath() + File.pathSeparatorChar
-                    + ClassPathUtils.getClassPathForGfClient("."));
+                values.add(gfInfo.agentJarPath() + File.pathSeparatorChar + getClassPathForGfClient("."));
                 final int result = super.processValue(args, slot);
                 String className = values.get(values.size() - 1);
                 agentArgs.add("client=class=" + className);
@@ -785,8 +789,7 @@ public class CLIBootstrap {
                 } else if (clientJarPath.endsWith(".jar")) {
                     introducer = null;
                     values.add("-classpath");
-                    values.add(gfInfo.agentJarPath() + File.pathSeparatorChar
-                        + ClassPathUtils.getClassPathForGfClient(clientJarPath));
+                    values.add(gfInfo.agentJarPath() + File.pathSeparatorChar + getClassPathForGfClient(clientJarPath));
                     String mainClass = ClassPathUtils.getMainClass(clientJarFile);
                     values.add(mainClass == null ? "" : mainClass);
                 } else {

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientContainerHolder.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientContainerHolder.java
@@ -201,7 +201,7 @@ public class AppClientContainerHolder implements ApplicationClientContainer {
         try (BufferedReader helpReader = new BufferedReader(new InputStreamReader(is))) {
             String line;
             while ((line = helpReader.readLine()) != null) {
-                System.err.println(line);
+                System.out.println(line);
             }
         } finally {
             System.exit(0);

--- a/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientContainerHolder.java
+++ b/appserver/appclient/client/acc/src/main/java/org/glassfish/appclient/client/AppClientContainerHolder.java
@@ -188,7 +188,7 @@ public class AppClientContainerHolder implements ApplicationClientContainer {
     }
 
     private static void usage(final int exitStatus) {
-        System.err.println(getUsage());
+        System.out.println(getUsage());
         System.exit(exitStatus);
     }
 

--- a/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
+++ b/appserver/appclient/client/appclient-scripts/src/main/resources/glassfish/bin/appclient.bat
@@ -29,12 +29,15 @@ call "%AS_CONFIG_BAT%" || (
     echo Error: Cannot load config file
     exit /B 1
 )
-set ARGS=%*
+
+REM This is used in CLIBootstrap to generate the final command and avoid issues with bat files.
+set APPCLIENT_WINDOWS_ARGS=%*
 
 REM Execute CLIBootstrap with the arguments passed to this script
 REM to retrieve the command to execute.
 REM FOR /F - processes command output line by line
 REM "delims=" - treats each line as a whole (no delimiter)
 REM %%i - loop variable for batch files, would be %i on command line
-FOR /F "delims=" %%i IN ("%JAVA%" --module-path "%AS_INSTALL%\lib\bootstrap" --add-modules ALL-MODULE-PATH -classpath "%AS_INSTALL%\lib\gf-client.jar" org.glassfish.appclient.client.acc.agent.CLIBootstrap %*) DO set CMD=%%i
-%CMD% %ARGS%
+FOR /F "usebackq delims=" %%i IN (`^""%JAVA%" --module-path "%AS_INSTALL%\lib\bootstrap" --add-modules ALL-MODULE-PATH -classpath "%AS_INSTALL%\lib\gf-client.jar" org.glassfish.appclient.client.acc.agent.CLIBootstrap^"`) DO set CMD=%%i
+%CMD%
+

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/GlassFishTestEnvironment.java
@@ -158,6 +158,13 @@ public class GlassFishTestEnvironment {
     }
 
     /**
+     * @return {@link Asadmin} command api for tests.
+     */
+    public static File getAppClient() {
+        return new File(getGlassFishDirectory(), isWindows() ? "bin/appclient.bat" : "bin/appclient");
+    }
+
+    /**
      * @return project's target directory.
      */
     public static File getTargetDirectory() {

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
 import org.junit.jupiter.api.Test;
 
-import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getGlassFishDirectory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,7 +36,7 @@ public class AppClientTest {
 
     @Test
     void noArgsAndHelp() throws Exception {
-        File appclient = new File(getGlassFishDirectory(), "bin/appclient");
+        File appclient = GlassFishTestEnvironment.getAppClient();
         assertTrue(appclient.canExecute(), "appclient executable");
         Process processNoArgs = new ProcessBuilder(appclient.getAbsolutePath()).start();
         Process processUsage = new ProcessBuilder(appclient.getAbsolutePath(), "-usage").start();

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.appclient;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.Test;
+
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getGlassFishDirectory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *
+ */
+public class AppClientTest {
+
+    @Test
+    void noArgsAndHelp() throws Exception {
+        File appclient = new File(getGlassFishDirectory(), "bin/appclient");
+        assertTrue(appclient.canExecute(), "appclient executable");
+        Process processNoArgs = new ProcessBuilder(appclient.getAbsolutePath()).start();
+        Process processUsage = new ProcessBuilder(appclient.getAbsolutePath(), "-usage").start();
+        processNoArgs.waitFor();
+        processUsage.waitFor();
+        String noArgsOutput = readOutput(processNoArgs);
+        String usageOutput = readOutput(processUsage);
+        assertEquals(1, processNoArgs.exitValue(), "appclient without args exit code. Output: " + noArgsOutput);
+        assertEquals(0, processUsage.exitValue(), "appclient -usage exit code. Output: " + usageOutput);
+        assertThat("outputs should be same", usageOutput,
+            stringContainsInOrder("appclient [ <classfile> | -client <appjar> ]", "or",
+                "appclient [ <valid JVM options and valid ACC options> ]"));
+        assertEquals(usageOutput, noArgsOutput, "outputs should be same");
+    }
+
+
+    private String readOutput(Process process) throws IOException {
+        try (InputStream output = process.getErrorStream()) {
+            return new String(output.readAllBytes(), Charset.defaultCharset());
+        }
+    }
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
@@ -24,13 +24,15 @@ import java.nio.charset.Charset;
 import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- *
+ * @author David Matejcek
  */
 public class AppClientTest {
 
@@ -43,19 +45,38 @@ public class AppClientTest {
         processNoArgs.waitFor();
         processUsage.waitFor();
         String noArgsOutput = readOutput(processNoArgs);
+        String noArgsError = readError(processNoArgs);
         String usageOutput = readOutput(processUsage);
-        assertEquals(1, processNoArgs.exitValue(), "appclient without args exit code. Output: " + noArgsOutput);
-        assertEquals(0, processUsage.exitValue(), "appclient -usage exit code. Output: " + usageOutput);
-        assertThat("outputs should be same", usageOutput,
-            stringContainsInOrder("appclient [ <classfile> | -client <appjar> ]", "or",
-                "appclient [ <valid JVM options and valid ACC options> ]"));
-        assertEquals(usageOutput, noArgsOutput, "outputs should be same");
+        String usageError = readError(processUsage);
+        assertAll(
+            () -> assertEquals(1, processNoArgs.exitValue(),
+                "appclient without args exit code. Output:\n" + noArgsOutput + "\nError:\n" + noArgsError),
+            () -> assertEquals(0, processUsage.exitValue(),
+                "appclient -usage exit code. Output:\n" + usageOutput + "\nError:\n" + usageError)
+        );
+        assertThat("user output", usageOutput, stringContainsInOrder("appclient [ <classfile> | -client <appjar> ]",
+            "or", "appclient [ <valid JVM options and valid ACC options> ]"));
+        assertThat("error output", usageError, equalTo(""));
+        assertAll(
+            () -> assertEquals(usageOutput, noArgsOutput, "user outputs should be same"),
+            () -> assertEquals(usageError, noArgsError, "error outputs should be same")
+        );
     }
 
 
     private String readOutput(Process process) throws IOException {
         try (InputStream output = process.getInputStream()) {
-            return new String(output.readAllBytes(), Charset.defaultCharset());
+            return read(output);
         }
+    }
+
+    private String readError(Process process) throws IOException {
+        try (InputStream output = process.getErrorStream()) {
+            return read(output);
+        }
+    }
+
+    private String read(InputStream stream) throws IOException {
+        return new String(stream.readAllBytes(), Charset.defaultCharset());
     }
 }

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/appclient/AppClientTest.java
@@ -54,7 +54,7 @@ public class AppClientTest {
 
 
     private String readOutput(Process process) throws IOException {
-        try (InputStream output = process.getErrorStream()) {
+        try (InputStream output = process.getInputStream()) {
             return new String(output.readAllBytes(), Charset.defaultCharset());
         }
     }


### PR DESCRIPTION
* Fix for #25666 - when using no arguments, the appclient crashed. When we fixed it, it still crashed on Windows when using arguments.
* Fixed appclient.bat having issues to parse output from CLIBootstrap
* New test for at least simple execution of the appclient script