### PR TITLE
Fix #25715 Enabling monitoring for JDBC connection pools unexpectedly enables monitoring for non-JDBC connection pools

### DIFF
--- a/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/JdbcPoolMonitoringExtension.java
+++ b/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/JdbcPoolMonitoringExtension.java
@@ -85,7 +85,8 @@ public class JdbcPoolMonitoringExtension implements ConnectionPoolMonitoringExte
      */
     @Override
     public void registerPool(PoolInfo poolInfo) {
-        if (poolManager.getPool(poolInfo) != null) {
+        ResourcePool pool = runtime.getConnectionPoolConfig(poolInfo);
+        if (pool instanceof JdbcConnectionPool && poolManager.getPool(poolInfo) != null) {
             getProbeProviderUtil().createJdbcProbeProvider();
             // Found in the pool table (pool has been initialized/created)
             JdbcConnPoolStatsProvider jdbcPoolStatsProvider = new JdbcConnPoolStatsProvider(poolInfo);


### PR DESCRIPTION
Fixes #25715.

For any connection pools (including JDBC connection pools and connector connection pools), the `registerPool` methods of the `ConnectionPoolMonitoringExtension` interface implementations are executed. 
The issue occurs because the `registerPool` method of the `JdbcPoolMonitoringExtension` class (implementing `ConnectionPoolMonitoringExtension`) is executed and handles not only JDBC connection pools but also connector connection pools.

To resolve the issue, we can modify the `registerPool` method of the `JdbcPoolMonitoringExtension` class to handle only JDBC connection pools, as in the [`registerConnectionPool`](https://github.com/eclipse-ee4j/glassfish/blob/4870d6def4c11bdc27451b40b71f32083caded1d/appserver/jdbc/jdbc-runtime/src/main/java/org/glassfish/jdbcruntime/JdbcPoolMonitoringExtension.java#L138) method.
