### PR TITLE
Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Zip distributions can be found on following paths:
 * `mvn clean install -Pfastest -T4C` - Building all distribution artifacts as fast as possible. Excludes everything not serving this purpose. Typical time: 1.5 minutes.
 
 After the build, you can run GlassFish in the following ways:
-* Run GlassFish server directly: Navigate to `appserver/distributions/glassfish/target/stage/glassfish7` - it's an unpacked version of GlassFish Full. Then you can run it as usual, e.g. with `bin/startserv`
+* Run GlassFish server directly: Navigate to `appserver/distributions/glassfish/target/stage/glassfish7` - it is an unpacked version of GlassFish Full. Then you can run it as usual, e.g. with `bin/startserv`
 * Run GlassFish server from a ZIP: A zip file is generated either at `appserver/distributions/glassfish/target/glassfish.zip` or in your local maven repository, e.g. at `<HOME>/.m2/repository/org/glassfish/main/distributions/glassfish/<VERSION>/glassfish-<VERSION>.zip`. Unpack it and run as usual
 * Run Embedded GlassFish: Find the JAR file at `appserver/extras/embedded/all/target/glassfish-embedded-all.jar` or in your local maven repository, e.g. at `<HOME>/.m2/repository/org/glassfish/main/extras/glassfish-embedded-all/<VERSION>/glassfish-embedded-all-<VERSION>.jar. Then run it with `java -jar glassfish-embedded-all.jar`
 
@@ -53,9 +53,9 @@ Note that this applies just for tests which are executed by Maven and which use 
 
 ### Special Profiles
 
-* `staging` - In some development stages may happen that some dependencies are available just in OSSRH staging repository.
+* `staging` - In some development stages it may happen that some dependencies are available just in the OSSRH staging repository.
   Then you have to use this profile, which is not enabled by default.
-* `jacoco` - enables the [JaCoCo](https://www.eclemma.org/jacoco/) agent in tests, so you can import it's output to you editor, ie. Eclipse, and see the code coverage.
+* `jacoco` - enables the [JaCoCo](https://www.eclemma.org/jacoco/) agent in tests, so you can import its output to your editor, i.e. Eclipse, and see the code coverage.
 * `jacoco-merge` - merges all JaCoCo output files found in subdirectories and merges them into one. It is useful to see code which wasn't even touched by tests.
 
 ### Special Scripts
@@ -80,7 +80,7 @@ They are quite old and have high technical debt, but at this moment they still p
 
 :warning: If the script fails, sometimes it doesn't stop the domain and you have to do that manually.
 
-:warning: Some of the scripts do inplace filtering or generate other sources which remain and later affect next executions. You have to remove those changes manually.
+:warning: Some of the scripts do in-place filtering or generate other sources which remain and later affect subsequent executions. You have to remove those changes manually.
 
 * `./runtests.sh batch_all` - Usual time: 1 minute
 * `./runtests.sh cdi_all` - Usual time: 6 minutes

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectorTimerProxy.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/util/ConnectorTimerProxy.java
@@ -209,7 +209,7 @@ public class ConnectorTimerProxy extends Timer {
     }
 
     /**
-     * Handle any exception occured during scheduling timer.
+     * Handle any exception occurred during scheduling timer.
      *
      * In case of unchecked exceptions, the timer is recreated to be used
      * by the subsequent requests for scheduling.

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/pool/ConnectionPool.java
@@ -1298,7 +1298,7 @@ public class ConnectionPool implements ResourcePool, ConnectionLeakListener, Res
 
     @Override
     public void resourceErrorOccurred(ResourceHandle resourceHandle) throws IllegalStateException {
-        LOG.log(FINE, "Resource error occured: {0}", resourceHandle);
+        LOG.log(FINE, "Resource error occurred: {0}", resourceHandle);
         if (failAllConnections) {
             // TODO: leakDetector is not updated and isBusy state of this resource is not updated correctly: possible bug.
             // leakDetector should be updated in the doFailAllConnectionsProcessing method. The resource can be updated here.

--- a/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ComponentValidator.java
+++ b/appserver/deployment/dol/src/main/java/com/sun/enterprise/deployment/util/ComponentValidator.java
@@ -702,7 +702,7 @@ public class ComponentValidator extends DefaultDOLVisitor implements ComponentVi
     // we need to split the accept(InjectionCapable) into two parts:
     // one needs classloader and one doesn't. This is needed because
     // in the standalone war case, the classloader is not created
-    // untill the web module is being started.
+    // until the web module is being started.
 
     protected void acceptWithCL(InjectionCapable injectable) {
         // If parsed from deployment descriptor, we need to determine whether

--- a/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/GlassFishToExousiaConverter.java
+++ b/appserver/ejb/ejb-container/src/main/java/org/glassfish/ejb/security/application/GlassFishToExousiaConverter.java
@@ -51,7 +51,7 @@ public class GlassFishToExousiaConverter {
      *
      * <p>
      * Phase 1: gets a map representing the methodPermission elements exactly as they
-     * occured for the ejb in the dd. The map is keyed by method-permission element and each method-permission is mapped to a list of
+     * occurred for the ejb in the dd. The map is keyed by method-permission element and each method-permission is mapped to a list of
      * method elements representing the method elements of the method permision element. Each method element is converted to a
      * corresponding EJBMethodPermission and added, based on its associated method-permission, to the returned JakartaPermissions instance.
      *

--- a/appserver/tests/admingui/README.md
+++ b/appserver/tests/admingui/README.md
@@ -1,36 +1,36 @@
-#How to run the dev test cases
-================================
-#Annotation: 
-All of the test cases can't be ran on the windows platform because 
-the firefox can't support the JSF based on the windows platform very well.
-If you want to ran the tests, please check out all of the codes to the linux, ubuntu or
-mac platform.
+# How to run the dev test cases
 
-#Preparation and Steps:
-1). Download the firefox and install it, On my platform, I have downloaded and installed 
-the firefox version 19.0
+## Annotation
+All of the test cases can't be run on the Windows platform because
+Firefox doesn't support JSF on the Windows platform very well.
+If you want to run the tests, please check out all of the code to the Linux, Ubuntu, or
+Mac platform.
 
-2). Download the selenium IDE plugin and installed, On my platform, I have installed the 
-selenium IDE 2.4.0
+## Preparation and Steps:
+1. Download Firefox and install it. On my platform, I have downloaded and installed
+   Firefox version 19.0
 
-3). Checkout the the tests from the github(https://github.com/LvSongping/GLASSFISH_ADMIN_CONSOLE_DEVTESTS/tree/master/auto-test) 
-to your hard disk.
+2. Download the Selenium IDE plugin and install it. On my platform, I have installed
+   Selenium IDE 2.4.0
 
-4). Before ran the tests, you need to restart the glassfish domain and try to access admin console's page(http://localhost:4848/common/index.jsf) 
-to make sure the GUI is available
+3. Check out the tests from GitHub (https://github.com/LvSongping/GLASSFISH_ADMIN_CONSOLE_DEVTESTS/tree/master/auto-test)
+   to your hard disk.
 
-5). Open a terminal window and access to the root directory of auto-tests, Then execute the command 
-as "mvn test" to run all of the tests
+4. Before running the tests, you need to restart the GlassFish domain and try to access the admin console's page (http://localhost:4848/common/index.jsf)
+   to make sure the GUI is available.
 
-6). If some of the test cases are failed, you can also rerun the error or failed test cases 
-using the command as "mvn test -Dtest=[ClassName]#[MethodName]" to confirm related test 
-cases.(if the failure test cases passed at the second time, we can regard the failure test 
-case as a passed case)
+5. Open a terminal window and access the root directory of auto-tests. Then execute the command
+   "mvn test" to run all of the tests.
 
-#Note:
-The expected test results listed as follows:
-test cases number:110
-passed number:110
-failed number:0
-error number:0
+6. If some of the test cases fail, you can also rerun the error or failed test cases
+   using the command "mvn test -Dtest=[ClassName]#[MethodName]" to confirm related test
+   cases. (If the failed test cases pass the second time, we can regard the failed test
+   case as a passed case.)
+
+## Note:
+The expected test results are as follows:
+- Test cases number: 110
+- Passed number: 110
+- Failed number: 0
+- Error number: 0
 

--- a/appserver/tests/appserv-tests/devtests/cdi/README.md
+++ b/appserver/tests/appserv-tests/devtests/cdi/README.md
@@ -1,9 +1,9 @@
-CDI developer tests README
+CDI Developer Tests README
 ==========================
 
-To checkout CDI devtests
-------------------------
-- checkout CDI developer tests using the following commands:
+To CheckOut CDI devtests
+-------------------------
+- Checkout CDI developer tests using the following commands:
 svn -N co https://svn.java.net/svn/glassfish~svn/trunk/v2/appserv-tests
 cd appserv-tests #this is the directory set later to APS_HOME
 svn co https://svn.java.net/svn/glassfish~svn/trunk/v2/appserv-tests/config
@@ -13,7 +13,7 @@ svn -N co https://svn.java.net/svn/glassfish~svn/trunk/v2/appserv-tests/devtests
 cd devtests
 svn co https://svn.java.net/svn/glassfish~svn/trunk/v2/appserv-tests/devtests/cdi
 
-Test setup
+Test Setup
 ----------
 - set S1AS_HOME, APS_HOME as appropriate
 export APS_HOME=<appserv-tests> directory
@@ -23,28 +23,28 @@ $S1AS_HOME/bin/asadmin start-domain domain1
 - start Derby
 $S1AS_HOME/bin/asadmin start-database
 
-To run all CDI developer tests
+To Run All CDI Developer Tests
 ------------------------------
 - cd $APS_HOME/devtests/cdi
 - ant all
 - results can be found at APS_HOME/test_results.html
 
 
-Test setup teardown
+Test Setup Teardown
 -------------------
 - stop GlassFish
 $S1AS_HOME/bin/asadmin stop-domain domain1
 - asadmin stop-database
 $S1AS_HOME/bin/asadmin stop-database
 
-To run a single CDI developer test
+To Run a Single CDI Developer Test
 ----------------------------------
-- after performing tasks under "Test setup"
+- after performing tasks under "Test Setup"
 - cd $APS_HOME/devtests/cdi/[test-dir]
 - ant all
-- perform tasks listed under "Test setup teardown"
+- perform tasks listed under "Test Setup Teardown"
 
-To run CDI developer test suite with Security Manager on
+To Run CDI Developer Test Suite with Security Manager On
 ---------------------------------------------------------
 - start domain and enable security manager by 
 asadmin create-jvm-options -Djava.security.manager 

--- a/appserver/tests/appserv-tests/reporter/src/main/java/com/sun/ejte/ccl/reporter/Reporter.java
+++ b/appserver/tests/appserv-tests/reporter/src/main/java/com/sun/ejte/ccl/reporter/Reporter.java
@@ -858,7 +858,7 @@ ong with expected and actual result. This is optional as in some case
                 // Now remove TestSuite from Hashtable: PENDING
              if ( writeResult==true )
              {
-                // If we could write teh content properly then remove the TestSuite from Hashtable
+                // If we could write the content properly then remove the TestSuite from Hashtable
              testSuiteHash.remove( testSuiteId.trim() );
              }
             return writeResult;

--- a/appserver/tests/v2-tests/appserv-tests/util/reporter/Reporter.java
+++ b/appserver/tests/v2-tests/appserv-tests/util/reporter/Reporter.java
@@ -860,7 +860,7 @@ ong with expected and actual result. This is optional as in some case
             // Now remove TestSuite from Hashtable: PENDING
             if ( writeResult==true )
             {
-                // If we could write teh content properly then remove the TestSuite from Hashtable
+                // If we could write the content properly then remove the TestSuite from Hashtable
                 testSuiteHash.remove( testSuiteId.trim() );
             }
             return writeResult;

--- a/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/descriptor/LoginConfigurationImpl.java
+++ b/appserver/web/web-glue/src/main/java/org/glassfish/web/deployment/descriptor/LoginConfigurationImpl.java
@@ -37,7 +37,7 @@ public class LoginConfigurationImpl extends Descriptor implements LoginConfigura
 
     static final Logger _logger = LogFacade.getLogger();
 
-    /** teh client authenticates using http basic authentication. */
+    /** the client authenticates using http basic authentication. */
     public static final String AUTHENTICATION_METHOD_BASIC = LoginConfiguration.BASIC_AUTHENTICATION;
     /** Digest authentication. */
     public static final String AUTHENTICATION_METHOD_DIGEST = LoginConfiguration.DIGEST_AUTHENTICATION;

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/LogUtils.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/LogUtils.java
@@ -281,7 +281,7 @@ public final class LogUtils {
     public static final String SERVLET_ENDPOINT_FAILURE = LOGMSG_PREFIX + "-00078";
 
     @LogMessageInfo(
-            message = "Error occured",
+            message = "Error occurred",
             level = "SEVERE",
             cause = "unknown",
             action = "unknown")

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ file by the `distribution` project.
 Only this combined jar file needs to be deployed to Maven.
 
 The `publish` project collects all of these distribution jar files
-for the current relase and previous releases  using the
+for the current release and previous releases using the
 `maven-dependency-plugin`, lays them out in the proper directory
 structure, and uses the `maven-scm-publish-plugin` to publish
 the content to the `gh-pages` branch of the GitHub repository.
@@ -76,7 +76,7 @@ git clone --branch gh-pages https://github.com/eclipse-ee4j/glassfish.git /separ
 * create a fork in GitHub
 * add the fork as a new remote to the other repository
 * commit the changes to the `gh-pages` branch
-* (force) push the `gh-pages` beanch: `git -C /separate/directory push --force https://github.com/myfork/glassfish.git refs/heads/gh-pages:refs/heads/gh-pages` (replace myfork with your GitHub username)
+* (force) push the `gh-pages` branch: `git -C /separate/directory push --force https://github.com/myfork/glassfish.git refs/heads/gh-pages:refs/heads/gh-pages` (replace myfork with your GitHub username)
 
 6. Preview the website
 

