### PR TITLE
Updated Derby to 10.16.1.1

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -183,7 +183,7 @@
         <!-- Other -->
         <dbschema.version>6.7</dbschema.version>
         <schema2beans.version>6.7</schema2beans.version>
-        <derby.version>10.15.2.0</derby.version>
+        <derby.version>10.16.1.1</derby.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <maven-rar-plugin.version>3.0.0</maven-rar-plugin.version>
 


### PR DESCRIPTION
* Requires Java17+
* Removed SecurityManager support
* https://db.apache.org/derby/
* https://repo1.maven.org/maven2/org/glassfish/external/derby/
* Run TCK before merge!