### PR TITLE
Publish surefire and failsafe reports

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -33,4 +33,8 @@ jobs:
       if: success() || failure() # do not run if build cancelled
       with:
         report_paths: '**/target/*-reports/TEST-*.xml'
-
+        annotate_only: true
+        simplified_summary: true
+        skip_success_summary: true
+        detailed_summary: true
+        flaky_summary: true

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,5 +32,5 @@ jobs:
       uses: mikepenz/action-junit-report@v5
       if: success() || failure() # do not run if build cancelled
       with:
-        report_paths: '**/target/surefire-reports/TEST-*.xml'
+        report_paths: '**/target/*-reports/TEST-*.xml'
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -28,3 +28,9 @@ jobs:
         name: server-logs
         path: '**/server.log*'
         retention-days: 3
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v5
+      if: success() || failure() # do not run if build cancelled
+      with:
+        report_paths: '**/target/surefire-reports/TEST-*.xml'
+

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,4 +33,8 @@ jobs:
       if: success() || failure() # do not run if build cancelled
       with:
         report_paths: '**/target/*-reports/TEST-*.xml'
-
+        annotate_only: true
+        simplified_summary: true
+        skip_success_summary: true
+        detailed_summary: true
+        flaky_summary: true

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -32,5 +32,5 @@ jobs:
       uses: mikepenz/action-junit-report@v5
       if: success() || failure() # do not run if build cancelled
       with:
-        report_paths: '**/target/surefire-reports/TEST-*.xml'
+        report_paths: '**/target/*-reports/TEST-*.xml'
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -28,3 +28,9 @@ jobs:
         name: server-logs
         path: '**/server.log*'
         retention-days: 3
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v5
+      if: success() || failure() # do not run if build cancelled
+      with:
+        report_paths: '**/target/surefire-reports/TEST-*.xml'
+

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,3 +26,9 @@ jobs:
         name: server-logs
         path: '**/server.log*'
         retention-days: 3
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v5
+      if: success() || failure() # do not run if build cancelled
+      with:
+        report_paths: '**/target/surefire-reports/TEST-*.xml'
+

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,5 +30,5 @@ jobs:
       uses: mikepenz/action-junit-report@v5
       if: success() || failure() # do not run if build cancelled
       with:
-        report_paths: '**/target/surefire-reports/TEST-*.xml'
+        report_paths: '**/target/*-reports/TEST-*.xml'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,4 +31,8 @@ jobs:
       if: success() || failure() # do not run if build cancelled
       with:
         report_paths: '**/target/*-reports/TEST-*.xml'
-
+        annotate_only: true
+        simplified_summary: true
+        skip_success_summary: true
+        detailed_summary: true
+        flaky_summary: true


### PR DESCRIPTION
When build failed, we always had to check logs. @OndroMih found a better solution, I just added also failsafe reports.
