### PR TITLE
Fixes processing of the detached admin commands

### DIFF
--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateExecCommand.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/TemplateExecCommand.java
@@ -136,7 +136,7 @@ public class TemplateExecCommand extends AbstractResource implements OptionsCapa
             .getCommandInvocation(null, commandName, new RestActionReporter(), null, notify, detach).parameters(params);
         final ResponseBuilder builder = Response.status(HTTP_OK);
         final AsyncAdminCommandInvoker<Response> invoker = detach
-            ? new DetachedSseAdminCommandInvoker(new RestActionReporter(), invocation, builder)
+            ? new DetachedSseAdminCommandInvoker(invocation, builder)
             : new SseAdminCommandInvoker(invocation, builder);
         return invoker.start();
     }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/admin/CommandResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/admin/CommandResource.java
@@ -331,7 +331,7 @@ public class CommandResource {
             builder.cookie(getJSessionCookie(jSessionId));
         }
         final AsyncAdminCommandInvoker<Response> invoker = detach
-            ? new DetachedSseAdminCommandInvoker(new PropsFileActionReporter(), invocation, builder)
+            ? new DetachedSseAdminCommandInvoker(invocation, builder)
             : new SseAdminCommandInvoker(invocation, builder);
         return invoker.start();
     }

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/SseEventOutput.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/SseEventOutput.java
@@ -21,7 +21,7 @@ import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.lang.System.Logger;
 
-import org.glassfish.api.admin.Job;
+import org.glassfish.api.admin.AdminCommandState;
 import org.glassfish.api.admin.ProgressEvent;
 import org.glassfish.jersey.media.sse.EventOutput;
 import org.glassfish.jersey.media.sse.OutboundEvent;
@@ -31,15 +31,15 @@ import static java.lang.System.Logger.Level.TRACE;
 import static org.glassfish.api.admin.AdminCommandState.EVENT_STATE_CHANGED;
 
 /**
- * A special {@link EventOutput} for sending Server Side Events related to the {@link Job}.
+ * A special {@link EventOutput} for sending Server Side Events related to the {@link AdminCommandState}.
  */
 public class SseEventOutput extends EventOutput {
     private static final Logger LOG = System.getLogger(SseEventOutput.class.getName());
 
-    private final Job job;
+    private final AdminCommandState state;
 
-    SseEventOutput(Job job) {
-        this.job = job;
+    SseEventOutput(AdminCommandState state) {
+        this.state = state;
     }
 
     void write(String eventName, ProgressEvent event) {
@@ -50,7 +50,7 @@ public class SseEventOutput extends EventOutput {
 
     void write() {
         if (!isClosed()) {
-            writeJson(EVENT_STATE_CHANGED, job);
+            writeJson(EVENT_STATE_CHANGED, state);
         }
     }
 


### PR DESCRIPTION
Sometimes detached `AdminCommandJob` is completed before the response is sent to the admin client. In this case the admin client receives a response as if the command was not detached.

Capture the detached `AdminCommandJob` state while creating a REST response and send it to the client.

* Closes #25575.