### PR TITLE
GitHub Actions updates + longer timeout for LoggingPrintStreamTest

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
     - name: List ports
       run: ss -tulpn
     - name: Build with Maven

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build GlassFish on Ubuntu
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-15
     name: Build GlassFish on MacOS
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-2025
     name: Build GlassFish on Windows
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,11 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
     - name: Build with Maven
       # qa skips documentation - we check it on Jenkins CI
       # We skip checkstyle too - we check it on Jenkins CI

--- a/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
+++ b/nucleus/glassfish-jul-extension/src/test/java/org/glassfish/main/jul/handler/LoggingPrintStreamTest.java
@@ -148,6 +148,7 @@ public class LoggingPrintStreamTest {
      */
     @Test
     @RepeatedTest(100)
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testStreamMethods() throws Exception {
         stream.append('x');
         stream.append("-y");


### PR DESCRIPTION
* LoggingPrintStreamTest.testStreamMethods is bit slower on Mac for example
* The maven cache is not required as GHA use fast Maven proxy (says Claude, confirmed, same times)
