### PR TITLE
Fixes in env vars references

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/administration-guide/src/main/asciidoc/overview.adoc
@@ -313,8 +313,8 @@ If a variable reference is not resolved, the reference will not be replaced. So,
 
 **System properties that adjust variable resolution:**
 
-* `org.glassfish.variableexpansion.envvars.disabled` -  disables resolution from environment variables and allows only resolving from system properties. This allows keeping the behavior of older versions of {productName}
-* `org.glassfish.variableexpansion.envvars.preferred` - changes the priority - values are resolved first from environment variables and then from system properties
+* `org.glassfish.variableExpansion.envDisabled` -  disables resolution from environment variables and allows only resolving from system properties. This allows keeping the behavior of older versions of {productName}
+* `org.glassfish.variableExpansion.envPreferred` - changes the priority - values are resolved first from environment variables and then from system properties
 
 The following is a list of variables defined by {productName} that can be used in variable references:
 

--- a/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
@@ -70,7 +70,7 @@ Variable references, e.g. `${variable}`, can be used anywhere in JVM options. In
 5. `asenv` properties
 6. Environment variables
 
-If a property `org.glassfish.envPreferredToProperties` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source. It's also possible to override options and system properties defined in JVM options with an environment variable that either has the same name, or same name if case is ignored and non-alphanumeric characters are replaced with the `_` character. For example, a property `-Dmy.name` can be defined by redefined by environment variables `my.name`, `my_name`, or `MY_NAME`.
+If a property `org.glassfish.variableExpansion.envPreferred` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source. It's also possible to override options and system properties defined in JVM options with an environment variable that either has the same name, or same name if case is ignored and non-alphanumeric characters are replaced with the `_` character. For example, a property `-Dmy.name` can be defined by redefined by environment variables `my.name`, `my_name`, or `MY_NAME`. If a property `org.glassfish.variableExpansion.envDisabled` is defined as `true`, then environment variables are ignored.
 
 [CAUTION]
 ====

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
@@ -77,7 +77,8 @@ public class SystemPropertyConstants {
     public static final String DEFAULT_ADMIN_TIMEOUT_PROPERTY = "org.glassfish.admin.timeout";
     private static final int DEFAULT_ADMIN_TIMEOUT_VALUE = 5000;
 
-    public static final String PREFER_ENV_VARS_OVER_PROPERTIES = "org.glassfish.envPreferredToProperties";
+    public static final String PREFER_ENV_VARS_OVER_PROPERTIES = "org.glassfish.variableExpansion.envPreferred";
+    public static final String DISABLE_ENV_VAR_EXPANSION_PROPERTY = "org.glassfish.variableExpansion.envDisabled";
 
     public static final String TRUSTSTORE_FILENAME_DEFAULT = "cacerts.p12";
     public static final String KEYSTORE_FILENAME_DEFAULT = "keystore.p12";


### PR DESCRIPTION


Fixes issues introduced in https://github.com/eclipse-ee4j/glassfish/pull/25541 - when the `org.glassfish.variableexpansion.envvars.preferred` set to `true`, and no matching env var existed, system properties are matched via property name in upper case, in the same form as last tried with env vars.

Also aligned property names with changes done in https://github.com/eclipse-ee4j/glassfish/pull/25382 and renamed Renamed `org.glassfish.envPreferredToProperties` system property to `org.glassfish.variableExpansion.envPreferred` to align property names. Also added support for `org.glassfish.variableExpansion.envDisabled` for JVM options substitution, so that variable expansion works the same in both JVM options and other places.