### PR TITLE
Use RAM disk for windows GitHub action to speed up the build.

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
     - name: List ports
       run: ss -tulpn
     - name: Build with Maven

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: mvn -B -e -ntp install -Pqa '-Dcheckstyle.skip=true'
+      run: mvn -B -e -ntp verify -Pqa '-Dcheckstyle.skip=true'
     - name: Upload server logs
       uses: actions/upload-artifact@v4
       if: failure()

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build GlassFish on Ubuntu
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,9 +22,7 @@ jobs:
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: mvn -B -e -ntp install -Pqa '-Dcheckstyle.skip=true' -Pfastest
-    - name: Test GF Starts
-      run: mvn -B -e -ntp install '-Dcheckstyle.skip=true' -pl :glassfish-itest-tools
+      run: mvn -B -e -ntp verify -Pqa '-Dcheckstyle.skip=true'
     - name: Upload server logs
       uses: actions/upload-artifact@v4
       if: failure()

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-15
     name: Build GlassFish on MacOS
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: mvn -B -e -ntp install -Pqa '-Dcheckstyle.skip=true'
+      run: mvn -B -e -ntp verify -Pqa '-Dcheckstyle.skip=true'
     - name: Upload server logs
       uses: actions/upload-artifact@v4
       if: failure()

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-2025
     name: Build GlassFish on Windows
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup RAM Disk
       uses: chad-golden/setup-ramdisk@v1.0.1
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "master", "7.0", "8.0" ]
 
+defaults:
+  run:
+    working-directory: 'R:\glassfish'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -13,22 +17,25 @@ jobs:
     runs-on: windows-2025
     name: Build GlassFish on Windows
     steps:
-    - uses: actions/checkout@v5
     - name: Setup RAM Disk
       uses: chad-golden/setup-ramdisk@v1.0.1
       with:
-        size-in-mb: 8096
-    - name: Setup directories in RAM Disk
+        size-in-mb: 10240
+    - name: Checkout
+      shell: powershell
+      working-directory: 'R:\'
       run: |
-        mkdir R:\temp
-        echo "TEMP=R:\temp" >> $env:GITHUB_ENV
-        echo "TMP=R:\temp" >> $env:GITHUB_ENV
+        git clone --filter=tree:0 --no-checkout ${{ github.server_url }}/${{ github.repository }} glassfish
+        cd glassfish
+        git fetch --depth=1 origin ${{ github.sha }}
+        git checkout ${{ github.sha }}
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
+    - name: Print System Info
+      run: systeminfo
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,9 +18,14 @@ jobs:
     name: Build GlassFish on Windows
     steps:
     - name: Setup RAM Disk
-      uses: chad-golden/setup-ramdisk@v1.0.1
-      with:
-        size-in-mb: 10240
+      shell: powershell
+      working-directory: 'D:\'
+      run: |
+        choco install imdisk-toolkit -y
+        imdisk -a -s 10G -m R: -p "/fs:ntfs /q /y"
+        # Verify it's mounted and formatted
+        Get-PSDrive R
+        Get-Volume | Where-Object {$_.DriveLetter -eq 'R'}
     - name: Checkout
       shell: powershell
       working-directory: 'R:\'
@@ -37,9 +42,28 @@ jobs:
     - name: Print System Info
       run: systeminfo
     - name: Build with Maven
+      # each step takes a lot of disk space, so we split it to multiple parts like on jenkins,
+      # and after each we don't delete test results, but we do delete files we don't need any more.
+      run: |
+        mvn -B -e -ntp install '-Pfastest' -T4C
+    - name: Main Tests
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI
-      run: mvn -B -e -ntp verify -Pqa '-Dcheckstyle.skip=true'
+      run: |
+        mvn -B -e -ntp verify '-Pqa,ci-main-tests' '-Dcheckstyle.skip=true'
+        mvn -B -e -ntp clean '-Pclean-partial,qa
+    - name: Admin Tests
+      run: |
+        mvn -B -e -ntp verify '-Dcheckstyle.skip=true' -pl ':admin-tests-parent' '-amd'
+        mvn -B -e -ntp clean '-Pclean-partial,qa' -pl ':admin-tests-parent' '-amd'
+    - name: Application Tests
+      run: |
+        mvn -B -e -ntp verify '-Dcheckstyle.skip=true' -pl ':application-tests'
+        mvn -B -e -ntp clean '-Pclean-partial' -pl ':application-tests'
+    - name: Embedded Tests
+      run: |
+        mvn -B -e -ntp verify '-Dcheckstyle.skip=true' -pl ':embedded-tests' '-amd'
+        mvn -B -e -ntp clean '-Pclean-partial' -pl ':embedded-tests' '-amd'
     - name: Upload server logs
       uses: actions/upload-artifact@v4
       if: failure()
@@ -57,5 +81,3 @@ jobs:
         skip_success_summary: true
         detailed_summary: true
         flaky_summary: true
-    - name: Dismount RAM Disk
-      uses: chad-golden/setup-ramdisk/dismount@v1.0.1

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -30,7 +30,7 @@ jobs:
         git fetch --depth=1 origin ${{ github.sha }}
         git checkout ${{ github.sha }}
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,6 +14,15 @@ jobs:
     name: Build GlassFish on Windows
     steps:
     - uses: actions/checkout@v4
+    - name: Setup RAM Disk
+      uses: chad-golden/setup-ramdisk@v1.0.1
+      with:
+        size-in-mb: 8096
+    - name: Setup directories in RAM Disk
+      run: |
+        mkdir R:\temp
+        echo "TEMP=R:\temp" >> $env:GITHUB_ENV
+        echo "TMP=R:\temp" >> $env:GITHUB_ENV
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
@@ -41,3 +50,5 @@ jobs:
         skip_success_summary: true
         detailed_summary: true
         flaky_summary: true
+    - name: Dismount RAM Disk
+      uses: chad-golden/setup-ramdisk/dismount@v1.0.1

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -148,6 +148,7 @@ public class LoggingPrintStreamTest {
      */
     @Test
     @RepeatedTest(100)
+    @Timeout(value = 1, unit = TimeUnit.MINUTES)
     public void testStreamMethods() throws Exception {
         stream.append('x');
         stream.append("-y");

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -2560,5 +2560,37 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>clean-partial</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-clean-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-clean</id>
+                                    <configuration>
+                                        <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                        <verbose>true</verbose>
+                                        <filesets>
+                                            <fileset>
+                                                <directory>${project.build.directory}</directory>
+                                                <includes>
+                                                    <include>**/*.class</include>
+                                                    <include>**/*.jar</include>
+                                                    <include>**/*.gz</include>
+                                                    <include>**/*.zip</include>
+                                                </includes>
+                                            </fileset>
+                                        </filesets>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Use only for temp dir. If used for workspace, we run out of space. Drive D is already used for workspace.

See why D and RAM disks should be used:
https://www.chadgolden.com/blog/github-actions-hosted-windows-runners-slower-than-expected-ci-and-you#windows-dev-drive--virtual-hard-disk-vhdx