--- a/docs/website/src/main/resources/README.md
+++ b/docs/website/src/main/resources/README.md
@@ -23,7 +23,7 @@ Faster Deployment was achieved by improved file handling; the team replaced cust
 
 ## March 14, 2025 -- Eclipse GlassFish 7.0.23 Available
 
-The key feature for this release is making SSH nodes work on the Windows operating system, and while at it improve the way they work on Linux. The team mainly focussed on this work, and a lot of effort went into it. We're really happy to have achieved the goal to have it fully working. Next to that some important fixes were done for logging and specifically a regression for the security principal was fixed.
+The key feature for this release is making SSH nodes work on the Windows operating system, and while at it improve the way they work on Linux. The team mainly focused on this work, and a lot of effort went into it. We're really happy to have achieved the goal to have it fully working. Next to that some important fixes were done for logging and specifically a regression for the security principal was fixed.
 
 Download links are available from the [GlassFish Download page](download.md).
 
@@ -83,7 +83,7 @@ With much joy we present you Eclipse GlassFish 7.0.16.
 
 Download links are available from the [GlassFish Download page](download.md).
 
-In this summer 2024 release of GlassFish we added several new features. Specifically new is an admin command logger, which logs graphical interactions with the admin UI for usage in scripts. GlassFish now also allows resource references in persistence.xml, and we added a great new feature where we are creating temporary snapshots of the external application libraries during application startup, so any update of these is not longer system dependent. We also did a major refactoring of the aging TLS code and optimized the GJULE logging.
+In this summer 2024 release of GlassFish we added several new features. Specifically new is an admin command logger, which logs graphical interactions with the admin UI for usage in scripts. GlassFish now also allows resource references in persistence.xml, and we added a great new feature where we are creating temporary snapshots of the external application libraries during application startup, so any update of these is no longer system dependent. We also did a major refactoring of the aging TLS code and optimized the GJULE logging.
 
 
 ## May 31, 2024 -- Eclipse GlassFish 7.0.15 Available

