### PR TITLE
Merge from master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ kind: Pod
 spec:
   containers:
   - name: maven
-    image: maven:3.9.6-eclipse-temurin-21
+    image: maven:3.9.11-eclipse-temurin-21
     command:
     - cat
     tty: true
@@ -220,14 +220,14 @@ spec:
                   timeout(time: 10, unit: 'MINUTES') {
                      sh '''
                      # Validate the structure in all submodules (especially version ids)
-                     mvn -B -e -fae clean validate -Ptck,set-version-id,staging
+                     mvn -B -e -fae clean validate -Ptck,set-version-id
 
                      # Until we fix ANTLR in cmp-support-sqlstore, broken in parallel builds. Just -Pfast after the fix.
-                     mvn -B -e install -Pfastest,staging,ci -T4C
+                     mvn -B -e install -Pfastest,ci -T4C
                      ./gfbuild.sh archive_bundles
                      ./gfbuild.sh archive_embedded
 
-                     mvn -B -e clean -Pstaging
+                     mvn -B -e clean
                      tar -c -C ${WORKSPACE}/appserver/tests common_test.sh gftest.sh appserv-tests quicklook | gzip --fast > ${WORKSPACE}/bundles/appserv_tests.tar.gz
                      ls -la ${WORKSPACE}/bundles
                      ls -la ${WORKSPACE}/embedded
@@ -256,7 +256,7 @@ spec:
                         dumpSysInfo()
                         timeout(time: 2, unit: 'HOURS') {
                            sh '''
-                           mvn -B -e clean install -Pstaging,qa,ci
+                           mvn -B -e clean install -Pqa,ci
                            '''
                         }
                      } finally {
@@ -281,7 +281,7 @@ spec:
                }
                tools {
                   jdk 'temurin-jdk21-latest'
-                  maven 'apache-maven-3.9.5'
+                  maven 'apache-maven-3.9.11'
                }
                steps {
                   script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ kind: Pod
 spec:
   containers:
   - name: maven
-    image: maven:3.9.9-eclipse-temurin-17
+    image: maven:3.9.11-eclipse-temurin-17
     command:
     - cat
     tty: true
@@ -220,14 +220,14 @@ spec:
                   timeout(time: 10, unit: 'MINUTES') {
                      sh '''
                      # Validate the structure in all submodules (especially version ids)
-                     mvn -B -e -fae clean validate -Ptck,set-version-id,staging
+                     mvn -B -e -fae clean validate -Ptck,set-version-id
 
                      # Until we fix ANTLR in cmp-support-sqlstore, broken in parallel builds. Just -Pfast after the fix.
-                     mvn -B -e install -Pfastest,staging,ci -T4C
+                     mvn -B -e install -Pfastest,ci -T4C
                      ./gfbuild.sh archive_bundles
                      ./gfbuild.sh archive_embedded
 
-                     mvn -B -e clean -Pstaging
+                     mvn -B -e clean
                      tar -c -C ${WORKSPACE}/appserver/tests common_test.sh gftest.sh appserv-tests quicklook | gzip --fast > ${WORKSPACE}/bundles/appserv_tests.tar.gz
                      ls -la ${WORKSPACE}/bundles
                      ls -la ${WORKSPACE}/embedded
@@ -256,7 +256,7 @@ spec:
                         dumpSysInfo()
                         timeout(time: 2, unit: 'HOURS') {
                            sh '''
-                           mvn -B -e clean install -Pstaging,qa,ci
+                           mvn -B -e clean install -Pqa,ci
                            '''
                         }
                      } finally {
@@ -281,7 +281,7 @@ spec:
                }
                tools {
                   jdk 'temurin-jdk17-latest'
-                  maven 'apache-maven-3.9.9'
+                  maven 'apache-maven-3.9.11'
                }
                steps {
                   script {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,8 @@ and refer zip from the build or from Maven Central Snapshots (same file).
        - It is possible that you will not have permissions to visit the namespace. Ask project leads or
          check if expected artifacts made it to Maven Central, then this was obviously successful.
     2. Verify that a new [7.1.0 tag](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.1.0) was created
-    3. Verify that it's present in [Maven Central](https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/) (usually takes few minutes now)
+    3. Verify that it's present in [Maven Central](https://repo.maven.apache.org/maven2/org/glassfish/main/distributions/glassfish)
+       (usually takes few minutes now)
 9. If everything is OK, then merge the PR.
 10. Delete the branch after merge, only tag will remain.
 11. Upload the new release to the Eclipse download folder.

--- a/appserver/admingui/jms-plugin/pom.xml
+++ b/appserver/admingui/jms-plugin/pom.xml
@@ -66,8 +66,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.messaging.mq</groupId>
-            <artifactId>imqjmx</artifactId>
+            <groupId>org.glassfish.mq</groupId>
+            <artifactId>mqjmx-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.java
+++ b/appserver/distributions/glassfish-common/src/main/resources/bin/asadmin.java
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.main.productroot.bin.asadmin;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.java
+++ b/appserver/distributions/glassfish-common/src/main/resources/glassfish/bin/asadmin.java
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.main.installroot.bin.asadmin;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/appserver/distributions/glassfish/pom.xml
+++ b/appserver/distributions/glassfish/pom.xml
@@ -65,6 +65,10 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/distributions/glassfish/pom.xml
+++ b/appserver/distributions/glassfish/pom.xml
@@ -65,10 +65,6 @@
             <type>zip</type>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jline</groupId>
-            <artifactId>jline</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/distributions/web/pom.xml
+++ b/appserver/distributions/web/pom.xml
@@ -33,7 +33,6 @@
     <name>Glassfish Web Profile Distribution</name>
 
     <properties>
-        <patch.classes>${project.build.directory}/dependency</patch.classes>
         <glassfish.modules>${project.build.directory}/stage/glassfish8/glassfish/modules</glassfish.modules>
         <patches>${basedir}/src/main/patches</patches>
     </properties>

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1907,5 +1907,11 @@
                 </exclusion>
             </exclusions>
        </dependency>
+
+        <!-- JLine for Admin CLI -->
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -42,6 +42,7 @@
             <version>${project.version}</version>
             <type>pom</type>
         </dependency>
+
         <!-- pull MicroProfile featureset -->
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/appserver/libpam4j/pom.xml
+++ b/appserver/libpam4j/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.17.0</version>
+            <version>5.18.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -194,7 +194,8 @@
         <!-- Other -->
         <dbschema.version>2.7.0-SNAPSHOT</dbschema.version>
         <schema2beans.version>2.7.0-SNAPSHOT</schema2beans.version>
-        <derby.version>10.17.1.0-SNAPSHOT</derby.version>
+        <derby.version>10.17.1.0</derby.version>
+        <derby.repackaged.version>10.17.1.0-SNAPSHOT</derby.repackaged.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <maven-rar-plugin.version>3.0.0</maven-rar-plugin.version>
 
@@ -700,7 +701,7 @@
             <dependency>
                 <groupId>org.glassfish.external</groupId>
                 <artifactId>derby</artifactId>
-                <version>${derby.version}</version>
+                <version>${derby.repackaged.version}</version>
                 <type>zip</type>
             </dependency>
             <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -98,6 +98,9 @@
         <jakarta.concurrent-api.version>3.1.1</jakarta.concurrent-api.version>
         <concurro.version>3.1.0-M6</concurro.version>
 
+        <!-- Jakarta Interceptors -->
+        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
+
         <!-- Jakarta Security + Authentication/Authorization -->
         <!-- APIs -->
         <jakarta.security-api.version>4.0.0</jakarta.security-api.version>
@@ -107,7 +110,6 @@
         <soteria.version>4.0.1</soteria.version>
         <exousia.version>3.0.0</exousia.version>
         <epicyro.version>3.1.0</epicyro.version>
-        <!-- Dependencies -->
         <nimbus.version>10.5</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
@@ -159,9 +161,6 @@
         <jakarta.cdi-api.version>4.1.0</jakarta.cdi-api.version>
         <weld.version>6.0.3.Final</weld.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
-
-        <!-- Jakarta Interceptors -->
-        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
 
         <!-- Jakarta MVC -->
         <jakarta.mvc-api.version>3.0.0</jakarta.mvc-api.version>
@@ -329,9 +328,9 @@
                 <version>${openmq.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.messaging.mq</groupId>
-                <artifactId>imqjmx</artifactId>
-                <version>4.6-b01</version>
+                <groupId>org.glassfish.mq</groupId>
+                <artifactId>mqjmx-api</artifactId>
+                <version>${openmq.version}</version>
             </dependency>
 
             <!-- Jakarta Data-->

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -107,7 +107,7 @@
         <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
         <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
         <!-- Implementations -->
-        <soteria.version>4.0.1</soteria.version>
+        <soteria.version>4.0.2-SNAPSHOT</soteria.version>
         <exousia.version>3.0.0</exousia.version>
         <epicyro.version>3.1.1</epicyro.version>
         <nimbus.version>10.5</nimbus.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -192,9 +192,9 @@
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <!-- Other -->
-        <dbschema.version>6.7</dbschema.version>
-        <schema2beans.version>6.7</schema2beans.version>
-        <derby.version>10.17.1.0</derby.version>
+        <dbschema.version>2.7.0-SNAPSHOT</dbschema.version>
+        <schema2beans.version>2.7.0-SNAPSHOT</schema2beans.version>
+        <derby.version>10.17.1.0-SNAPSHOT</derby.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <maven-rar-plugin.version>3.0.0</maven-rar-plugin.version>
 

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -96,7 +96,7 @@
 
         <!-- Jakarta Concurrency -->
         <jakarta.concurrent-api.version>3.1.1</jakarta.concurrent-api.version>
-        <concurro.version>3.1.0-M6</concurro.version>
+        <concurro.version>3.1.0-SNAPSHOT</concurro.version>
 
         <!-- Jakarta Interceptors -->
         <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- Jakarta Faces -->
         <jakarta.faces-api.version>4.0.1</jakarta.faces-api.version>
-        <mojarra.version>4.0.11</mojarra.version>
+        <mojarra.version>4.0.12</mojarra.version>
 
         <!-- Jakarta WebSocket -->
         <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>
@@ -96,7 +96,7 @@
 
         <!-- Jakarta Concurrency -->
         <jakarta.concurrent-api.version>3.0.4</jakarta.concurrent-api.version>
-        <concurrent.version>3.0.1</concurrent.version>
+        <concurrent.version>3.0.2</concurrent.version>
 
         <!-- Jakarta Interceptors -->
         <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
@@ -105,7 +105,7 @@
         <soteria.version>3.0.4</soteria.version>
         <exousia.version>2.1.3</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>10.4.2</nimbus.version>
+        <nimbus.version>10.5</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->
@@ -114,8 +114,8 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
-        <eclipselink.version>4.0.5</eclipselink.version>
-        <eclipselink.asm.version>9.7.1</eclipselink.asm.version>
+        <eclipselink.version>4.0.8</eclipselink.version>
+        <eclipselink.asm.version>9.8.0</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
@@ -143,13 +143,13 @@
         <wasp.version>3.2.2</wasp.version>
 
         <!-- Used for Jakarta SOAP (XML Web Services) -->
-        <xmlsec.version>4.0.3</xmlsec.version>
-        <woodstox.version>7.1.0</woodstox.version>
+        <xmlsec.version>4.0.4</xmlsec.version>
+        <woodstox.version>7.1.1</woodstox.version>
         <stax2-api.version>4.2.2</stax2-api.version>
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.0.1</jakarta.cdi-api.version>
-        <weld.version>5.1.5.Final</weld.version>
+        <weld.version>5.1.6.Final</weld.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta MVC -->
@@ -158,7 +158,7 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1</microprofile.config-api.version>
-        <helidon-config.version>3.2.12</helidon-config.version>
+        <helidon-config.version>3.2.15</helidon-config.version>
 
 
         <!-- MicroProfile Health -->
@@ -303,9 +303,9 @@
                 <version>${openmq.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.messaging.mq</groupId>
-                <artifactId>imqjmx</artifactId>
-                <version>4.6-b01</version>
+                <groupId>org.glassfish.mq</groupId>
+                <artifactId>mqjmx-api</artifactId>
+                <version>${openmq.version}</version>
             </dependency>
 
             <!-- Jakarta Persistence -->
@@ -477,7 +477,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.17.1</version>
+                <version>1.19.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -192,8 +192,8 @@
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <!-- Other -->
-        <dbschema.version>2.7.0-SNAPSHOT</dbschema.version>
-        <schema2beans.version>2.7.0-SNAPSHOT</schema2beans.version>
+        <dbschema.version>6.7</dbschema.version>
+        <schema2beans.version>6.7</schema2beans.version>
         <derby.version>10.17.1.0</derby.version>
         <derby.repackaged.version>10.17.1.0-SNAPSHOT</derby.repackaged.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -109,7 +109,7 @@
         <!-- Implementations -->
         <soteria.version>4.0.1</soteria.version>
         <exousia.version>3.0.0</exousia.version>
-        <epicyro.version>3.1.0</epicyro.version>
+        <epicyro.version>3.1.1</epicyro.version>
         <nimbus.version>10.5</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 

--- a/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/authorization/PolicyLoader.java
+++ b/appserver/security/core-ee/src/main/java/com/sun/enterprise/security/ee/authorization/PolicyLoader.java
@@ -106,7 +106,7 @@ public class PolicyLoader {
         }
 
         setProperty("simple.jacc.provider.JACCRoleMapper.class",
-            "com.sun.enterprise.security.ee.web.integration.GlassfishRoleMapper", false);
+            "com.sun.enterprise.security.ee.authorization.GlassfishRoleMapper", false);
 
         // Now install the policy provider if one was identified
         if (javaPolicyClassName != null) {

--- a/appserver/tests/admin/ssh-cluster/src/test/java/org/glassfish/main/test/clusterssh/docker/GlassFishContainer.java
+++ b/appserver/tests/admin/ssh-cluster/src/test/java/org/glassfish/main/test/clusterssh/docker/GlassFishContainer.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.Network;
 public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
 
     public GlassFishContainer(Network network, String hostname, String logPrefix, String command) {
-        super("eclipse-temurin:17");
+        super("eclipse-temurin:" + Runtime.version().feature());
         withNetwork(network)
         .withEnv("TZ", "UTC").withEnv("LC_ALL", "en_US.UTF-8")
         .withStartupAttempts(1)

--- a/appserver/tests/admin/ssh-cluster/src/test/java/org/glassfish/main/test/clusterssh/docker/GlassFishContainer.java
+++ b/appserver/tests/admin/ssh-cluster/src/test/java/org/glassfish/main/test/clusterssh/docker/GlassFishContainer.java
@@ -27,7 +27,7 @@ import org.testcontainers.containers.Network;
 public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
 
     public GlassFishContainer(Network network, String hostname, String logPrefix, String command) {
-        super("eclipse-temurin:21");
+        super("eclipse-temurin:" + Runtime.version().feature());
         withNetwork(network)
         .withEnv("TZ", "UTC").withEnv("LC_ALL", "en_US.UTF-8")
         .withStartupAttempts(1)

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/GJULEvsJDKLogManagerIT.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/GJULEvsJDKLogManagerIT.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Example from the Windows command line:
- * <code>.\appserver\tests\admin\tests\target\glassfish7\bin\asadmin create-jvm-options '-XX\:ErrorFile=C\:\\Users\\vboxuser\\glassfish 7\\java_error%%p.log'</code>
+ * <code>.\appserver\tests\admin\tests\target\glassfish8\bin\asadmin create-jvm-options '-XX\:ErrorFile=C\:\\Users\\vboxuser\\glassfish 8\\java_error%%p.log'</code>
  * <p>
  * Apostrophes are needed to prevent interpretation for any command line interpreter
  * Beware of quoting, especially on windows it completely changes interpretation rules.

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ApplicationITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ApplicationITest.java
@@ -28,7 +28,6 @@ import org.glassfish.main.itest.tools.DomainAdminRestClient;
 import org.glassfish.main.itest.tools.RandomGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -39,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author jasonlee
  */
-@Disabled("TEMPORARY FOR GLASSFISH 8 M1 - timeout")
 public class ApplicationITest extends RestTestBase {
 
 

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ConfigITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ConfigITest.java
@@ -21,7 +21,6 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 
 import org.glassfish.main.itest.tools.RandomGenerator;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -30,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * @author jasonlee
  */
-@Disabled("TEMPORARY FOR GLASSFISH 8 M1 - Operation timed out")
 public class ConfigITest extends RestTestBase {
 
     @Test

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ElementStarITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/ElementStarITest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.glassfish.main.itest.tools.RandomGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -38,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author jasonlee
  */
-@Disabled("TEMPORARY FOR GLASSFISH 8 M1 - Unable to delete the temporary JMS Resource test_jms_adapter.")
 public class ElementStarITest extends RestTestBase {
     private static final String URL_CREATE_INSTANCE = "/domain/create-instance";
 

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JmsITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JmsITest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author jasonlee 2010
  * @author David Matejcek 2022
  */
-@Disabled("TEMPORARY FOR GLASSFISH 8 M1 - Unable to delete the temporary JMS Resource test_jms_adapter.")
 public class JmsITest extends RestTestBase {
     private static final String URL_ADMIN_OBJECT_RESOURCE = "/domain/resources/admin-object-resource";
     private static final String URL_CONNECTOR_CONNECTION_POOL = "/domain/resources/connector-connection-pool";

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/StatusGeneratorITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/StatusGeneratorITest.java
@@ -19,7 +19,6 @@ package org.glassfish.main.admin.test.rest;
 import jakarta.ws.rs.core.Response;
 
 import org.glassfish.main.itest.tools.DomainAdminRestClient;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -30,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 /**
  * @author David Matejcek
  */
-@Disabled("TEMPORARY FOR GLASSFISH 8 M1 - create-instance is missing")
 public class StatusGeneratorITest extends RestTestBase {
 
     @Test
@@ -43,7 +41,6 @@ public class StatusGeneratorITest extends RestTestBase {
                 () -> assertThat(response.readEntity(String.class),
                     stringContainsInOrder("All Commands used in REST Admin",
                         "Missing Commands not used in REST Admin",
-                        "create-instance",
                         "REST-REDIRECT Commands defined on ConfigBeans",
                         "Commands to Resources Mapping Usage in REST Admin",
                         "Resources with Delete Commands in REST Admin (not counting RESTREDIRECT")

--- a/appserver/tests/embedded/maven-plugin/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/pom.xml
@@ -190,7 +190,7 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.3.9</version>
+                <version>3.9.11</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
+++ b/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.runnable.app;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+
+import java.util.logging.Logger;
+
+/**
+ * @author Ondro Mihalyi
+ */
+@ApplicationScoped
+public class SystemPropertyApp {
+
+    private static final Logger LOG = Logger.getLogger(SystemPropertyApp.class.getName());
+
+    public void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        String myName = System.getProperty("my.name");
+        LOG.info("System property my.name: " + myName);
+    }
+}

--- a/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
+++ b/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.runnable.app;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.ws.rs.core.Application;
+
+import java.util.logging.Logger;
+
+/**
+ * @author Ondro Mihalyi
+ */
+@ApplicationScoped
+public class SystemPropertyApp extends Application {
+
+    private static final Logger LOG = Logger.getLogger(SystemPropertyApp.class.getName());
+
+    public void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        String myName = System.getProperty("my.name");
+        LOG.info("System property my.name: " + myName);
+    }
+}

--- a/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
+++ b/appserver/tests/embedded/runnable/src/main/java/org/glassfish/tests/embedded/runnable/app/SystemPropertyApp.java
@@ -18,7 +18,6 @@ package org.glassfish.tests.embedded.runnable.app;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
-import jakarta.ws.rs.core.Application;
 
 import java.util.logging.Logger;
 
@@ -26,7 +25,7 @@ import java.util.logging.Logger;
  * @author Ondro Mihalyi
  */
 @ApplicationScoped
-public class SystemPropertyApp extends Application {
+public class SystemPropertyApp {
 
     private static final Logger LOG = Logger.getLogger(SystemPropertyApp.class.getName());
 

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
@@ -35,10 +35,21 @@ import static java.util.stream.Collectors.joining;
  */
 public class GfEmbeddedUtils {
 
-    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug.port";
+    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug";
+
+    public static Optional<String> getDebugArg() {
+        return Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
+                .filter(debugPort -> List.of("none", "disabled", "false").stream()
+                .allMatch(value -> !value.equalsIgnoreCase(debugPort))
+                );
+    }
+
+    public static boolean isDebugEnabled() {
+        return getDebugArg().isPresent();
+    }
 
     public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws
-IOException {
+            IOException {
         return runGlassFishEmbedded(glassfishEmbeddedJarName, List.of(), additionalArguments);
     }
 
@@ -75,12 +86,9 @@ IOException {
     }
 
     private static void addDebugArgsIfDebugEnabled(List<String> arguments) {
-        Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
-                .filter(debugPort -> List.of("none", "disabled", "false").stream()
-                        .allMatch(value -> !value.equalsIgnoreCase(debugPort))
-                )
-                .ifPresent(debugPort -> {
-                    arguments.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" + debugPort);
+        getDebugArg()
+                .ifPresent(debugArgs -> {
+                    arguments.add(debugArgs);
                 });
 
     }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
@@ -20,11 +20,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.System.err;
+import static java.util.stream.Collectors.joining;
 
 /**
  *
@@ -32,15 +35,29 @@ import static java.lang.System.err;
  */
 public class GfEmbeddedUtils {
 
-    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws IOException {
+    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug.port";
+
+    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws
+IOException {
+        return runGlassFishEmbedded(glassfishEmbeddedJarName, List.of(), additionalArguments);
+    }
+
+    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, List<String> jvmOpts, String... additionalArguments) throws IOException {
         List<String> arguments = new ArrayList<>();
-        arguments.addAll(List.of(ProcessHandle.current().info().command().get(),
-                //                "-Xrunjdwp:transport=dt_socket,server=y,suspend=y", // enable debugging on random port
+        arguments.add(ProcessHandle.current().info().command().get());
+        addDebugArgsIfDebugEnabled(arguments);
+        arguments.addAll(jvmOpts);
+        arguments.addAll(List.of(
                 "-jar", glassfishEmbeddedJarName,
+                "--noPort",
                 "--stop"));
         for (String argument : additionalArguments) {
             arguments.add(argument);
         }
+        System.out.println("\nCurrent directory: " + Paths.get(".").toFile().getAbsolutePath());
+        System.out.println("Going to run Embedded GlassFish: " + arguments.stream()
+                .map(arg -> "'" + arg + "'")
+                .collect(joining(" ")) + "\n");
         return new ProcessBuilder()
                 .redirectOutput(ProcessBuilder.Redirect.INHERIT)
                 .redirectError(ProcessBuilder.Redirect.PIPE)
@@ -55,6 +72,17 @@ public class GfEmbeddedUtils {
         )
                 .lines()
                 .peek(err::println);
+    }
+
+    private static void addDebugArgsIfDebugEnabled(List<String> arguments) {
+        Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
+                .filter(debugPort -> List.of("none", "disabled", "false").stream()
+                        .allMatch(value -> !value.equalsIgnoreCase(debugPort))
+                )
+                .ifPresent(debugPort -> {
+                    arguments.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" + debugPort);
+                });
+
     }
 
 }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/GfEmbeddedUtils.java
@@ -20,11 +20,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.System.err;
+import static java.util.stream.Collectors.joining;
 
 /**
  *
@@ -32,15 +35,40 @@ import static java.lang.System.err;
  */
 public class GfEmbeddedUtils {
 
-    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws IOException {
+    public static final String DEBUG_PROPERTY_NAME = "glassfish.test.debug";
+
+    public static Optional<String> getDebugArg() {
+        return Optional.ofNullable(System.getProperty(DEBUG_PROPERTY_NAME))
+                .filter(debugPort -> List.of("none", "disabled", "false").stream()
+                .allMatch(value -> !value.equalsIgnoreCase(debugPort))
+                );
+    }
+
+    public static boolean isDebugEnabled() {
+        return getDebugArg().isPresent();
+    }
+
+    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, String... additionalArguments) throws
+            IOException {
+        return runGlassFishEmbedded(glassfishEmbeddedJarName, List.of(), additionalArguments);
+    }
+
+    public static Process runGlassFishEmbedded(String glassfishEmbeddedJarName, List<String> jvmOpts, String... additionalArguments) throws IOException {
         List<String> arguments = new ArrayList<>();
-        arguments.addAll(List.of(ProcessHandle.current().info().command().get(),
-                //                "-Xrunjdwp:transport=dt_socket,server=y,suspend=y", // enable debugging on random port
+        arguments.add(ProcessHandle.current().info().command().get());
+        addDebugArgsIfDebugEnabled(arguments);
+        arguments.addAll(jvmOpts);
+        arguments.addAll(List.of(
                 "-jar", glassfishEmbeddedJarName,
+                "--noPort",
                 "--stop"));
         for (String argument : additionalArguments) {
             arguments.add(argument);
         }
+        System.out.println("\nCurrent directory: " + Paths.get(".").toFile().getAbsolutePath());
+        System.out.println("Going to run Embedded GlassFish: " + arguments.stream()
+                .map(arg -> "'" + arg + "'")
+                .collect(joining(" ")) + "\n");
         return new ProcessBuilder()
                 .redirectOutput(ProcessBuilder.Redirect.INHERIT)
                 .redirectError(ProcessBuilder.Redirect.PIPE)
@@ -55,6 +83,14 @@ public class GfEmbeddedUtils {
         )
                 .lines()
                 .peek(err::println);
+    }
+
+    private static void addDebugArgsIfDebugEnabled(List<String> arguments) {
+        getDebugArg()
+                .ifPresent(debugArgs -> {
+                    arguments.add(debugArgs);
+                });
+
     }
 
 }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
@@ -54,12 +54,11 @@ public class SystemPropertyTest {
         try {
             warFile = createSystemPropertyApp();
             Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
-                    List.of("-Dmy.name=GlassFish"),
-                    "--noPort",
+                    List.of("-Dmy.name=Embedded GlassFish"),
                     warFile.getAbsolutePath()
             );
             assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
-                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
                     "Application should print the value of the my.name system property.");
             gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
         } finally {
@@ -74,11 +73,11 @@ public class SystemPropertyTest {
         try {
             warFile = createSystemPropertyApp();
             Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
-                    "create-system-properties my.name=GlassFish",
+                    "create-system-properties my.name=Embedded\\ GlassFish",
                     warFile.getAbsolutePath()
             );
             assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
-                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
                     "Application should print the value of the my.name system property.");
             gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
         } finally {
@@ -98,7 +97,7 @@ public class SystemPropertyTest {
                     warFile.getAbsolutePath()
             );
             assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
-                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
                     "Application should print the value of the my.name system property.");
             gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
         } finally {
@@ -111,7 +110,7 @@ public class SystemPropertyTest {
         WebArchive warArchive = ShrinkWrap.create(WebArchive.class, warName)
                 .addClass(SystemPropertyApp.class);
         File warFile = new File(warName);
-        warArchive.as(ZipExporter.class).exportTo(warFile);
+        warArchive.as(ZipExporter.class).exportTo(warFile, true);
         logArchiveContent(warArchive, warName, LOG::info);
         return warFile;
     }

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.runnable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.glassfish.tests.embedded.runnable.TestArgumentProviders.GfEmbeddedJarNameProvider;
+import org.glassfish.tests.embedded.runnable.app.SystemPropertyApp;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.glassfish.tests.embedded.runnable.GfEmbeddedUtils.outputToStreamOfLines;
+import static org.glassfish.tests.embedded.runnable.GfEmbeddedUtils.runGlassFishEmbedded;
+import static org.glassfish.tests.embedded.runnable.ShrinkwrapUtils.logArchiveContent;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Ondro Mihalyi
+ */
+public class SystemPropertyTest {
+
+    private static final Logger LOG = Logger.getLogger(SystemPropertyTest.class.getName());
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromJvmOption(String gfEmbeddedJarName) throws Exception {
+        File warFile = null;
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    List.of("-Dmy.name=Embedded GlassFish"),
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromAdminCommand(String gfEmbeddedJarName) throws Exception {
+        File warFile = null;
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "create-system-properties my.name=Embedded\\ GlassFish",
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromPropertyFileDirectly(String gfEmbeddedJarName, TestInfo testInfo) throws Exception {
+        File warFile = null;
+        Path propertiesFile = preparePropertiesFile(testInfo);
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "--properties=" + propertiesFile.toFile().getPath(),
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromDomainConfig(String gfEmbeddedJarName, TestInfo testInfo) throws Exception {
+        File warFile = null;
+        Path domainConfigFile = prepareDomainConfig(testInfo);
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "--domainConfigFile=" + domainConfigFile.toFile().getPath(),
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: Embedded GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    private File createSystemPropertyApp() throws Exception {
+        String warName = "systemPropertyApp.war";
+        WebArchive warArchive = ShrinkWrap.create(WebArchive.class, warName)
+                .addClass(SystemPropertyApp.class);
+        File warFile = new File(warName);
+        warArchive.as(ZipExporter.class).exportTo(warFile, true);
+        logArchiveContent(warArchive, warName, LOG::info);
+        return warFile;
+    }
+
+    private Path prepareDomainConfig(TestInfo testInfo) throws IOException {
+        String testClassName = testInfo.getTestClass().get().getSimpleName();
+        String testMethodName = testInfo.getTestMethod().get().getName();
+        Path domainConfigFile = Paths.get(testClassName + "-" + testMethodName + "-" + "domain.xml");
+        Files.copy(getClass().getClassLoader().getResourceAsStream(testClassName + "/domain.xml"),
+                domainConfigFile,
+                StandardCopyOption.REPLACE_EXISTING);
+        return domainConfigFile;
+    }
+
+    private Path preparePropertiesFile(TestInfo testInfo) throws IOException {
+        String testClassName = testInfo.getTestClass().get().getSimpleName();
+        String testMethodName = testInfo.getTestMethod().get().getName();
+        Path propertiesFile = Paths.get(testClassName + "-" + testMethodName + "-" + "glassfish.properties");
+        Files.copy(getClass().getClassLoader().getResourceAsStream(testClassName + "/glassfish.properties"),
+                propertiesFile,
+                StandardCopyOption.REPLACE_EXISTING);
+        return propertiesFile;
+    }
+
+}

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/SystemPropertyTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.runnable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.glassfish.tests.embedded.runnable.TestArgumentProviders.GfEmbeddedJarNameProvider;
+import org.glassfish.tests.embedded.runnable.app.SystemPropertyApp;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import static org.glassfish.tests.embedded.runnable.GfEmbeddedUtils.outputToStreamOfLines;
+import static org.glassfish.tests.embedded.runnable.GfEmbeddedUtils.runGlassFishEmbedded;
+import static org.glassfish.tests.embedded.runnable.ShrinkwrapUtils.logArchiveContent;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Ondro Mihalyi
+ */
+public class SystemPropertyTest {
+
+    private static final Logger LOG = Logger.getLogger(SystemPropertyTest.class.getName());
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromJvmOption(String gfEmbeddedJarName) throws Exception {
+        File warFile = null;
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    List.of("-Dmy.name=GlassFish"),
+                    "--noPort",
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromAdminCommand(String gfEmbeddedJarName) throws Exception {
+        File warFile = null;
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "create-system-properties my.name=GlassFish",
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(GfEmbeddedJarNameProvider.class)
+    void testSystemPropertyFromDomainConfig(String gfEmbeddedJarName, TestInfo testInfo) throws Exception {
+        File warFile = null;
+        Path domainConfigFile = prepareDomainConfig(testInfo);
+        try {
+            warFile = createSystemPropertyApp();
+            Process gfEmbeddedProcess = runGlassFishEmbedded(gfEmbeddedJarName,
+                    "--domainConfigFile=" + domainConfigFile.toFile().getPath(),
+                    warFile.getAbsolutePath()
+            );
+            assertTrue(outputToStreamOfLines(gfEmbeddedProcess)
+                    .anyMatch(line -> line.contains("System property my.name: GlassFish")),
+                    "Application should print the value of the my.name system property.");
+            gfEmbeddedProcess.waitFor(30, TimeUnit.SECONDS);
+        } finally {
+            Optional.ofNullable(warFile).ifPresent(File::delete);
+        }
+    }
+
+    private File createSystemPropertyApp() throws Exception {
+        String warName = "systemPropertyApp.war";
+        WebArchive warArchive = ShrinkWrap.create(WebArchive.class, warName)
+                .addClass(SystemPropertyApp.class);
+        File warFile = new File(warName);
+        warArchive.as(ZipExporter.class).exportTo(warFile);
+        logArchiveContent(warArchive, warName, LOG::info);
+        return warFile;
+    }
+
+    private Path prepareDomainConfig(TestInfo testInfo) throws IOException {
+        String testClassName = testInfo.getTestClass().get().getSimpleName();
+        String testMethodName = testInfo.getTestMethod().get().getName();
+        Path domainConfigFile = Paths.get(testClassName + "-" + testMethodName + "-" + "domain.xml");
+        Files.copy(getClass().getClassLoader().getResourceAsStream(testClassName + "/domain.xml"),
+                domainConfigFile,
+                StandardCopyOption.REPLACE_EXISTING);
+        return domainConfigFile;
+    }
+
+}

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/TestArgumentProviders.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/TestArgumentProviders.java
@@ -15,6 +15,8 @@
  */
 package org.glassfish.tests.embedded.runnable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -31,20 +33,14 @@ public class TestArgumentProviders {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext ec) throws Exception {
-            return Stream.of(Arguments.of("glassfish-embedded-all.jar"), Arguments.of("glassfish-embedded-web.jar"));
+            List<Arguments> arguments = new ArrayList<>();
+            arguments.add(Arguments.of("glassfish-embedded-all.jar"));
+            if (!GfEmbeddedUtils.isDebugEnabled()) {
+                arguments.add(Arguments.of("glassfish-embedded-web.jar"));
+            }
+            return arguments.stream();
         }
 
     }
 
-    /**
-     * For testing a single execution when debugging
-     */
-    public static class SingleGfEmbeddedJarNameProvider implements ArgumentsProvider {
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext ec) throws Exception {
-            return Stream.of(Arguments.of("glassfish-embedded-all.jar"));
-        }
-
-    }
 }

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
@@ -1,0 +1,176 @@
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+  <security-configurations>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/embedded_default" />
+      <property name="connectionAttributes" value=";create=true" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="server" config-ref="server-config">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+    </server>
+  </servers>
+ <configs>
+   <config name="server-config">
+     <system-property name="my.name" value="Embedded GlassFish"/>
+     <http-service>
+        <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
+        <virtual-server id="server" network-listeners="http-listener, https-listener" />
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="3700" id="orb-listener-1" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3820" id="SSL">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3920" id="SSL_MUTUALAUTH">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector enabled="false" auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="8686" name="system" />
+        <das-config autodeploy-enabled="false" dynamic-reload-enabled="true" deploy-xml-validation="full" autodeploy-dir="${com.sun.aas.instanceRoot}/autodeploy" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+      <ejb-container steady-pool-size="0" max-pool-size="32" session-store="${com.sun.aas.instanceRoot}/session-store" pool-resize-quantity="8">
+        <ejb-timer-service />
+      </ejb-container>
+      <mdb-container steady-pool-size="0" max-pool-size="32" pool-resize-quantity="8" >
+      </mdb-container>
+      <jms-service type="EMBEDDED" default-jms-host="default_JMS_host">
+        <jms-host name="default_JMS_host" host="localhost" port="7676" admin-user-name="admin" admin-password="admin" lazy-init="false"/>
+      </jms-service>
+      <log-service file="${com.sun.aas.instanceRoot}/logs/server.log" log-rotation-limit-in-bytes="2000000">
+        <module-log-levels />
+      </log-service>
+      <security-service activate-default-principal-to-role-mapping="true" jacc="simple">
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <monitoring-service>
+        <module-monitoring-levels />
+      </monitoring-service>
+      <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" >
+      </transaction-service>
+      <java-config>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Dorg.glassfish.jms.InitializeOnDemand=true</jvm-options>
+      </java-config>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+          <protocol security-enabled="true" name="https-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="0" protocol="http-listener" transport="tcp" name="http-listener" thread-pool="http-thread-pool" enabled="false" />
+          <network-listener port="0" protocol="https-listener" transport="tcp" name="https-listener" thread-pool="http-thread-pool" enabled="false" />
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+      </thread-pools>
+    </config>
+  </configs>
+  <property name="administrative.domain.name" value="domain1"/>
+</domain>

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
@@ -46,7 +46,7 @@
   </servers>
  <configs>
    <config name="server-config">
-     <system-property name="my.name" value="GlassFish"/>
+     <system-property name="my.name" value="Embedded GlassFish"/>
      <http-service>
         <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
         <virtual-server id="server" network-listeners="http-listener, https-listener" />

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
@@ -17,7 +17,6 @@
 -->
 
 <domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
-  <property name="administrative.domain.name" value="myDomain"/>
   <security-configurations>
     <authorization-service default="true" name="authorizationService">
       <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
@@ -47,6 +46,7 @@
   </servers>
  <configs>
    <config name="server-config">
+     <system-property name="my.name" value="Embedded GlassFish"/>
      <http-service>
         <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
         <virtual-server id="server" network-listeners="http-listener, https-listener" />
@@ -140,8 +140,8 @@
       <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" >
       </transaction-service>
       <java-config>
-        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
-        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.p12</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
         <jvm-options>-Dorg.glassfish.jms.InitializeOnDemand=true</jvm-options>
       </java-config>
       <network-config>
@@ -172,4 +172,5 @@
       </thread-pools>
     </config>
   </configs>
+  <property name="administrative.domain.name" value="domain1"/>
 </domain>

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/domain.xml
@@ -1,0 +1,176 @@
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+  <security-configurations>
+    <authorization-service default="true" name="authorizationService">
+      <security-provider name="simpleAuthorization" type="Simple" provider-name="simpleAuthorizationProvider">
+        <authorization-provider-config support-policy-deploy="false" name="simpleAuthorizationProviderConfig"></authorization-provider-config>
+      </security-provider>
+    </authorization-service>
+  </security-configurations>
+  <system-applications />
+  <applications />
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin" />
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default" object-type="system-all" />
+    <jdbc-connection-pool name="__TimerPool" datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource">
+      <property value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer" name="databaseName" />
+      <property value=";create=true" name="connectionAttributes" />
+    </jdbc-connection-pool>
+    <jdbc-connection-pool is-isolation-level-guaranteed="false" name="DerbyPool" datasource-classname="org.apache.derby.jdbc.EmbeddedDataSource" res-type="javax.sql.DataSource">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/embedded_default" />
+      <property name="connectionAttributes" value=";create=true" />
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="server" config-ref="server-config">
+      <resource-ref ref="jdbc/__TimerPool" />
+      <resource-ref ref="jdbc/__default" />
+    </server>
+  </servers>
+ <configs>
+   <config name="server-config">
+     <system-property name="my.name" value="GlassFish"/>
+     <http-service>
+        <access-log rotation-interval-in-minutes="15" rotation-suffix="yyyy-MM-dd" />
+        <virtual-server id="server" network-listeners="http-listener, https-listener" />
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1" />
+        <iiop-listener address="0.0.0.0" port="3700" id="orb-listener-1" />
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3820" id="SSL">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" />
+        </iiop-listener>
+        <iiop-listener security-enabled="true" address="0.0.0.0" port="3920" id="SSL_MUTUALAUTH">
+          <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" cert-nickname="s1as" client-auth-enabled="true" />
+        </iiop-listener>
+      </iiop-service>
+      <admin-service type="das-and-server" system-jmx-connector-name="system">
+        <jmx-connector enabled="false" auth-realm-name="admin-realm" security-enabled="false" address="0.0.0.0" port="8686" name="system" />
+        <das-config autodeploy-enabled="false" dynamic-reload-enabled="true" deploy-xml-validation="full" autodeploy-dir="${com.sun.aas.instanceRoot}/autodeploy" />
+        <property value="/admin" name="adminConsoleContextRoot" />
+        <property value="${com.sun.aas.installRoot}/lib/install/applications/admingui.war" name="adminConsoleDownloadLocation" />
+        <property value="${com.sun.aas.installRoot}/.." name="ipsRoot" />
+      </admin-service>
+      <connector-service shutdown-timeout-in-seconds="30">
+      </connector-service>
+      <ejb-container steady-pool-size="0" max-pool-size="32" session-store="${com.sun.aas.instanceRoot}/session-store" pool-resize-quantity="8">
+        <ejb-timer-service />
+      </ejb-container>
+      <mdb-container steady-pool-size="0" max-pool-size="32" pool-resize-quantity="8" >
+      </mdb-container>
+      <jms-service type="EMBEDDED" default-jms-host="default_JMS_host">
+        <jms-host name="default_JMS_host" host="localhost" port="7676" admin-user-name="admin" admin-password="admin" lazy-init="false"/>
+      </jms-service>
+      <log-service file="${com.sun.aas.instanceRoot}/logs/server.log" log-rotation-limit-in-bytes="2000000">
+        <module-log-levels />
+      </log-service>
+      <security-service activate-default-principal-to-role-mapping="true" jacc="simple">
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="admin-realm">
+          <property value="${com.sun.aas.instanceRoot}/config/admin-keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.file.FileRealm" name="file">
+          <property value="${com.sun.aas.instanceRoot}/config/keyfile" name="file" />
+          <property value="fileRealm" name="jaas-context" />
+        </auth-realm>
+        <auth-realm classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm" name="certificate" />
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default">
+          <property value="${com.sun.aas.instanceRoot}/generated/policy" name="repository" />
+        </jacc-provider>
+        <jacc-provider policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory" policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" />
+        <audit-module classname="com.sun.enterprise.security.ee.Audit" name="default">
+          <property value="false" name="auditOn" />
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule" provider-type="client">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="dynamic.username.password" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+          <provider-config provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+          </provider-config>
+          <provider-config provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule" provider-type="server">
+            <request-policy auth-source="content" />
+            <response-policy auth-source="content" />
+            <property value="s1as" name="encryption.key.alias" />
+            <property value="s1as" name="signature.key.alias" />
+            <property value="false" name="debug" />
+            <property value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml" name="security.config" />
+          </provider-config>
+        </message-security-config>
+        <property value="SHA-256" name="default-digest-algorithm" />
+      </security-service>
+      <monitoring-service>
+        <module-monitoring-levels />
+      </monitoring-service>
+      <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs" >
+      </transaction-service>
+      <java-config>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks</jvm-options>
+        <jvm-options>-Dorg.glassfish.jms.InitializeOnDemand=true</jvm-options>
+      </java-config>
+      <network-config>
+        <protocols>
+          <protocol name="http-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+          </protocol>
+          <protocol security-enabled="true" name="https-listener">
+            <http default-virtual-server="server" max-connections="250">
+              <file-cache enabled="false"></file-cache>
+            </http>
+            <ssl classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl" ssl3-enabled="false" cert-nickname="s1as"></ssl>
+          </protocol>
+        </protocols>
+        <network-listeners>
+          <network-listener port="0" protocol="http-listener" transport="tcp" name="http-listener" thread-pool="http-thread-pool" enabled="false" />
+          <network-listener port="0" protocol="https-listener" transport="tcp" name="https-listener" thread-pool="http-thread-pool" enabled="false" />
+        </network-listeners>
+        <transports>
+          <transport name="tcp"></transport>
+        </transports>
+      </network-config>
+      <thread-pools>
+          <thread-pool name="http-thread-pool" max-queue-size="4096"></thread-pool>
+          <thread-pool name="thread-pool-1" max-thread-pool-size="200"/>
+      </thread-pools>
+    </config>
+  </configs>
+  <property name="administrative.domain.name" value="domain1"/>
+</domain>

--- a/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/glassfish.properties
+++ b/appserver/tests/embedded/runnable/src/test/resources/SystemPropertyTest/glassfish.properties
@@ -1,0 +1,15 @@
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+my.name=Embedded GlassFish

--- a/appserver/tests/jdbc/pom.xml
+++ b/appserver/tests/jdbc/pom.xml
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.7</version>
+            <version>42.7.8</version>
             <scope>test</scope>
         </dependency>
 

--- a/appserver/tests/jdbc/src/test/java/org/glassfish/main/test/perf/util/GlassFishContainer.java
+++ b/appserver/tests/jdbc/src/test/java/org/glassfish/main/test/perf/util/GlassFishContainer.java
@@ -44,6 +44,7 @@ import static java.lang.System.Logger.Level.INFO;
 public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
 
     public static final int LIMIT_HTTP_THREADS = 1000;
+    private static final int LIMIT_HTTP_REQUEST_TIMEOUT = 5;
 
     private static final Logger LOG = System.getLogger(GlassFishContainer.class.getName());
     private static final java.util.logging.Logger LOG_GF = java.util.logging.Logger.getLogger("GF");
@@ -56,6 +57,7 @@ public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
     private static final Path PATH_DOCKER_GF_DOMAIN1_SERVER_LOG = PATH_DOCKER_GF_DOMAIN
         .resolve(Path.of("logs", "server.log"));
 
+
     /**
      * Creates preconfigured container with GlassFish.
      *
@@ -65,7 +67,7 @@ public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
      * @param logPrefix
      */
     public GlassFishContainer(MountableFile glassFishZip, Network network, String hostname, String logPrefix) {
-        super("eclipse-temurin:17");
+        super("eclipse-temurin:" + Runtime.version().feature());
         withNetwork(network)
         .withCopyFileToContainer(glassFishZip, "/glassfish.zip")
         .withEnv("TZ", "UTC").withEnv("LC_ALL", "en_US.UTF-8")

--- a/appserver/tests/jdbc/src/test/java/org/glassfish/main/test/perf/util/GlassFishContainer.java
+++ b/appserver/tests/jdbc/src/test/java/org/glassfish/main/test/perf/util/GlassFishContainer.java
@@ -44,6 +44,7 @@ import static java.lang.System.Logger.Level.INFO;
 public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
 
     public static final int LIMIT_HTTP_THREADS = 1000;
+    private static final int LIMIT_HTTP_REQUEST_TIMEOUT = 5;
 
     private static final Logger LOG = System.getLogger(GlassFishContainer.class.getName());
     private static final java.util.logging.Logger LOG_GF = java.util.logging.Logger.getLogger("GF");
@@ -56,6 +57,7 @@ public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
     private static final Path PATH_DOCKER_GF_DOMAIN1_SERVER_LOG = PATH_DOCKER_GF_DOMAIN
         .resolve(Path.of("logs", "server.log"));
 
+
     /**
      * Creates preconfigured container with GlassFish.
      *
@@ -65,7 +67,7 @@ public class GlassFishContainer extends GenericContainer<GlassFishContainer> {
      * @param logPrefix
      */
     public GlassFishContainer(MountableFile glassFishZip, Network network, String hostname, String logPrefix) {
-        super("eclipse-temurin:21");
+        super("eclipse-temurin:" + Runtime.version().feature());
         withNetwork(network)
         .withCopyFileToContainer(glassFishZip, "/glassfish.zip")
         .withEnv("TZ", "UTC").withEnv("LC_ALL", "en_US.UTF-8")

--- a/docs/administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/administration-guide/src/main/asciidoc/overview.adoc
@@ -313,8 +313,8 @@ If a variable reference is not resolved, the reference will not be replaced. So,
 
 **System properties that adjust variable resolution:**
 
-* `org.glassfish.variableexpansion.envvars.disabled` -  disables resolution from environment variables and allows only resolving from system properties. This allows keeping the behavior of older versions of {productName}
-* `org.glassfish.variableexpansion.envvars.preferred` - changes the priority - values are resolved first from environment variables and then from system properties
+* `org.glassfish.variableExpansion.envDisabled` -  disables resolution from environment variables and allows only resolving from system properties. This allows keeping the behavior of older versions of {productName}
+* `org.glassfish.variableExpansion.envPreferred` - changes the priority - values are resolved first from environment variables and then from system properties
 
 The following is a list of variables defined by {productName} that can be used in variable references:
 

--- a/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
+++ b/docs/embedded-server-guide/src/main/asciidoc/embedded-server-guide.adoc
@@ -285,6 +285,9 @@ The value will be treated as a command to execute at startup.
     - Keys that start with the "deploy." prefix, followed by any text. The
 value will be treated as an application to deploy at startup, as if it
 was specified on the command line.
+    - If a property name doesn't match any already supported patterns and is not
+a recognized GlassFish property, it will be set as a system property, if
+it's not already defined.
 For example, the ${productName} domain directory can be specified with the
 usual Embedded ${productName} property
 "glassfish.embedded.tmpdir=myDomainDir", as well as with the property

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>2.3.20</asciidoctorj.pdf.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <productName>Eclipse GlassFish</productName>
@@ -173,9 +173,7 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/docs/parent/pom.xml
+++ b/docs/parent/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>2.3.20</asciidoctorj.pdf.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <productName>Eclipse GlassFish</productName>
@@ -174,9 +174,7 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -232,7 +232,7 @@
             <!-- Publish the entire web site to the gh-pages branch. -->
             <plugin>
                 <artifactId>maven-scm-publish-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>deploy-site</id>

--- a/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-jvm-options.adoc
@@ -70,7 +70,7 @@ Variable references, e.g. `${variable}`, can be used anywhere in JVM options. In
 5. `asenv` properties
 6. Environment variables
 
-If a property `org.glassfish.envPreferredToProperties` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source. It's also possible to override options and system properties defined in JVM options with an environment variable that either has the same name, or same name if case is ignored and non-alphanumeric characters are replaced with the `_` character. For example, a property `-Dmy.name` can be defined by redefined by environment variables `my.name`, `my_name`, or `MY_NAME`.
+If a property `org.glassfish.variableExpansion.envPreferred` is defined as `true` (in any source except environment variables), then environment variables take precedence over other sources, instead of being the last resolved source. It's also possible to override options and system properties defined in JVM options with an environment variable that either has the same name, or same name if case is ignored and non-alphanumeric characters are replaced with the `_` character. For example, a property `-Dmy.name` can be defined by redefined by environment variables `my.name`, `my_name`, or `MY_NAME`. If a property `org.glassfish.variableExpansion.envDisabled` is defined as `true`, then environment variables are ignored.
 
 [CAUTION]
 ====

--- a/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
+++ b/docs/upgrade-guide/src/main/asciidoc/upgrading-legacy-installation.adoc
@@ -212,5 +212,5 @@ when `type=das-and-server`.
 [[terminology]]
 === Terminology
 Source Domain Directory:: Directory of the domain being upgraded (e.g., `c:\glassfish\domains\domain1`).
-Target Root Domain's Directory:: Directory where domains are created in the new installation (e.g., `c:\glassfish7\glassfish\domains`).
+Target Root Domain's Directory:: Directory where domains are created in the new installation (e.g., `c:\glassfish8\glassfish\domains`).
 Master Password:: SSL certificate database password (default: `changeit`).

--- a/nucleus/admin/cli/pom.xml
+++ b/nucleus/admin/cli/pom.xml
@@ -236,6 +236,10 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -56,6 +56,7 @@ import org.glassfish.main.jdke.i18n.LocalStringsImpl;
 import org.jline.builtins.Completers;
 import org.jline.reader.Candidate;
 import org.jline.reader.Completer;
+import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.ParsedLine;
@@ -312,7 +313,7 @@ public class MultimodeCommand extends CLICommand {
         }
         return (LineReader line, ParsedLine parsedLine, List<Candidate> candidates) -> {
             // For cases where we don't know which values would be valid, only return the
-            // FileNameCompleter when the user use a file-like value
+            // FileNameCompleter when the user tries to autocomplete a file-like value
             if (Stream.of(".", "..", "../", "~", "/", "..\\", "./")
                     .anyMatch(parsedLine.word()::startsWith)) {
                 new Completers.FileNameCompleter().complete(line, parsedLine, candidates);
@@ -404,7 +405,7 @@ public class MultimodeCommand extends CLICommand {
                     return reader.readLine(message);
                 }
                 return reader.readLine();
-            } catch (UserInterruptException ignored) {
+            } catch (UserInterruptException | EndOfFileException ignored) {
                 return null;
             }
         }

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -79,11 +79,7 @@ public class MultimodeCommand extends CLICommand {
     private boolean echo; // saved echo flag
     private static final LocalStringsImpl strings = new LocalStringsImpl(MultimodeCommand.class);
 
-    private static final boolean DISABLE_JLINE;
-
-    static {
-        DISABLE_JLINE = Boolean.getBoolean("glassfish.disable.jline") || Boolean.parseBoolean(System.getenv("AS_DISABLE_JLINE"));
-    }
+    private static final boolean DISABLE_JLINE = Boolean.getBoolean("glassfish.disable.jline") || Boolean.parseBoolean(System.getenv("AS_DISABLE_JLINE"));
 
     /**
      * The validate method validates that the type and quantity of parameters and operands matches the requirements for this

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/MultimodeCommand.java
@@ -188,7 +188,7 @@ public class MultimodeCommand extends CLICommand {
             systemCompleter.compile(Candidate::new);
 
             LineReader lineReader = LineReaderBuilder.builder()
-                    .completer(new AggregateCompleter(systemCompleter, new RemoteCommandsCompleter()))
+                    .completer(new AggregateCompleter(systemCompleter, new RemoteCommandsCompleter(), new StringsCompleter("exit", "quit")))
                     .variable(LineReader.HISTORY_FILE, Paths.get(System.getProperty("user.home"), ".gfclient", ".cli-history"))
                     .terminal(build).build();
             return new JLinePrompter(lineReader);
@@ -237,7 +237,6 @@ public class MultimodeCommand extends CLICommand {
         if (!"".equals(shortName)) {
             builder.add("-" + shortName);
         }
-        System.out.println("Param: " + parameterName + " Type: " + option.getType() + " -> " + param);
         return builder.build();
     }
 

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/admin/CommandResource.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/resources/admin/CommandResource.java
@@ -270,7 +270,7 @@ public class CommandResource {
             @HeaderParam(RemoteRestAdminCommand.COMMAND_MODEL_MATCH_HEADER) String modelETag,
             @CookieParam(SESSION_COOKIE_NAME) Cookie jSessionId, ParamsWithPayload pwp) {
         CommandName commandName = new CommandName(normalizeCommandName(command));
-        RestLogging.restLogger.log(Level.FINEST, "execCommandMultInMultOut({0})", commandName);
+        RestLogging.restLogger.log(Level.FINEST, "execCommandMultInSseOut({0})", commandName);
         ParameterMap data = null;
         if (pwp != null) {
             data = pwp.getParameters();
@@ -285,7 +285,7 @@ public class CommandResource {
             @HeaderParam(RemoteRestAdminCommand.COMMAND_MODEL_MATCH_HEADER) String modelETag,
             @CookieParam(SESSION_COOKIE_NAME) Cookie jSessionId) {
         CommandName commandName = new CommandName(normalizeCommandName(command));
-        RestLogging.restLogger.log(Level.FINEST, "execCommandEmptyInMultOut({0})", commandName);
+        RestLogging.restLogger.log(Level.FINEST, "execCommandEmptyInSseOut({0})", commandName);
         ParameterMap data = new ParameterMap();
         return executeSseCommand(commandName, null, data, modelETag, jSessionId);
     }

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/util/SystemPropertyConstants.java
@@ -77,7 +77,8 @@ public class SystemPropertyConstants {
     public static final String DEFAULT_ADMIN_TIMEOUT_PROPERTY = "org.glassfish.admin.timeout";
     private static final int DEFAULT_ADMIN_TIMEOUT_VALUE = 5000;
 
-    public static final String PREFER_ENV_VARS_OVER_PROPERTIES = "org.glassfish.envPreferredToProperties";
+    public static final String PREFER_ENV_VARS_OVER_PROPERTIES = "org.glassfish.variableExpansion.envPreferred";
+    public static final String DISABLE_ENV_VAR_EXPANSION_PROPERTY = "org.glassfish.variableExpansion.envDisabled";
 
     public static final String TRUSTSTORE_FILENAME_DEFAULT = "cacerts.p12";
     public static final String KEYSTORE_FILENAME_DEFAULT = "keystore.p12";

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
@@ -18,7 +18,6 @@ package org.glassfish.embeddable;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -127,10 +126,6 @@ public enum GlassFishVariable {
      */
     public String getSystemPropertyName() {
         return this.sysPropName;
-    }
-
-    public Optional<String> getSystemPropertyValue() {
-        return Optional.ofNullable(System.getProperty(getSystemPropertyName()));
     }
 
     /**

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
@@ -18,6 +18,7 @@ package org.glassfish.embeddable;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -128,6 +129,9 @@ public enum GlassFishVariable {
         return this.sysPropName;
     }
 
+    public Optional<String> getSystemPropertyValue() {
+        return Optional.ofNullable(System.getProperty(getSystemPropertyName()));
+    }
 
     /**
      * The map contains pairs of {@link #getEnvName()} and {@link #getSystemPropertyName()}.

--- a/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
+++ b/nucleus/common/simple-glassfish-api/src/main/java/org/glassfish/embeddable/GlassFishVariable.java
@@ -128,7 +128,6 @@ public enum GlassFishVariable {
         return this.sysPropName;
     }
 
-
     /**
      * The map contains pairs of {@link #getEnvName()} and {@link #getSystemPropertyName()}.
      * When the {@link #getEnvName()} returns null, the mapping is not included.

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
@@ -37,6 +37,7 @@ import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.main.boot.impl.GlassFishImpl;
+import org.glassfish.main.jdke.props.SystemProperties;
 
 import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.AUTO_DELETE;
 
@@ -79,7 +80,12 @@ class AutoDisposableGlassFish extends GlassFishImpl {
                         && resultList.getOutput().contains(propertyPrefix)) {
                     knownPropertyPrefixes.add(propertyPrefix);
                 } else {
-                    // unknown property prefix, skip it
+                    if (!key.startsWith("com.sun.aas.") && !key.startsWith("-")) {
+                        // unknown property, set as system property
+                        LOG.log(Level.INFO, "Setting system property " + key + " from GlassFish properties, it doesn't match any known property");
+                        SystemProperties.setProperty(key, gfProps.getProperty(key), false);
+                    }
+                    // not a dotted name, doesn't start with a supported prefix, do not set it later
                     continue;
                 }
             }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
@@ -135,7 +135,7 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
     private void setSystemPropertiesFromEnv(boolean forceOverwrite) {
         // adding our version of some system properties.
         setProperty(JAVA_ROOT.getSystemPropertyName(), System.getProperty(JAVA_HOME.getSystemPropertyName()), forceOverwrite);
-        if (HOST_NAME.getSystemPropertyValue().isEmpty()) {
+        if (forceOverwrite || null == System.getProperty(HOST_NAME.getSystemPropertyName())) {
             String hostname = "localhost";
             try {
                 // canonical name checks to make sure host is proper
@@ -144,7 +144,7 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
                 LOG.log(Level.SEVERE, KernelLoggerInfo.exceptionHostname, ex);
             }
             if (hostname != null) {
-                setProperty(HOST_NAME.getSystemPropertyName(), hostname, false);
+                setProperty(HOST_NAME.getSystemPropertyName(), hostname, true);
             }
         }
     }

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SystemTasksImpl.java
@@ -90,12 +90,16 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
     public void postConstruct() {
         if (env.isEmbedded()) {
             initEmbeddedSystemOptions();
+            boolean overwriteProperties = false;
+            setSystemPropertiesFromEnv(overwriteProperties);
+            setSystemPropertiesFromDomainXml(overwriteProperties);
             LOG.log(INFO, "Loaded embedded server named: {0}", server.getName());
             return;
         }
         setVersion();
-        setSystemPropertiesFromEnv();
-        setSystemPropertiesFromDomainXml();
+        boolean overwriteProperties = true;
+        setSystemPropertiesFromEnv(overwriteProperties);
+        setSystemPropertiesFromDomainXml(overwriteProperties);
         resolveJavaConfig();
         LOG.log(INFO, "Loaded server named: {0}", server.getName());
     }
@@ -128,22 +132,24 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
         setProperty("glassfish.version", Version.getProductIdInfo(), true);
     }
 
-    private void setSystemPropertiesFromEnv() {
+    private void setSystemPropertiesFromEnv(boolean forceOverwrite) {
         // adding our version of some system properties.
-        setProperty(JAVA_ROOT.getSystemPropertyName(), System.getProperty(JAVA_HOME.getSystemPropertyName()), true);
-        String hostname = "localhost";
-        try {
-            // canonical name checks to make sure host is proper
-            hostname = NetUtils.getCanonicalHostName();
-        } catch (Exception ex) {
-            LOG.log(Level.SEVERE, KernelLoggerInfo.exceptionHostname, ex);
-        }
-        if (hostname != null) {
-            setProperty(HOST_NAME.getSystemPropertyName(), hostname, false);
+        setProperty(JAVA_ROOT.getSystemPropertyName(), System.getProperty(JAVA_HOME.getSystemPropertyName()), forceOverwrite);
+        if (forceOverwrite || null == System.getProperty(HOST_NAME.getSystemPropertyName())) {
+            String hostname = "localhost";
+            try {
+                // canonical name checks to make sure host is proper
+                hostname = NetUtils.getCanonicalHostName();
+            } catch (Exception ex) {
+                LOG.log(Level.SEVERE, KernelLoggerInfo.exceptionHostname, ex);
+            }
+            if (hostname != null) {
+                setProperty(HOST_NAME.getSystemPropertyName(), hostname, true);
+            }
         }
     }
 
-    private void setSystemPropertiesFromDomainXml() {
+    private void setSystemPropertiesFromDomainXml(boolean forceOverwrite) {
         // precedence order from high to low
         // 0. server
         // 1. cluster
@@ -158,14 +164,14 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
         final List<SystemProperty> clusterSPList = cluster == null ? null : cluster.getSystemProperty();
         List<SystemProperty> serverSPList = server.getSystemProperty();
 
-        setSystemProperties(domainSPList);
-        setSystemProperties(configSPList);
+        setSystemProperties(domainSPList, forceOverwrite);
+        setSystemProperties(configSPList, forceOverwrite);
 
         if (clusterSPList != null) {
-            setSystemProperties(clusterSPList);
+            setSystemProperties(clusterSPList, forceOverwrite);
 
         }
-        setSystemProperties(serverSPList);
+        setSystemProperties(serverSPList, forceOverwrite);
     }
 
     private List<SystemProperty> getConfigSystemProperties() {
@@ -202,13 +208,13 @@ public class SystemTasksImpl implements SystemTasks, PostConstruct {
         }
     }
 
-    private void setSystemProperties(List<SystemProperty> spList) {
+    private void setSystemProperties(List<SystemProperty> spList, boolean forceOverwrite) {
         for (SystemProperty sp : spList) {
             String name = sp.getName();
             String value = sp.getValue();
 
             if (ok(name)) {
-                setProperty(name, value, true);
+                setProperty(name, value, forceOverwrite);
             }
         }
     }

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
@@ -185,7 +185,7 @@ public class UberMain {
             commandParams = new String[split.length - 1];
             for (int i = 1; i < split.length; i++) {
                 commandParams[i - 1] = split[i].trim();
-        }
+            }
         }
         try {
             CommandResult result = commandParams == null

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
@@ -177,14 +177,15 @@ public class UberMain {
 
     private void executeCommandFromString(String stringCommand) {
         logger.log(FINE, () -> "Executing command: " + stringCommand);
-        String[] split = stringCommand.split(" ");
+        // Split according to empty space but not if empty space is escaped by \
+        String[] split = stringCommand.split("(?<!\\\\)\\s+");
         String command = split[0].trim();
         String[] commandParams = null;
         if (split.length > 1) {
             commandParams = new String[split.length - 1];
             for (int i = 1; i < split.length; i++) {
                 commandParams[i - 1] = split[i].trim();
-            }
+        }
         }
         try {
             CommandResult result = commandParams == null

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/UberMain.java
@@ -177,7 +177,8 @@ public class UberMain {
 
     private void executeCommandFromString(String stringCommand) {
         logger.log(FINE, () -> "Executing command: " + stringCommand);
-        String[] split = stringCommand.split(" ");
+        // Split according to empty space but not if empty space is escaped by \
+        String[] split = stringCommand.split("(?<!\\\\)\\s+");
         String command = split[0].trim();
         String[] commandParams = null;
         if (split.length > 1) {

--- a/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/commandline/Option.java
+++ b/nucleus/core/kernel/src/main/java/org/glassfish/runnablejar/commandline/Option.java
@@ -51,7 +51,9 @@ public enum Option {
             + " - Keys that start with the \"" + Arguments.DEPLOY_KEY_PREFIX
             + "\" prefix, followed by any text. The value will be"
             + " treated as an application to deploy at startup, as if it was specified on the command line.\n"
-            + "For example, the GlassFish domain directory can be specified with the usual GlassFish Embedded"
+            + " - If a property name doesn't match any already supported patterns and is not"
+            + " a recognized GlassFish property, it will be set as a system property, if it's not already defined.\n"
+            + "\nFor example, the GlassFish domain directory can be specified with the usual GlassFish Embedded"
             + " property \"glassfish.embedded.tmpdir=myDomainDir\", as well as with the property"
             + " \"domainDir=myDomainDir\" that represents the \"--domainDir=myDomainDir\" command-line option."
             + " A command to deploy an application can be specified via a property key"

--- a/nucleus/core/kernel/src/test/java/org/glassfish/runnablejar/commandline/WordWrapperTest.java
+++ b/nucleus/core/kernel/src/test/java/org/glassfish/runnablejar/commandline/WordWrapperTest.java
@@ -38,7 +38,7 @@ public class WordWrapperTest {
                                     .map(Option::getHelpText)
                                     .collect(wordWrapper);
         final List<String> linesEndingWithSpace = message.lines()
-                .filter(line -> line.endsWith(" "))
+                .filter(line -> line.endsWith(" ") && !line.isBlank())
                 .collect(toList());
         assertTrue(linesEndingWithSpace.isEmpty(), "Some lines end with a space: " + linesEndingWithSpace);
 

--- a/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.java
+++ b/nucleus/distributions/nucleus-common/src/main/resources/bin/nadmin.java
@@ -14,8 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.main.bin.nadmin;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -163,7 +163,7 @@
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>
         <ant.version>1.10.15</ant.version>
-        <ant.external.version>1.10.2</ant.external.version>
+        <ant.external.version>1.10.15-SNAPSHOT</ant.external.version>
         <jackson.version>2.20.0</jackson.version>
         <jackson.version2>2.20</jackson.version2>
         <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -886,7 +886,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                     <configuration>
                         <release>17</release>
                         <excludes>
@@ -921,7 +921,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
@@ -1138,7 +1138,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1254,7 +1254,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.18.0</version>
+                    <version>2.19.1</version>
                     <executions>
                         <execution>
                             <id>default-cli</id>
@@ -1278,7 +1278,6 @@
                                                     <version>20030911</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.external</groupId>
@@ -1293,7 +1292,6 @@
                                                     <version>10.0-b..</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.hk2</groupId>
@@ -1308,7 +1306,6 @@
                                                     <version>2.4.0</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.external</groupId>
@@ -1319,7 +1316,6 @@
                                                     <version>[2,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <!-- Jakarta EE 11 major versions to exclude -->
@@ -1337,7 +1333,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1353,7 +1348,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1369,7 +1363,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1385,7 +1378,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1405,7 +1397,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1425,7 +1416,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1445,7 +1435,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1460,7 +1449,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1475,7 +1463,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1494,7 +1481,6 @@
                                                     <version>.*RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1513,7 +1499,6 @@
                                                     <version>.*RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1528,7 +1513,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1547,7 +1531,6 @@
                                                     <version>.*-B.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1562,7 +1545,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1594,7 +1576,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1626,7 +1607,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1641,7 +1621,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1656,7 +1635,6 @@
                                                     <version>.*M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1672,7 +1650,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1687,7 +1664,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1702,7 +1678,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1717,7 +1692,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1732,7 +1706,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1747,7 +1720,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1762,7 +1734,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1777,7 +1748,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1792,7 +1762,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1807,7 +1776,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1822,7 +1790,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1838,7 +1805,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1853,7 +1819,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1872,7 +1837,6 @@
                                                     <version>.*-B.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1899,7 +1863,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1926,7 +1889,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1953,7 +1915,6 @@
                                                     <version>.*-ALPHA.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1969,7 +1930,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                     </rules>
@@ -2343,7 +2303,7 @@
             <id>jacoco</id>
             <properties>
                 <jacoco.report.outputDirectory>${project.build.directory}/jacoco</jacoco.report.outputDirectory>
-                <jacoco.version>0.8.12</jacoco.version>
+                <jacoco.version>0.8.13</jacoco.version>
                 <maven.test.failure.ignore>true</maven.test.failure.ignore>
                 <surefire.argLine>${maven.test.jvmoptions} @{argLine}</surefire.argLine>
             </properties>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -162,8 +162,8 @@
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>
-        <ant.version>1.10.15</ant.version>
-        <ant.external.version>1.10.15-SNAPSHOT</ant.external.version>
+        <ant.version>1.10.2</ant.version>
+        <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.20.0</jackson.version>
         <jackson.version2>2.20</jackson.version2>
         <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -126,12 +126,12 @@
         <jersey.version>4.0.0-M4</jersey.version>
 
         <!-- Jakarta Mail -->
-        <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>
-        <angus.mail.version>2.0.3</angus.mail.version>
+        <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>
+        <angus.mail.version>2.0.5</angus.mail.version>
 
         <!-- Jakarta Activation -->
-        <activation.version>2.1.3</activation.version>
-        <angus.activation.version>2.0.2</angus.activation.version>
+        <activation.version>2.1.4</activation.version>
+        <angus.activation.version>2.0.3</angus.activation.version>
 
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
@@ -143,8 +143,8 @@
 
         <!-- ORB -->
         <pfl.version>5.1.0</pfl.version>
-        <glassfish-corba.version>5.0.0</glassfish-corba.version> <!-- Note: patched in appserver/distributions/glassfish/pom.xml to support PFL 5 -->
-        <gmbal.version>4.1.0</gmbal.version> <!-- Note: patched in appserver/distributions/glassfish/pom.xml to support PFL 5 -->
+        <glassfish-corba.version>5.0.0</glassfish-corba.version>
+        <gmbal.version>4.1.0</gmbal.version>
 
         <shoal.version>3.1.0</shoal.version>
         <ha-api.version>3.1.13</ha-api.version>
@@ -157,7 +157,7 @@
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
-        <asm.version>9.8</asm.version>
+        <asm.version>9.9</asm.version>
         <jsch.version>2.27.3</jsch.version>
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
@@ -174,11 +174,14 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>5.13.4</junit.version>
-        <junit-platform.version>1.13.4</junit-platform.version>
+        <junit.version>5.14.0</junit.version>
+        <junit-platform.version>1.14.0</junit-platform.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
+
+        <surefire.version>3.5.4</surefire.version>
+        <junit5-surefire-tree-reporter.version>1.4.0</junit5-surefire-tree-reporter.version>
 
         <file.executable.suffix></file.executable.suffix>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -215,6 +218,11 @@
         <test.logLevel>INFO</test.logLevel>
         <test.enableDefaultLogCfg>true</test.enableDefaultLogCfg>
         <glassfish.distribution.dir>appserver/distributions/glassfish/target/stage/glassfish8/glassfish</glassfish.distribution.dir>
+
+        <!-- Do not autopublish by default -->
+        <release.autopublish>false</release.autopublish>
+        <!-- By default block until everything is really published -->
+        <release.waitUntil>published</release.waitUntil>
     </properties>
 
     <dependencyManagement>
@@ -841,13 +849,6 @@
                     <configuration>
                         <includeDate>false</includeDate>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.8</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
@@ -865,7 +866,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                     <configuration>
                         <release>21</release>
                         <excludes>
@@ -900,7 +901,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
@@ -935,7 +936,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -956,11 +957,19 @@
                             <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -979,7 +988,15 @@
                             <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>integration-test</id>
@@ -1101,7 +1118,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1217,7 +1234,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.2</version>
+                    <version>2.19.1</version>
                     <executions>
                         <execution>
                             <id>default-cli</id>
@@ -1246,7 +1263,6 @@
                                                     <version>8.0.0-JDK17-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                     </rules>
                                 </ruleSet>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -143,11 +143,12 @@
         <!-- GlassFish Components -->
         <grizzly.version>4.0.2</grizzly.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
-
-        <glassfish-corba.version>5.0.0</glassfish-corba.version>
         <glassfish-management-api.version>3.3.0</glassfish-management-api.version>
-        <gmbal.version>4.1.0</gmbal.version>
+
+        <!-- ORB -->
         <pfl.version>5.1.0</pfl.version>
+        <glassfish-corba.version>5.0.0</glassfish-corba.version>
+        <gmbal.version>4.1.0</gmbal.version>
 
         <shoal.version>3.1.0</shoal.version>
         <ha-api.version>3.1.13</ha-api.version>
@@ -155,18 +156,18 @@
         <command.security.maven.plugin.isFailureFatal>true</command.security.maven.plugin.isFailureFatal>
 
         <!-- 3rd party dependencies -->
-        <commons-io.version>2.18.0</commons-io.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-io.version>2.20.0</commons-io.version>
+        <commons-lang3.version>3.19.0</commons-lang3.version>
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.8</asm.version>
-        <jsch.version>0.2.24</jsch.version>
+        <jsch.version>2.27.3</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.18.3</jackson.version>
-        <fasterxml.classmate.version>1.7.0</fasterxml.classmate.version>
+        <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>
         <mimepull.version>1.10.0</mimepull.version>
@@ -179,6 +180,7 @@
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
+
 
         <file.executable.suffix></file.executable.suffix>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -546,7 +548,7 @@
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.webconsole</artifactId>
-                <version>5.0.10</version>
+                <version>5.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -609,7 +611,7 @@
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>3.29.0</version>
+                <version>3.30.6</version>
             </dependency>
 
             <!--3rd party dependencies -->
@@ -712,6 +714,12 @@
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>
@@ -744,13 +752,13 @@
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>
+                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>
                         <artifactId>asm</artifactId>
                     </exclusion>
                 </exclusions>
-                <scope>test</scope>
             </dependency>
             <!-- Used by some dependencies (shrinkwrap, testcontainers) in older versions -->
             <dependency>
@@ -852,6 +860,13 @@
                     <configuration>
                         <includeDate>false</includeDate>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>9.8</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
@@ -869,7 +884,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                     <configuration>
                         <release>17</release>
                         <excludes>
@@ -918,16 +933,11 @@
                             <artifactId>commons-io</artifactId>
                             <version>${commons-io.version}</version>
                         </dependency>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-utils</artifactId>
-                            <version>4.0.2</version>
-                        </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <notimestamp>false</notimestamp>
@@ -940,7 +950,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -1006,7 +1016,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
@@ -1110,7 +1120,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1143,6 +1153,10 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
@@ -1193,7 +1207,7 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>9.0.1</version>
+                    <version>9.0.2</version>
                     <executions>
                         <execution>
                             <id>get-the-git-infos</id>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -104,7 +104,7 @@
 
         <!-- Jakarta Validation -->
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
+        <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>
 
         <!-- Jakarta XML Web Services -->
         <jakarta.xml.ws-api.version>4.0.2</jakarta.xml.ws-api.version>
@@ -118,20 +118,20 @@
         <hk2.plugin.version>3.1.1</hk2.plugin.version>
 
         <!-- Jakarta XML Binding -->
-        <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
-        <jakarta.jaxb-impl.version>4.0.5</jakarta.jaxb-impl.version>
+        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
+        <jakarta.jaxb-impl.version>4.0.6</jakarta.jaxb-impl.version>
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>3.1.0</jakarta.rest-api.version>
         <jersey.version>3.1.11</jersey.version>
 
         <!-- Jakarta Mail -->
-        <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>
-        <angus.mail.version>2.0.3</angus.mail.version>
+        <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>
+        <angus.mail.version>2.0.5</angus.mail.version>
 
         <!-- Jakarta Activation -->
-        <activation.version>2.1.3</activation.version>
-        <angus.activation.version>2.0.2</angus.activation.version>
+        <activation.version>2.1.4</activation.version>
+        <angus.activation.version>2.0.3</angus.activation.version>
 
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -143,11 +143,12 @@
         <!-- GlassFish Components -->
         <grizzly.version>4.0.2</grizzly.version>
         <grizzly.npn.version>2.0.0</grizzly.npn.version>
-
-        <glassfish-corba.version>5.0.0</glassfish-corba.version>
         <glassfish-management-api.version>3.3.0</glassfish-management-api.version>
-        <gmbal.version>4.1.0</gmbal.version>
+
+        <!-- ORB -->
         <pfl.version>5.1.0</pfl.version>
+        <glassfish-corba.version>5.0.0</glassfish-corba.version>
+        <gmbal.version>4.1.0</gmbal.version>
 
         <shoal.version>3.1.0</shoal.version>
         <ha-api.version>3.1.13</ha-api.version>
@@ -155,18 +156,19 @@
         <command.security.maven.plugin.isFailureFatal>true</command.security.maven.plugin.isFailureFatal>
 
         <!-- 3rd party dependencies -->
-        <commons-io.version>2.18.0</commons-io.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-io.version>2.20.0</commons-io.version>
+        <commons-lang3.version>3.19.0</commons-lang3.version>
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
-        <asm.version>9.8</asm.version>
-        <jsch.version>0.2.24</jsch.version>
+        <asm.version>9.9</asm.version>
+        <jsch.version>2.27.3</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
-        <jackson.version>2.18.3</jackson.version>
-        <fasterxml.classmate.version>1.7.0</fasterxml.classmate.version>
+        <jackson.version>2.20.0</jackson.version>
+        <jackson.version2>2.20</jackson.version2>
+        <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>
         <mimepull.version>1.10.0</mimepull.version>
@@ -174,11 +176,14 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>5.13.4</junit.version>
-        <junit-platform.version>1.13.4</junit-platform.version>
+        <junit.version>5.14.0</junit.version>
+        <junit-platform.version>1.14.0</junit-platform.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
+
+        <surefire.version>3.5.4</surefire.version>
+        <junit5-surefire-tree-reporter.version>1.4.0</junit5-surefire-tree-reporter.version>
 
         <file.executable.suffix></file.executable.suffix>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -546,7 +551,7 @@
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.webconsole</artifactId>
-                <version>5.0.10</version>
+                <version>5.0.18</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -609,7 +614,7 @@
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>3.29.0</version>
+                <version>3.30.6</version>
             </dependency>
 
             <!--3rd party dependencies -->
@@ -680,7 +685,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.version2}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -710,6 +715,12 @@
                 <version>${mimepull.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
@@ -744,13 +755,13 @@
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>
+                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.ow2.asm</groupId>
                         <artifactId>asm</artifactId>
                     </exclusion>
                 </exclusions>
-                <scope>test</scope>
             </dependency>
             <!-- Used by some dependencies (shrinkwrap, testcontainers) in older versions -->
             <dependency>
@@ -869,7 +880,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.1</version>
                     <configuration>
                         <release>17</release>
                         <excludes>
@@ -904,7 +915,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.9.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
@@ -918,16 +929,11 @@
                             <artifactId>commons-io</artifactId>
                             <version>${commons-io.version}</version>
                         </dependency>
-                        <dependency>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-utils</artifactId>
-                            <version>4.0.2</version>
-                        </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <notimestamp>false</notimestamp>
@@ -940,11 +946,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -965,11 +971,19 @@
                             <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -988,7 +1002,15 @@
                             <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>integration-test</id>
@@ -1006,7 +1028,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
@@ -1110,7 +1132,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1143,6 +1165,10 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.9.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
@@ -1193,7 +1219,7 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>9.0.1</version>
+                    <version>9.0.2</version>
                     <executions>
                         <execution>
                             <id>get-the-git-infos</id>
@@ -1222,7 +1248,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.18.0</version>
+                    <version>2.19.1</version>
                     <executions>
                         <execution>
                             <id>default-cli</id>
@@ -1246,7 +1272,6 @@
                                                     <version>20030911</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.external</groupId>
@@ -1261,7 +1286,6 @@
                                                     <version>10.0-b..</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.hk2</groupId>
@@ -1276,7 +1300,6 @@
                                                     <version>2.4.0</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
                                         <rule>
                                             <groupId>org.glassfish.external</groupId>
@@ -1287,10 +1310,22 @@
                                                     <version>[2,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <!-- Jakarta EE 11 major versions to exclude -->
+                                        <rule>
+                                            <groupId>jakarta.activation</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
 
                                         <rule>
                                             <groupId>jakarta.annotation</groupId>
@@ -1305,7 +1340,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1321,7 +1355,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1337,7 +1370,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1353,7 +1385,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1373,7 +1404,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1393,7 +1423,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1413,7 +1442,6 @@
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1428,7 +1456,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1443,7 +1470,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1462,7 +1488,6 @@
                                                     <version>.*RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1481,7 +1506,6 @@
                                                     <version>.*RC.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1496,7 +1520,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1515,7 +1538,6 @@
                                                     <version>.*-B.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1530,7 +1552,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1562,7 +1583,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1594,7 +1614,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1609,7 +1628,20 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>jakarta.mail</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
                                         </rule>
 
                                         <rule>
@@ -1624,7 +1656,6 @@
                                                     <version>.*M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1640,7 +1671,27 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.apache.derby</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[10.17,)</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+                                        <rule>
+                                            <groupId>org.glassfish.external</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[10.17,)</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
                                         </rule>
 
                                         <rule>
@@ -1655,7 +1706,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1670,7 +1720,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1685,7 +1734,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1700,7 +1748,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1715,7 +1762,16 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.glassfish.mq</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[6.6,)</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
                                         </rule>
 
                                         <rule>
@@ -1730,7 +1786,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1745,7 +1800,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1760,7 +1814,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1775,7 +1828,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1790,7 +1842,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1806,7 +1857,6 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1821,7 +1871,51 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.angus</groupId>
+                                            <artifactId>angus-activation</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.1.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.microprofile.jwt</groupId>
+                                            <artifactId>microprofile-jwt-auth-api</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.angus</groupId>
+                                            <artifactId>angus-mail</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.1.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
                                         </rule>
 
                                         <rule>
@@ -1840,7 +1934,6 @@
                                                     <version>.*-B.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1867,7 +1960,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1894,7 +1986,6 @@
                                                     <version>.*Alpha.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1921,7 +2012,6 @@
                                                     <version>.*-ALPHA.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
                                         </rule>
 
                                         <rule>
@@ -1937,7 +2027,16 @@
                                                     <version>.*-M.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
-                                            <comparisonMethod>maven</comparisonMethod>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.slf4j</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
                                         </rule>
 
                                     </rules>
@@ -2311,7 +2410,7 @@
             <id>jacoco</id>
             <properties>
                 <jacoco.report.outputDirectory>${project.build.directory}/jacoco</jacoco.report.outputDirectory>
-                <jacoco.version>0.8.12</jacoco.version>
+                <jacoco.version>0.8.13</jacoco.version>
                 <maven.test.failure.ignore>true</maven.test.failure.ignore>
                 <surefire.argLine>${maven.test.jvmoptions} @{argLine}</surefire.argLine>
             </properties>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -104,7 +104,7 @@
 
         <!-- Jakarta Validation -->
         <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
+        <hibernate-validator.version>8.0.3.Final</hibernate-validator.version>
 
         <!-- Jakarta XML Web Services -->
         <jakarta.xml.ws-api.version>4.0.2</jakarta.xml.ws-api.version>
@@ -118,20 +118,20 @@
         <hk2.plugin.version>3.1.1</hk2.plugin.version>
 
         <!-- Jakarta XML Binding -->
-        <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
-        <jakarta.jaxb-impl.version>4.0.5</jakarta.jaxb-impl.version>
+        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
+        <jakarta.jaxb-impl.version>4.0.6</jakarta.jaxb-impl.version>
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>3.1.0</jakarta.rest-api.version>
         <jersey.version>3.1.11</jersey.version>
 
         <!-- Jakarta Mail -->
-        <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>
-        <angus.mail.version>2.0.3</angus.mail.version>
+        <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>
+        <angus.mail.version>2.0.5</angus.mail.version>
 
         <!-- Jakarta Activation -->
-        <activation.version>2.1.3</activation.version>
-        <angus.activation.version>2.0.2</angus.activation.version>
+        <activation.version>2.1.4</activation.version>
+        <angus.activation.version>2.0.3</angus.activation.version>
 
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
@@ -161,12 +161,13 @@
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.1.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
-        <asm.version>9.8</asm.version>
+        <asm.version>9.9</asm.version>
         <jsch.version>2.27.3</jsch.version>
         <antlr.version>2.7.8</antlr.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
-        <jackson.version>2.18.3</jackson.version>
+        <jackson.version>2.20.0</jackson.version>
+        <jackson.version2>2.20</jackson.version2>
         <fasterxml.classmate.version>1.7.1</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>
@@ -175,8 +176,8 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>5.13.4</junit.version>
-        <junit-platform.version>1.13.4</junit-platform.version>
+        <junit.version>5.14.0</junit.version>
+        <junit-platform.version>1.14.0</junit-platform.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -684,7 +685,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.version2}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -862,13 +863,6 @@
                     <configuration>
                         <includeDate>false</includeDate>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.8</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.hk2</groupId>
@@ -1319,6 +1313,19 @@
                                         </rule>
 
                                         <!-- Jakarta EE 11 major versions to exclude -->
+                                        <rule>
+                                            <groupId>jakarta.activation</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
 
                                         <rule>
                                             <groupId>jakarta.annotation</groupId>
@@ -1624,6 +1631,20 @@
                                         </rule>
 
                                         <rule>
+                                            <groupId>jakarta.mail</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
                                             <groupId>jakarta.mvc</groupId>
                                             <ignoreVersions>
                                                 <ignoreVersion>
@@ -1648,6 +1669,27 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.apache.derby</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[10.17,)</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+                                        <rule>
+                                            <groupId>org.glassfish.external</groupId>
+                                            <artifactId>derby</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[10.17,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>
@@ -1718,6 +1760,16 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.glassfish.mq</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[6.6,)</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>
@@ -1813,6 +1865,51 @@
                                                 <ignoreVersion>
                                                     <type>range</type>
                                                     <version>[8.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.angus</groupId>
+                                            <artifactId>angus-activation</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.1.0,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.microprofile.jwt</groupId>
+                                            <artifactId>microprofile-jwt-auth-api</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.2,)</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.eclipse.angus</groupId>
+                                            <artifactId>angus-mail</artifactId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>range</type>
+                                                    <version>[2.1.0,)</version>
                                                 </ignoreVersion>
                                                 <ignoreVersion>
                                                     <type>regex</type>
@@ -1928,6 +2025,16 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                            </ignoreVersions>
+                                        </rule>
+
+                                        <rule>
+                                            <groupId>org.slf4j</groupId>
+                                            <ignoreVersions>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*-.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -181,6 +181,8 @@
         <osgi-resource-locator.version>1.0.4</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
 
+        <surefire.version>3.5.4</surefire.version>
+        <junit5-surefire-tree-reporter.version>1.4.0</junit5-surefire-tree-reporter.version>
 
         <file.executable.suffix></file.executable.suffix>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -954,7 +956,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -975,11 +977,19 @@
                             <glassfish.suspend>${glassfish.suspend}</glassfish.suspend>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <environmentVariables>
                             <LANG>en</LANG>
@@ -998,7 +1008,15 @@
                             <java.util.logging.config.defaultLevel>${test.logLevel}</java.util.logging.config.defaultLevel>
                             <junit.jupiter.extensions.autodetection.enabled>true</junit.jupiter.extensions.autodetection.enabled>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>${junit5-surefire-tree-reporter.version}</version>
+                        </dependency>
+                    </dependencies>
                     <executions>
                         <execution>
                             <id>integration-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.12</version>
+                        <version>0.8.13</version>
                         <executions>
                             <execution>
                                 <id>jacoco-merge</id>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -19,7 +19,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                     <executions>
                         <execution>
                             <id>default-compile</id>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -19,7 +19,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.14.1</version>
                     <executions>
                         <execution>
                             <id>default-compile</id>
@@ -33,7 +33,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.4</version>
                     <executions>
                         <execution>
                             <id>default-test</id>


### PR DESCRIPTION
* Multimode and autocomplete
* Disabled staging in Jenkinsfile
* Fixes
* Updates
* Depends on https://github.com/eclipse-ee4j/glassfish-concurro/pull/148 - instead of release, for now we can temporarily depend on snapshots until Concurro deploys to Maven Central.

Have to be released:
* Soteria
  * https://github.com/eclipse-ee4j/soteria/pull/401
* Derby repackaged
* Concurro
* `org.glassfish.external:schema2beans:jar:6.7` ... new needs Antlr4, and problem is just with the `go-offline`, so we can keep it yet for a while.
* Ant - we can stay with the old one, but once I release Derby, I can release this one too.
  * EDIT: We must stay:
    ```
    org.glassfish.main.persistence.cmp.support-ejb [48]
    missing requirement
        &(package = org.netbeans.modules.schema2beans) (password = GlassFish) (version >= 6.5.0) (!(version >= 7.0.0))
        caused by:
            Unable to resolve
                org.glassfish.external.schema2beans [88]
                missing requirement
                    package = org.apache.tools.ant
                    caused by:
                        Unable to resolve
                            org.glassfish.external.ant [303]
                            missing requirement
                                package = com.sun.tools.javah)]]
    ```
* All snapshots were temporarily deployed to verify that this PR passes on Jenkins.