### PR TITLE
Update Docker images documentation link

### DIFF
--- a/docs/website/src/main/resources/documentation.md
+++ b/docs/website/src/main/resources/documentation.md
@@ -46,7 +46,9 @@ layout: documentation
 
 ## Documentation for GlassFish Docker images {#docker}
 
-The Eclipse GlassFish project publishes Docker Images of GlassFish Server at [ghcr.io/eclipse-ee4j/glassfish](https://ghcr.io/eclipse-ee4j/glassfish).
+The documentation for the official Docker images is here:
+
+* [Eclipse GlassFish Docker Images](https://github.com/eclipse-ee4j/glassfish.docker/wiki)
 
 ## IDE plugins {#ide-plugins}
 


### PR DESCRIPTION
Replaced link to Docker registry with a direct link to Eclipse GlassFish Docker Images documentation.

It's easier to find the documentation and the documentation also links to the Docker registry and provides all essential info.