--- a/docs/website/src/main/resources/certifications/Jakarta EE 9.1 compatibility.md
+++ b/docs/website/src/main/resources/certifications/Jakarta EE 9.1 compatibility.md
@@ -58,7 +58,7 @@ Pruned in 9.0
 
 ### Jakarta JSON Binding
 
-* [Jakarta JSON Binding 2.0](certificatoins/jakarta-jsonb/2.0/TCK-Results-6.1-RC1)
+* [Jakarta JSON Binding 2.0](certifications/jakarta-jsonb/2.0/TCK-Results-6.1-RC1)
 
 ### Jakarta JSON Processing
 
@@ -130,4 +130,4 @@ Pruned in 9.0
 
 ### Jakarta XML Web Services
 
-* [jakarta XML Web Services 3.0](certifications/jakarta-xml-web-services/3.0/TCK-Results-6.1-RC1)
+* [Jakarta XML Web Services 3.0](certifications/jakarta-xml-web-services/3.0/TCK-Results-6.1-RC1)

--- a/docs/website/src/main/resources/download_gf7.md
+++ b/docs/website/src/main/resources/download_gf7.md
@@ -61,7 +61,7 @@ Eclipse GlassFish is an application server, implementing Jakarta EE. This releas
 
 GlassFish 7.0.23 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 23. MicroProfile support requires JDK 17 or higher.
 
