### PR TITLE
Decrease log level of logs in command execution

### DIFF
--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/admin/AdminAdapter.java
@@ -518,10 +518,10 @@ public abstract class AdminAdapter extends StaticHttpHandler implements Adapter,
             if (validatePrivacy(adminCommand)) {
                 CommandInvocation<AdminCommandJob> inv = commandRunner.getCommandInvocation(scope, command, report,
                     subject, parameters.containsKey("notify"), parameters.containsKey("detach"));
-                LOG.log(Level.INFO, "Executing command {0} with parameters {1}, outboundPayload: {2}",
+                LOG.log(Level.FINE, "Executing command {0} with parameters {1}, outboundPayload: {2}",
                     new Object[] {command, parameters, outboundPayload});
                 inv.parameters(parameters).inbound(inboundPayload).outbound(outboundPayload).execute();
-                LOG.log(Level.INFO, "Command {0} executed, outboundPayload: {1}",
+                LOG.log(Level.FINE, "Command {0} executed, outboundPayload: {1}",
                     new Object[] {command, outboundPayload});
                 try {
                     // note it has become extraordinarily difficult to change the reporter!


### PR DESCRIPTION
Some commands are regularly being executed, either from Admin Console, or IDEs (e.g. __locations command). INFO level would log them by default, which only trashes the logs.

Example:

```
Executing command __locations with parameters {}, outboundPayload: org.glassfish.admin.payload.ZipPayloadImpl$Outbound@44d4e19f|#]
```