### PR TITLE
Fix Command Logger button in Admin Console

### DIFF
--- a/appserver/admingui/commandrecorder/pom.xml
+++ b/appserver/admingui/commandrecorder/pom.xml
@@ -63,7 +63,7 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>dev</id>

--- a/appserver/admingui/commandrecorder/pom.xml
+++ b/appserver/admingui/commandrecorder/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -63,4 +63,14 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+                <copy.modules.to.distribution.destFile>${basedir}/../../distributions/glassfish/target/stage/glassfish7/glassfish/lib/install/applications/__admingui/WEB-INF/lib/${project.artifactId}-${project.version}.jar</copy.modules.to.distribution.destFile>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/admingui/commandrecorder/src/main/java/org/glassfish/commandrecorder/admingui/plugin/CommandRecorderConsolePlugin.java
+++ b/appserver/admingui/commandrecorder/src/main/java/org/glassfish/commandrecorder/admingui/plugin/CommandRecorderConsolePlugin.java
@@ -15,6 +15,7 @@
  */
 package org.glassfish.commandrecorder.admingui.plugin;
 
+
 import java.net.URL;
 
 import org.glassfish.api.admingui.ConsoleProvider;

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2025 Contributors to the Eclipse Foundation
     Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -129,4 +130,14 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/appserver/admingui/core/pom.xml
+++ b/appserver/admingui/core/pom.xml
@@ -70,6 +70,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.core</groupId>
+            <artifactId>kernel</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/25746.

This is a regression introduced in the 7.1.0-SNAPSHOT

After the CommandRunner HK2 service was changed to use generics, injection into CDI beans stopped working. It's enough to add a producer for the specific generic type. I also added support for the Job supertype and for the application service locator, just in case it's needed later.