### PR TITLE
Embedded GlassFish - fixes related to system properties

### DIFF
--- a/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
+++ b/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.runnable.app;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.ws.rs.core.Application;
+
+import java.util.logging.Logger;
+
+/**
+ * @author Ondro Mihalyi
+ */
+@ApplicationScoped
+public class SystemPropertyApp extends Application {
+
+    private static final Logger LOG = Logger.getLogger(SystemPropertyApp.class.getName());
+
+    public void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        String myName = System.getProperty("my.name");
+        LOG.info("System property my.name: " + myName);
+    }
+}

--- a/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
+++ b/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
@@ -18,7 +18,6 @@ package org.glassfish.tests.embedded.runnable.app;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
-import jakarta.ws.rs.core.Application;
 
 import java.util.logging.Logger;
 
@@ -26,7 +25,7 @@ import java.util.logging.Logger;
  * @author Ondro Mihalyi
  */
 @ApplicationScoped
-public class SystemPropertyApp extends Application {
+public class SystemPropertyApp {
 
     private static final Logger LOG = Logger.getLogger(SystemPropertyApp.class.getName());
 

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
@@ -35,10 +35,21 @@ import static java.util.stream.Collectors.joining;
  */
 public class GfEmbeddedUtils {
 
-    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug.port";
+    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug";
+
+    public static Optional<String> getDebugArg() {
+        return Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
+                .filter(debugPort -> List.of("none", "disabled", "false").stream()
+                .allMatch(value -> !value.equalsIgnoreCase(debugPort))
+                );
+    }
+
+    public static boolean isDebugEnabled() {
+        return getDebugArg().isPresent();
+    }
 
     public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws
-IOException {
+            IOException {
         return runGlassFishEmbedded(glassfishEmbeddedJarName, List.of(), additionalArguments);
     }
 
@@ -75,12 +86,9 @@ IOException {
     }
 
     private static void addDebugArgsIfDebugEnabled(List<String> arguments) {
-        Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
-                .filter(debugPort -> List.of("none", "disabled", "false").stream()
-                        .allMatch(value -> !value.equalsIgnoreCase(debugPort))
-                )
-                .ifPresent(debugPort -> {
-                    arguments.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" + debugPort);
+        getDebugArg()
+                .ifPresent(debugArgs -> {
+                    arguments.add(debugArgs);
                 });
 
     }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
@@ -20,11 +20,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.System.err;
+import static java.util.stream.Collectors.joining;
 
 /**
  *
@@ -32,15 +35,29 @@ import static java.lang.System.err;
  */
 public class GfEmbeddedUtils {
 
-    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws IOException {
+    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug.port";
+
+    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws
+IOException {
+        return runGlassFishEmbedded(glassfishEmbeddedJarName, List.of(), additionalArguments);
+    }
+
+    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, List<String> jvmOpts, String... additionalArguments) throws IOException {
         List<String> arguments = new ArrayList<>();
-        arguments.addAll(List.of(ProcessHandle.current().info().command().get(),
-                //                "-Xrunjdwp:transport=dt_socket,server=y,suspend=y", // enable debugging on random port
+        arguments.add(ProcessHandle.current().info().command().get());
+        addDebugArgsIfDebugEnabled(arguments);
+        arguments.addAll(jvmOpts);
+        arguments.addAll(List.of(
                 "-jar", glassfishEmbeddedJarName,
+                "--noPort",
                 "--stop"));
         for (String argument : additionalArguments) {
             arguments.add(argument);
         }
+        System.out.println("\nCurrent directory: " + Paths.get(".").toFile().getAbsolutePath());
+        System.out.println("Going to run Embedded GlassFish: " + arguments.stream()
+                .map(arg -> "'" + arg + "'")
+                .collect(joining(" ")) + "\n");
         return new ProcessBuilder()
                 .redirectOutput(ProcessBuilder.Redirect.INHERIT)
                 .redirectError(ProcessBuilder.Redirect.PIPE)
@@ -55,6 +72,17 @@ public class GfEmbeddedUtils {
         )
                 .lines()
                 .peek(err::println);
+    }
+
+    private static void addDebugArgsIfDebugEnabled(List<String> arguments) {
+        Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
+                .filter(debugPort -> List.of("none", "disabled", "false").stream()
+                        .allMatch(value -> !value.equalsIgnoreCase(debugPort))
+                )
+                .ifPresent(debugPort -> {
+                    arguments.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" + debugPort);
+                });
+
     }
 
 }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
@@ -54,12 +54,11 @@ public class SystemPropertyTest {
         try {
             warFile = createSystemPropertyApp();
             Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
-                    List.of("-Dmy.name=GlassFish"),
-                    "--noPort",
+                    List.of("-Dmy.name=Embedded GlassFish"),
                     warFile.getAbsolutePath()
             );
             assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
-                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
                     "Application should print the value of the my.name system property.");
             gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
         } finally {
@@ -74,11 +73,11 @@ public class SystemPropertyTest {
         try {
             warFile = createSystemPropertyApp();
             Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
-                    "create-system-properties my.name=GlassFish",
+                    "create-system-properties my.name=Embedded\\ GlassFish",
                     warFile.getAbsolutePath()
             );
             assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
-                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
                     "Application should print the value of the my.name system property.");
             gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
         } finally {
@@ -98,7 +97,7 @@ public class SystemPropertyTest {
                     warFile.getAbsolutePath()
             );
             assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
-                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
                     "Application should print the value of the my.name system property.");
             gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
         } finally {
@@ -111,7 +110,7 @@ public class SystemPropertyTest {
         WebArchive warArchive = ShrinkWrap.create(WebArchive.class, warName)
                 .addClass(SystemPropertyApp.class);
         File warFile = new File(warName);
-        warArchive.as(ZipExporter.class).exportTo(warFile);
+        warArchive.as(ZipExporter.class).exportTo(warFile, true);
         logArchiveContent(warArchive, warName, LOG::info);
         return warFile;
     }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.runnable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.glassfish.tests.embedded.runnable.TestArgumentProviders.GfEmbeddedJarNameProvider;
+import org.glassfish.tests.embedded.runnable.app.SystemPropertyApp;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.glassfish.tests.embedded.runnable.GfEmbeddedUtils.outputToStreamOfLines;
+import static org.glassfish.tests.embedded.runnable.GfEmbeddedUtils.runGlassFishEmbedded;
+import static org.glassfish.tests.embedded.runnable.ShrinkwrapUtils.logArchiveContent;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Ondro Mihalyi
+ */
+public class SystemPropertyTest {
+
+    private static final Logger LOG = Logger.getLogger(SystemPropertyTest.class.getName());
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromJvmOption(String gfEmbeddedJarName) throws Exception {
+        File warFile = null;
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    List.of("-Dmy.name=GlassFish"),
+                    "--noPort",
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromAdminCommand(String gfEmbeddedJarName) throws Exception {
+        File warFile = null;
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "create-system-properties my.name=GlassFish",
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromDomainConfig(String gfEmbeddedJarName, TestInfo testInfo) throws Exception {
+        File warFile = null;
+        Path domainConfigFile = prepareDomainConfig(testInfo);
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "--domainConfigFile=" + domainConfigFile.toFile().getPath(),
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    private File createSystemPropertyApp() throws Exception {
+        String warName = "systemPropertyApp.war";
+        WebArchive warArchive = ShrinkWrap.create(WebArchive.class, warName)
+                .addClass(SystemPropertyApp.class);
+        File warFile = new File(warName);
+        warArchive.as(ZipExporter.class).exportTo(warFile);
+        logArchiveContent(warArchive, warName, LOG::info);
+        return warFile;
+    }
+
+    private Path prepareDomainConfig(TestInfo testInfo) throws IOException {
+        String testClassName = testInfo.getTestClass().get().getSimpleName();
+        String testMethodName = testInfo.getTestMethod().get().getName();
+        Path domainConfigFile = Paths.get(testClassName + "-" + testMethodName + "-" + "domain.xml");
+        Files.copy(getClass().getClassLoader().getResourceAsStream(testClassName + "/domain.xml"),
+                domainConfigFile,
+                StandardCopyOption.REPLACE_EXISTING);
+        return domainConfigFile;
+    }
+
+}

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/TestArgumentProviders.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/TestArgumentProviders.java
@@ -15,6 +15,8 @@
  */
 package org.glassfish.tests.embedded.runnable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -31,20 +33,14 @@ public class TestArgumentProviders {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext ec) throws Exception {
-            return Stream.of(Arguments.of("glassfish-embedded-all.jar"), Arguments.of("glassfish-embedded-web.jar"));
+            List<Arguments> arguments = new ArrayList<>();
+            arguments.add(Arguments.of("glassfish-embedded-all.jar"));
+            if (!GfEmbeddedUtils.isDebugEnabled()) {
+                arguments.add(Arguments.of("glassfish-embedded-web.jar"));
+            }
+            return arguments.stream();
         }
 
     }
 
-    /**
-     * For testing a single execution when debugging
-     */
-    public static class SingleGfEmbeddedJarNameProvider implements ArgumentsProvider {
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext ec) throws Exception {
-            return Stream.of(Arguments.of("glassfish-embedded-all.jar"));
-        }
-
-    }
 }

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
@@ -46,7 +46,7 @@
   </servers>
  <configs>
    <config name="server-config">
-     <system-property name="my.name" value="GlassFish"/>
+     <system-property name="my.name" value="Embedded GlassFish"/>
      <http-service>
         <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
         <virtual-server id="server" network-listeners="http-listener, https-listener" />

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
@@ -1,0 +1,176 @@
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+  <security-configurations>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/embedded_default" />
+      <property name="connectionAttributes" value=";create=true" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="server" config-ref="server-config">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+    </server>
+  </servers>
+ <configs>
+   <config name="server-config">
+     <system-property name="my.name" value="GlassFish"/>
+     <http-service>
+        <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
+        <virtual-server id="server" network-listeners="http-listener, https-listener" />
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="3700" id="orb-listener-1" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3820" id="SSL">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3920" id="SSL_MUTUALAUTH">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector enabled="false" auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="8686" name="system" />
+        <das-config autodeploy-enabled="false" dynamic-reload-enabled="true" deploy-xml-validation="full" autodeploy-dir="${com.sun.aas.instanceRoot}/autodeploy" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+      <ejb-container steady-pool-size="0" max-pool-size="32" session-store="${com.sun.aas.instanceRoot}/session-store" pool-resize-quantity="8">
+        <ejb-timer-service />
+      </ejb-container>
+      <mdb-container steady-pool-size="0" max-pool-size="32" pool-resize-quantity="8" >
+      </mdb-container>
+      <jms-service type="EMBEDDED" default-jms-host="default_JMS_host">
+        <jms-host name="default_JMS_host" host="localhost" port="7676" admin-user-name="admin" admin-password="admin" lazy-init="false"/>
+      </jms-service>
+      <log-service file="${com.sun.aas.instanceRoot}/logs/server.log" log-rotation-limit-in-bytes="2000000">
+        <module-log-levels />
+      </log-service>
+      <security-service activate-default-principal-to-role-mapping="true" jacc="simple">
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <monitoring-service>
+        <module-monitoring-levels />
+      </monitoring-service>
+      <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" >
+      </transaction-service>
+      <java-config>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Dorg.glassfish.jms.InitializeOnDemand=true</jvm-options>
+      </java-config>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+          <protocol security-enabled="true" name="https-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="0" protocol="http-listener" transport="tcp" name="http-listener" thread-pool="http-thread-pool" enabled="false" />
+          <network-listener port="0" protocol="https-listener" transport="tcp" name="https-listener" thread-pool="http-thread-pool" enabled="false" />
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+      </thread-pools>
+    </config>
+  </configs>
+  <property name="administrative.domain.name" value="domain1"/>
+</domain>

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/glassfish.properties
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/glassfish.properties
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+my.name=Embedded GlassFish

--- a/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
@@ -285,6 +285,9 @@ The value will be treated as a command to execute at startup.
     - Keys that start with the "deploy." prefix, followed by any text. The
 value will be treated as an application to deploy at startup, as if it
 was specified on the command line.
+    - If a property name doesn't match any already supported patterns and is not
+a recognized GlassFish property, it will be set as a system property, if
+it's not already defined.
 For example, the ${productName} domain directory can be specified with the
 usual Embedded ${productName} property
 "glassfish.embedded.tmpdir=myDomainDir", as well as with the property

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
@@ -18,7 +18,6 @@ package org.glassfish.embeddable;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -127,10 +126,6 @@ public enum GlassFishVariable {
      */
     public String getSystemPropertyName() {
         return this.sysPropName;
-    }
-
-    public Optional<String> getSystemPropertyValue() {
-        return Optional.ofNullable(System.getProperty(getSystemPropertyName()));
     }
 
     /**

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
@@ -18,6 +18,7 @@ package org.glassfish.embeddable;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -128,6 +129,9 @@ public enum GlassFishVariable {
         return this.sysPropName;
     }
 
+    public Optional<String> getSystemPropertyValue() {
+        return Optional.ofNullable(System.getProperty(getSystemPropertyName()));
+    }
 
     /**
      * The map contains pairs of {@link #getEnvName()} and {@link #getSystemPropertyName()}.

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
@@ -37,6 +37,7 @@ import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.main.boot.impl.GlassFishImpl;
+import org.glassfish.main.jdke.props.SystemProperties;
 
 import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.AUTO_DELETE;
 
@@ -79,7 +80,12 @@ class AutoDisposableGlassFish extends GlassFishImpl {
                         && resultList.getOutput().contains(propertyPrefix)) {
                     knownPropertyPrefixes.add(propertyPrefix);
                 } else {
-                    // unknown property prefix, skip it
+                    if (!key.startsWith("com.sun.aas.") && !key.startsWith("-")) {
+                        // unknown property, set as system property
+                        LOG.log(Level.INFO, "Setting system property " + key + " from GlassFish properties, it doesn't match any known property");
+                        SystemProperties.setProperty(key, gfProps.getProperty(key), false);
+                    }
+                    // not a dotted name, doesn't start with a supported prefix, do not set it later
                     continue;
                 }
             }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
@@ -135,7 +135,7 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
     private void setSystemPropertiesFromEnv(boolean forceOverwrite) {
         // adding our version of some system properties.
         setProperty(JAVA_ROOT.getSystemPropertyName(), System.getProperty(JAVA_HOME.getSystemPropertyName()), forceOverwrite);
-        if (HOST_NAME.getSystemPropertyValue().isEmpty()) {
+        if (forceOverwrite || null == System.getProperty(HOST_NAME.getSystemPropertyName())) {
             String hostname = "localhost";
             try {
                 // canonical name checks to make sure host is proper
@@ -144,7 +144,7 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
                 LOG.log(Level.SEVERE, KernelLoggerInfo.exceptionHostname, ex);
             }
             if (hostname != null) {
-                setProperty(HOST_NAME.getSystemPropertyName(), hostname, false);
+                setProperty(HOST_NAME.getSystemPropertyName(), hostname, true);
             }
         }
     }

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
@@ -185,7 +185,7 @@ public class UberMain {
             commandParams = new String[split.length - 1];
             for (int i = 1; i < split.length; i++) {
                 commandParams[i - 1] = split[i].trim();
-        }
+            }
         }
         try {
             CommandResult result = commandParams == null

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
@@ -177,14 +177,15 @@ public class UberMain {
 
     private void executeCommandFromString(String stringCommand) {
         logger.log(FINE, () -> "Executing command: " + stringCommand);
-        String[] split = stringCommand.split(" ");
+        // Split according to empty space but not if empty space is escaped by \
+        String[] split = stringCommand.split("(?<!\\\\)\\s+");
         String command = split[0].trim();
         String[] commandParams = null;
         if (split.length > 1) {
             commandParams = new String[split.length - 1];
             for (int i = 1; i < split.length; i++) {
                 commandParams[i - 1] = split[i].trim();
-            }
+        }
         }
         try {
             CommandResult result = commandParams == null

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/commandline/Option.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/commandline/Option.java
@@ -51,7 +51,9 @@ public enum Option {
             + " - Keys that start with the \"" + Arguments.DEPLOY_KEY_PREFIX
             + "\" prefix, followed by any text. The value will be"
             + " treated as an application to deploy at startup, as if it was specified on the command line.\n"
-            + "For example, the GlassFish domain directory can be specified with the usual GlassFish Embedded"
+            + " - If a property name doesn't match any already supported patterns and is not"
+            + " a recognized GlassFish property, it will be set as a system property, if it's not already defined.\n"
+            + "\nFor example, the GlassFish domain directory can be specified with the usual GlassFish Embedded"
             + " property \"glassfish.embedded.tmpdir=myDomainDir\", as well as with the property"
             + " \"domainDir=myDomainDir\" that represents the \"--domainDir=myDomainDir\" command-line option."
             + " A command to deploy an application can be specified via a property key"

--- a/nucleus/core/kernel/src/test/java/org/glassfish/runnablejar/commandline/WordWrapperTest.java
+++ b/nucleus/core/kernel/src/test/java/org/glassfish/runnablejar/commandline/WordWrapperTest.java
@@ -38,7 +38,7 @@ public class WordWrapperTest {
                                     .map(Option::getHelpText)
                                     .collect(wordWrapper);
         final List<String> linesEndingWithSpace = message.lines()
-                .filter(line -> line.endsWith(" "))
+                .filter(line -> line.endsWith(" ") && !line.isBlank())
                 .collect(toList());
         assertTrue(linesEndingWithSpace.isEmpty(), "Some lines end with a space: " + linesEndingWithSpace);
 


### PR DESCRIPTION
System properties can be set by the following means:

1. on command line, with -D Java argument - overrides properties set in the configuration
2. via create-system-properties admin command (spaces in property names or values must be escaped by '\')
3. via setting the property directly in the `--propeties` file (e.g. property "my.name" should have line "my.name=GlassFish Server" in the properties file, spaces shouldn't be escaped)
4. via system-property element in domain.xml

Fixes number 3, which worked in 7.0.25 but stopped working in master.
Allows empty spaces in property values if setting via the create-system-properties admin command - space escaped by `\` is treated as value not as a separator. This follows the same pattern as in the asadmin CLI tool.