### PR TITLE
ProgressCustomCommand now uses Java Time api

### DIFF
--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -249,10 +249,11 @@ public class Asadmin {
             command.add("-Xms64m");
             command.add("-Xmx64m");
             command.add("-Xss286k");
-            // Disable GC
             command.add("-XX:+UnlockExperimentalVMOptions");
             command.add("-XX:+UseEpsilonGC");
-            command.add("-XX:+AlwaysPreTouch");
+            command.add("-XX:TieredStopAtLevel=1");
+            command.add("-XX:-UsePerfData");
+            command.add("-Djava.awt.headless=true");
         }
         command.add(asadmin.getAbsolutePath());
         command.add("--user");

--- a/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
+++ b/appserver/itest-tools/src/main/java/org/glassfish/main/itest/tools/asadmin/Asadmin.java
@@ -248,11 +248,17 @@ public class Asadmin {
             command.add(JAVA_EXECUTABLE);
             command.add("-Xms64m");
             command.add("-Xmx64m");
-            command.add("-Xss286k");
+            command.add("-Xss256k");
             command.add("-XX:+UnlockExperimentalVMOptions");
+            // NOOP GC
             command.add("-XX:+UseEpsilonGC");
+            // Would touch heap pages BEFORE start, so makes it slower
+            command.add("-XX:-AlwaysPreTouch");
+            // Reduce JIT interventions
             command.add("-XX:TieredStopAtLevel=1");
+            // Disable jvmstat monitoring
             command.add("-XX:-UsePerfData");
+            command.add("-Xlog:gc*=off");
             command.add("-Djava.awt.headless=true");
         }
         command.add(asadmin.getAbsolutePath());

