### PR TITLE
Remove empty `main` method

### DIFF
--- a/appserver/persistence/entitybean-container/src/main/java/org/glassfish/persistence/ejb/entitybean/container/cache/FIFOEJBObjectCache.java
+++ b/appserver/persistence/entitybean-container/src/main/java/org/glassfish/persistence/ejb/entitybean/container/cache/FIFOEJBObjectCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -427,9 +427,4 @@ public class FIFOEJBObjectCache
             totalRefCount -= count;
         }
     }
-
-    public static void main(String[] args)
-    {
-    }
-
 }


### PR DESCRIPTION
- https://github.com/eclipse-ee4j/glassfish/pull/24222#issue-1510859155:

> 3. If the class can be turned to not be executable - removing that empty now main method could save about 118 additional bytes.