### PR TITLE
Upgrade easymock to run tests on Java 25

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -148,7 +148,7 @@
 
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
-        <easymock.version>5.5.0</easymock.version>
+        <easymock.version>5.6.0</easymock.version>
         <junit.version>5.13.4</junit.version>
         <junit-platform.version>1.13.4</junit-platform.version>
         <jmh.version>1.37</jmh.version>


### PR DESCRIPTION
An upgrade of EasyMock is required to run the tests on Java 25. An older version uses an older version of ASM which doesn't support Java 25 bytecode.