### PR TITLE
Upgrade dojo.js

### DIFF
--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -73,8 +73,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
-            <artifactId>dojo-ajax-nodemo</artifactId>
+            <groupId>org.glassfish.woodstock.external</groupId>
+            <artifactId>dojo</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -131,7 +131,7 @@
                             <outputDirectory>${dependencies.extra.directory}</outputDirectory>
                             <includeArtifactIds>
                                 commons-io,
-                                dojo-ajax-nodemo,json,prototype,
+                                dojo,json,prototype,
                                 woodstock-webui-jsf,woodstock-webui-jsf-suntheme
                             </includeArtifactIds>
                             <includeScope>provided</includeScope>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -37,5 +37,5 @@
     </locale-charset-info>
     <class-loader
         delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-${woodstock.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -185,9 +185,8 @@
         <!-- Admin console components -->
         <jsftemplating.version>4.1.0-M1</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.0.1</woodstock.version>
+        <woodstock.version>6.1.0-SNAPSHOT</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
-        <woodstock-dojo-ajax-nodemo.version>1.12.4</woodstock-dojo-ajax-nodemo.version>
         <woodstock-json.version>2.0</woodstock-json.version>
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
@@ -674,9 +673,9 @@
                 <version>${woodstock-json.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
-                <artifactId>dojo-ajax-nodemo</artifactId>
-                <version>${woodstock-dojo-ajax-nodemo.version}</version>
+                <groupId>org.glassfish.woodstock.external</groupId>
+                <artifactId>dojo</artifactId>
+                <version>${woodstock.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -185,7 +185,7 @@
         <!-- Admin console components -->
         <jsftemplating.version>4.1.0-M1</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.1.0-SNAPSHOT</woodstock.version>
+        <woodstock.version>6.0.2</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
         <woodstock-json.version>2.0</woodstock-json.version>
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>


### PR DESCRIPTION
This PR changes the source of dojo.js -- from direct dependency to the one repackaged by the woodstock. At the same time, I upgraded dojo.js in woodstock.

Compile woodstock ([PR 1457](https://github.com/eclipse-ee4j/glassfish-woodstock/pull/1457)):
```
mvn clean install
```
Then compile GlassFish.

## Testing
### Testing Performed
I when through the AdminUI.
1. Check, if the dojo.js is delivered (browser, Networking tab in dev tools)
2. Open left tree (doesn't work without it), click some buttons, e.g. Ping in JDBC

### Testing Environment
Linux, OpenJDK 21

## Notes for Reviewers
I'm leaving this as draft PR, because we need to publish woodstock first.
When published, we'll remove the `-SNAPSHOT` from the dependency and finish the PR.