--- a/appserver/tests/admin/admin-extension/src/main/java/com/sun/enterprise/tests/progress/ProgressCustomCommand.java
+++ b/appserver/tests/admin/admin-extension/src/main/java/com/sun/enterprise/tests/progress/ProgressCustomCommand.java
@@ -21,7 +21,6 @@ import java.lang.System.Logger;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.glassfish.api.ActionReport;
@@ -96,14 +95,14 @@ public class ProgressCustomCommand implements AdminCommand {
 
 
     /**
-     * @param content time of one interval in milliseconds
-     * @param count of intervals
+     * @param timespan total time to split to 100 intervals
      * @return String which can be used as an argument.
      */
-    public static String generateRegularIntervals(long content, int count) {
-        final long[] intervals = new long[count];
-        Arrays.fill(intervals, content);
-        return generateIntervals(intervals);
+    public static String generateRegularIntervals(long timespan) {
+        final int steps = 10;
+        final String[] intervals = new String[steps];
+        Arrays.fill(intervals, Duration.ofMillis(timespan <= steps ? steps : (timespan/steps)).toString());
+        return String.join(",", intervals);
     }
 
     /**
@@ -111,7 +110,8 @@ public class ProgressCustomCommand implements AdminCommand {
      * @return String which can be used as an argument.
      */
     public static String generateIntervals(long... intervals) {
-        return Arrays.stream(intervals).mapToObj(Duration::ofMillis).map(Duration::toString)
-            .collect(Collectors.joining(","));
+        final String[] durations = new String[intervals.length];
+        Arrays.setAll(durations, i -> Duration.ofMillis(intervals[i]).toString());
+        return String.join(",", durations);
     }
 }

--- a/appserver/tests/admin/admin-extension/src/main/java/com/sun/enterprise/tests/progress/ProgressCustomCommand.java
+++ b/appserver/tests/admin/admin-extension/src/main/java/com/sun/enterprise/tests/progress/ProgressCustomCommand.java
@@ -17,9 +17,10 @@
 
 package com.sun.enterprise.tests.progress;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.regex.Pattern;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.glassfish.api.ActionReport;
 import org.glassfish.api.I18n;
@@ -34,6 +35,7 @@ import org.jvnet.hk2.annotations.Service;
 
 /**
  * @author mmares
+ * @author David Matejcek
  */
 @Service(name = "progress-custom")
 @PerLookup
@@ -42,149 +44,49 @@ import org.jvnet.hk2.annotations.Service;
 @Progress
 public class ProgressCustomCommand implements AdminCommand {
 
-    /** Value must be in for {@code [Nx][MINSEC-]MAXSEC}
+    /**
+     * Value must be in for {@code [Nx][MINSEC-]MAXSEC}
      */
-    @Param(primary=true, optional=true, multiple=true, defaultValue="0")
-    String[] intervals;
+    @Param(primary = true, separator = ',')
+    private String[] intervals;
 
-    private static final Pattern keyPattern = Pattern.compile("([\\ds]+x){0,1}(\\d+-){0,1}\\d+");
-
-    private static class Interval {
-
-        private boolean valid = true;
-        private String origInterval;
-        private int multiplicator = 1;
-        private int minSec = -1;
-        private int maxSec = 0;
-        private boolean spin = false;
-
-        private Interval(String interval) {
-            origInterval = interval;
-            try {
-                if (!keyPattern.matcher(interval).matches()) {
-                    valid = false;
-                    return;
-                }
-                int ind = interval.indexOf('x');
-                if (ind > 0) {
-                    String substring = interval.substring(0, ind);
-                    if (substring.contains("s")) {
-                        this.spin = true;
-                    } else {
-                        multiplicator = Integer.parseInt(substring);
-                    }
-                    interval = interval.substring(ind + 1);
-                }
-                ind = interval.indexOf('-');
-                if (ind > 0) {
-                    minSec = Integer.parseInt(interval.substring(0, ind));
-                    interval = interval.substring(ind + 1);
-                }
-                if (!interval.isEmpty()) {
-                    maxSec = Integer.parseInt(interval);
-                }
-                if (minSec > maxSec) {
-                    int tmp = minSec;
-                    minSec = maxSec;
-                    maxSec = tmp;
-                }
-            } catch (Exception ex) {
-                valid  = false;
-            }
-        }
-
-        public boolean isSpin() {
-            return this.spin;
-        }
-
-        public int getMultiplicator() {
-            if (valid) {
-                return multiplicator;
-            }
-            return 1;
-        }
-
-        public boolean isValid() {
-            return valid;
-        }
-
-        public int getMaxSec() {
-            return maxSec;
-        }
-
-        public long getMilis() {
-            if (!valid) {
-                return 0L;
-            }
-            if (minSec < 0) {
-                return maxSec * 1000L;
-            }
-            return Math.round(Math.random() * ((maxSec - minSec) * 1000L)) + (minSec * 1000L);
-        }
-
-        @Override
-        public String toString() {
-            return origInterval;
-        }
-
-    }
-
-    private Collection<Interval> parsedIntervals;
-
-    private int getStepCount() {
-        if (parsedIntervals == null) {
-            return 0;
-        }
-        int result = 0;
-        for (Interval interval : parsedIntervals) {
-            result += interval.getMultiplicator();
-        }
-        return result;
-    }
 
     @Override
     public void execute(AdminCommandContext context) {
-        ProgressStatus ps = context.getProgressStatus();
-        parsedIntervals = new ArrayList<>(intervals != null ? intervals.length : 0);
-        ActionReport report = context.getActionReport();
-        for (String interval : intervals) {
-            parsedIntervals.add(new Interval(interval));
-        }
-        //Count
-        if (parsedIntervals.isEmpty()) {
+        final ActionReport report = context.getActionReport();
+        if (intervals == null || intervals.length == 0) {
             report.setMessage("Done command process without waiting interval.");
             return;
         }
-        ps.setTotalStepCount(getStepCount());
+
+        final ProgressStatus progressStatus = context.getProgressStatus();
+        final List<Duration> parsedIntervals = Stream.of(intervals).map(Duration::parse).toList();
+
+        progressStatus.setTotalStepCount(parsedIntervals.size());
         int blockId = 0;
-        for (Interval interval : parsedIntervals) {
+        for (Duration interval : parsedIntervals) {
             blockId++;
-            if (interval.isValid()) {
-                int multip = interval.getMultiplicator();
-                if (interval.getMaxSec() == 0) {
-                    ps.progress(multip, "Finished block without sleeping: [" + blockId + "] " + interval);
-                } else {
-                    for (int i = 0; i < multip; i++) {
-                        if (i == 0) {
-                            ps.progress(0, "Starting block [" + blockId + "] " + interval, interval.isSpin());
-                        }
-                        try {
-                            Thread.sleep(interval.getMilis());
-                        } catch (InterruptedException ex) {
-                            Thread.currentThread().interrupt();
-                        }
-                        if (i == (multip - 1)) {
-                            ps.progress(1, "Finished block [" + blockId + "] " + interval);
-                        } else {
-                            ps.progress(1, "Block [" + blockId + "] " + interval + ", step: " + (i + 1));
-                        }
-                    }
-                }
+            String intervalText = interval.toMillis() + " ms";
+            if (interval.isZero()) {
+                progressStatus.progress(1, "Finished block without sleeping: [" + blockId + "] " + intervalText);
             } else {
-                ps.progress(1, "Finished unparsable block [" +blockId + "] " + interval);
+                progressStatus.progress(0, "Starting block [" + blockId + "] " + intervalText, false);
+                try {
+                    Thread.sleep(interval.toMillis());
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                progressStatus.progress(1, "Finished block [" + blockId + "] " + intervalText);
             }
         }
         report.setMessage("Finished command process in " + parsedIntervals.size() + " block(s).");
     }
 
+    /**
+     * @param intervals in milliseconds
+     * @return String which can be used as an argument.
+     */
+    public static String generateIntervals(Integer... intervals) {
+        return Stream.of(intervals).map(Duration::ofMillis).map(Duration::toString).collect(Collectors.joining(","));
+    }
 }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/DetachAttachITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/DetachAttachITest.java
@@ -22,28 +22,31 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
 import org.glassfish.main.itest.tools.asadmin.Asadmin;
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
 import org.glassfish.main.itest.tools.asadmin.DetachedTerseAsadminResult;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static com.sun.enterprise.tests.progress.ProgressCustomCommand.generateIntervals;
 import static com.sun.enterprise.tests.progress.ProgressCustomCommand.generateRegularIntervals;
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.INFO;
 import static org.glassfish.main.admin.test.progress.UsualLatency.getMeasuredLatency;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminError;
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,9 +56,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ExtendWith(JobTestExtension.class)
 public class DetachAttachITest {
+
     private static final Logger LOG = System.getLogger(DetachAttachITest.class.getName());
+
+    private static final int STEP_MULTIPLIER = 10;
+    private static final long MEASURED_LATENCY = getMeasuredLatency();
+
     private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin(false);
 
+    private ExecutorService threadPool;
+
+    @AfterEach
+    void poolShutdown() throws Exception {
+        if (threadPool != null) {
+            threadPool.shutdown();
+            assertTrue(threadPool.awaitTermination(1, TimeUnit.MINUTES), "Threads did not finish in one minute.");
+        }
+    }
 
     @Test
     public void uptimePeriodically() throws Exception {
@@ -79,46 +96,69 @@ public class DetachAttachITest {
 
 
     @Test
-    public void commandWithProgressStatus() throws Exception {
-        // We have to be faster than the job finishes.
-        final String intervals = generateIntervals(1, getMeasuredLatency() + 1000, 10, 20, 30);
-        final DetachedTerseAsadminResult detached = ASADMIN.execDetached("progress-custom", intervals);
-        assertThat(detached, asadminOK());
-        final AsadminResult attachResult = ASADMIN.exec("attach", detached.getJobId());
-        assertThat(attachResult, asadminOK());
-        assertThat(attachResult.getStdOut(), stringContainsInOrder("progress-custom"));
-        List<ProgressMessage> prgs = ProgressMessage.grepProgressMessages(attachResult.getStdOut());
-        assertFalse(prgs.isEmpty(), "ProgressMessages.isEmpty()");
-        assertThat(prgs.get(0).getValue(), greaterThanOrEqualTo(0));
-        assertEquals(100, prgs.get(prgs.size() - 1).getValue());
+    public void detachOnesAttachLifecycle() throws Exception {
+        {
+            final AsadminResult result = ASADMIN.exec((int) MEASURED_LATENCY + 1000, "attach", "99999999");
+            assertThat(result, asadminError("Job with id 99999999 does not exist"));
+        }
 
+        // We have to be faster than the job finishes.
+        final String intervals = generateRegularIntervals(5 * MEASURED_LATENCY);
+        final DetachedTerseAsadminResult jobIdResult = ASADMIN.execDetached("progress-custom", intervals);
+        assertThat(jobIdResult, asadminOK());
+        assertNotNull(jobIdResult.getJobId(), "id");
+
+        // This will block until jobs finishes.
+        final AsadminResult progResult = ASADMIN.exec("attach", jobIdResult.getJobId());
+        // This will get the final result without waiting
+        final AsadminResult finalResult = ASADMIN.exec("attach", jobIdResult.getJobId());
+        assertAll(
+            () -> assertThat(progResult, asadminOK()),
+            () -> assertThat(progResult.getStdOut(), containsString("progress-custom")),
+            () -> checkProgressOutput(progResult), () -> assertThat(finalResult, asadminOK()),
+            () -> assertThat(finalResult.getStdOut(), containsString("progress-custom")),
+            () -> assertThat(finalResult.getStdOut(), not(containsString("%")))
+        );
         JobTestExtension.doAndDisableJobCleanup();
-        assertThat("Attach again", ASADMIN.exec("attach", detached.getJobId()), not(asadminOK()));
+        assertThat("Attach after cleanup", ASADMIN.exec("attach", jobIdResult.getJobId()), not(asadminOK()));
     }
 
 
     @Test
-    public void detachOnesAttachMulti() throws Exception {
+    public void detachOnesAttachConcurrent() throws Exception {
         // This affects scheduling of threads and makes the test repeatable
-        final int attachCount = Runtime.getRuntime().availableProcessors() + 2;
-        final String intervals = generateRegularIntervals(10, (int) getMeasuredLatency());
+        final int attachCount = Runtime.getRuntime().availableProcessors();
+        // Latency multiplier estimated to make tests pass on most environments.
+        // With faster asadmin and job scheduling it may me needed to change it.
+        final String intervals = generateRegularIntervals(10 * MEASURED_LATENCY);
         final DetachedTerseAsadminResult jobIdResult = ASADMIN.execDetached("progress-custom", intervals);
         assertThat(jobIdResult, asadminOK());
         assertNotNull(jobIdResult.getJobId(), "id");
-        // Let the job start
-        Thread.sleep(getMeasuredLatency());
-        final List<CompletableFuture<AsadminResult>> futureResults = new ArrayList<>(attachCount);
+
+        // Let the job start. It will spend 10 * latency by its work.
+        // There is a bit tricky causality issue:
+        // The job must be already running and managed by JobManager so we could
+        // monitor its progress.
+        // If the job is still in some preparation phase we will not find it.
+        // If it already completed, we will only find its report.
+        // So we measured how much time it usually takes to run this command and get result.
+        Thread.sleep(MEASURED_LATENCY);
+        threadPool = createExecutor("Detached-asadmin-", Thread.MAX_PRIORITY, attachCount);
+        final List<Future<AsadminResult>> futureResults = new ArrayList<>(attachCount);
         for (int i = 0; i < attachCount; i++) {
-            futureResults.add(CompletableFuture.supplyAsync(() -> ASADMIN.exec("attach", jobIdResult.getJobId())));
+            futureResults.add(threadPool.submit(() -> {
+                AsadminResult result = ASADMIN.exec("--echo", "attach", jobIdResult.getJobId());
+                LOG.log(DEBUG, () -> "Received result. Error: " + result.isError());
+                return result;
+            }));
         }
         LOG.log(INFO, () -> "Started " + attachCount + " attaches to job id " + jobIdResult.getJobId());
-        // TODO: On Java21 we can have more control using Executors.newThreadPerTaskExecutor
-        boolean progressNoticed = false;
         for (Future<AsadminResult> futureResult : futureResults) {
             final AsadminResult result = futureResult.get();
             final List<ProgressMessage> prgs = ProgressMessage.grepProgressMessages(result.getStdOut());
             assertAll(
                 () -> assertThat(result, asadminOK()),
+                // Twice. First is caused by --echo
                 () -> assertThat(result.getStdOut(), containsString("progress-custom")),
                 () -> assertThat(result.getStdOut(), not(containsString("FAILURE")))
             );
@@ -126,12 +166,27 @@ public class DetachAttachITest {
                 // We were late to watch the progress, however soon enough to get the result.
                 continue;
             }
-            progressNoticed = true;
-            assertAll(
-                () -> assertThat(prgs.get(0).getValue(), greaterThanOrEqualTo(0)),
-                () -> assertEquals(100, prgs.get(prgs.size() - 1).getValue())
-            );
+            checkProgressOutput(result);
         }
-        assertTrue(progressNoticed, "Noticed at least one progress report");
+    }
+
+    private static ExecutorService createExecutor(final String namePrefix, final int priority, final int attachCount) {
+        final AtomicInteger counter = new AtomicInteger();
+        return Executors.newFixedThreadPool(attachCount, command -> {
+            Thread thread = new Thread(command, namePrefix + counter.incrementAndGet());
+            thread.setPriority(priority);
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    private static void checkProgressOutput(final AsadminResult progResult) {
+        final List<ProgressMessage> prgs = ProgressMessage.grepProgressMessages(progResult.getStdOut());
+        assertFalse(prgs.isEmpty(), "ProgressMessages.isEmpty()");
+        assertAll(
+            () -> assertThat("Min progress", prgs.get(0).getValue(), greaterThanOrEqualTo(0)),
+            // Sometimes the completion status comes earlier than the last progress
+            () -> assertThat("Max progress", prgs.get(prgs.size() - 1).getValue(), greaterThanOrEqualTo(99))
+        );
     }
 }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/ProgressStatusFailITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/ProgressStatusFailITest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static com.sun.enterprise.tests.progress.ProgressCustomCommand.generateIntervals;
 import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
@@ -56,14 +57,17 @@ public class ProgressStatusFailITest {
 
     /**
      * This tests that we receive output even for job executed synchronously (not detached)
-     * but timing out. This is possible because we use the SSE (Server Sent Events for the
+     * but timing out. This is possible because we use the SSE (Server Sent Events) for the
      * communication between the asadmin command and the server.
      */
     @Test
     public void timeout() {
-        AsadminResult result = ASADMIN.exec(3100, "progress-custom", "1x1", "1x2", "1x1");
+        final int firstStep = 1000;
+        final int secondStep = 2000;
+        final String intervals = generateIntervals(firstStep, secondStep, 10);
+        final AsadminResult result = ASADMIN.exec(firstStep + secondStep/2, "progress-custom", intervals);
         assertThat(result, not(asadminOK()));
-        List<ProgressMessage> prgs = ProgressMessage.grepProgressMessages(result.getStdOut());
+        final List<ProgressMessage> prgs = ProgressMessage.grepProgressMessages(result.getStdOut());
         assertFalse(prgs.isEmpty(), "progress messages empty");
         assertEquals(33, prgs.get(prgs.size() - 1).getValue());
     }

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/UsualLatency.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/UsualLatency.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.admin.test.progress;
+
+import org.glassfish.main.itest.tools.asadmin.AsadminResult;
+import org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher;
+
+import static com.sun.enterprise.tests.progress.ProgressCustomCommand.generateIntervals;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getAsadmin;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+final class UsualLatency {
+    private static Long latency;
+
+    static final synchronized long getMeasuredLatency() {
+        if (latency == null) {
+            final long start = System.currentTimeMillis();
+            final AsadminResult result = getAsadmin().exec("progress-custom", generateIntervals(0L));
+            latency = System.currentTimeMillis() - start;
+            assertThat(result, AsadminResultMatcher.asadminOK());
+        }
+        return latency;
+    }
+}

--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/UsualLatency.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/progress/UsualLatency.java
@@ -16,14 +16,18 @@
 
 package org.glassfish.main.admin.test.progress;
 
+import java.lang.System.Logger;
+
 import org.glassfish.main.itest.tools.asadmin.AsadminResult;
 import org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher;
 
 import static com.sun.enterprise.tests.progress.ProgressCustomCommand.generateIntervals;
+import static java.lang.System.Logger.Level.INFO;
 import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.getAsadmin;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 final class UsualLatency {
+    private static final Logger LOG = System.getLogger(UsualLatency.class.getName());
     private static Long latency;
 
     static final synchronized long getMeasuredLatency() {
@@ -32,6 +36,7 @@ final class UsualLatency {
             final AsadminResult result = getAsadmin().exec("progress-custom", generateIntervals(0L));
             latency = System.currentTimeMillis() - start;
             assertThat(result, AsadminResultMatcher.asadminOK());
+            LOG.log(INFO, "Measured sample time for the progress-custom command is {0} ms", latency);
         }
         return latency;
     }

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/monitoring/AppClient.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/monitoring/AppClient.java
@@ -85,8 +85,10 @@ final class AppClient {
         try {
             HttpURLConnection connection = GlassFishTestEnvironment.openConnection(port, context);
             connection.setRequestMethod("GET");
+            connection.setUseCaches(false);
             connection.setConnectTimeout(100);
             connection.setReadTimeout(requestTimeout);
+            connection.connect();
             return connection;
         } catch (IOException e) {
             throw new IllegalStateException("Failed to open connection to " + context, e);

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/monitoring/ThreadPoolMonitoringTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/monitoring/ThreadPoolMonitoringTest.java
@@ -197,13 +197,10 @@ public class ThreadPoolMonitoringTest {
 
         generator1.close();
         generatorTest.close();
-        waitForThreadsBusyCount(HTTP_POOL_1_PORT, 0);
-        waitForThreadsBusyCount(HTTP_POOL_TEST_PORT, 0);
         waitForTaskCountStoppedChanging(HTTP_POOL_1_PORT);
         waitForTaskCountStoppedChanging(HTTP_POOL_TEST_PORT);
-        // FIXME: Even those waits don't ensure that task count will not increase.
-        //        Reproduced on GHA, more probable on Windows machine - task count changed by a number of currentThreadCount.
-        Thread.sleep(1000L);
+        waitForThreadsBusyCount(HTTP_POOL_1_PORT, 0);
+        waitForThreadsBusyCount(HTTP_POOL_TEST_PORT, 0);
         final ThreadPoolMetrics metrics1 = getThreadPoolMetrics(HTTP_POOL_1);
         final ThreadPoolMetrics metricsTest = getThreadPoolMetrics(HTTP_POOL_TEST);
         assertAll(

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/monitoring/ThreadPoolMonitoringTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/monitoring/ThreadPoolMonitoringTest.java
@@ -182,8 +182,10 @@ public class ThreadPoolMonitoringTest {
         assertThat(new AppClient(HTTP_POOL_TEST_PORT, 5000).test(), stringContainsInOrder(HTTP_POOL_TEST));
 
         // Create load on both listeners simultaneously
-        final HttpLoadGenerator generator1 = startHttpTestLoadGenerator(HTTP_POOL_1_PORT, 10, 1_000_000);
-        final HttpLoadGenerator generatorTest = startHttpTestLoadGenerator(HTTP_POOL_TEST_PORT, 10, 1_000_000);
+        final HttpLoadGenerator generator1 = startHttpTestLoadGenerator(HTTP_POOL_1_PORT,
+            metrics1Baseline.maxThreads(), 1_000_000);
+        final HttpLoadGenerator generatorTest = startHttpTestLoadGenerator(HTTP_POOL_TEST_PORT,
+            metricsTestBaseline.maxThreads(), 1_000_000);
 
         waitFor(Duration.ofSeconds(60L), () -> {
             ThreadPoolMetrics metrics1 = getThreadPoolMetrics(HTTP_POOL_1);

--- a/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/SseAdminCommandInvoker.java
+++ b/nucleus/admin/rest/rest-service/src/main/java/org/glassfish/admin/rest/utils/SseAdminCommandInvoker.java
@@ -83,6 +83,7 @@ public final class SseAdminCommandInvoker extends AsyncAdminCommandInvoker<Respo
         @Override
         public void onAdminCommandEvent(String eventName, ProgressEvent event) {
             try {
+                LOG.log(TRACE, "onAdminCommandEvent, name: {0}, event: {1}", eventName, event);
                 eventOutput.write(eventName, event);
             } catch (Exception e) {
                 // Log the exception but do not stop processing the state change event.


### PR DESCRIPTION
- The former syntax was confusing and overcomplicated
- the test detachOnesAttachMulti did not check job result, now does
- Stabilized tests
