### PR TITLE
Remove duplication of CDI extensions

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -34,6 +34,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.archive.ReadableArchive;
 import org.glassfish.cdi.CDILoggerInfo;
 import org.glassfish.deployment.common.DeploymentContextImpl;
+import org.glassfish.internal.api.CompositeClassLoader;
 import org.glassfish.javaee.core.deployment.ApplicationHolder;
 import org.glassfish.weld.connector.WeldUtils.BDAType;
 import org.jboss.weld.bootstrap.WeldBootstrap;
@@ -284,21 +286,28 @@ public class DeploymentImpl implements CDI11Deployment {
             }
         }
 
+        CompositeClassLoader compositeClassLoader = new CompositeClassLoader();
+        Set<ClassLoader> orderedSetOfClassLoaders = new LinkedHashSet<>();
         for (BeanDeploymentArchive beanDeploymentArchive : getBeanDeploymentArchives()) {
             if (!(beanDeploymentArchive instanceof RootBeanDeploymentArchive)) {
-                ClassLoader classLoader = new FilteringClassLoader(((BeanDeploymentArchiveImpl) beanDeploymentArchive)
-                    .getModuleClassLoaderForBDA());
-                Iterable<Metadata<Extension>> classPathExtensions = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class)
-                    .loadExtensions(classLoader);
-
-                if (classPathExtensions != null) {
-                    for (Metadata<Extension> beanDeploymentArchiveExtension : classPathExtensions) {
-                        extensionsList.add(beanDeploymentArchiveExtension);
-                    }
-                }
+                ClassLoader classLoader = ((BeanDeploymentArchiveImpl) beanDeploymentArchive)
+                    .getModuleClassLoaderForBDA();
+                orderedSetOfClassLoaders.add(classLoader);
             }
         }
+        for (ClassLoader classLoader : orderedSetOfClassLoaders) {
+                // For a WebApp it should be a single WebApp classloader.
+                // Just in case we have more ClassLoaders, we merge them, to avoid duplicate extensions
+                compositeClassLoader.addClassLoader(new FilteringClassLoader(classLoader));
+        }
+        Iterable<Metadata<Extension>> classPathExtensions = context.getTransientAppMetaData(WELD_BOOTSTRAP, WeldBootstrap.class)
+            .loadExtensions(compositeClassLoader);
 
