### PR TITLE
Always delegate resolving MicroProfile APIs even with delegate=false

### DIFF
--- a/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
+++ b/appserver/web/war-util/src/main/java/org/glassfish/web/loader/WebappClassLoader.java
@@ -155,7 +155,8 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
         "org.xml.sax",                               // SAX 1 & 2 (JRE, jrt-fs.jar)
         "org.w3c.dom",                               // DOM 1 & 2 (JRE, jrt-fs.jar)
         "org.glassfish.wasp.standard",               // wasp.jar
-        "com.sun.faces"                              // jakarta.faces.jar
+        "com.sun.faces",                             // jakarta.faces.jar
+        "org.eclipse.microprofile"                   // MicroProfile classes
     );
     private static final Set<String> DELEGATED_RESOURCE_PATHS = DELEGATED_PACKAGES.stream()
         .map(PACKAGE_TO_PATH).collect(Collectors.toUnmodifiableSet());
@@ -741,7 +742,7 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
         LOG.log(DEBUG, "getResource(name={0})", name);
         checkStatus(LifeCycleStatus.RUNNING);
         // (1) Delegate to parent if requested, or if the requested resource
-        // belongs to one of the packages that are part of the Jakarta EE platform
+        // belongs to one of the packages that are part of the Jakarta EE platform or MicroProfile
         if (isDelegateFirstResource(name)) {
             URL url = getDelegateClassLoader().getResource(name);
             if (url != null) {
@@ -805,7 +806,7 @@ public final class WebappClassLoader extends GlassfishUrlClassLoader
         }
 
         // (1) Delegate to parent if requested, or if the requested resource
-        // belongs to one of the packages that are part of the Jakarta EE platform
+        // belongs to one of the packages that are part of the Jakarta EE platform or MicroProfile
         if (isDelegateFirstResource(name)) {
             stream = getDelegateClassLoader().getResourceAsStream(name);
             if (stream != null) {


### PR DESCRIPTION
Similarly to Jakarta EE, MicroProfile APIs should be always delegated.
