### PR TITLE
Fix MicroProfile Config in Embedded - add transitive dependencies

### DIFF
--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -46,12 +46,6 @@
             <version>${project.version}</version>
             <type>pom</type>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.github.mwiede</groupId>
-                    <artifactId>jsch</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
     </dependencies>

--- a/appserver/featuresets/microprofile/pom.xml
+++ b/appserver/featuresets/microprofile/pom.xml
@@ -40,91 +40,43 @@
             <groupId>org.glassfish.main.microprofile</groupId>
             <artifactId>microprofile-connectors</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- MicroProfile Config -->
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.microprofile</groupId>
             <artifactId>microprofile-config</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- MicroProfile Health -->
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.microprofile</groupId>
             <artifactId>microprofile-health</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.microprofile</groupId>
             <artifactId>health-glassfish</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- MicroProfile JWT -->
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.omnifaces</groupId>
             <artifactId>microprofile-jwt-auth</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- MicroProfile REST Client -->

--- a/appserver/tests/embedded/microprofile/config/pom.xml
+++ b/appserver/tests/embedded/microprofile/config/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.tests.embedded</groupId>
+        <artifactId>microprofile</artifactId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.tests.embedded.microprofile</groupId>
+    <artifactId>config</artifactId>
+    <name>Test MicroProfile Config</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-with-uber-jar</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-all</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>run-with-uber-jar-web</id>
+            <activation>
+                <property>
+                    <name>build</name>
+                    <value>uber-jar-web</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-web</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>run-with-shell-jar</id>
+            <activation>
+                <property>
+                    <name>build</name>
+                    <value>static-shell</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-static-shell</artifactId>
+                    <version>${project.version}</version>
+                    <scope>system</scope>
+                    <systemPath>${env.S1AS_HOME}/lib/embedded/glassfish-embedded-static-shell.jar
+                    </systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/appserver/tests/embedded/microprofile/config/src/main/java/org/glassfish/tests/embedded/microprofile/config/ConfigServlet.java
+++ b/appserver/tests/embedded/microprofile/config/src/main/java/org/glassfish/tests/embedded/microprofile/config/ConfigServlet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.microprofile.config;
+
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+@WebServlet("/config")
+public class ConfigServlet extends HttpServlet {
+
+    // TODO: Injecting config to servlets doesn't work. We need to inject it into a CDI bean
+    @Inject
+    ValueService valueService;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Config config = ConfigProvider.getConfig();
+        String value = config.getValue("test.config.value", String.class);
+        resp.getWriter().write(value + "," + valueService.getValue());
+    }
+}

--- a/appserver/tests/embedded/microprofile/config/src/main/java/org/glassfish/tests/embedded/microprofile/config/ValueService.java
+++ b/appserver/tests/embedded/microprofile/config/src/main/java/org/glassfish/tests/embedded/microprofile/config/ValueService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.microprofile.config;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@ApplicationScoped
+public class ValueService {
+    @Inject
+    @ConfigProperty(name = "test.config.inject.value")
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/appserver/tests/embedded/microprofile/config/src/main/resources/META-INF/microprofile-config.properties
+++ b/appserver/tests/embedded/microprofile/config/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+test.config.value=Hello MicroProfile
+test.config.inject.value=Injected

--- a/appserver/tests/embedded/microprofile/config/src/test/java/org/glassfish/tests/embedded/microprofile/config/MicroProfileConfigTest.java
+++ b/appserver/tests/embedded/microprofile/config/src/test/java/org/glassfish/tests/embedded/microprofile/config/MicroProfileConfigTest.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.tests.embedded.microprofile.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
@@ -33,6 +31,8 @@ import org.glassfish.embeddable.archive.ScatteredArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test MicroProfile Config functionality in embedded GlassFish

--- a/appserver/tests/embedded/microprofile/config/src/test/java/org/glassfish/tests/embedded/microprofile/config/MicroProfileConfigTest.java
+++ b/appserver/tests/embedded/microprofile/config/src/test/java/org/glassfish/tests/embedded/microprofile/config/MicroProfileConfigTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.microprofile.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.glassfish.embeddable.Deployer;
+import org.glassfish.embeddable.GlassFish;
+import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
+import org.glassfish.embeddable.archive.ScatteredArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test MicroProfile Config functionality in embedded GlassFish
+ */
+public class MicroProfileConfigTest {
+
+    private static final String PROJECT_DIR = System.getProperty("basedir", System.getProperty("user.dir"));
+    private static final int HTTP_PORT = 8080;
+    private static final String APP_NAME = "config";
+
+    static GlassFish glassfish;
+    static String appName;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        GlassFishProperties props = new GlassFishProperties();
+        props.setPort("http-listener", HTTP_PORT);
+        glassfish = GlassFishRuntime.bootstrap().newGlassFish(props);
+        glassfish.start();
+
+        File classesDir = new File(PROJECT_DIR, "target/classes");
+
+        ScatteredArchive sa = new ScatteredArchive(APP_NAME, ScatteredArchive.Type.WAR);
+        sa.addClassPath(classesDir);
+        URI warURI = sa.toURI();
+
+        Deployer deployer = glassfish.getDeployer();
+        appName = deployer.deploy(warURI);
+    }
+
+    @Test
+    void testConfigValueInjection() throws Exception {
+        URL servlet = new URL("http://localhost:" + HTTP_PORT + "/" + APP_NAME + "/config");
+        URLConnection connection = servlet.openConnection();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        String response = reader.readLine();
+        reader.close();
+
+        assertEquals("Hello MicroProfile,Injected", response);
+    }
+
+    @AfterAll
+    static void shutdownServer() throws Exception {
+        if (appName != null) {
+            glassfish.getDeployer().undeploy(appName);
+        }
+        if (glassfish != null) {
+            glassfish.dispose();
+        }
+    }
+}

--- a/appserver/tests/embedded/microprofile/pom.xml
+++ b/appserver/tests/embedded/microprofile/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.tests</groupId>
+        <artifactId>embedded</artifactId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.tests.embedded</groupId>
+    <artifactId>microprofile</artifactId>
+    <packaging>pom</packaging>
+    <name>MicroProfile Tests</name>
+
+    <modules>
+        <module>config</module>
+    </modules>
+</project>

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -47,6 +47,7 @@
         <module>ejb</module>
         <module>glassfish_resources_xml</module>
         <module>maven-plugin</module>
+        <module>microprofile</module>
         <module>runnable</module>
         <module>scatteredarchive</module>
         <module>utils</module>


### PR DESCRIPTION
Embedded distributions need all transitive dependencies, while server only takes direct dependencies, so no need to exclude anything for the server.

Some Helidon dependencies are packaged as embedded JARs inside an OSGi bundle. In Embedded they are needed as transitive dependencies.

I tested with a simple app that uses MP Config and it worked with Embedded GlassFish All.