### PR TITLE
Fix 'port' to 'portNumber' in JDBC documentation

### DIFF
--- a/docs/reference-manual/src/main/asciidoc/create-jdbc-connection-pool.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-jdbc-connection-pool.adoc
@@ -381,7 +381,7 @@ Possible values of `--wrapjdbcobjects` are as follows:
     Specifies the database for this connection pool.
   `serverName`;;
     Specifies the database server for this connection pool.
-  `port`;;
+  `portNumber`;;
     Specifies the port on which the database server listens for
     requests.
   `networkProtocol`;;


### PR DESCRIPTION
Fixed the property name from 'port' to 'portNumber'.

Fixes #25774.