### PR TITLE
Fix #25689 HTTP status 404 in the admin console help window

### DIFF
--- a/appserver/admingui/common/src/main/resources/js/adminjsf.js
+++ b/appserver/admingui/common/src/main/resources/js/adminjsf.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -2627,7 +2627,10 @@ admingui.ajax = {
                 alert("'execButton' not found!  Unable to submit JSF2 Ajax Request!");
             } else {
                 // Don't ping b/c this is from the header and therefor is a ping
-                faces.ajax.request(src, null,
+                faces.ajax.request(src,
+                {
+                    type: 'click'
+                },
                 {
                     execute: 'execButton',
                     render: 'execResp',


### PR DESCRIPTION
Fixes #25689

This issue is caused by a change in a trigger mechanism for Ajax events in Mojarra 4.0.9:
https://github.com/eclipse-ee4j/mojarra/pull/5502

Due to the change above, the [ButtonRenderer#wasClieked](https://github.com/eclipse-ee4j/mojarra/blob/4.0.9-RELEASE/impl/src/main/java/com/sun/faces/renderkit/html_basic/ButtonRenderer.java#L172) method now returns `false` instead of `true` for Ajax requests issued when the help button is clicked.
This prevents the [calculateHelpUrl](https://github.com/eclipse-ee4j/glassfish/blob/7.0.25/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/handlers/PluginHandlers.java#L551) handler from being called, leading to the construction of a URL containing "undefined".

This issue can be resolved by explicitly specifying the event type of the Ajax request, in the same way as:
https://github.com/eclipse-ee4j/glassfish/blob/085e1292a685ee93b9c2c8a67e2d6c7b66a22abd/appserver/admingui/common/src/main/resources/js/adminjsf.js#L591-L593