-The key feature for this release is making SSH nodes work on the Windows operating system, and while at it improve the way they work on Linux. The team mainly focussed on this work, and a lot of effort went into it. We're really happy to have achieved the goal to have it fully working. Next to that some important fixes were done for logging and specifically a regression for the security principal was fixed.
+The key feature for this release is making SSH nodes work on the Windows operating system, and while at it improve the way they work on Linux. The team mainly focused on this work, and a lot of effort went into it. We're really happy to have achieved the goal to have it fully working. Next to that some important fixes were done for logging and specifically a regression for the security principal was fixed.
 
 Download:
 
@@ -200,9 +200,9 @@ More details:
 
 GlassFish 7.0.16 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-GlassFish 7.0.16 compiles and passes all internal tests using OpenJDK 21. The Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is now also JDK 21 compatible and it's possible to run all the Jakarta EE TCK tests.
+GlassFish 7.0.16 compiles and passes all internal tests using OpenJDK 21. The Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is now also JDK 21 compatible and it is possible to run all the Jakarta EE TCK tests.
 
-In this summer 2024 release of GlassFish we added several new features. Specifically new is an admin command logger, which logs graphical interactions with the admin UI for usage in scripts. GlassFish now also allows resource references in persistence.xml, and we added a great new feature where we are creating temporary snapshots of the external application libraries during application startup, so any update of these is not longer system dependent. We also did a major refactoring of the aging TLS code and optimized the GJULE logging.
+In this summer 2024 release of GlassFish we added several new features. Specifically new is an admin command logger, which logs graphical interactions with the admin UI for usage in scripts. GlassFish now also allows resource references in persistence.xml, and we added a great new feature where we are creating temporary snapshots of the external application libraries during application startup, so any update of these is no longer system dependent. We also did a major refactoring of the aging TLS code and optimized the GJULE logging.
 
 Download:
 