+        if (classPathExtensions != null) {
+            for (Metadata<Extension> beanDeploymentArchiveExtension : classPathExtensions) {
+                extensionsList.add(beanDeploymentArchiveExtension);
+            }
+        }
         return extensions = extensionsList;
     }
 

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/weld/CDIExtensionDeduplicationTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/weld/CDIExtensionDeduplicationTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.weld;
+
+import org.easymock.EasyMock;
+import org.glassfish.internal.api.CompositeClassLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import static org.easymock.EasyMock.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration test to verify that CDI extensions are properly deduplicated
+ * when using CompositeClassLoader in the Weld integration.
+ */
+class CDIExtensionDeduplicationTest {
+
+    private ClassLoader mockClassLoader1;
+    private ClassLoader mockClassLoader2;
+    private CompositeClassLoader compositeClassLoader;
+
+    @BeforeEach
+    void setUp() {
+        mockClassLoader1 = createMock(ClassLoader.class);
+        mockClassLoader2 = createMock(ClassLoader.class);
+        compositeClassLoader = new CompositeClassLoader();
+    }
+
+    @Test
+    void shouldDeduplicateServiceFilesFromMultipleClassLoaders() throws Exception {
+        // Simulate the same service file being found in multiple classloaders
+        URL serviceUrl1 = URI.create("file:///path/to/services/jakarta.enterprise.inject.spi.Extension").toURL();
+        URL serviceUrl2 = URI.create("file:///path/to/services/jakarta.enterprise.inject.spi.Extension").toURL(); // Same URL
+        URL serviceUrl3 = URI.create("file:///different/path/services/jakarta.enterprise.inject.spi.Extension").toURL();
+
+        List<URL> urls1 = new ArrayList<>();
+        urls1.add(serviceUrl1);
+        urls1.add(serviceUrl3);
+
+        List<URL> urls2 = new ArrayList<>();
+        urls2.add(serviceUrl2); // Duplicate of serviceUrl1
+        urls2.add(serviceUrl3); // Duplicate
+
+        expect(mockClassLoader1.getResources("META-INF/services/jakarta.enterprise.inject.spi.Extension"))
+            .andReturn(Collections.enumeration(urls1));
+        expect(mockClassLoader2.getResources("META-INF/services/jakarta.enterprise.inject.spi.Extension"))
+            .andReturn(Collections.enumeration(urls2));
+
+        replay(mockClassLoader1, mockClassLoader2);
+
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        Enumeration<URL> resources = compositeClassLoader.getResources(
+            "META-INF/services/jakarta.enterprise.inject.spi.Extension");
+
+        // Convert to list once to avoid consuming enumeration multiple times
+        List<URL> resourceList = Collections.list(resources);
+        
+        // Should only return unique URLs
+        assertThat(resourceList, hasSize(2));
+        assertThat(resourceList, containsInAnyOrder(serviceUrl1, serviceUrl3));
+
+        verify(mockClassLoader1, mockClassLoader2);
+    }
+
+    @Test
+    void shouldPreventDuplicateClassLoadersAutomatically() throws Exception {
+        // When the same classloader instance is added multiple times (common case for web apps)
+        URLClassLoader singleClassLoader = new URLClassLoader(new URL[0]);
+        
+        compositeClassLoader.addClassLoader(singleClassLoader);
+        compositeClassLoader.addClassLoader(singleClassLoader); // Same instance added twice
+        
+        // Set automatically prevents duplicates
+        assertThat(compositeClassLoader.getClassLoaders(), hasSize(1));
+        assertThat(compositeClassLoader.getClassLoaders(), contains(singleClassLoader));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPreventDuplicateExtensionInstances() throws Exception {
+        // This test simulates the core issue: preventing duplicate CDI extension instances
+        // when the same extension class is found through multiple classloaders
+        
+        String extensionClassName = "com.example.MyExtension";
+        
+        expect(mockClassLoader1.loadClass(extensionClassName))
+            .andReturn((Class) String.class);
+        expect(mockClassLoader2.loadClass(extensionClassName))
+            .andThrow(new ClassNotFoundException()).anyTimes();
+
+        replay(mockClassLoader1, mockClassLoader2);
+
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        // Should load from first available classloader
+        Class<?> loadedClass = compositeClassLoader.loadClass(extensionClassName);
+        
+        assertThat(loadedClass, is(String.class));
+
+        verify(mockClassLoader1, mockClassLoader2);
+    }
+}

--- a/nucleus/common/internal-api/pom.xml
+++ b/nucleus/common/internal-api/pom.xml
@@ -89,6 +89,16 @@
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/CompositeClassLoader.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/CompositeClassLoader.java
@@ -1,0 +1,94 @@
+package org.glassfish.internal.api;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * A ClassLoader that aggregates multiple ClassLoaders and returns unique resources/classes.
+ * This addresses the issue that when multiple ClassLoaders share the same parent,
+ * some resources or classes are duplicated if fetched from all of these ClassLoaders individually.
+ *
+ * For single resource/class lookups, returns the first match found,
+ * coming from the first ClassLoader in the list that contains it.
+ * For enumeration methods, returns all unique resources from all ClassLoaders.
+ *
+ * This ClassLoader doesn't delegate to any parent ClassLoader. Instead, it delegates to the
+ * provided list of ClassLoaders, which should delegate to their parent ClassLoaders.
+ */
+public class CompositeClassLoader extends ClassLoader {
+
+    static {
+        registerAsParallelCapable();
+    }
+
+    private final List<ClassLoader> classLoaders = new CopyOnWriteArrayList<>();
+
+    public CompositeClassLoader() {
+        super(null);
+    }
+
+    public void addClassLoader(ClassLoader classLoader) {
+        if (classLoader != null) {
+            classLoaders.add(classLoader);
+        }
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        for (ClassLoader cl : classLoaders) {
+            try {
+                return cl.loadClass(name);
+            } catch (ClassNotFoundException ignored) {
+                // Continue to next ClassLoader
+            }
+        }
+        throw new ClassNotFoundException(name);
+    }
+
+    @Override
+    public URL getResource(String name) {
+        for (ClassLoader cl : classLoaders) {
+            URL resource = cl.getResource(name);
+            if (resource != null) {
+                return resource;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        if (classLoaders.size() == 1) {
+            return classLoaders.get(0).getResources(name);
+        }
+        List<Enumeration<URL>> enumerations = new ArrayList<>();
+        for (ClassLoader cl : classLoaders) {
+            enumerations.add(cl.getResources(name));
+        }
+        return new LazyEnumeration(enumerations);
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        return loadClass(name);
+    }
+
+    @Override
+    protected URL findResource(String name) {
+        return getResource(name);
+    }
+
+    @Override
+    protected Enumeration<URL> findResources(String name) throws IOException {
+        return getResources(name);
+    }
+
+    public List<ClassLoader> getClassLoaders() {
+        return Collections.unmodifiableList(classLoaders);
+    }
+}

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/CompositeClassLoader.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/CompositeClassLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package org.glassfish.internal.api;
 
 import java.io.IOException;
@@ -5,8 +21,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
 
 /**
  * A ClassLoader that aggregates multiple ClassLoaders and returns unique resources/classes.
@@ -26,7 +43,7 @@ public class CompositeClassLoader extends ClassLoader {
         registerAsParallelCapable();
     }
 
-    private final List<ClassLoader> classLoaders = new CopyOnWriteArrayList<>();
+    private final Set<ClassLoader> classLoaders = Collections.synchronizedSet(new LinkedHashSet<>());
 
     public CompositeClassLoader() {
         super(null);
@@ -64,7 +81,7 @@ public class CompositeClassLoader extends ClassLoader {
     @Override
     public Enumeration<URL> getResources(String name) throws IOException {
         if (classLoaders.size() == 1) {
-            return classLoaders.get(0).getResources(name);
+            return classLoaders.iterator().next().getResources(name);
         }
         List<Enumeration<URL>> enumerations = new ArrayList<>();
         for (ClassLoader cl : classLoaders) {
@@ -89,6 +106,6 @@ public class CompositeClassLoader extends ClassLoader {
     }
 
     public List<ClassLoader> getClassLoaders() {
-        return Collections.unmodifiableList(classLoaders);
+        return new ArrayList<>(classLoaders);
     }
 }

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/LazyEnumeration.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/LazyEnumeration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package org.glassfish.internal.api;
 
 import java.util.Enumeration;

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/LazyEnumeration.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/api/LazyEnumeration.java
@@ -1,0 +1,62 @@
+package org.glassfish.internal.api;
+
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Lazy enumeration that returns only distinct elements while iterating through
+ * multiple enumerations.
+ */
+class LazyEnumeration<T> implements Enumeration<T> {
+
+    private final Iterator<Enumeration<T>> enumerationIterator;
+    private final Set<T> seenElements = new HashSet<>();
+    private Enumeration<T> currentEnumeration;
+    private T nextElement;
+
+    public LazyEnumeration(List<Enumeration<T>> enumerations) {
+        this.enumerationIterator = enumerations.iterator();
+        advance();
+    }
+
+    @Override
+    public boolean hasMoreElements() {
+        return nextElement != null;
+    }
+
+    @Override
+    public T nextElement() {
+        if (nextElement == null) {
+            throw new NoSuchElementException();
+        }
+        T result = nextElement;
+        advance();
+        return result;
+    }
+
+    private void advance() {
+        nextElement = null;
+
+        while (nextElement == null) {
+            // Find next unique element in current enumeration
+            while (currentEnumeration != null && currentEnumeration.hasMoreElements()) {
+                T candidate = currentEnumeration.nextElement();
+                if (seenElements.add(candidate)) {
+                    nextElement = candidate;
+                    return;
+                }
+            }
+
+            // Move to next enumeration if available
+            if (enumerationIterator.hasNext()) {
+                currentEnumeration = enumerationIterator.next();
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/CompositeClassLoaderTest.java
+++ b/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/CompositeClassLoaderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.internal.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for CompositeClassLoader to ensure it properly aggregates multiple ClassLoaders
+ * and prevents duplicate resources/classes.
+ */
+class CompositeClassLoaderTest {
+
+    private CompositeClassLoader compositeClassLoader;
+    private ClassLoader mockClassLoader1;
+    private ClassLoader mockClassLoader2;
+
+    @BeforeEach
+    void setUp() {
+        compositeClassLoader = new CompositeClassLoader();
+        // Create simple URLClassLoaders for testing
+        mockClassLoader1 = new URLClassLoader(new URL[0]);
+        mockClassLoader2 = new URLClassLoader(new URL[0]);
+    }
+
+    @Test
+    void shouldPreventDuplicateClassLoaders() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(mockClassLoader1); // Same instance added twice
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        assertThat(compositeClassLoader.getClassLoaders(), hasSize(2));
+        assertThat(compositeClassLoader.getClassLoaders(), contains(mockClassLoader1, mockClassLoader2));
+    }
+
+    @Test
+    void shouldIgnoreNullClassLoaders() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(null);
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        assertThat(compositeClassLoader.getClassLoaders(), hasSize(2));
+        assertThat(compositeClassLoader.getClassLoaders(), contains(mockClassLoader1, mockClassLoader2));
+    }
+
+    @Test
+    void shouldAddClassLoadersSuccessfully() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        assertThat(compositeClassLoader.getClassLoaders(), hasSize(2));
+        assertThat(compositeClassLoader.getClassLoaders(), contains(mockClassLoader1, mockClassLoader2));
+    }
+
+    @Test
+    void shouldLoadClassFromFirstAvailableClassLoader() throws ClassNotFoundException {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(getClass().getClassLoader()); // This one has String class
+
+        Class<?> stringClass = compositeClassLoader.loadClass("java.lang.String");
+        assertThat(stringClass, is(String.class));
+    }
+
+    @Test
+    void shouldThrowClassNotFoundExceptionWhenClassNotAvailable() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        assertThrows(ClassNotFoundException.class, 
+            () -> compositeClassLoader.loadClass("com.nonexistent.Class"));
+    }
+
+    @Test
+    void shouldReturnFirstAvailableResource() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(getClass().getClassLoader());
+
+        URL resource = compositeClassLoader.getResource("java/lang/String.class");
+        assertThat(resource, is(notNullValue()));
+    }
+
+    @Test
+    void shouldReturnNullWhenResourceNotFound() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        compositeClassLoader.addClassLoader(mockClassLoader2);
+
+        URL resource = compositeClassLoader.getResource("nonexistent/resource.txt");
+        assertThat(resource, is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnUniqueResourcesFromAllClassLoaders() throws IOException {
+        compositeClassLoader.addClassLoader(getClass().getClassLoader());
+
+        Enumeration<URL> resources = compositeClassLoader.getResources("META-INF/MANIFEST.MF");
+        
+        List<URL> resourceList = Collections.list(resources);
+        // Should have at least one MANIFEST.MF, exact count depends on classpath
+        assertThat(resourceList, is(not(empty())));
+    }
+
+    @Test
+    void shouldReturnCopyOfClassLoadersList() {
+        compositeClassLoader.addClassLoader(mockClassLoader1);
+        
+        List<ClassLoader> classLoaders = compositeClassLoader.getClassLoaders();
+        classLoaders.add(mockClassLoader2); // Should not affect internal state
+        
+        // Internal state should remain unchanged
+        assertThat(compositeClassLoader.getClassLoaders(), hasSize(1));
+        assertThat(compositeClassLoader.getClassLoaders(), contains(mockClassLoader1));
+    }
+}

--- a/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/CompositeClassLoaderTest.java
+++ b/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/CompositeClassLoaderTest.java
@@ -16,9 +16,6 @@
 
 package org.glassfish.internal.api;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -26,8 +23,17 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -91,7 +97,7 @@ class CompositeClassLoaderTest {
         compositeClassLoader.addClassLoader(mockClassLoader1);
         compositeClassLoader.addClassLoader(mockClassLoader2);
 
-        assertThrows(ClassNotFoundException.class, 
+        assertThrows(ClassNotFoundException.class,
             () -> compositeClassLoader.loadClass("com.nonexistent.Class"));
     }
 
@@ -118,7 +124,7 @@ class CompositeClassLoaderTest {
         compositeClassLoader.addClassLoader(getClass().getClassLoader());
 
         Enumeration<URL> resources = compositeClassLoader.getResources("META-INF/MANIFEST.MF");
-        
+
         List<URL> resourceList = Collections.list(resources);
         // Should have at least one MANIFEST.MF, exact count depends on classpath
         assertThat(resourceList, is(not(empty())));
@@ -127,10 +133,10 @@ class CompositeClassLoaderTest {
     @Test
     void shouldReturnCopyOfClassLoadersList() {
         compositeClassLoader.addClassLoader(mockClassLoader1);
-        
+
         List<ClassLoader> classLoaders = compositeClassLoader.getClassLoaders();
         classLoaders.add(mockClassLoader2); // Should not affect internal state
-        
+
         // Internal state should remain unchanged
         assertThat(compositeClassLoader.getClassLoaders(), hasSize(1));
         assertThat(compositeClassLoader.getClassLoaders(), contains(mockClassLoader1));

--- a/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/LazyEnumerationTest.java
+++ b/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/LazyEnumerationTest.java
@@ -16,8 +16,6 @@
 
 package org.glassfish.internal.api;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -25,8 +23,13 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Vector;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -118,7 +121,7 @@ class LazyEnumerationTest {
 
         LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(enumerations);
         List<String> result = new ArrayList<>();
-        
+
         while (lazyEnum.hasMoreElements()) {
             result.add(lazyEnum.nextElement());
         }

--- a/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/LazyEnumerationTest.java
+++ b/nucleus/common/internal-api/src/test/java/org/glassfish/internal/api/LazyEnumerationTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.internal.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Vector;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for LazyEnumeration to ensure it properly handles multiple enumerations
+ * and returns only distinct elements.
+ */
+class LazyEnumerationTest {
+
+    @Test
+    void shouldReturnDistinctElementsFromMultipleEnumerations() {
+        Vector<String> vector1 = new Vector<>();
+        vector1.add("element1");
+        vector1.add("element2");
+        vector1.add("duplicate");
+
+        Vector<String> vector2 = new Vector<>();
+        vector2.add("element3");
+        vector2.add("duplicate"); // This should be filtered out
+        vector2.add("element4");
+
+        List<Enumeration<String>> enumerations = List.of(
+            vector1.elements(),
+            vector2.elements()
+        );
+
+        LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(enumerations);
+        List<String> result = Collections.list(lazyEnum);
+
+        assertThat(result, hasSize(5));
+        assertThat(result, containsInAnyOrder("element1", "element2", "element3", "element4", "duplicate"));
+    }
+
+    @Test
+    void shouldHandleEmptyEnumerations() {
+        Vector<String> emptyVector = new Vector<>();
+        Vector<String> nonEmptyVector = new Vector<>();
+        nonEmptyVector.add("element1");
+
+        List<Enumeration<String>> enumerations = List.of(
+            emptyVector.elements(),
+            nonEmptyVector.elements(),
+            emptyVector.elements()
+        );
+
+        LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(enumerations);
+        List<String> result = Collections.list(lazyEnum);
+
+        assertThat(result, hasSize(1));
+        assertThat(result, contains("element1"));
+    }
+
+    @Test
+    void shouldHandleAllEmptyEnumerations() {
+        Vector<String> emptyVector1 = new Vector<>();
+        Vector<String> emptyVector2 = new Vector<>();
+
+        List<Enumeration<String>> enumerations = List.of(
+            emptyVector1.elements(),
+            emptyVector2.elements()
+        );
+
+        LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(enumerations);
+
+        assertThat(lazyEnum.hasMoreElements(), is(false));
+    }
+
+    @Test
+    void shouldThrowNoSuchElementExceptionWhenEmpty() {
+        List<Enumeration<String>> emptyEnumerations = new ArrayList<>();
+        LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(emptyEnumerations);
+
+        assertThrows(NoSuchElementException.class, lazyEnum::nextElement);
+    }
+
+    @Test
+    void shouldMaintainOrderFromFirstEnumerationThenSecond() {
+        Vector<String> vector1 = new Vector<>();
+        vector1.add("first");
+        vector1.add("second");
+
+        Vector<String> vector2 = new Vector<>();
+        vector2.add("third");
+        vector2.add("fourth");
+
+        List<Enumeration<String>> enumerations = List.of(
+            vector1.elements(),
+            vector2.elements()
+        );
+
+        LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(enumerations);
+        List<String> result = new ArrayList<>();
+        
+        while (lazyEnum.hasMoreElements()) {
+            result.add(lazyEnum.nextElement());
+        }
+
+        assertThat(result, contains("first", "second", "third", "fourth"));
+    }
+
+    @Test
+    void shouldFilterDuplicatesAcrossMultipleEnumerations() {
+        Vector<String> vector1 = new Vector<>();
+        vector1.add("same");
+        vector1.add("different1");
+
+        Vector<String> vector2 = new Vector<>();
+        vector2.add("same"); // Duplicate
+        vector2.add("different2");
+
+        Vector<String> vector3 = new Vector<>();
+        vector3.add("same"); // Another duplicate
+        vector3.add("different3");
+
+        List<Enumeration<String>> enumerations = List.of(
+            vector1.elements(),
+            vector2.elements(),
+            vector3.elements()
+        );
+
+        LazyEnumeration<String> lazyEnum = new LazyEnumeration<>(enumerations);
+        List<String> result = Collections.list(lazyEnum);
+
+        assertThat(result, hasSize(4));
+        assertThat(result, containsInAnyOrder("same", "different1", "different2", "different3"));
+    }
+}


### PR DESCRIPTION
The list of extensions in coming from the `DeploymentImpl.getExtensions` method contained each extension multiple times. This was because multiple bean deployment archives shared the same classloader, and wrapping each classloader with `FilteringClassLoader` and then loading extensions via service loader produced multiple instances from the same class.