### PR TITLE
Fix GlassFish static shell bootstrap setup

### DIFF
--- a/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
+++ b/appserver/extras/embedded/shell/glassfish-embedded-static-shell/pom.xml
@@ -1395,7 +1395,7 @@
                         </manifest>
                         <manifestEntries>
                             <Bundle-SymbolicName>org.glassfish.embedded.static-shell</Bundle-SymbolicName>
-                            <Class-Path>${classpath.derby} ../asadmin/server-mgmt.jar ../../admin-cli.jar</Class-Path>
+                            <Class-Path>${classpath.derby} ../asadmin/server-mgmt.jar ../../admin-cli.jar ../bootstrap/simple-glassfish-api.jar ../bootstrap/glassfish-jdk-extensions.jar ../bootstrap/glassfish.jar ../bootstrap/glassfish-jul-extension.jar </Class-Path>
                             <Main-Class>org.glassfish.runnablejar.UberMain</Main-Class>
                             <Add-Opens>java.base/java.lang java.base/java.io java.base/java.util java.base/sun.nio.fs java.base/sun.net.www.protocol.jrt java.naming/javax.naming.spi java.rmi/sun.rmi.transport jdk.management/com.sun.management.internal java.base/jdk.internal.vm.annotation</Add-Opens>
                             <Add-Exports>java.naming/com.sun.jndi.ldap java.base/jdk.internal.vm.annotation</Add-Exports>

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -79,6 +79,7 @@
                         <systemPropertyVariables>
                             <project.directory>${basedir}</project.directory>
                             <buildDir>${surefire.workdir}</buildDir>
+                            <glassfish.version>${glassfish.version}</glassfish.version>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/appserver/tests/embedded/runnable/pom.xml
+++ b/appserver/tests/embedded/runnable/pom.xml
@@ -44,6 +44,12 @@
             <type>pom</type>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <type>zip</type>
+            <version>${glassfish.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.extras</groupId>
             <artifactId>glassfish-embedded-all</artifactId>
         </dependency>
@@ -59,12 +65,25 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-dependencies</id>
+                        <id>copy-embedded</id>
                         <phase>generate-test-resources</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
+                            <includeGroupIds>org.glassfish.main.extras</includeGroupIds>
+                            <outputDirectory>${surefire.workdir}</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-static-shell</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.glassfish.main.distributions</includeGroupIds>
                             <outputDirectory>${surefire.workdir}</outputDirectory>
                             <stripVersion>true</stripVersion>
                         </configuration>

--- a/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/TestArgumentProviders.java
+++ b/appserver/tests/embedded/runnable/src/test/java/org/glassfish/tests/embedded/runnable/TestArgumentProviders.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 /**
  *
@@ -32,13 +33,25 @@ public class TestArgumentProviders {
     public static class GfEmbeddedJarNameProvider implements ArgumentsProvider {
 
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext ec) throws Exception {
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations declarations, ExtensionContext ec) throws Exception {
             List<Arguments> arguments = new ArrayList<>();
             arguments.add(Arguments.of("glassfish-embedded-all.jar"));
             if (!GfEmbeddedUtils.isDebugEnabled()) {
                 arguments.add(Arguments.of("glassfish-embedded-web.jar"));
+                arguments.add(Arguments.of("glassfishXX/glassfish/lib/embedded/glassfish-embedded-static-shell.jar"
+                        .replace("XX", getGlassFishMajorVersion())));
             }
             return arguments.stream();
+        }
+
+        private static String getGlassFishMajorVersion() {
+            String versionProperty = "glassfish.version";
+            String version = System.getProperty(versionProperty);
+            if (version != null) {
+                return version.split("\\.")[0];
+            } else {
+                throw new IllegalArgumentException("The " + versionProperty + " system property is not defined. It should define the GlassFish version");
+            }
         }
 
     }

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -131,6 +131,7 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
     }
 
     private void setEnv(GlassFishProperties gfProps) throws Exception {
+        gfProps.setProperty("-type", "EMBEDDED");
         String instanceRootValue = gfProps.getInstanceRoot();
         if (instanceRootValue == null) {
             instanceRootValue = createTempInstanceRoot(gfProps);
@@ -144,7 +145,6 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         String installRootValue = System.getProperty("org.glassfish.embeddable.installRoot");
         if (installRootValue == null) {
             installRootValue = instanceRoot.getAbsolutePath();
-            gfProps.setProperty("-type", "EMBEDDED");
             JarUtil.extractRars(installRootValue);
         }
         JarUtil.setEnv(installRootValue);


### PR DESCRIPTION
* Was missing several JARs in the JAR classpath after they were relocated earlier
* Behaved as DAS. Now behaves as Embedded
* Added static shell as another target for Embedded tests