@@ -221,7 +221,7 @@ More details:
 
 GlassFish 7.0.15 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-GlassFish 7.0.15 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+GlassFish 7.0.15 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 In this release we updated and thoroughly tested a lot of important components, including Exousia (Security), Mojarra (Faces), Jersey (REST) and Yasson/Parsson (JSON).
 
@@ -246,7 +246,7 @@ More details:
 
 GlassFish 7.0.14 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-GlassFish 7.0.14 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+GlassFish 7.0.14 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 This release features among others an important NPE fix for the SSHLauncher and is highly recommended for our users who make use of this launcher.
 
@@ -273,7 +273,7 @@ More details:
 
 GlassFish 7.0.13 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-GlassFish 7.0.13 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+GlassFish 7.0.13 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 In the release for this month we replaced many synchronized blocks by reentrant locks (to accommodate JDK 21 virtual threads).
 
@@ -298,7 +298,7 @@ More details:
 
 GlassFish 7.0.12 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-GlassFish 7.0.12 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+GlassFish 7.0.12 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 This release we focused on finding and fixing the root cause of several "strange" WebSocket related bugs that we witnessed in the past. We also did a similar thing related to several issues with running apps on the default context root, especially where after authentication redirects happened to another URL.
 
@@ -322,7 +322,7 @@ More details:
 
 GlassFish 7.0.11 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-GlassFish 7.0.11 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+GlassFish 7.0.11 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 This release sees an important fix where WebSockets would not work at all for applications on the default context root (e.g. https://example.com vs https://example.com/myapp).
 
@@ -347,7 +347,7 @@ More details:
 
 GlassFish 7.0.10 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-This release is the second GlassFish release after OpenJDK 21 was released. GlassFish 7.0.10 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+This release is the second GlassFish release after OpenJDK 21 was released. GlassFish 7.0.10 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 In this release a 10 months long operation to get an internal dependency to the slf4j-api removed finally got to fruition. This involved the intense cooperation of multiple teams, and we're exceptionally happy to have finally been able to do this.
 
@@ -371,7 +371,7 @@ More details:
 
 GlassFish 7.0.9 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 21. MicroProfile support requires JDK 17 or higher.
 
-This release is the first GlassFish release after OpenJDK 21 was released. GlassFish 7.0.9 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it's not possible to run all the Jakarta EE TCK tests.
+This release is the first GlassFish release after OpenJDK 21 was released. GlassFish 7.0.9 compiles and passes all internal tests using OpenJDK 21. Several Jakarta EE 10 TCKs passed on JDK 21 as well. The Jakarta EE 10 TCK as a whole is not JDK 21 compatible and it is not possible to run all the Jakarta EE TCK tests.
 
 In this release the modularity of GlassFish is once again increased by moving the Jakarta Authentication implementation code to a new standalone project: [Epicyro](https://github.com/eclipse-ee4j/epicyro). We also enabled the GlassFish embedded tests again, which were dormant for a long time. Among the many updated components, Exousia was updated specifically to fix a bug with deployments on virtual servers, and the ORB was updated to fix a somewhat obscure bug where a remote EJB returned a JDK defined enum type.
 

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/invocation/InvocationManagerImpl.java
@@ -43,7 +43,7 @@ public class InvocationManagerImpl implements InvocationManager {
     // This TLS variable stores an ArrayList.
     // The ArrayList contains ComponentInvocation objects which represent
     // the stack of invocations on this thread. Accesses to the ArrayList
-    // dont need to be synchronized because each thread has its own ArrayList.
+    // don't need to be synchronized because each thread has its own ArrayList.
     private InheritableThreadLocal<InvocationArray<ComponentInvocation>> frames;
 
     private final ThreadLocal<Stack<ApplicationEnvironment>> applicationEnvironments = new ThreadLocal<>() {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/AppServerStartup.java
@@ -673,7 +673,7 @@ public class AppServerStartup implements PostConstruct, ModuleStartup {
         public void onError(RunLevelFuture future, ErrorInformation info) {
             if (future.isDown()) {
                 // TODO: Need a log message
-                logger.log(Level.WARNING, "An error occured when the system was coming down", info.getError());
+                logger.log(Level.WARNING, "An error occurred when the system was coming down", info.getError());
                 return;
             }
 

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LoggerInfoMetadataService.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/LoggerInfoMetadataService.java
@@ -57,7 +57,7 @@ public class LoggerInfoMetadataService implements LoggerInfoMetadata, ModuleChan
     private Set<String> moduleNames;
     private boolean valid;
 
-    // Reset valid flag if teh set of modules changes, so meta-data will be recomputed
+    // Reset valid flag if the set of modules changes, so meta-data will be recomputed
     private Set<String> currentModuleNames() {
         Set<String> currentNames = new HashSet<>();
         for (HK2Module module : modulesRegistry.getModules()) {

--- a/nucleus/hk2-config-generator/src/main/java/org/jvnet/hk2/config/Dom.java
+++ b/nucleus/hk2-config-generator/src/main/java/org/jvnet/hk2/config/Dom.java
@@ -1415,7 +1415,7 @@ public class Dom extends AbstractActiveDescriptor implements InvocationHandler, 
         }
 
         /**
-         * If someone has explicitly called the skipFromXml then dont write the element to
+         * If someone has explicitly called the skipFromXml then don't write the element to
          * domain.xml
          */
         if (!writeToXml) {

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/common/iiop/security/GSSUPName.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/common/iiop/security/GSSUPName.java
@@ -192,7 +192,7 @@ public class GSSUPName {
         }
 
         /**
-         * Do not append realm name: this ensures that we dont sent "default" or "certificate" to another appserver.
+         * Do not append realm name: this ensures that we don't sent "default" or "certificate" to another appserver.
          *
          * // append an AT-CHAR only if realm is not null. // NOTe: In the current implementation, realm will never // be null. It is
          * either "certificate" or "default".


### PR DESCRIPTION
Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help
