### PR TITLE
Fixed compatibility with Java25 + updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ kind: Pod
 spec:
   containers:
   - name: maven
-    image: maven:3.9.9-eclipse-temurin-17
+    image: maven:3.9.11-eclipse-temurin-17
     command:
     - cat
     tty: true
@@ -220,14 +220,14 @@ spec:
                   timeout(time: 10, unit: 'MINUTES') {
                      sh '''
                      # Validate the structure in all submodules (especially version ids)
-                     mvn -B -e -fae clean validate -Ptck,set-version-id,staging
+                     mvn -B -e -fae clean validate -Ptck,set-version-id
 
                      # Until we fix ANTLR in cmp-support-sqlstore, broken in parallel builds. Just -Pfast after the fix.
-                     mvn -B -e install -Pfastest,staging,ci -T4C
+                     mvn -B -e install -Pfastest,ci -T4C
                      ./gfbuild.sh archive_bundles
                      ./gfbuild.sh archive_embedded
 
-                     mvn -B -e clean -Pstaging
+                     mvn -B -e clean
                      tar -c -C ${WORKSPACE}/appserver/tests common_test.sh gftest.sh appserv-tests quicklook | gzip --fast > ${WORKSPACE}/bundles/appserv_tests.tar.gz
                      ls -la ${WORKSPACE}/bundles
                      ls -la ${WORKSPACE}/embedded
@@ -256,7 +256,7 @@ spec:
                         dumpSysInfo()
                         timeout(time: 2, unit: 'HOURS') {
                            sh '''
-                           mvn -B -e clean install -Pstaging,qa,ci
+                           mvn -B -e clean install -Pqa,ci
                            '''
                         }
                      } finally {
@@ -281,7 +281,7 @@ spec:
                }
                tools {
                   jdk 'temurin-jdk17-latest'
-                  maven 'apache-maven-3.9.9'
+                  maven 'apache-maven-3.9.11'
                }
                steps {
                   script {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,8 @@ and refer zip from the build or from Maven Central Snapshots (same file).
        - It is possible that you will not have permissions to visit the namespace. Ask project leads or
          check if expected artifacts made it to Maven Central, then this was obviously successful.
     2. Verify that a new [7.1.0 tag](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.1.0) was created
-    3. Verify that it's present in [Maven Central](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/) (usually takes few minutes now)
+    3. Verify that it's present in [Maven Central](https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish)
+       (usually takes few minutes now)
 9. If everything is OK, then merge the PR.
 10. Delete the branch after merge, only tag will remain.
 11. Upload the new release to the Eclipse download folder.

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -66,8 +66,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.messaging.mq</groupId>
-            <artifactId>imqjmx</artifactId>
+            <groupId>org.glassfish.mq</groupId>
+            <artifactId>mqjmx-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.java
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.java
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.main.productroot.bin.asadmin;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.java
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.java
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.main.installroot.bin.asadmin;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/appserver/libpam4j/pom.xml
+++ b/appserver/libpam4j/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.17.0</version>
+            <version>5.18.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- Jakarta Faces -->
         <jakarta.faces-api.version>4.0.1</jakarta.faces-api.version>
-        <mojarra.version>4.0.11</mojarra.version>
+        <mojarra.version>4.0.12</mojarra.version>
 
         <!-- Jakarta WebSocket -->
         <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
@@ -96,7 +96,7 @@
 
         <!-- Jakarta Concurrency -->
         <jakarta.concurrent-api.version>3.0.4</jakarta.concurrent-api.version>
-        <concurrent.version>3.0.1</concurrent.version>
+        <concurrent.version>3.0.2</concurrent.version>
 
         <!-- Jakarta Interceptors -->
         <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
@@ -105,7 +105,7 @@
         <soteria.version>3.0.4</soteria.version>
         <exousia.version>2.1.3</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>10.4.2</nimbus.version>
+        <nimbus.version>10.5</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->
@@ -114,8 +114,8 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
-        <eclipselink.version>4.0.5</eclipselink.version>
-        <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
+        <eclipselink.version>4.0.8</eclipselink.version>
+        <eclipselink.asm.version>9.8.0</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
@@ -143,13 +143,13 @@
         <wasp.version>3.2.2</wasp.version>
 
         <!-- Used for Jakarta SOAP (XML Web Services) -->
-        <xmlsec.version>4.0.3</xmlsec.version>
-        <woodstox.version>7.1.0</woodstox.version>
+        <xmlsec.version>4.0.4</xmlsec.version>
+        <woodstox.version>7.1.1</woodstox.version>
         <stax2-api.version>4.2.2</stax2-api.version>
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.0.1</jakarta.cdi-api.version>
-        <weld.version>5.1.5.Final</weld.version>
+        <weld.version>5.1.6.Final</weld.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->
@@ -158,7 +158,7 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1</microprofile.config-api.version>
-        <helidon-config.version>3.2.12</helidon-config.version>
+        <helidon-config.version>3.2.15</helidon-config.version>
 
 
         <!-- MicroProfile Health -->
@@ -303,9 +303,9 @@
                 <version>${openmq.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.messaging.mq</groupId>
-                <artifactId>imqjmx</artifactId>
-                <version>4.6-b01</version>
+                <groupId>org.glassfish.mq</groupId>
+                <artifactId>mqjmx-api</artifactId>
+                <version>${openmq.version}</version>
             </dependency>
 
             <!-- Jakarta Persistence -->
@@ -477,7 +477,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.17.1</version>
+                <version>1.19.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/appserver/tests/admin/ssh-cluster/src/test/java/org/glassfish/main/test/clusterssh/docker/GlassFishContainer.java
+++ b/appserver/tests/admin/ssh-cluster/src/test/java/org/glassfish/main/test/clusterssh/docker/GlassFishContainer.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.Network;
 public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
 
     public GlassFishContainer(Network network, String hostname, String logPrefix, String command) {
-        super("eclipse-temurin:17");
+        super("eclipse-temurin:" + Runtime.version().feature());
         withNetwork(network)
         .withEnv("TZ", "UTC").withEnv("LC_ALL", "en_US.UTF-8")
         .withStartupAttempts(1)

--- a/appserver/tests/embedded/maven-plugin/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/pom.xml
@@ -190,7 +190,7 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.3.9</version>
+                <version>3.9.11</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/appserver/tests/jdbc/pom.xml
+++ b/appserver/tests/jdbc/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.7</version>
+            <version>42.7.8</version>
             <scope>test</scope>
         </dependency>
 

--- a/appserver/tests/jdbc/src/test/java/org/glassfish/main/test/perf/util/GlassFishContainer.java
+++ b/appserver/tests/jdbc/src/test/java/org/glassfish/main/test/perf/util/GlassFishContainer.java
@@ -44,6 +44,7 @@ import static java.lang.System.Logger.Level.INFO;
 public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
 
     public static final int LIMIT_HTTP_THREADS = 1000;
+    private static final int LIMIT_HTTP_REQUEST_TIMEOUT = 5;
 
     private static final Logger LOG = System.getLogger(GlassFishContainer.class.getName());
     private static final java.util.logging.Logger LOG_GF = java.util.logging.Logger.getLogger("GF");
@@ -56,6 +57,7 @@ public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
     private static final Path PATH_DOCKER_GF_DOMAIN1_SERVER_LOG = PATH_DOCKER_GF_DOMAIN
         .resolve(Path.of("logs", "server.log"));
 
+
     /**
      * Creates preconfigured container with GlassFish.
      *
@@ -65,7 +67,7 @@ public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
      * @param logPrefix
      */
     public GlassFishContainer(MountableFile glassFishZip, Network network, String hostname, String logPrefix) {
-        super("eclipse-temurin:17");
+        super("eclipse-temurin:" + Runtime.version().feature());
         withNetwork(network)
         .withCopyFileToContainer(glassFishZip, "/glassfish.zip")
         .withEnv("TZ", "UTC").withEnv("LC_ALL", "en_US.UTF-8")

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>2.3.20</asciidoctorj.pdf.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <productName>Eclipse GlassFish</productName>
@@ -173,9 +173,7 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -232,7 +232,7 @@
             <!-- Publish the entire web site to the gh-pages branch. -->
             <plugin>
                 <artifactId>maven-scm-publish-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>deploy-site</id>

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.java
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.java
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.main.bin.nadmin;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -886,7 +886,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                     <configuration>
                         <release>17</release>
                         <excludes>
@@ -921,7 +921,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
@@ -1138,7 +1138,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1254,7 +1254,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.18.0</version>
+                    <version>2.19.1</version>
                     <executions>
                         <execution>
                             <id>default-cli</id>
@@ -1278,7 +1278,6 @@
                                                     <version>20030911</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.external</groupId>
@@ -1293,7 +1292,6 @@
                                                     <version>10.0-b..</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.hk2</groupId>
@@ -1308,7 +1306,6 @@
                                                     <version>2.4.0</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.external</groupId>
@@ -1319,7 +1316,6 @@
                                                     <version>[2,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <!-- Jakarta EE 11 major versions to exclude -->
@@ -1337,7 +1333,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1353,7 +1348,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1369,7 +1363,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1385,7 +1378,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1405,7 +1397,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1425,7 +1416,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1445,7 +1435,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1460,7 +1449,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1475,7 +1463,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1494,7 +1481,6 @@
                                                     <version>.*RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1513,7 +1499,6 @@
                                                     <version>.*RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1528,7 +1513,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1547,7 +1531,6 @@
                                                     <version>.*-B.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1562,7 +1545,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1594,7 +1576,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1626,7 +1607,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1641,7 +1621,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1656,7 +1635,6 @@
                                                     <version>.*M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1672,7 +1650,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1687,7 +1664,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1702,7 +1678,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1717,7 +1692,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1732,7 +1706,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1747,7 +1720,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1762,7 +1734,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1777,7 +1748,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1792,7 +1762,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1807,7 +1776,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1822,7 +1790,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1838,7 +1805,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1853,7 +1819,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1872,7 +1837,6 @@
                                                     <version>.*-B.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1899,7 +1863,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1926,7 +1889,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1953,7 +1915,6 @@
                                                     <version>.*-ALPHA.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1969,7 +1930,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                     </rules>
@@ -2343,7 +2303,7 @@
             <id>jacoco</id>
             <properties>
                 <jacoco.report.outputDirectory>${project.build.directory}/jacoco</jacoco.report.outputDirectory>
-                <jacoco.version>0.8.12</jacoco.version>
+                <jacoco.version>0.8.13</jacoco.version>
                 <maven.test.failure.ignore>true</maven.test.failure.ignore>
                 <surefire.argLine>${maven.test.jvmoptions} @{argLine}</surefire.argLine>
             </properties>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -143,11 +143,12 @@
         <!-- GlassFish Components -->
         <grizzly.version>4.0.2</grizzly.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
-
-        <glassfish-corba.version>5.0.0</glassfish-corba.version>
         <glassfish-management-api.version>3.3.0</glassfish-management-api.version>
-        <gmbal.version>4.1.0</gmbal.version>
+
+        <!-- ORB -->
         <pfl.version>5.1.0</pfl.version>
+        <glassfish-corba.version>5.0.0</glassfish-corba.version>
+        <gmbal.version>4.1.0</gmbal.version>
 
         <shoal.version>3.1.0</shoal.version>
         <ha-api.version>3.1.13</ha-api.version>
@@ -155,18 +156,18 @@
         <command.security.maven.plugin.isFailureFatal>true</command.security.maven.plugin.isFailureFatal>
 
         <!-- 3rd party dependencies -->
-        <commons-io.version>2.18.0</commons-io.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-io.version>2.20.0</commons-io.version>
+        <commons-lang3.version>3.19.0</commons-lang3.version>
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.8</asm.version>
-        <jsch.version>0.2.24</jsch.version>
+        <jsch.version>2.27.3</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.18.3</jackson.version>
-        <fasterxml.classmate.version>1.7.0</fasterxml.classmate.version>
+        <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>
         <mimepull.version>1.10.0</mimepull.version>
@@ -179,6 +180,7 @@
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
+
 
         <file.executable.suffix></file.executable.suffix>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -546,7 +548,7 @@
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.webconsole</artifactId>
-                <version>5.0.10</version>
+                <version>5.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -609,7 +611,7 @@
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>3.29.0</version>
+                <version>3.30.6</version>
             </dependency>
 
             <!--3rd party dependencies -->
@@ -712,6 +714,12 @@
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
@@ -744,13 +752,13 @@
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>
+                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>
                         <artifactId>asm</artifactId>
                     </exclusion>
                 </exclusions>
-                <scope>test</scope>
             </dependency>
             <!-- Used by some dependencies (shrinkwrap, testcontainers) in older versions -->
             <dependency>
@@ -852,6 +860,13 @@
                     <configuration>
                         <includeDate>false</includeDate>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>9.8</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
@@ -869,7 +884,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                     <configuration>
                         <release>17</release>
                         <excludes>
@@ -918,16 +933,11 @@
                             <artifactId>commons-io</artifactId>
                             <version>${commons-io.version}</version>
                         </dependency>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-utils</artifactId>
-                            <version>4.0.2</version>
-                        </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <notimestamp>false</notimestamp>
@@ -940,7 +950,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -1006,7 +1016,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
@@ -1110,7 +1120,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1143,6 +1153,10 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
@@ -1193,7 +1207,7 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>9.0.1</version>
+                    <version>9.0.2</version>
                     <executions>
                         <execution>
                             <id>get-the-git-infos</id>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -104,7 +104,7 @@
 
         <!-- Jakarta Validation -->
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
+        <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>
 
         <!-- Jakarta XML Web Services -->
         <jakarta.xml.ws-api.version>4.0.2</jakarta.xml.ws-api.version>
@@ -118,20 +118,20 @@
         <hk2.plugin.version>3.1.1</hk2.plugin.version>
 
         <!-- Jakarta XML Binding -->
-        <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
-        <jakarta.jaxb-impl.version>4.0.5</jakarta.jaxb-impl.version>
+        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
+        <jakarta.jaxb-impl.version>4.0.6</jakarta.jaxb-impl.version>
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>3.1.0</jakarta.rest-api.version>
         <jersey.version>3.1.11</jersey.version>
 
         <!-- Jakarta Mail -->
-        <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>
-        <angus.mail.version>2.0.3</angus.mail.version>
+        <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>
+        <angus.mail.version>2.0.5</angus.mail.version>
 
         <!-- Jakarta Activation -->
-        <activation.version>2.1.3</activation.version>
-        <angus.activation.version>2.0.2</angus.activation.version>
+        <activation.version>2.1.4</activation.version>
+        <angus.activation.version>2.0.3</angus.activation.version>
 
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -161,12 +161,13 @@
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
-        <asm.version>9.8</asm.version>
+        <asm.version>9.9</asm.version>
         <jsch.version>2.27.3</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
-        <jackson.version>2.18.3</jackson.version>
+        <jackson.version>2.20.0</jackson.version>
+        <jackson.version2>2.20</jackson.version2>
         <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>
@@ -175,8 +176,8 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>5.13.4</junit.version>
-        <junit-platform.version>1.13.4</junit-platform.version>
+        <junit.version>5.14.0</junit.version>
+        <junit-platform.version>1.14.0</junit-platform.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -684,7 +685,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.version2}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -862,13 +863,6 @@
                     <configuration>
                         <includeDate>false</includeDate>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.8</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
@@ -1319,6 +1313,19 @@
                                         </rule>
 
                                         <!-- Jakarta EE 11 major versions to exclude -->
+                                        <rule>
+                                            <groupId>jakarta.activation</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
 
                                         <rule>
                                             <groupId>jakarta.annotation</groupId>
@@ -1624,6 +1631,20 @@
                                         </rule>
 
                                         <rule>
+                                            <groupId>jakarta.mail</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
                                             <groupId>jakarta.mvc</groupId>
                                             <ignoreVersions>
                                                 <ignoreVersion>
@@ -1648,6 +1669,27 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.apache.derby</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[10.17,)</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+                                        <rule>
+                                            <groupId>org.glassfish.external</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[10.17,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>
@@ -1718,6 +1760,16 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.glassfish.mq</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[6.6,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>
@@ -1813,6 +1865,51 @@
                                                 <ignoreVersion>
                                                     <type>range</type>
                                                     <version>[8.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.angus</groupId>
+                                            <artifactId>angus-activation</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.1.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.microprofile.jwt</groupId>
+                                            <artifactId>microprofile-jwt-auth-api</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.angus</groupId>
+                                            <artifactId>angus-mail</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.1.0,)</version>
                                                 </ignoreVersion>
                                                 <ignoreVersion>
                                                     <type>regex</type>
@@ -1928,6 +2025,16 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.slf4j</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -181,6 +181,8 @@
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
 
+        <surefire.version>3.5.4</surefire.version>
+        <junit5-surefire-tree-reporter.version>1.4.0</junit5-surefire-tree-reporter.version>
 
         <file.executable.suffix></file.executable.suffix>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -954,7 +956,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -975,11 +977,19 @@
                             <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -998,7 +1008,15 @@
                             <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.12</version>
+                        <version>0.8.13</version>
                         <executions>
                             <execution>
                                 <id>jacoco-merge</id>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -19,7 +19,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                     <executions>
                         <execution>
                             <id>default-compile</id>
@@ -33,7 +33,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.4</version>
                     <executions>
                         <execution>
                             <id>default-test</id>


### PR DESCRIPTION
* Obsoleted dependency imqjmx seems to contains same classes as mq-jmxapi: https://github.com/eclipse-ee4j/openmq/blob/87478dbef246b9dd638776e3864c1fd53e08734f/mq/main/mqjmx-api/pom.xml
* TestContainers tests should use the same java as the build
* `asadmin.java` cannot declare package - Java 22+ requirement is to reflect that in the directory structure. See https://openjdk.org/jeps/458 for more.
* Updated URL to maven central
* Many updates of dependencies
  * https://github.com/java-native-access/jna/tags
  * https://maven.apache.org/docs/history.html
  * https://github.com/eclipse-ee4j/mojarra/releases
  * https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt
  * https://eclipse.dev/eclipselink/releases/index.html
  * https://weld.cdi-spec.org/news/
  * https://github.com/helidon-io/helidon/releases
  * https://commons.apache.org/proper/commons-codec/changes.html
  * https://github.com/asciidoctor/asciidoctorj-pdf/releases
  * https://github.com/apache/maven-compiler-plugin/releases
  * https://github.com/apache/maven-surefire/releases
  * https://www.jacoco.org/jacoco/trunk/doc/changes.html