### PR TITLE
Updated Derby to 10.17.1.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -195,7 +195,7 @@
         <dbschema.version>6.7</dbschema.version>
         <schema2beans.version>6.7</schema2beans.version>
         <derby.version>10.17.1.0</derby.version>
-        <derby.repackaged.version>10.17.1.0-SNAPSHOT</derby.repackaged.version>
+        <derby.repackaged.version>${derby.version}</derby.repackaged.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <maven-rar-plugin.version>3.0.0</maven-rar-plugin.version>
 


### PR DESCRIPTION
Derby was already released, so we don't have to depend on snapshot
* https://db.apache.org/derby/
* https://repo1.maven.org/maven2/org/glassfish/external/derby/