### PR TITLE
Documentation for --server-output, plus fixes after testing

### DIFF
--- a/appserver/tests/appserv-tests/devtests/ejb/ports.java
+++ b/appserver/tests/appserv-tests/devtests/ejb/ports.java
@@ -59,13 +59,13 @@ public class ports {
         while (true) {
             counter++;
             try (ServerSocket socket = new ServerSocket(0)) {
-                final int port = socket.getLocalPort();
+                final String port = Integer.toString(socket.getLocalPort());
                 socket.setSoTimeout(1);
                 if (excluded.contains(port) && counter >= 20) {
                     throw new IllegalStateException("Cannot open random port, tried 20 times. Port " + port
                         + " is excluded and we were not able to find another.");
                 }
-                return Integer.toString(port);
+                return port;
             } catch (IOException e) {
                 if (counter >= 20) {
                     throw new IllegalStateException("Cannot open random port, tried 20 times.", e);

--- a/docs/reference-manual/src/main/asciidoc/copy-config.adoc
+++ b/docs/reference-manual/src/main/asciidoc/copy-config.adoc
@@ -79,8 +79,10 @@ asadmin-options::
     requires superuser privileges.
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
-    connections to the Java Platform Debugger Architecture (JPDA)
-    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+    connections to the Specifies whether the domain is restarted with
+  https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
+  debugging enabled.
+
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/create-cluster.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-cluster.adoc
@@ -130,9 +130,7 @@ asadmin-options::
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
     connections to the
-    http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-    Platform Debugger Architecture (JPDA)]
-    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+    https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/create-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-domain.adoc
@@ -211,9 +211,7 @@ When the `--portbase` option is specified, the output of this
   `java.debugger.port`;;
     This property specifies the port number of the port that is used for
     connections to the
-    http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-    Platform Debugger Architecture (JPDA)]
-    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+    https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `jms.port`;;

--- a/docs/reference-manual/src/main/asciidoc/create-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-instance.adoc
@@ -212,8 +212,7 @@ When the `--portbase` option is specified, the output of this
     requires superuser privileges.
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
-    connections to the Java Platform Debugger Architecture (JPDA)
-    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+    connections to the https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/create-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/create-local-instance.adoc
@@ -266,8 +266,7 @@ When the `--portbase` option is specified, the output of this
     requires superuser privileges.
   `JAVA_DEBUGGER_PORT`;;
     This property specifies the port number of the port that is used for
-    connections to the Java Platform Debugger Architecture (JPDA)
-    (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+    connections to the https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
     debugger. Valid values are 1-65535. On UNIX, creating sockets that
     listen on ports 1-1024 requires superuser privileges.
   `JMS_PROVIDER_PORT`;;

--- a/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
@@ -55,9 +55,7 @@ asadmin-options::
   Displays the help text for the subcommand.
 `--debug`::
   Specifies whether the domain is restarted with
-  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-  Platform Debugger Architecture (JPDA)]
-  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+  https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
   debugging enabled.
   Possible values are as follows:
 

--- a/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-domain.adoc
@@ -23,6 +23,7 @@ asadmin restart-domain
 [--force[=<force(default:true)>]]
 [--help|-?]
 [--kill[=<kill(default:false)>]]
+[--server-output|-o=<server-output(default:false)>]]
 [--timeout <timeout>]
 [domain_name]
 ----
@@ -94,6 +95,17 @@ The default is the current setting of this option for the domain that
   `true`;;
     The domain is killed. The subcommand uses functionality of the
     operating system to terminate the domain process.
+
+`--server-output`::
+`-o`::
+   Specifies if the command should or should not print the server output.
+   If not set, server prints the output just when the command failed.
+   Possible values are as follows:
+
+   `true`;;
+    The output of the server startup will be printed after the command finishes.
+   `false`;;
+     The output of the server startup will not be printed.
 
 `--timeout`::
   Specifies timeout in seconds to evaluate the expected result.

--- a/docs/reference-manual/src/main/asciidoc/restart-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-instance.adoc
@@ -78,9 +78,7 @@ asadmin-options::
   Displays the help text for the subcommand.
 `--debug`::
   Specifies whether the instance is restarted with
-  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-  Platform Debugger Architecture
-  (JPDA)](https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+  https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
   debugging enabled. Possible values are as follows:
 
   `true`;;

--- a/docs/reference-manual/src/main/asciidoc/restart-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/restart-local-instance.adoc
@@ -82,9 +82,7 @@ asadmin-options::
   Displays the help text for the subcommand.
 `--debug`::
   Specifies whether the instance is restarted with
-  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-  Platform Debugger Architecture (JPDA)]
-  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+  https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
   debugging enabled.
   Possible values are as follows:
 

--- a/docs/reference-manual/src/main/asciidoc/start-domain.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-domain.adoc
@@ -23,6 +23,7 @@ asadmin start-domain
 [--drop-interrupted-commands[=<drop-interrupted-commands(default:false)>]]
 [--dry-run|-n[=<dry-run(default:false)>]]
 [--help|-?]
+[--server-output|-o=<server-output(default:false)>]]
 [--suspend|-s[=<suspend(default:false)>]]
 [--timeout <timeout>]
 [--upgrade[=<upgrade(default:false)>]]
@@ -100,6 +101,17 @@ asadmin-options::
   including all options. Reviewing this command can be useful to confirm
   JVM options and when troubleshooting startup issues. +
   The default value is `false`.
+
+`--server-output`::
+`-o`::
+   Specifies if the command should or should not print the server output.
+   If not set, server prints the output just when the command failed.
+   Possible values are as follows:
+
+   `true`;;
+    The output of the server startup will be printed after the command finishes.
+   `false`;;
+     The output of the server startup will not be printed.
 
 `--suspend`::
 `-s`::

--- a/docs/reference-manual/src/main/asciidoc/start-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-instance.adoc
@@ -59,9 +59,7 @@ asadmin-options::
   Displays the help text for the subcommand.
 `--debug`::
   Specifies whether the instance is started with
-  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-  Platform Debugger Architecture (JPDA)]
-  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+  https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
   debugging enabled. +
   Possible values are as follows:
 

--- a/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
@@ -64,9 +64,7 @@ asadmin-options::
 `--debug`::
 `-d`::
   Specifies whether the instance is started with
-  http://java.sun.com/javase/technologies/core/toolsapis/jpda/[Java
-  Platform Debugger Architecture (JPDA)]
-  (https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html)
+  https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/jpda.html[Java Platform Debugger Architecture (JPDA)]
   debugging enabled.
 +
 Possible values are as follows:

--- a/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
+++ b/docs/reference-manual/src/main/asciidoc/start-local-instance.adoc
@@ -23,6 +23,7 @@ asadmin start-local-instance
 [--help|-?]
 [--node <node>]
 [--nodedir <nodedir>]
+[--server-output|-o=<server-output(default:false)>]]
 [--sync <sync(default:normal)>]
 [--timeout <timeout>]
 [--verbose|-v[=<verbose(default:false)>]]
@@ -74,6 +75,7 @@ Possible values are as follows:
     number for JPDA debugging is displayed.
   `false`;;
     The instance is started with JPDA debugging disabled (default).
+
 `--dry-run`::
 `-n`::
   Suppresses actual starting of the instance. Instead,
@@ -90,6 +92,18 @@ Possible values are as follows:
   Specifies the directory that contains the instance's node directory.
   The instance's files are stored in the instance's node directory. The
   default is as-install``/nodes``.
+
+`--server-output`::
+`-o`::
+   Specifies if the command should or should not print the server output.
+   If not set, server prints the output just when the command failed.
+   Possible values are as follows:
+
+   `true`;;
+    The output of the server startup will be printed after the command finishes.
+   `false`;;
+     The output of the server startup will not be printed.
+
 `--sync`::
   The type of synchronization between the DAS and the instance's files
   when the instance is started. +

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncher.java
@@ -17,13 +17,8 @@
 package com.sun.enterprise.admin.launcher;
 
 import com.sun.enterprise.admin.launcher.CommandLine.CommandFormat;
-import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
-import com.sun.enterprise.universal.glassfish.GFLauncherUtils;
-import com.sun.enterprise.universal.glassfish.TokenResolver;
 import com.sun.enterprise.universal.process.ProcessStreamDrainer;
-import com.sun.enterprise.universal.xml.MiniXmlParser;
 import com.sun.enterprise.universal.xml.MiniXmlParserException;
-import com.sun.enterprise.util.io.FileUtils;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -35,132 +30,38 @@ import java.lang.System.Logger;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.sun.enterprise.admin.launcher.GFLauncher.LaunchType.fake;
-import static com.sun.enterprise.admin.launcher.GFLauncherConstants.DEFAULT_LOGFILE;
-import static com.sun.enterprise.admin.launcher.GFLauncherConstants.FLASHLIGHT_AGENT_NAME;
-import static com.sun.enterprise.admin.launcher.GFLauncherConstants.LIBMON_NAME;
 import static com.sun.enterprise.admin.launcher.GFLauncherLogger.COMMAND_LINE;
-import static com.sun.enterprise.universal.collections.CollectionUtils.propertiesToStringMap;
-import static com.sun.enterprise.universal.glassfish.GFLauncherUtils.ok;
 import static com.sun.enterprise.util.OS.isDarwin;
-import static com.sun.enterprise.util.SystemPropertyConstants.DEBUG_MODE_PROPERTY;
-import static com.sun.enterprise.util.SystemPropertyConstants.DISABLE_ENV_VAR_EXPANSION_PROPERTY;
-import static com.sun.enterprise.util.SystemPropertyConstants.DROP_INTERRUPTED_COMMANDS;
-import static com.sun.enterprise.util.SystemPropertyConstants.PREFER_ENV_VARS_OVER_PROPERTIES;
-import static java.lang.Boolean.TRUE;
-import static java.lang.System.Logger.Level.INFO;
-import static java.lang.System.Logger.Level.WARNING;
+import static java.lang.System.Logger.Level.DEBUG;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
-import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
-import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
-import static org.glassfish.embeddable.GlassFishVariable.INSTANCE_ROOT;
-import static org.glassfish.embeddable.GlassFishVariable.JAVA_ROOT;
 
 /**
  * This is the main Launcher class designed for external and internal usage.
  *
  * <p>
- * Each of the 3 kinds of server, domain, node-agent and instance, need to
- * subclass this class.
+ * Each of kinds of server, domain, node-agent and instance, need to subclass this class.
  *
  * @author bnevins
  */
 public abstract class GFLauncher {
     private static final Logger LOG = System.getLogger(GFLauncher.class.getName());
 
+    private LaunchType mode = LaunchType.normal;
+
     /**
      * Parameters provided by the caller of a launcher, either programmatically
      * (for GF embedded) or as commandline parameters (GF DAS or Instance).
      *
      */
-    private final GFLauncherInfo callerParameters;
-
-    /**
-     * Properties from asenv.conf, such as
-     * <code>AS_DEF_DOMAINS_PATH="../domains"</code>
-     */
-    private Map<String, String> asenvProps;
-
-    /**
-     * The <code>java-config</code> attributes in domain.xml
-     */
-    private JavaConfig domainXMLjavaConfig;
-
-    /**
-     * the <code>debug-options</code> attribute from <code>java-config</code> in
-     * domain.xml
-     */
-    private List<String> domainXMLjavaConfigDebugOptions;
-
-    /**
-     * The debug port (<code>address</code>) primarily extracted from
-     * <code>domainXMLjavaConfigDebugOptions</code>
-     */
-    private Integer debugPort;
-
-    /**
-     * The debug suspend (<code>suspend</code>) primarily extracted from
-     * <code>domainXMLjavaConfigDebugOptions</code>
-     */
-    private boolean debugSuspend;
-
-    /**
-     * The combined <code>jvm-options</code> from <code>java-config</code>,
-     * <code>profiler</code> in domain.xml and extra ones added by this launcher
-     */
-    private JvmOptions domainXMLjvmOptions;
-
-    /**
-     * Same data as domainXMLjvmOptions, but as list
-     */
-    private final List<String> domainXMLJvmOptionsAsList = new ArrayList<>();
-
-    /**
-     * The <code>profiler<code> from <code>java-config</code> in domain.xml
-     */
-    private Profiler domainXMLJavaConfigProfiler;
-
-    /**
-     * The (combined) <code>system-property</code> elements in domain.xml
-     */
-    private Map<String, String> domainXMLSystemProperty;
-
-    private Path javaExe;
-    private File[] modulepath;
-    private File[] classpath;
-    private String adminFileRealmKeyFile;
-    private boolean secureAdminEnabled;
-
-    /**
-     * The file name to log to using a
-     * <code>java.util.logging.FileHandler.FileHandler</code>
-     */
-    private String logFilename; // defaults to "logs/server.log"
-
-    /**
-     * Tracks whether the fixLogFileName() method was called.
-     */
-    private boolean logFilenameWasFixed;
-
-    // Tracks upgrading from V2 to V3. Since we're at V6 atm of wring, is this really needed?
-    private boolean needsAutoUpgrade;
-    private boolean needsManualUpgrade;
-
-    private LaunchType mode = LaunchType.normal;
+    private final GFLauncherInfo parameters;
 
     /**
      * The full commandline string used to start GlassFish in process
@@ -184,152 +85,85 @@ public abstract class GFLauncher {
      */
     private int exitValue = -1;
 
-    private Long pidBeforeRestart;
 
-    GFLauncher(GFLauncherInfo info) {
-        this.callerParameters = info;
+    protected GFLauncher(GFLauncherInfo parameters) {
+        this.parameters = parameters;
     }
 
-
-    abstract List<File> getMainModulepath() throws GFLauncherException;
-
-    abstract List<File> getMainClasspath() throws GFLauncherException;
-
-    abstract String getMainClass() throws GFLauncherException;
 
     /**
-     * Launches the server.
-     *
-     * @throws GFLauncherException if launch failed.
+     * @return PID of the previous JVM process of the server, sent from that as a system property. Can be null.
      */
-    public final void launch() throws GFLauncherException {
-        if (debugPort != null) {
-            if (debugSuspend) {
-                LOG.log(INFO,
-                    () -> "Debugging will be available and the server will start suspended on port " + debugPort + ".");
-            } else {
-                LOG.log(INFO, () -> "Debugging will be available on port " + debugPort + ".");
-            }
-        }
-        logCommandLine();
-        try {
-            startTime = System.currentTimeMillis();
-            if (isFakeLaunch()) {
-                return;
-            }
-            launchInstance();
-        } catch (GFLauncherException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new GFLauncherException(e);
-        } finally {
-            GFLauncherLogger.removeLogFileHandler();
-        }
-    }
-
-    public void setup() throws GFLauncherException, MiniXmlParserException {
-        asenvProps = getAsEnvConfReader().getProps();
-        pidBeforeRestart = resolvePidBeforeRestart();
-
-        callerParameters.setup();
-        setupLogLevels();
-
-        MiniXmlParser domainXML = new MiniXmlParser(callerParameters.getConfigFile(), callerParameters.getInstanceName());
-
-        String domainName = domainXML.getDomainName();
-        if (ok(domainName)) {
-            callerParameters.setDomainName(domainName);
-        }
-
-        // Can be empty! Then local commands will set what they have from user
-        callerParameters.setXmlAdminAddresses(domainXML.getAdminAddresses());
-        domainXMLjavaConfig = new JavaConfig(domainXML.getJavaConfig());
-        setupProfilerAndJvmOptions(domainXML);
-        setupUpgradeSecurity();
-
-        Map<String, String> realmprops = domainXML.getAdminRealmProperties();
-        if (realmprops != null) {
-            String classname = realmprops.get("classname");
-            String keyfile = realmprops.get("file");
-            if ("com.sun.enterprise.security.auth.realm.file.FileRealm".equals(classname) && keyfile != null) {
-                adminFileRealmKeyFile = keyfile;
-            }
-        }
-
-        secureAdminEnabled = domainXML.getSecureAdminEnabled();
-
-        renameOsgiCache();
-        setupMonitoring(domainXML);
-        domainXMLSystemProperty = domainXML.getSystemProperties();
-        asenvProps.put(INSTANCE_ROOT.getSystemPropertyName(), callerParameters.getInstanceRootDir().getPath());
-
-        // Set the config java-home value as the Java home for the environment,
-        // unless it is empty or it is already referring to a substitution of
-        // the environment variable.
-        String javaHome = domainXMLjavaConfig.getJavaHome();
-        if (ok(javaHome) && !javaHome.trim().equals(JAVA_ROOT.toExpression())) {
-            asenvProps.put(JAVA_ROOT.getPropertyName(), javaHome);
-        }
-
-        domainXMLjavaConfigDebugOptions = getDebugOptionsFromDomainXMLJavaConfig();
-        parseJavaConfigDebugOptions();
-        domainXML.setupConfigDir(callerParameters.getConfigDir(), callerParameters.getInstallDir());
-
-        setLogFilename(domainXML);
-        resolveAllTokens();
-        fixLogFilename();
-        GFLauncherLogger.addLogFileHandler(logFilename);
-
-        setJavaExecutable();
-        setModulepath();
-        setClasspath();
-        initCommandLine();
-        setJvmOptions();
-
-        // if no <network-config> element, we need to upgrade this domain
-        needsAutoUpgrade = !domainXML.hasNetworkConfig();
-        needsManualUpgrade = !domainXML.hasDefaultConfig();
-    }
+    public abstract Long getPidBeforeRestart();
 
     /**
+     * Execute launch preparations. Configure the launcher, prepare the command line, some files.
      *
-     * @return The callerParameters object that contains startup caller parameters
+     * @throws GFLauncherException
+     * @throws MiniXmlParserException
      */
-    public final GFLauncherInfo getInfo() {
-        return callerParameters;
-    }
+    public abstract void setup() throws GFLauncherException, MiniXmlParserException;
 
     /**
      * @return the admin realm key file for the server, if the admin realm is a FileRealm.
-     * Otherwise return null. This value can be used to create a FileRealm for the server.
+     *         Otherwise return null. This value can be used to create a FileRealm for the server.
      */
-    public String getAdminRealmKeyFile() {
-        return adminFileRealmKeyFile;
-    }
+    public abstract File getAdminRealmKeyFile();
+
 
     /**
      * @return true if secure admin is enabled
      */
-    public boolean isSecureAdminEnabled() {
-        return secureAdminEnabled;
+    public abstract boolean isSecureAdminEnabled();
+
+    /**
+     * Get the location of the server logfile
+     *
+     * @return The full path of the logfile
+     */
+    public abstract Path getLogFile();
+
+    /**
+     * @return null or a port number
+     */
+    public abstract Integer getDebugPort();
+
+    /**
+     * @return true if {@link #getDebugPort()} is not null and server's JVM is set to start in suspended mode.
+     */
+    public abstract boolean isSuspendEnabled();
+
+    /**
+     * Does this domain need to be automatically upgraded before it can be
+     * started?
+     *
+     * @return true if the domain needs to be upgraded first
+     */
+    public abstract boolean needsAutoUpgrade();
+
+    /**
+     * Does this domain need to be manually upgraded before it can be started?
+     *
+     * @return true if the domain needs to be upgraded first
+     */
+    public abstract boolean needsManualUpgrade();
+
+    /**
+     * @return The callerParameters object that contains startup caller parameters
+     */
+    public final GFLauncherInfo getParameters() {
+        return parameters;
     }
 
     /**
      * Returns the exit value of the glassFishProcess.
      * This only makes sense when we ran in verbose mode and waited for the glassFishProcess to exit
-     * in the {@link #wait(Process)} method.
+     * in the {@link #waiForExit(Process)} method.
      *
      * @return the glassFishProcess' exit value if it completed and we waited. Otherwise it returns -1
      */
     public final int getExitValue() {
         return exitValue;
-    }
-
-    /**
-     * @return PID of the previous JVM process of the server, sent from that as a system property.
-     */
-    public Long getPidBeforeRestart() {
-        return this.pidBeforeRestart;
     }
 
     /**
@@ -363,118 +197,33 @@ public abstract class GFLauncher {
     }
 
     /**
-     * Get the location of the server logfile
+     * Launches the server.
      *
-     * @return The full path of the logfile
+     * @throws GFLauncherException if launch failed.
      */
-    public String getLogFilename() {
-        if (logFilenameWasFixed) {
-            return logFilename;
-        }
-        throw new IllegalStateException("Call to getLogFilename() before it has been initialized!");
-    }
-
-    /**
-     * @return null or a port number
-     */
-    public final Integer getDebugPort() {
-        return debugPort;
-    }
-
-    /**
-     * Does this domain need to be automatically upgraded before it can be
-     * started?
-     *
-     * @return true if the domain needs to be upgraded first
-     */
-    public final boolean needsAutoUpgrade() {
-        return needsAutoUpgrade;
-    }
-
-    /**
-     * Does this domain need to be manually upgraded before it can be started?
-     *
-     * @return true if the domain needs to be upgraded first
-     */
-    public final boolean needsManualUpgrade() {
-        return needsManualUpgrade;
-    }
-
-    private void launchInstance() throws GFLauncherException {
-        final List<String> securityTokens = callerParameters.getSecurityTokens();
-        final List<String> cmds = createCommand(!securityTokens.isEmpty());
-
-        // When calling cluster nodes, this will be visible in the server.log too.
-        System.err.println("Executing: " + cmds.stream().collect(Collectors.joining(" ")));
-        System.err.println("Please look at the server log for more details...");
-        ProcessBuilder processBuilder = new ProcessBuilder(cmds);
-        if (callerParameters.isVerboseOrWatchdog()) {
-            processBuilder.redirectOutput(Redirect.INHERIT);
-            processBuilder.redirectError(Redirect.INHERIT);
-        }
-
-        // Change the directory if there is one specified, o/w stick with the default.
-        processBuilder.directory(callerParameters.getConfigDir());
-
-        // Run the glassFishProcess and attach Stream Drainers
+    public final void launch() throws GFLauncherException {
+        logCommandLine();
         try {
-            // We have to abandon server.log file to avoid file locking issues on Windows.
-            // From now on the server.log file is owned by the server, not by launcher.
-            GFLauncherLogger.removeLogFileHandler();
-
-            // Startup GlassFish
-            glassFishProcess = processBuilder.start();
-
-            String name = callerParameters.getDomainName();
-
-            // verbose trumps watchdog.
-            if (callerParameters.isIgnoreOutput()) {
-                processStreamDrainer = ProcessStreamDrainer.dispose(name, glassFishProcess);
-            } else if (callerParameters.isVerbose()) {
-                processStreamDrainer = ProcessStreamDrainer.redirect(name, glassFishProcess);
-            } else if (callerParameters.isWatchdog()) {
-                processStreamDrainer = ProcessStreamDrainer.dispose(name, glassFishProcess);
-            } else {
-                processStreamDrainer = ProcessStreamDrainer.save(name, glassFishProcess);
+            startTime = System.currentTimeMillis();
+            if (isFakeLaunch()) {
+                return;
             }
-            handleDeadProcess(glassFishProcess, processStreamDrainer);
-            if (!securityTokens.isEmpty()) {
-                writeSecurityTokens(glassFishProcess, processStreamDrainer, securityTokens);
+            launchInstance();
+
+            // If verbose, hang around until the domain stops
+            // We end otherwise, just in case server crashes, the exit value will be in the exception message.
+            if (parameters.isVerboseOrWatchdog()) {
+                exitValue = waiForExit(glassFishProcess);
             }
+        } catch (GFLauncherException e) {
+            throw e;
         } catch (Exception e) {
-            throw new GFLauncherException("jvmfailure", e, e);
-        }
-
-        // If verbose, hang around until the domain stops
-        if (callerParameters.isVerboseOrWatchdog()) {
-            wait(glassFishProcess);
+            throw new GFLauncherException(e);
+        } finally {
+            GFLauncherLogger.removeLogFileHandler();
         }
     }
 
-    private List<String> createCommand(final boolean securityTokensAvailable) throws GFLauncherException {
-        final List<String> cmds;
-        // Use launchctl bsexec on MacOS versions before 10.10
-        // otherwise use regular startup.
-        if (isDarwin() && useLaunchCtl(System.getProperty("os.version")) && !callerParameters.isVerboseOrWatchdog()) {
-            cmds = new ArrayList<>();
-            cmds.add("launchctl");
-            cmds.add("bsexec");
-            cmds.add("/");
-            cmds.addAll(commandLine.toList());
-        } else if (commandLine.getFormat() == CommandFormat.Script) {
-            cmds = prepareWindowsEnvironment(commandLine, callerParameters.getConfigDir().toPath(), securityTokensAvailable);
-        } else if (callerParameters.isVerboseOrWatchdog()) {
-            cmds = new ArrayList<>();
-            cmds.addAll(commandLine.toList());
-        } else {
-            cmds = new ArrayList<>();
-            if (!isWindows()) {
-                cmds.add("nohup");
-            }
-            cmds.addAll(commandLine.toList());
-        }
-        return cmds;
-    }
 
     boolean isFakeLaunch() {
         return mode == fake;
@@ -486,17 +235,6 @@ public abstract class GFLauncher {
 
     protected final void setCommandLine(CommandLine commandLine) {
         this.commandLine = commandLine;
-    }
-
-    // unit tests will want 'fake' so that the glassFishProcess is not really started.
-    enum LaunchType {
-        normal,
-        debug,
-        trace,
-        /**
-         * Useful just for unit tests so the server will not be started.
-         */
-        fake
     }
 
     void setMode(LaunchType mode) {
@@ -511,488 +249,89 @@ public abstract class GFLauncher {
         return startTime;
     }
 
-    final Map<String, String> getEnvProps() {
-        return asenvProps;
-    }
+    private void launchInstance() throws GFLauncherException {
+        final List<String> securityTokens = parameters.getSecurityTokens();
+        final List<String> cmds = createCommand(!securityTokens.isEmpty());
 
-    private ASenvPropertyReader getAsEnvConfReader() {
-        if (isFakeLaunch()) {
-            return new ASenvPropertyReader(callerParameters.getInstallDir());
-        }
-        return new ASenvPropertyReader();
-    }
-
-    private List<String> getDebugOptionsFromDomainXMLJavaConfig() {
-        if (callerParameters.isDebug() || callerParameters.isSuspend() || domainXMLjavaConfig.isDebugEnabled()) {
-            // Suspend setting from domain.xml can be overridden by caller
-            if (!callerParameters.isSuspend()) {
-                return domainXMLjavaConfig.getDebugOptions();
-            }
-
-            return domainXMLjavaConfig.getDebugOptions().stream().filter(e -> e.startsWith("-agentlib:jdwp"))
-                    .map(e -> e.replace("suspend=n", "suspend=y")).collect(toList());
+        // When calling cluster nodes, this will be visible in the server.log too.
+        LOG.log(DEBUG, () -> "Executing: " + cmds.stream().collect(Collectors.joining(" ")));
+        ProcessBuilder processBuilder = new ProcessBuilder(cmds);
+        if (parameters.isVerboseOrWatchdog()) {
+            processBuilder.redirectOutput(Redirect.INHERIT);
+            processBuilder.redirectError(Redirect.INHERIT);
         }
 
-        return emptyList();
-    }
+        // Change the directory if there is one specified, o/w stick with the default.
+        processBuilder.directory(parameters.getConfigDir());
 
-    /**
-     *
-     * look for an option of this form:
-     * <code>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9009</code>
-     * and extract the suspend and port values.
-     *
-     */
-    private void parseJavaConfigDebugOptions() {
-        for (String option : domainXMLjavaConfigDebugOptions) {
-            if (!option.startsWith("-agentlib:jdwp")) {
-                continue;
-            }
-
-            String[] attributes = option.substring(10).split(",");
-            for (String attribute : attributes) {
-                if (attribute.startsWith("address=")) {
-                    try {
-                        debugPort = Integer.parseInt(attribute.substring(10));
-                    } catch (NumberFormatException ex) {
-                        debugPort = null;
-                    }
-                }
-
-                if (attribute.startsWith("suspend=")) {
-                    try {
-                        debugSuspend = attribute.substring(8).toLowerCase(Locale.getDefault()).equals("y");
-                    } catch (Exception ex) {
-                        debugSuspend = false;
-                    }
-                }
-            }
-        }
-    }
-
-    private void setLogFilename(MiniXmlParser domainXML) {
-        logFilename = domainXML.getLogFilename();
-
-        if (logFilename == null) {
-            logFilename = DEFAULT_LOGFILE;
-        }
-    }
-
-    private void resolveAllTokens() {
-        // resolve jvm-options against:
-        // 1. itself
-        // 2. <system-property>'s from domain.xml
-        // 3. system properties -- essential there is, e.g. "${path.separator}" in domain.xml
-        // 4. asenvProps
-        // 5. env variables (if the above contain a switch to prefer env variables, then they go first, before 1.
-        // i.e. add in reverse order to get the precedence right
-
-        Map<String, String> all = new HashMap<>();
-
-        all.putAll(asenvProps);
-        all.putAll(propertiesToStringMap(System.getProperties()));
-        all.putAll(domainXMLSystemProperty);
-        all.putAll(domainXMLjvmOptions.getCombinedMap());
-        all.putAll(domainXMLJavaConfigProfiler.getConfig());
-
-        if (!isEnvVarExpansionDisabled(all)) {
-            if (isPreferEnvOverProperties(all)) {
-                all.putAll(System.getenv());
-                replacePropertiesWithEnvVars(domainXMLjvmOptions.xProps);
-                replacePropertiesWithEnvVars(domainXMLjvmOptions.xxProps);
-                replacePropertiesWithEnvVars(domainXMLjvmOptions.plainProps);
-                replacePropertiesWithEnvVars(domainXMLjvmOptions.longProps);
-                replacePropertiesWithEnvVars(domainXMLjvmOptions.sysProps);
-            } else {
-                System.getenv().forEach((name, value) -> all.putIfAbsent(name, value));
-            }
-        }
-
-        TokenResolver resolver = new TokenResolver(all);
-        resolver.resolve(domainXMLjvmOptions.xProps);
-        resolver.resolve(domainXMLjvmOptions.xxProps);
-        resolver.resolve(domainXMLjvmOptions.plainProps);
-        resolver.resolve(domainXMLjvmOptions.longProps);
-        resolver.resolve(domainXMLjvmOptions.sysProps);
-        resolver.resolve(domainXMLjavaConfig.getMap());
-        resolver.resolve(domainXMLJavaConfigProfiler.getConfig());
-        resolver.resolve(domainXMLjavaConfigDebugOptions);
-
-        logFilename = resolver.resolve(logFilename);
-        adminFileRealmKeyFile = resolver.resolve(adminFileRealmKeyFile);
-    }
-
-    private void replacePropertiesWithEnvVars(Map<String, String> properties) {
-        Pattern invalidEnvVarCharsPattern = Pattern.compile("[^_0-9a-zA-Z]");
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            String envValue = System.getenv(entry.getKey());
-            if (envValue != null) {
-                entry.setValue(envValue);
-            } else {
-                final String sanitizedKey = invalidEnvVarCharsPattern
-                        .matcher(entry.getKey())
-                        .replaceAll("_");
-                envValue = System.getenv(sanitizedKey);
-                if (envValue != null) {
-                    entry.setValue(envValue);
-                } else {
-                    envValue = System.getenv(sanitizedKey.toUpperCase());
-                    if (envValue != null) {
-                        entry.setValue(envValue);
-                    }
-                }
-            }
-
-        }
-    }
-
-    private static Boolean isPreferEnvOverProperties(Map<String, String> properties) {
-        return Boolean.parseBoolean(properties.get(PREFER_ENV_VARS_OVER_PROPERTIES));
-    }
-
-    private static boolean isEnvVarExpansionDisabled(Map<String, String> all) {
-        return Boolean.parseBoolean(all.get(DISABLE_ENV_VAR_EXPANSION_PROPERTY));
-    }
-
-    private void fixLogFilename() throws GFLauncherException {
-        if (!ok(logFilename)) {
-            logFilename = DEFAULT_LOGFILE;
-        }
-
-        File logFile = new File(logFilename);
-        if (!logFile.isAbsolute()) {
-            // this is quite normal. Logging Service will by default return a relative path!
-            logFile = new File(callerParameters.getInstanceRootDir(), logFilename);
-        }
-
-        // Get rid of garbage like "c:/gf/./././../gf"
-        logFile = logFile.toPath().toAbsolutePath().normalize().toFile();
-
-        // if the file doesn't exist -- make sure the parent dir exists
-        // this is common in unit tests AND the first time the instance is
-        // started....
-        if (!logFile.exists()) {
-            File parent = logFile.getParentFile();
-            if (!parent.isDirectory()) {
-                boolean wasCreated = parent.mkdirs();
-                if (!wasCreated) {
-                    logFile = null; // give up!!
-                }
-            }
-        }
-
-        if (logFile == null) {
-            logFilename = null;
-        } else {
-            logFilename = logFile.getPath();
-        }
-
-        logFilenameWasFixed = true;
-    }
-
-    private void setJavaExecutable() throws GFLauncherException {
-        // first choice is from domain.xml
-        if (setJavaExecutableIfValid(domainXMLjavaConfig.getJavaHome())) {
-            return;
-        }
-
-        // second choice is from asenv
-        if (!setJavaExecutableIfValid(asenvProps.get(JAVA_ROOT.getPropertyName()))) {
-            throw new GFLauncherException("nojvm");
-        }
-
-    }
-
-    boolean setJavaExecutableIfValid(String filename) {
-        if (!ok(filename)) {
-            return false;
-        }
-
-        File javaFile = new File(filename);
-
-        if (!javaFile.isDirectory()) {
-            return false;
-        }
-
-        if (GFLauncherUtils.isWindows()) {
-            javaFile = new File(javaFile, "bin/java.exe");
-        } else {
-            javaFile = new File(javaFile, "bin/java");
-        }
-
-        if (javaFile.exists()) {
-            javaExe = javaFile.toPath().toAbsolutePath();
-            return true;
-        }
-
-        return false;
-    }
-
-    void setModulepath() throws GFLauncherException {
-        setModulepath(getMainModulepath().toArray(File[]::new));
-    }
-
-    void setClasspath() throws GFLauncherException {
-        List<File> mainCP = getMainClasspath();
-        List<File> envCP = domainXMLjavaConfig.getEnvClasspath();
-        List<File> sysCP = domainXMLjavaConfig.getSystemClasspath();
-        List<File> prefixCP = domainXMLjavaConfig.getPrefixClasspath();
-        List<File> suffixCP = domainXMLjavaConfig.getSuffixClasspath();
-        List<File> profilerCP = domainXMLJavaConfigProfiler.getClasspath();
-
-        // create a list of all the classpath pieces in the right order
-        List<File> all = new ArrayList<>();
-        all.addAll(prefixCP);
-        all.addAll(profilerCP);
-        all.addAll(mainCP);
-        all.addAll(sysCP);
-        all.addAll(envCP);
-        all.addAll(suffixCP);
-        setClasspath(all.toArray(File[]::new));
-    }
-
-    void initCommandLine() throws GFLauncherException {
-        final boolean useScript = !callerParameters.isVerboseOrWatchdog() && isSurviveWinUserSession();
-        final CommandLine cmdLine = new CommandLine(useScript ? CommandFormat.Script : CommandFormat.ProcessBuilder);
-        cmdLine.append(javaExe);
-        if (modulepath.length > 0) {
-            cmdLine.appendModulePath(getModulepath());
-        }
-        if (classpath.length > 0) {
-            cmdLine.appendClassPath(getClasspath());
-        }
-        addIgnoreNull(cmdLine, domainXMLjavaConfigDebugOptions);
-
-        String CLIStartTime = System.getProperty("WALL_CLOCK_START");
-        if (CLIStartTime != null) {
-            cmdLine.append("-DWALL_CLOCK_START=" + CLIStartTime);
-        }
-
-        if (debugPort != null) {
-            cmdLine.appendSystemOption(DEBUG_MODE_PROPERTY, TRUE.toString());
-        }
-
-        if (domainXMLjvmOptions != null) {
-            domainXMLjvmOptions.toList().forEach(cmdLine::appendJavaOption);
-        }
-
-        GFLauncherNativeHelper nativeHelper = new GFLauncherNativeHelper(callerParameters, domainXMLjavaConfig,
-                domainXMLjvmOptions, domainXMLJavaConfigProfiler);
-        cmdLine.appendNativeLibraryPath(nativeHelper.getNativePath());
-        addIgnoreNull(cmdLine, getMainClass());
-
+        // Run the glassFishProcess and attach Stream Drainers
         try {
-            addIgnoreNull(cmdLine, callerParameters.getArgsAsList());
-        } catch (GFLauncherException gfle) {
-            throw gfle;
+            // We have to abandon server.log file to avoid file locking issues on Windows.
+            // From now on the server.log file is owned by the server, not by launcher.
+            GFLauncherLogger.removeLogFileHandler();
+
+            // Startup GlassFish
+            glassFishProcess = processBuilder.start();
+
+            final String name = parameters.getDomainName();
+
+            // verbose trumps watchdog.
+            if (parameters.isIgnoreOutput()) {
+                processStreamDrainer = ProcessStreamDrainer.dispose(name, glassFishProcess);
+            } else if (parameters.isVerbose()) {
+                processStreamDrainer = ProcessStreamDrainer.redirect(name, glassFishProcess);
+            } else if (parameters.isWatchdog()) {
+                processStreamDrainer = ProcessStreamDrainer.dispose(name, glassFishProcess);
+            } else {
+                processStreamDrainer = ProcessStreamDrainer.save(name, glassFishProcess);
+            }
+            handleDeadProcess(glassFishProcess, processStreamDrainer);
+            if (!securityTokens.isEmpty()) {
+                writeSecurityTokens(glassFishProcess, processStreamDrainer, securityTokens);
+            }
         } catch (Exception e) {
-            throw new GFLauncherException(e);
-        }
-
-        setCommandLine(cmdLine);
-    }
-
-    void setJvmOptions() {
-        domainXMLJvmOptionsAsList.clear();
-        if (domainXMLjvmOptions != null) {
-            domainXMLjvmOptions.toList().forEach(domainXMLJvmOptionsAsList::add);
+            throw new GFLauncherException("jvmfailure", e, e);
         }
     }
 
-    void logCommandLine() {
+    private List<String> createCommand(final boolean securityTokensAvailable) throws GFLauncherException {
+        final List<String> cmds;
+        // Use launchctl bsexec on MacOS versions before 10.10
+        // otherwise use regular startup.
+        if (isDarwin() && useLaunchCtl(System.getProperty("os.version")) && !parameters.isVerboseOrWatchdog()) {
+            cmds = new ArrayList<>();
+            cmds.add("launchctl");
+            cmds.add("bsexec");
+            cmds.add("/");
+            cmds.addAll(commandLine.toList());
+        } else if (commandLine.getFormat() == CommandFormat.Script) {
+            cmds = prepareWindowsEnvironment(commandLine, parameters.getConfigDir().toPath(), securityTokensAvailable);
+        } else if (parameters.isVerboseOrWatchdog()) {
+            cmds = new ArrayList<>();
+            cmds.addAll(commandLine.toList());
+        } else {
+            cmds = new ArrayList<>();
+            if (!isWindows()) {
+                cmds.add("nohup");
+            }
+            cmds.addAll(commandLine.toList());
+        }
+        return cmds;
+    }
+
+
+    private void logCommandLine() {
         if (!isFakeLaunch()) {
             GFLauncherLogger.info(COMMAND_LINE, commandLine.toString("\n"));
         }
     }
 
-    public final List<String> getJvmOptions() {
-        return domainXMLJvmOptionsAsList;
-    }
-
-    private void addIgnoreNull(CommandLine command, String s) {
-        if (ok(s)) {
-            command.append(s);
-        }
-    }
-
-    private void addIgnoreNull(CommandLine command, Collection<String> ss) {
-        if (ss != null && !ss.isEmpty()) {
-            ss.forEach(command::append);
-        }
-    }
-
-    private void wait(final Process p) throws GFLauncherException {
+    private int waiForExit(final Process p) throws GFLauncherException {
         try {
             p.waitFor();
-            exitValue = p.exitValue();
+            return p.exitValue();
         } catch (InterruptedException ex) {
             throw new GFLauncherException("verboseInterruption", ex, ex);
-        }
-    }
-
-    private void setupProfilerAndJvmOptions(MiniXmlParser domainXML) throws MiniXmlParserException, GFLauncherException {
-        // Add JVM options from Profiler *last* so they override config's JVM options
-        domainXMLJavaConfigProfiler = new Profiler(domainXML.getProfilerConfig(), domainXML.getProfilerJvmOptions(),
-                domainXML.getProfilerSystemProperties());
-
-        List<String> rawJvmOptions = domainXML.getJvmOptions();
-        rawJvmOptions.addAll(getSpecialSystemProperties());
-        if (domainXMLJavaConfigProfiler.isEnabled()) {
-            rawJvmOptions.addAll(domainXMLJavaConfigProfiler.getJvmOptions());
-        }
-
-        domainXMLjvmOptions = new JvmOptions(rawJvmOptions);
-        if (callerParameters.isDropInterruptedCommands()) {
-            domainXMLjvmOptions.sysProps.put(DROP_INTERRUPTED_COMMANDS, TRUE.toString());
-        }
-    }
-
-    private void setupUpgradeSecurity() throws GFLauncherException {
-        // If this is an upgrade and the security manager is on,
-        // copy the current server.policy file to the domain
-        // before the upgrade.
-        if (callerParameters.isUpgrade() && domainXMLjvmOptions.sysProps.containsKey("java.security.manager")) {
-
-            GFLauncherLogger.info(GFLauncherLogger.copy_server_policy);
-            Path source = callerParameters.getInstallDir().toPath().resolve(Path.of("lib", "templates", "server.policy"));
-            Path target = callerParameters.getConfigDir().toPath().resolve("server.policy");
-            try {
-                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException ioe) {
-                // the actual error is wrapped differently depending on
-                // whether the problem was with the source or target
-                Throwable cause = ioe.getCause() == null ? ioe : ioe.getCause();
-                throw new GFLauncherException("copy_server_policy_error", ioe, cause.getMessage());
-            }
-        }
-    }
-
-    /**
-     * Because of some issues in GlassFish OSGi launcher, a server updated from
-     * version 3.0.x to 3.1 won't start if a OSGi cache directory populated with
-     * 3.0.x modules is used. So, as a work around, we rename the cache
-     * directory when upgrade path is used. See GLASSFISH-15772 for more
-     * details.
-     *
-     * @throws GFLauncherException if it fails to rename the cache directory
-     */
-    private void renameOsgiCache() throws GFLauncherException {
-        if (callerParameters.isUpgrade()) {
-            File osgiCacheDir = new File(callerParameters.getDomainRootDir(), "osgi-cache");
-            File backupOsgiCacheDir = new File(callerParameters.getDomainRootDir(), "osgi-cache-" + System.currentTimeMillis());
-            if (osgiCacheDir.exists() && !backupOsgiCacheDir.exists()) {
-                if (FileUtils.renameFile(osgiCacheDir, backupOsgiCacheDir)) {
-                    GFLauncherLogger.fine("rename_osgi_cache_succeeded", osgiCacheDir, backupOsgiCacheDir);
-                } else {
-                    throw new GFLauncherException("rename_osgi_cache_failed", osgiCacheDir, backupOsgiCacheDir);
-                }
-            }
-        }
-    }
-
-    private void setupMonitoring(MiniXmlParser parser) {
-        // As usual we have to be very careful.
-
-        // If it is NOT enabled -- we are out of here!!!
-        if (parser.isMonitoringEnabled() == false) {
-            return;
-        }
-
-        // if the user has a hard-coded "-javaagent" jvm-option that uses OUR jar
-        // then we do NOT want to add our own.
-        Set<String> plainKeys = domainXMLjvmOptions.plainProps.keySet();
-        for (String key : plainKeys) {
-            if (key.startsWith("javaagent:")) {
-                // complications -- of course!! They may have mix&match forward and back slashes
-                key = key.replace('\\', '/');
-                if (key.indexOf(FLASHLIGHT_AGENT_NAME) >= 0) {
-                    return; // Done!!!!
-                }
-            }
-        }
-
-        // It is not already specified AND monitoring is enabled.
-        try {
-            domainXMLjvmOptions.plainProps.put(getMonitoringAgentJvmOptionString(), null);
-        } catch (GFLauncherException gfe) {
-            // This has been defined as a non-fatal error.
-            // Silently ignore it -- but do NOT add it as an option
-        }
-    }
-
-    private String getMonitoringAgentJvmOptionString() throws GFLauncherException {
-        File libMonDir = new File(callerParameters.getInstallDir(), LIBMON_NAME);
-        File flashlightJarFile = new File(libMonDir, FLASHLIGHT_AGENT_NAME);
-
-        if (flashlightJarFile.isFile()) {
-            return "javaagent:" + flashlightJarFile.toPath().toAbsolutePath().normalize();
-        }
-        GFLauncherLogger.warning(GFLauncherLogger.NO_FLASHLIGHT_AGENT, flashlightJarFile);
-        throw new GFLauncherException("no_flashlight_agent", flashlightJarFile);
-    }
-
-
-    private List<String> getSpecialSystemProperties() throws GFLauncherException {
-        Map<String, String> props = new HashMap<>();
-        props.put(INSTALL_ROOT.getSystemPropertyName(), callerParameters.getInstallDir().getAbsolutePath());
-        props.put(INSTANCE_ROOT.getSystemPropertyName(), callerParameters.getInstanceRootDir().getAbsolutePath());
-
-        return propsToJvmOptions(props);
-    }
-
-    final File[] getClasspath() {
-        return classpath;
-    }
-
-    final void setClasspath(File... classpath) {
-        this.classpath = classpath;
-    }
-
-    File[] getModulepath() {
-        return modulepath;
-    }
-
-    void setModulepath(File... modulepath) {
-        this.modulepath = modulepath;
-    }
-
-    private List<String> propsToJvmOptions(Map<String, String> map) {
-        List<String> ss = new ArrayList<>();
-        Set<Map.Entry<String, String>> entries = map.entrySet();
-
-        for (Map.Entry<String, String> entry : entries) {
-            String name = entry.getKey();
-            String value = entry.getValue();
-            String jvm = "-D" + name;
-
-            if (value != null) {
-                jvm += "=" + value;
-            }
-
-            ss.add(jvm);
-        }
-
-        return ss;
-    }
-
-    private void setupLogLevels() {
-        if (callerParameters.isVerbose()) {
-            GFLauncherLogger.setConsoleLevel(java.util.logging.Level.INFO);
-        } else {
-            GFLauncherLogger.setConsoleLevel(java.util.logging.Level.WARNING);
-        }
-    }
-
-    private static Long resolvePidBeforeRestart() {
-        String pid = System.getProperty("AS_RESTART_PREVIOUS_PID");
-        if (pid == null) {
-            return null;
-        }
-        try {
-            return Long.valueOf(pid);
-        } catch (NumberFormatException e) {
-            LOG.log(WARNING, "Cannot parse pid {0} required for waiting for the death of the parent process.", pid);
-            return null;
         }
     }
 
@@ -1028,21 +367,8 @@ public abstract class GFLauncher {
         }
     }
 
-    private static boolean isSurviveWinUserSession() {
-        String surviveSessionValue = System.getenv("AS_SURVIVE_WIN_USER_SESSION");
-        if (surviveSessionValue == null) {
-            return isWindows() && isOverSSHSession();
-        }
-        return Boolean.parseBoolean(surviveSessionValue);
-    }
-
-    private static boolean isWindows() {
+    static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
-    }
-
-    private static boolean isOverSSHSession() {
-        return System.getenv("SSH_CLIENT") != null || System.getenv("SSH_CONNECTION") != null
-                || System.getenv("SSH_TTY") != null;
     }
 
     private static List<String> prepareWindowsEnvironment(final CommandLine command, final Path configDir,
@@ -1194,11 +520,22 @@ public abstract class GFLauncher {
         if (process.isAlive()) {
             return null;
         }
-        int ev = process.exitValue();
-        if (ev == 0) {
+        int exitValue = process.exitValue();
+        if (exitValue == 0) {
             return null;
         }
-        return "The server exited prematurely with exit code " + ev
+        return "The server exited prematurely with exit code " + exitValue
             + ".\nBefore it died, it produced the following output:\n\n" + drainer.getOutErrString();
+    }
+
+    // unit tests will want 'fake' so that the glassFishProcess is not really started.
+    enum LaunchType {
+        normal,
+        debug,
+        trace,
+        /**
+         * Useful just for unit tests so the server will not be started.
+         */
+        fake
     }
 }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherConstants.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,6 +34,5 @@ class GFLauncherConstants {
     static final String NATIVE_LIB_SUFFIX = "native-library-path-suffix";
     static final String LIBMON_NAME = "lib/monitor";
     static final String FLASHLIGHT_AGENT_NAME = "flashlight-agent.jar";
-    static final String DEFAULT_LOGFILE = "logs/server.log";
     static final boolean OS_SUPPORTS_BTRACE = !OS.isAix();
 }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +18,8 @@
 package com.sun.enterprise.admin.launcher;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -79,10 +81,6 @@ public class GFLauncherLogger {
     @LogMessageInfo(message = "Could not locate the flashlight agent here: {0}", comment = "catastrophic error", cause = "see message", action = "Find the agent file.", level = "SEVERE")
     public static final String NO_FLASHLIGHT_AGENT = "NCLS-GFLAUNCHER-00003";
 
-    @LogMessageInfo(message = "Will copy glassfish/lib/templates/server.policy file to domain before upgrading.", comment = "Upgrade Information", level = "INFO")
-
-    public static final String copy_server_policy = "NCLS-GFLAUNCHER-00004";
-
     @LogMessageInfo(message = "JVM invocation command line:\n{0}", comment = "Routine Information", cause = "NA", action = "NA", level = "INFO")
     public static final String COMMAND_LINE = "NCLS-GFLAUNCHER-00005";
 
@@ -122,12 +120,13 @@ public class GFLauncherLogger {
      * @param logFile The logfile
      * @throws GFLauncherException if the info object has not been setup
      */
-    static void addLogFileHandler(String logFile) throws GFLauncherException {
+    static void addLogFileHandler(Path logFile) throws GFLauncherException {
         try {
             if (logFile == null || logfileHandler != null) {
                 return;
             }
-            logfileHandler = new FileHandler(logFile, true);
+            Files.createDirectories(logFile.getParent());
+            logfileHandler = new FileHandler(logFile.toString(), true);
             logfileHandler.setFormatter(new ODLLogFormatter());
             logfileHandler.setLevel(INFO);
             LOG.addHandler(logfileHandler);

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherMain.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GFLauncherMain.java
@@ -43,7 +43,7 @@ public class GFLauncherMain {
     public static void main(String[] args) {
         try {
             GFLauncher launcher = GFLauncherFactory.getInstance(DAS);
-            launcher.getInfo().addArgs(args);
+            launcher.getParameters().addArgs(args);
             launcher.setup();
             launcher.launch();
         } catch (GFLauncherException | MiniXmlParserException ex) {

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
@@ -17,11 +17,45 @@
 
 package com.sun.enterprise.admin.launcher;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.util.List;
+import com.sun.enterprise.admin.launcher.CommandLine.CommandFormat;
+import com.sun.enterprise.universal.glassfish.ASenvPropertyReader;
+import com.sun.enterprise.universal.glassfish.GFLauncherUtils;
+import com.sun.enterprise.universal.glassfish.TokenResolver;
+import com.sun.enterprise.universal.xml.MiniXmlParser;
+import com.sun.enterprise.universal.xml.MiniXmlParserException;
+import com.sun.enterprise.util.io.FileUtils;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.System.Logger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.sun.enterprise.admin.launcher.GFLauncherConstants.FLASHLIGHT_AGENT_NAME;
+import static com.sun.enterprise.admin.launcher.GFLauncherConstants.LIBMON_NAME;
+import static com.sun.enterprise.universal.collections.CollectionUtils.propertiesToStringMap;
+import static com.sun.enterprise.universal.glassfish.GFLauncherUtils.ok;
+import static com.sun.enterprise.util.SystemPropertyConstants.DEBUG_MODE_PROPERTY;
+import static com.sun.enterprise.util.SystemPropertyConstants.DISABLE_ENV_VAR_EXPANSION_PROPERTY;
+import static com.sun.enterprise.util.SystemPropertyConstants.DROP_INTERRUPTED_COMMANDS;
+import static com.sun.enterprise.util.SystemPropertyConstants.PREFER_ENV_VARS_OVER_PROPERTIES;
+import static java.lang.Boolean.TRUE;
+import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.WARNING;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
+import static org.glassfish.embeddable.GlassFishVariable.INSTANCE_ROOT;
+import static org.glassfish.embeddable.GlassFishVariable.JAVA_ROOT;
 
 /**
  * Prepares JVM configuration to use GlassFishMain to launch the domain or instance of the server
@@ -30,8 +64,67 @@ import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
  * @author bnevins
  */
 class GlassFishMainLauncher extends GFLauncher {
+    private static final Logger LOG = System.getLogger(GlassFishMainLauncher.class.getName());
 
     private static final String MAIN_CLASS = "com.sun.enterprise.glassfish.bootstrap.GlassFishMain";
+
+    private final Long pidBeforeRestart;
+
+    /**
+     * System properties based on asenv file, but extended.
+     */
+    private Map<String, String> asenvProps;
+
+    private Path javaExe;
+
+    /**
+     * The <code>java-config</code> attributes in domain.xml
+     */
+    private JavaConfig domainXMLjavaConfig;
+
+    /**
+     * the <code>debug-options</code> attribute from <code>java-config</code> in
+     * domain.xml
+     */
+    private List<String> domainXMLjavaConfigDebugOptions;
+
+    private File adminFileRealmKeyFile;
+
+    private boolean secureAdminEnabled;
+
+    private Path logFile;
+
+    private boolean needsAutoUpgrade;
+    private boolean needsManualUpgrade;
+
+    /**
+     * The <code>profiler<code> from <code>java-config</code> in domain.xml
+     */
+    private Profiler domainXMLJavaConfigProfiler;
+
+    /**
+     * The combined <code>jvm-options</code> from <code>java-config</code>,
+     * <code>profiler</code> in domain.xml and extra ones added by this launcher
+     */
+    private JvmOptions jvmOptions;
+
+    /**
+     * The debug port (<code>address</code>) primarily extracted from
+     * <code>domainXMLjavaConfigDebugOptions</code>
+     */
+    private Integer debugPort;
+
+    /**
+     * The debug suspend (<code>suspend</code>) primarily extracted from
+     * <code>domainXMLjavaConfigDebugOptions</code>
+     */
+    private boolean debugSuspend;
+
+    private boolean setup;
+
+    private File modulepath;
+    private File[] classpath;
+
 
     // sample profiler config
     //
@@ -44,21 +137,521 @@ class GlassFishMainLauncher extends GFLauncher {
 
     GlassFishMainLauncher(GFLauncherInfo info) {
         super(info);
+        pidBeforeRestart = resolvePidBeforeRestart();
     }
 
     @Override
-    List<File> getMainClasspath() throws GFLauncherException {
-        return List.of();
+    public Long getPidBeforeRestart() {
+        return this.pidBeforeRestart;
     }
 
     @Override
-    List<File> getMainModulepath() throws GFLauncherException {
-        Path installRoot = new File(getEnvProps().get(INSTALL_ROOT.getPropertyName())).toPath();
-        return List.of(installRoot.resolve(Path.of("lib", "bootstrap")).toAbsolutePath().normalize().toFile());
+    public File getAdminRealmKeyFile() {
+        return adminFileRealmKeyFile;
     }
 
     @Override
-    String getMainClass() throws GFLauncherException {
-        return MAIN_CLASS;
+    public boolean isSecureAdminEnabled() {
+        return secureAdminEnabled;
+    }
+
+    @Override
+    public Integer getDebugPort() {
+        return debugPort;
+    }
+
+    @Override
+    public boolean isSuspendEnabled() {
+        return getDebugPort() != null && debugSuspend;
+    }
+
+    @Override
+    public Path getLogFile() {
+        return logFile;
+    }
+
+    @Override
+    public final boolean needsAutoUpgrade() {
+        return needsAutoUpgrade;
+    }
+
+    @Override
+    public final boolean needsManualUpgrade() {
+        return needsManualUpgrade;
+    }
+
+
+    @Override
+    public void setup() throws GFLauncherException, MiniXmlParserException {
+        if (setup) {
+            throw new IllegalStateException("The setup() was already executed.");
+        }
+        setup = true;
+        final GFLauncherInfo callerParameters = getParameters();
+        callerParameters.setup();
+        setupLogLevels(callerParameters.isVerbose());
+
+        asenvProps = getAsEnvConfReader(callerParameters, isFakeLaunch()).getProps();
+
+        final MiniXmlParser domainXML = new MiniXmlParser(callerParameters.getConfigFile(),
+            callerParameters.getInstanceName());
+        final String domainName = domainXML.getDomainName();
+        if (ok(domainName)) {
+            callerParameters.setDomainName(domainName);
+        }
+
+        // Can be empty! Then local commands will set what they have from user
+        callerParameters.setXmlAdminAddresses(domainXML.getAdminAddresses());
+        domainXMLjavaConfig = new JavaConfig(domainXML.getJavaConfig());
+
+        domainXMLJavaConfigProfiler = createProfiler(domainXML);
+        jvmOptions = createJvmOptions(callerParameters, domainXMLJavaConfigProfiler, domainXML.getJvmOptions());
+
+        secureAdminEnabled = domainXML.getSecureAdminEnabled();
+
+        if (domainXML.isMonitoringEnabled()) {
+            setupMonitoring(callerParameters.getInstallDir());
+        }
+        final  Map<String, String> domainXMLSystemProperties = domainXML.getSystemProperties();
+        asenvProps.put(INSTANCE_ROOT.getSystemPropertyName(), callerParameters.getInstanceRootDir().getPath());
+
+        // Set the config java-home value as the Java home for the environment,
+        // unless it is empty or it is already referring to a substitution of
+        // the environment variable.
+        String javaHome = domainXMLjavaConfig.getJavaHome();
+        if (ok(javaHome) && !javaHome.trim().equals(JAVA_ROOT.toExpression())) {
+            asenvProps.put(JAVA_ROOT.getPropertyName(), javaHome);
+        }
+
+        domainXMLjavaConfigDebugOptions = getDebugOptionsFromDomainXMLJavaConfig(callerParameters);
+        setupDebugging(domainXMLjavaConfigDebugOptions);
+        domainXML.setupConfigDir(callerParameters.getConfigDir(), callerParameters.getInstallDir());
+
+
+        TokenResolver resolver = createTokenResolver(domainXMLSystemProperties);
+        resolveAllTokens(resolver);
+
+        adminFileRealmKeyFile = resolveAdminFileRealmKeyFile(domainXML, resolver);
+        logFile = resolveLogFile(domainXML.getLogFilename(), callerParameters, resolver);
+        GFLauncherLogger.addLogFileHandler(logFile);
+
+        javaExe = resolveJavaExecutable();
+
+        final Path installRoot = new File(asenvProps.get(INSTALL_ROOT.getPropertyName())).toPath();
+        modulepath = installRoot.resolve(Path.of("lib", "bootstrap")).toAbsolutePath().normalize().toFile();
+        classpath = createClasspath();
+        setCommandLine(prepareCommandLine(callerParameters));
+
+        // if no <network-config> element, we need to upgrade this domain
+        needsAutoUpgrade = !domainXML.hasNetworkConfig();
+        needsManualUpgrade = !domainXML.hasDefaultConfig();
+
+        // Moving and removing files
+        setupUpgradeSecurity(callerParameters);
+        renameOsgiCache(callerParameters);
+    }
+
+    private CommandLine prepareCommandLine(final GFLauncherInfo callerParameters) throws GFLauncherException {
+        final boolean useScript = !callerParameters.isVerboseOrWatchdog() && isSurviveWinUserSession();
+        final CommandLine cmdLine = new CommandLine(useScript ? CommandFormat.Script : CommandFormat.ProcessBuilder);
+        cmdLine.append(javaExe);
+        cmdLine.appendModulePath(modulepath);
+        if (classpath.length > 0) {
+            cmdLine.appendClassPath(classpath);
+        }
+        addIgnoreNull(cmdLine, domainXMLjavaConfigDebugOptions);
+
+        final String cliStartTime = System.getProperty("WALL_CLOCK_START");
+        if (cliStartTime != null) {
+            cmdLine.append("-DWALL_CLOCK_START=" + cliStartTime);
+        }
+
+        if (getDebugPort() != null) {
+            cmdLine.appendSystemOption(DEBUG_MODE_PROPERTY, TRUE.toString());
+        }
+
+        jvmOptions.toList().forEach(cmdLine::appendJavaOption);
+
+        GFLauncherNativeHelper nativeHelper = new GFLauncherNativeHelper(callerParameters, domainXMLjavaConfig,
+            jvmOptions, domainXMLJavaConfigProfiler);
+        cmdLine.appendNativeLibraryPath(nativeHelper.getNativePath());
+        cmdLine.append(MAIN_CLASS);
+
+        try {
+            addIgnoreNull(cmdLine, callerParameters.getArgsAsList());
+        } catch (GFLauncherException gfle) {
+            throw gfle;
+        } catch (Exception e) {
+            throw new GFLauncherException(e);
+        }
+        return cmdLine;
+    }
+
+
+    private ASenvPropertyReader getAsEnvConfReader(final GFLauncherInfo callerParameters, final boolean fakeLaunch) {
+        return fakeLaunch ? new ASenvPropertyReader(callerParameters.getInstallDir()) : new ASenvPropertyReader();
+    }
+
+    private Path resolveJavaExecutable() throws GFLauncherException {
+        final Path javaFromDomainXml = getJavaExecutable(domainXMLjavaConfig.getJavaHome());
+        if (javaFromDomainXml != null) {
+            return javaFromDomainXml;
+        }
+        final Path javaFromAsenv = getJavaExecutable(asenvProps.get(JAVA_ROOT.getPropertyName()));
+        if (javaFromAsenv != null) {
+            return javaFromAsenv;
+        }
+        throw new GFLauncherException("nojvm");
+    }
+
+    private Path getJavaExecutable(String filename) {
+        if (filename == null) {
+            return null;
+        }
+
+        final File javaDir = new File(filename);
+        if (!javaDir.isDirectory()) {
+            return null;
+        }
+
+        final File javaFile;
+        if (GFLauncherUtils.isWindows()) {
+            javaFile = new File(javaDir, "bin/java.exe");
+        } else {
+            javaFile = new File(javaDir, "bin/java");
+        }
+
+        if (javaFile.exists()) {
+            return javaFile.toPath().toAbsolutePath();
+        }
+        return null;
+    }
+
+
+    /**
+     * Resolves jvm-options against:
+     * <ol>
+     * <li>itself
+     * <li><system-property>'s from domain.xml
+     * <li>system properties -- essential there is, e.g. "${path.separator}" in domain.xml
+     * <li>asenvProps
+     * <li>env variables (if the above contain a switch to prefer env variables, then they go first,
+     *     before 1., i.e. add in reverse order to get the precedence right
+     * </ol>
+     *
+     * @param domainXMLSystemProperties
+     * @return {@link TokenResolver}
+     */
+    private TokenResolver createTokenResolver(final  Map<String, String> domainXMLSystemProperties) {
+        Map<String, String> all = new HashMap<>();
+        all.putAll(asenvProps);
+        all.putAll(propertiesToStringMap(System.getProperties()));
+        all.putAll(domainXMLSystemProperties);
+        all.putAll(jvmOptions.getCombinedMap());
+        all.putAll(domainXMLJavaConfigProfiler.getConfig());
+
+        if (!isEnvVarExpansionDisabled(all)) {
+            if (isPreferEnvOverProperties(all)) {
+                all.putAll(System.getenv());
+                replacePropertiesWithEnvVars(jvmOptions.xProps);
+                replacePropertiesWithEnvVars(jvmOptions.xxProps);
+                replacePropertiesWithEnvVars(jvmOptions.plainProps);
+                replacePropertiesWithEnvVars(jvmOptions.longProps);
+                replacePropertiesWithEnvVars(jvmOptions.sysProps);
+            } else {
+                System.getenv().forEach((name, value) -> all.putIfAbsent(name, value));
+            }
+        }
+        return new TokenResolver(all);
+    }
+
+
+    private void resolveAllTokens(TokenResolver resolver) {
+        resolver.resolve(jvmOptions.xProps);
+        resolver.resolve(jvmOptions.xxProps);
+        resolver.resolve(jvmOptions.plainProps);
+        resolver.resolve(jvmOptions.longProps);
+        resolver.resolve(jvmOptions.sysProps);
+        resolver.resolve(domainXMLjavaConfig.getMap());
+        resolver.resolve(domainXMLJavaConfigProfiler.getConfig());
+        resolver.resolve(domainXMLjavaConfigDebugOptions);
+    }
+
+    private void replacePropertiesWithEnvVars(Map<String, String> properties) {
+        Pattern invalidEnvVarCharsPattern = Pattern.compile("[^_0-9a-zA-Z]");
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String envValue = System.getenv(entry.getKey());
+            if (envValue != null) {
+                entry.setValue(envValue);
+            } else {
+                final String sanitizedKey = invalidEnvVarCharsPattern
+                        .matcher(entry.getKey())
+                        .replaceAll("_");
+                envValue = System.getenv(sanitizedKey);
+                if (envValue != null) {
+                    entry.setValue(envValue);
+                } else {
+                    envValue = System.getenv(sanitizedKey.toUpperCase());
+                    if (envValue != null) {
+                        entry.setValue(envValue);
+                    }
+                }
+            }
+
+        }
+    }
+
+    private Profiler createProfiler(MiniXmlParser domainXML) throws MiniXmlParserException {
+        // Add JVM options from Profiler *last* so they override config's JVM options
+        return new Profiler(domainXML.getProfilerConfig(), domainXML.getProfilerJvmOptions(),
+            domainXML.getProfilerSystemProperties());
+    }
+
+
+    private JvmOptions createJvmOptions(GFLauncherInfo callerParameters, Profiler profiler,
+        final List<String> domainXmlJvmOptions) throws GFLauncherException {
+        final Map<String, String> props = new HashMap<>();
+        props.put(INSTALL_ROOT.getSystemPropertyName(), callerParameters.getInstallDir().getAbsolutePath());
+        props.put(INSTANCE_ROOT.getSystemPropertyName(), callerParameters.getInstanceRootDir().getAbsolutePath());
+        List<String> rawJvmOptions = new ArrayList<>(domainXmlJvmOptions);
+        rawJvmOptions.addAll(propsToJvmOptions(props));
+        if (profiler.isEnabled()) {
+            rawJvmOptions.addAll(profiler.getJvmOptions());
+        }
+        JvmOptions jvm = new JvmOptions(rawJvmOptions);
+        if (callerParameters.isDropInterruptedCommands()) {
+            jvm.sysProps.put(DROP_INTERRUPTED_COMMANDS, TRUE.toString());
+        }
+
+        return jvm;
+    }
+
+    private void setupUpgradeSecurity(GFLauncherInfo callerParameters) throws GFLauncherException {
+        // If this is an upgrade and the security manager is on,
+        // copy the current server.policy file to the domain
+        // before the upgrade.
+        if (callerParameters.isUpgrade() && jvmOptions.sysProps.containsKey("java.security.manager")) {
+
+            LOG.log(INFO, "Will copy glassfish/lib/templates/server.policy file to domain before upgrading.");
+            Path source = callerParameters.getInstallDir().toPath().resolve(Path.of("lib", "templates", "server.policy"));
+            Path target = callerParameters.getConfigDir().toPath().resolve("server.policy");
+            try {
+                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException ioe) {
+                throw new GFLauncherException(
+                    "Could not copy server.policy to domain. You may need to turn off the security manager before upgrading. "
+                        + ioe.getMessage(),
+                    ioe);
+            }
+        }
+    }
+
+    /**
+     * Because of some issues in GlassFish OSGi launcher, a server updated from
+     * version 3.0.x to 3.1 won't start if a OSGi cache directory populated with
+     * 3.0.x modules is used. So, as a work around, we rename the cache
+     * directory when upgrade path is used. See GLASSFISH-15772 for more
+     * details.
+     *
+     * @throws GFLauncherException if it fails to rename the cache directory
+     */
+    private void renameOsgiCache(GFLauncherInfo callerParameters) throws GFLauncherException {
+        if (callerParameters.isUpgrade()) {
+            File osgiCacheDir = new File(callerParameters.getDomainRootDir(), "osgi-cache");
+            File backupOsgiCacheDir = new File(callerParameters.getDomainRootDir(), "osgi-cache-" + System.currentTimeMillis());
+            if (osgiCacheDir.exists() && !backupOsgiCacheDir.exists()) {
+                if (FileUtils.renameFile(osgiCacheDir, backupOsgiCacheDir)) {
+                    GFLauncherLogger.fine("rename_osgi_cache_succeeded", osgiCacheDir, backupOsgiCacheDir);
+                } else {
+                    throw new GFLauncherException("rename_osgi_cache_failed", osgiCacheDir, backupOsgiCacheDir);
+                }
+            }
+        }
+    }
+
+    private void setupMonitoring(File installDirr) {
+        // if the user has a hard-coded "-javaagent" jvm-option that uses OUR jar
+        // then we do NOT want to add our own.
+        Set<String> plainKeys = jvmOptions.plainProps.keySet();
+        for (String key : plainKeys) {
+            if (key.startsWith("javaagent:")) {
+                // complications -- of course!! They may have mix&match forward and back slashes
+                key = key.replace('\\', '/');
+                if (key.indexOf(FLASHLIGHT_AGENT_NAME) >= 0) {
+                    return; // Done!!!!
+                }
+            }
+        }
+
+        // It is not already specified AND monitoring is enabled.
+        try {
+            jvmOptions.plainProps.put(getMonitoringAgentJvmOptionString(installDirr), null);
+        } catch (GFLauncherException gfe) {
+            // This has been defined as a non-fatal error.
+            // Silently ignore it -- but do NOT add it as an option
+        }
+    }
+
+    private static Boolean isPreferEnvOverProperties(Map<String, String> properties) {
+        return Boolean.parseBoolean(properties.get(PREFER_ENV_VARS_OVER_PROPERTIES));
+    }
+
+    private static boolean isEnvVarExpansionDisabled(Map<String, String> all) {
+        return Boolean.parseBoolean(all.get(DISABLE_ENV_VAR_EXPANSION_PROPERTY));
+    }
+
+    private List<String> getDebugOptionsFromDomainXMLJavaConfig(GFLauncherInfo callerParameters) {
+        if (callerParameters.isDebug() || callerParameters.isSuspend() || domainXMLjavaConfig.isDebugEnabled()) {
+            // Suspend setting from domain.xml can be overridden by caller
+            if (!callerParameters.isSuspend()) {
+                return domainXMLjavaConfig.getDebugOptions();
+            }
+            return domainXMLjavaConfig.getDebugOptions().stream().filter(e -> e.startsWith("-agentlib:jdwp"))
+                    .map(e -> e.replace("suspend=n", "suspend=y")).collect(toList());
+        }
+        return emptyList();
+    }
+    private List<String> propsToJvmOptions(Map<String, String> map) {
+        List<String> sysProps = new ArrayList<>();
+        Set<Map.Entry<String, String>> entries = map.entrySet();
+
+        for (Map.Entry<String, String> entry : entries) {
+            String name = entry.getKey();
+            String value = entry.getValue();
+            String jvm = "-D" + name;
+
+            if (value != null) {
+                jvm += "=" + value;
+            }
+
+            sysProps.add(jvm);
+        }
+
+        return sysProps;
+    }
+
+    private void setupLogLevels(boolean verbose) {
+        if (verbose) {
+            GFLauncherLogger.setConsoleLevel(java.util.logging.Level.INFO);
+        } else {
+            GFLauncherLogger.setConsoleLevel(java.util.logging.Level.WARNING);
+        }
+    }
+
+
+    /** create a list of all the classpath pieces in the right order */
+    private File[] createClasspath() {
+        List<File> all = new ArrayList<>();
+        all.addAll(domainXMLjavaConfig.getPrefixClasspath());
+        all.addAll(domainXMLJavaConfigProfiler.getClasspath());
+        all.addAll(domainXMLjavaConfig.getSystemClasspath());
+        all.addAll(domainXMLjavaConfig.getEnvClasspath());
+        all.addAll(domainXMLjavaConfig.getSuffixClasspath());
+        return all.toArray(File[]::new);
+    }
+
+
+    /**
+     *
+     * look for an option of this form:
+     * <code>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9009</code>
+     * and extract the suspend and port values.
+     *
+     */
+    private void setupDebugging(List<String> domainXMLjavaConfigDebugOptions) {
+        for (String option : domainXMLjavaConfigDebugOptions) {
+            if (!option.startsWith("-agentlib:jdwp")) {
+                continue;
+            }
+
+            String[] attributes = option.substring(10).split(",");
+            for (String attribute : attributes) {
+                if (attribute.startsWith("address=")) {
+                    try {
+                        debugPort = Integer.parseInt(attribute.substring(10));
+                    } catch (NumberFormatException ex) {
+                        debugPort = null;
+                    }
+                }
+
+                if (attribute.startsWith("suspend=")) {
+                    try {
+                        debugSuspend = attribute.substring(8).toLowerCase(Locale.getDefault()).equals("y");
+                    } catch (Exception ex) {
+                        debugSuspend = false;
+                    }
+                }
+            }
+        }
+    }
+
+    private static String getMonitoringAgentJvmOptionString(File installDir) throws GFLauncherException {
+        File libMonDir = new File(installDir, LIBMON_NAME);
+        File flashlightJarFile = new File(libMonDir, FLASHLIGHT_AGENT_NAME);
+
+        if (flashlightJarFile.isFile()) {
+            return "javaagent:" + flashlightJarFile.toPath().toAbsolutePath().normalize();
+        }
+        GFLauncherLogger.warning(GFLauncherLogger.NO_FLASHLIGHT_AGENT, flashlightJarFile);
+        throw new GFLauncherException("no_flashlight_agent", flashlightJarFile);
+    }
+
+
+    private static File resolveAdminFileRealmKeyFile(MiniXmlParser domainXML, TokenResolver resolver) {
+        final Map<String, String> realmprops = domainXML.getAdminRealmProperties();
+        if (realmprops == null) {
+            return null;
+        }
+        final String classname = realmprops.get("classname");
+        final String keyfile = realmprops.get("file");
+        // Do not include class reference, we see it in compilation, but not in server's asadmin!
+        if (keyfile == null || !"com.sun.enterprise.security.auth.realm.file.FileRealm".equals(classname)) {
+            return null;
+        }
+        return new File(resolver.resolve(keyfile));
+    }
+
+    private static Path resolveLogFile(String domainXmlLogFile, GFLauncherInfo callerParameters, TokenResolver resolver)
+        throws GFLauncherException {
+        final String stringPath = ok(domainXmlLogFile) ? domainXmlLogFile : "logs/server.log";
+        final Path logFilePath = Path.of(resolver.resolve(stringPath));
+        // this is quite normal. Logging Service will by default return a relative path!
+        if (logFilePath.isAbsolute()) {
+            return logFilePath.normalize();
+        }
+        return callerParameters.getInstanceRootDir().toPath().resolve(logFilePath).normalize();
+    }
+
+    private static Long resolvePidBeforeRestart() {
+        String pid = System.getProperty("AS_RESTART_PREVIOUS_PID");
+        if (pid == null) {
+            return null;
+        }
+        try {
+            return Long.valueOf(pid);
+        } catch (NumberFormatException e) {
+            LOG.log(WARNING, "Cannot parse pid {0} required for waiting for the death of the parent process.", pid);
+            return null;
+        }
+    }
+
+
+    private static boolean isSurviveWinUserSession() {
+        String surviveSessionValue = System.getenv("AS_SURVIVE_WIN_USER_SESSION");
+        if (surviveSessionValue == null) {
+            return isWindows() && isOverSSHSession();
+        }
+        return Boolean.parseBoolean(surviveSessionValue);
+    }
+
+    private static boolean isOverSSHSession() {
+        return System.getenv("SSH_CLIENT") != null || System.getenv("SSH_CONNECTION") != null
+                || System.getenv("SSH_TTY") != null;
+    }
+
+    private static void addIgnoreNull(CommandLine command, Collection<String> values) {
+        if (values != null && !values.isEmpty()) {
+            values.forEach(command::append);
+        }
     }
 }

--- a/nucleus/admin/launcher/src/main/resources/com/sun/enterprise/admin/launcher/LocalStrings.properties
+++ b/nucleus/admin/launcher/src/main/resources/com/sun/enterprise/admin/launcher/LocalStrings.properties
@@ -45,10 +45,6 @@ respawninfo.illegalToken=It is illegal to use this special token [{1}] in any co
   It was found in this argument: {0}
 Wait a moment longer.  Always call launch before calling this method.
 #
-# issue 11665
-copy_server_policy_error=Could not copy server.policy to domain. You may need to turn off the \
-   security manager before upgrading.\nCause: {0}
-
 #issue 15772
 rename_osgi_cache_failed=Failed to rename OSGi persistence store from {0} to {1}
 rename_osgi_cache_succeeded=Renamed OSGi persistence store from {0} to {1}

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeAdminPasswordCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ChangeAdminPasswordCommand.java
@@ -29,6 +29,7 @@ import com.sun.enterprise.util.SystemPropertyConstants;
 import com.sun.enterprise.util.net.NetUtils;
 
 import java.io.Console;
+import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
 
@@ -174,9 +175,9 @@ public class ChangeAdminPasswordCommand extends LocalDomainCommand {
 
         try {
             GFLauncher launcher = GFLauncherFactory.getInstance(RuntimeType.DAS);
-            GFLauncherInfo info = launcher.getInfo();
-            info.setDomainName(domainName);
-            info.setDomainParentDir(domainDir);
+            GFLauncherInfo launchParams = launcher.getParameters();
+            launchParams.setDomainName(domainName);
+            launchParams.setDomainParentDir(domainDir);
             launcher.setup();
 
             //If secure admin is enabled and if new password is null
@@ -187,7 +188,7 @@ public class ChangeAdminPasswordCommand extends LocalDomainCommand {
                 }
             }
 
-            String adminKeyFile = launcher.getAdminRealmKeyFile();
+            File adminKeyFile = launcher.getAdminRealmKeyFile();
 
             if (adminKeyFile == null) {
                 //Cannot change password locally for non file realms

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/LocalServerCommand.java
@@ -420,7 +420,7 @@ public abstract class LocalServerCommand extends CLICommand {
         final ServerLifeSignChecker checker = new ServerLifeSignChecker(lifeSignCheck, pidFile, adminEndpointsSupplier, printDots);
         final GlassFishProcess process = GlassFishProcess.of(pid);
         final ServerLifeSigns signs = checker.watchStartup(process, startTimeout);
-        final String report = report(signs);
+        final String report = report(signs, lifeSignCheck.isPrintServerOutput(signs.isError()));
         if (signs.isError()) {
             throw new CommandException(report);
         }
@@ -437,7 +437,7 @@ public abstract class LocalServerCommand extends CLICommand {
         return error + "\n" + restartLog;
     }
 
-    private String report(ServerLifeSigns signs) {
+    private String report(ServerLifeSigns signs, boolean printOutput) {
         final StringBuilder report = new StringBuilder(2048);
         report.append('\n').append(signs.getSummary());
         if (signs.getSuggestion() != null) {
@@ -448,7 +448,7 @@ public abstract class LocalServerCommand extends CLICommand {
         if (situationReport != null) {
             report.append(signs.getSituationReport());
         }
-        if (signs.isError()) {
+        if (printOutput) {
             final String restartLog = loadRestartLog(serverDirs.getRestartLogFile());
             if (restartLog != null) {
                 report.append('\n').append(restartLog);

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
@@ -36,8 +36,8 @@ import org.jvnet.hk2.annotations.Service;
 
 import static com.sun.enterprise.admin.cli.CLIConstants.DEATH_TIMEOUT_MS;
 import static com.sun.enterprise.admin.cli.CLIConstants.WAIT_FOR_DAS_TIME_MS;
-import static com.sun.enterprise.admin.servermgmt.cli.ServerLifeSignChecker.step;
 import static com.sun.enterprise.admin.servermgmt.cli.StartServerHelper.parseCustomEndpoints;
+import static com.sun.enterprise.admin.servermgmt.util.CommandAction.step;
 
 /**
  * THe restart-domain command. The local portion of this command is only used to block until:
@@ -112,6 +112,10 @@ public class RestartDomainCommand extends StopDomainCommand {
             startTimeout = timeout;
         }
 
+        // Well, this looks duplicit, but it is not. The port watcher starts before we run the command
+        // on the instance. It will attach to the admin endpoint and wait for the disconnection.
+        // Meanwhile we ask the instance for restart.
+        // After we are sure that the server stopped, we will monitor its start.
         if (portWatcher != null && !portWatcher.get(startTimeout)) {
             logger.warning("The endpoint is still listening after timeout: " + oldAdminAddress);
         }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
@@ -175,7 +175,6 @@ public class RestartDomainCommand extends StopDomainCommand {
         opts.add("--check-admin-port");
         opts.add(Boolean.toString(checkAdminEndpoint));
         if (printServerOutput != null) {
-            // TODO: At this moment works just when the domain was not running
             opts.add("--server-output");
             opts.add(Boolean.toString(printServerOutput));
         }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ServerLifeSignCheck.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ServerLifeSignCheck.java
@@ -105,4 +105,12 @@ public class ServerLifeSignCheck {
     public List<HostAndPort> getCustomEndpoints() {
         return customEndpoints;
     }
+
+    /**
+     * @param wasError
+     * @return if the output should be printed or not.
+     */
+    public boolean isPrintServerOutput(boolean wasError) {
+        return getPrintServerOutput() == Boolean.TRUE || (wasError && getPrintServerOutput() == null);
+    }
 }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartDomainCommand.java
@@ -28,6 +28,7 @@ import com.sun.enterprise.universal.xml.MiniXmlParserException;
 import com.sun.enterprise.util.HostAndPort;
 import com.sun.enterprise.util.ObjectAnalyzer;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -192,7 +193,7 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
     @Override
     public final GFLauncher createLauncher() throws GFLauncherException, MiniXmlParserException, CommandException {
         final GFLauncher gfLauncher = GFLauncherFactory.getInstance(getType());
-        launchParameters = gfLauncher.getInfo();
+        launchParameters = gfLauncher.getParameters();
         launchParameters.setDomainName(getDomainName());
         launchParameters.setDomainParentDir(getDomainsDir().getPath());
         launchParameters.setVerbose(verbose || upgrade);
@@ -284,7 +285,7 @@ public class StartDomainCommand extends LocalDomainCommand implements StartServe
      * NOTE: this depends on glassFishLauncher.setup having already been called.
      */
     private void doAdminPasswordCheck() throws CommandException {
-        String adminRealmKeyFile = launcher.getAdminRealmKeyFile();
+        File adminRealmKeyFile = launcher.getAdminRealmKeyFile();
         if (adminRealmKeyFile == null) {
             return;
         }

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -169,9 +169,7 @@ public final class StartServerHelper {
         }
         // Print output just if user explicitly asked
         // or start failed and user did not explicitly forbid the print.
-        if (launcher.getPidBeforeRestart() != null
-            || lifeSignCheck.getPrintServerOutput() == Boolean.TRUE
-            || (signs.isError() && lifeSignCheck.getPrintServerOutput() != Boolean.FALSE)) {
+        if (launcher.getPidBeforeRestart() != null || lifeSignCheck.isPrintServerOutput(signs.isError())) {
             report.append("\n\n").append(getProcessOutput());
         }
         return report.append('\n').toString();

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainSecurity.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/domain/DomainSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -43,8 +43,7 @@ public class DomainSecurity extends MasterPasswordFileManager {
      * @param password Password.
      */
     void processAdminKeyFile(File keyFile, String user, String password, final String[] adminUserGroups) throws IOException {
-        final String keyFilePath = keyFile.getAbsolutePath();
-        final FileRealmHelper fileRealm = new FileRealmHelper(keyFilePath);
+        final FileRealmHelper fileRealm = new FileRealmHelper(keyFile.getAbsoluteFile());
         final String[] group = adminUserGroups;
         fileRealm.addUser(user, password.toCharArray(), group);
         fileRealm.persist();

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/util/CommandAction.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/util/CommandAction.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.admin.servermgmt.util;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.glassfish.api.admin.CommandException;
+
+/**
+ * Action to be executed by {@link #step(String, Duration, CommandAction)} and wraoped by a simple time
+ * monitoring report.
+ * Example of the standard output:
+ * <pre>
+ * Waiting until start of domain domain1 completes... finished after 1488 ms
+ * </pre>
+ */
+@FunctionalInterface
+public interface CommandAction {
+
+    /**
+     * Action implementation.
+     * Use {@link #step(String, Duration, CommandAction)} to execute the action.
+     *
+     * @throws CommandException
+     */
+    void action() throws CommandException;
+
+    /**
+     * Action to be executed by {@link #step(String, Duration, CommandAction)} and wraoped by a simple time
+     * monitoring report.
+     * Example of the standard output:
+     * <pre>
+     * Waiting until start of domain domain1 completes... finished after 1488 ms
+     * </pre>
+     * @param message The message will be printed before the action.
+     * @param timeout can be null
+     * @param action action to be executed
+     * @return remaining timeout.
+     * @throws CommandException
+     */
+    static Duration step(String message, Duration timeout, CommandAction action) throws CommandException {
+        if (timeout != null && timeout.isNegative()) {
+            return timeout;
+        }
+        if (message != null) {
+            System.out.print(message);
+        }
+        Instant start = Instant.now();
+        action.action();
+        Duration stopDuration = Duration.between(start, Instant.now());
+        if (message != null) {
+            System.out.println(" ... finished after " + stopDuration.toMillis() + " ms.");
+        }
+        return timeout == null ? null : timeout.minus(stopDuration);
+    }
+}

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/restart-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/restart-domain.1
@@ -10,6 +10,7 @@ SYNOPSIS
         [--force[=<force(default:true)>]]
         [--help|-?]
         [--kill[=<kill(default:false)>]]
+        [--server-output|-o=<server-output(default:false)>]]
         [--timeout <timeout>]
         [domain_name]
 
@@ -88,6 +89,18 @@ OPTIONS
            true
                The domain is killed. The subcommand uses functionality of the
                operating system to terminate the domain process.
+
+       --server-output, -o
+           Specifies if the command should or should not print the server output.
+           If not set, server prints the output just when the command failed.
+
+           Possible values are as follows:
+
+           true
+              The output of the server startup will be printed after the command finishes.
+
+           false
+               The output of the server startup will not be printed.
 
        --timeout
             Specifies timeout in seconds to evaluate the expected result.

--- a/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1
+++ b/nucleus/admin/server-mgmt/src/main/manpages/com/sun/enterprise/admin/servermgmt/cli/start-domain.1
@@ -10,6 +10,7 @@ SYNOPSIS
         [--drop-interrupted-commands[=<drop-interrupted-commands(default:false)>]]
         [--dry-run|-n[=<dry-run(default:false)>]]
         [--help|-?]
+        [--server-output|-o=<server-output(default:false)>]]
         [--suspend|-s[=<suspend(default:false)>]]
         [--timeout <timeout>]
         [--upgrade[=<upgrade(default:false)>]]
@@ -97,6 +98,18 @@ OPTIONS
        --help, -?
            Displays the help text for the subcommand.
 
+       --server-output, -o
+           Specifies if the command should or should not print the server output.
+           If not set, server prints the output just when the command failed.
+
+           Possible values are as follows:
+
+           true
+              The output of the server startup will be printed after the command finishes.
+
+           false
+               The output of the server startup will not be printed.
+
        --suspend, -s
            Specifies whether the domain is started with Java Platform Debugger
            Architecture (JPDA) debugging enabled and suspends the newly started VM
@@ -106,18 +119,18 @@ OPTIONS
 
            Possible values are as follows:
 
-          true
+           true
               The instance is started with JPDA debugging enabled and a suspend policy
               of `SUSPEND_ALL`. The port number for JPDA debugging is displayed.
 
-          false
+           false
               The instance is started with JPDA debugging disabled (default).
 
        --timeout
-            Specifies timeout in seconds to evaluate the expected result.
-            If the timeout is exceeded, the command fails - however it does
-            not mean it did not make any changes. The domain status is unknown
-            in such case.
+           Specifies timeout in seconds to evaluate the expected result.
+           If the timeout is exceeded, the command fails - however it does
+           not mean it did not make any changes. The domain status is unknown
+           in such case.
 
        --upgrade
            Specifies whether the configuration of the domain administration

--- a/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-instance.1
+++ b/nucleus/cluster/admin/src/main/manpages/com/sun/enterprise/v3/admin/cluster/start-instance.1
@@ -99,10 +99,10 @@ OPTIONS
                the instance's directories.
 
        --timeout
-            Specifies timeout in seconds to evaluate the expected result.
-            If the timeout is exceeded, the command fails - however it does
-            not mean it did not make any changes. The instance status is unknown
-            in such case.
+           Specifies timeout in seconds to evaluate the expected result.
+           If the timeout is exceeded, the command fails - however it does
+           not mean it did not make any changes. The instance status is unknown
+           in such case.
 
 OPERANDS
        instance-name

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/RestartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/RestartLocalInstanceCommand.java
@@ -37,7 +37,7 @@ import org.jvnet.hk2.annotations.Service;
 
 import static com.sun.enterprise.admin.cli.CLIConstants.DEATH_TIMEOUT_MS;
 import static com.sun.enterprise.admin.cli.CLIConstants.WAIT_FOR_DAS_TIME_MS;
-import static com.sun.enterprise.admin.servermgmt.cli.ServerLifeSignChecker.step;
+import static com.sun.enterprise.admin.servermgmt.util.CommandAction.step;
 
 /**
  * @author Byron Nevins
@@ -81,6 +81,10 @@ public class RestartLocalInstanceCommand extends StopLocalInstanceCommand {
             startTimeout = timeout;
         }
 
+        // Well, this looks duplicit, but it is not. The port watcher starts before we run the command
+        // on the instance. It will attach to the admin endpoint and wait for the disconnection.
+        // Meanwhile we ask the instance for restart.
+        // After we are sure that the server stopped, we will monitor its start.
         if (portWatcher != null && !portWatcher.get(startTimeout)) {
             logger.warning("The endpoint is still listening after timeout: " + oldAdminAddress);
         }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/StartLocalInstanceCommand.java
@@ -165,7 +165,7 @@ public class StartLocalInstanceCommand extends SynchronizeInstanceCommand implem
     @Override
     public final GFLauncher createLauncher() throws GFLauncherException, MiniXmlParserException, CommandException {
         final GFLauncher gfLauncher = GFLauncherFactory.getInstance(getType());
-        this.launchParameters = gfLauncher.getInfo();
+        this.launchParameters = gfLauncher.getParameters();
         launchParameters.setInstanceName(instanceName);
         launchParameters.setInstanceRootDir(instanceDir);
         launchParameters.setVerbose(verbose);

--- a/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/start-local-instance.1
+++ b/nucleus/cluster/cli/src/main/manpages/com/sun/enterprise/admin/cli/cluster/start-local-instance.1
@@ -11,6 +11,7 @@ SYNOPSIS
         [--help|-?]
         [--node <node>]
         [--nodedir <nodedir>]
+        [--server-output|-o=<server-output(default:false)>]]
         [--sync <sync(default:normal)>]
         [--timeout <timeout>]
         [--verbose|-v[=<verbose(default:false)>]]
@@ -76,6 +77,18 @@ OPTIONS
            Specifies the directory that contains the instance's node
            directory. The instance's files are stored in the instance's node
            directory. The default is as-install/nodes.
+
+       --server-output, -o
+           Specifies if the command should or should not print the server output.
+           If not set, server prints the output just when the command failed.
+
+           Possible values are as follows:
+
+           true
+              The output of the server startup will be printed after the command finishes.
+
+           false
+              The output of the server startup will not be printed.
 
        --sync
            The type of synchronization between the DAS and the instance's

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -204,7 +204,7 @@ public final class ProcessUtils {
         final boolean result = action.get();
         DotPrinter.stopWaiting(dotPrinter);
         final long millis = Duration.between(start, Instant.now()).toMillis();
-        LOG.log(result ? DEBUG : WARNING, () -> "Waiting finished after " + millis + " ms. Endpoint " + endpoint
+        LOG.log(DEBUG, () -> "Waiting finished after " + millis + " ms. Endpoint " + endpoint
             + (result ? " stopped" : " did not stop") + " listening.");
         return result;
     }
@@ -302,7 +302,7 @@ public final class ProcessUtils {
         final Boolean result = action.get();
         DotPrinter.stopWaiting(dotPrinter);
         final long millis = Duration.between(start, Instant.now()).toMillis();
-        LOG.log(result ? DEBUG : INFO,
+        LOG.log(DEBUG,
             () -> "Waiting finished after " + millis + " ms. Action " + (result ? "succeeded." : "timed out."));
         return result;
     }
@@ -394,7 +394,6 @@ public final class ProcessUtils {
                     System.out.flush();
                 }
             } catch (InterruptedException e) {
-                System.out.println();
                 Thread.currentThread().interrupt();
             }
         }

--- a/nucleus/common/common-util/src/main/java/org/glassfish/security/common/FileRealmHelper.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/security/common/FileRealmHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -113,13 +113,12 @@ public final class FileRealmHelper
      * @exception IOException If the configuration parameters
      *     identify a corrupt keyfile
      */
-    public FileRealmHelper(String keyfileName) throws IOException
-    {
-        keyfile = new File(keyfileName);
+    public FileRealmHelper(File keyfile) throws IOException {
+        this.keyfile = keyfile;
         // if not existent, try to create
         if (!keyfile.exists()) {
             if (keyfile.createNewFile() == false) {
-                throw new IOException(sm.getString("filerealm.badwrite", keyfileName));
+                throw new IOException(sm.getString("filerealm.badwrite", keyfile));
             }
         }
         loadKeyFile();

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/file/FileRealm.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/auth/realm/file/FileRealm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -27,6 +27,7 @@ import com.sun.enterprise.security.auth.realm.exceptions.NoSuchRealmException;
 import com.sun.enterprise.security.auth.realm.exceptions.NoSuchUserException;
 import com.sun.enterprise.security.util.IASSecurityException;
 
+import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -191,10 +192,13 @@ public final class FileRealm extends Realm {
         _logger.log(FINE, "FileRealm : " + JAAS_CONTEXT_PARAM + "={0}", jaasCtx);
 
         try {
+            final File realmFile;
             if (isEmbeddedServer()) {
-                file = writeConfigFileToTempDir(file).getAbsolutePath();
+                realmFile = writeConfigFileToTempDir(file).getAbsoluteFile();
+            } else {
+                realmFile = new File(file);
             }
-            fileRealmHelper = new FileRealmHelper(file);
+            fileRealmHelper = new FileRealmHelper(realmFile);
         } catch (IOException ioe) {
             throw new BadRealmException(MessageFormat.format("Unable to create keyfile: {0}", ioe.toString()));
         }


### PR DESCRIPTION
- Refactoring around GFLauncher and both children
- Fixed printing output for restart-domain
- Fixed links to JPDA
- Improved output of start/restart commands
  - ie. Konsole in KDE now allows to click directly on the admin endpoint link and open it in a default browser
- I did not document other parameters added in #25790 , because it is not much safe to use them as I tried locally and on Windows machines. They might be useful sometimes, however, ie. when we start docker container, and we don't care about the admin port, just about PID. However there we would still use rather start-serv ... it depends, because sometimes I am restarting domain in container, and in such case I prefer asadmin. We have pretty flexible monster ;-)

```
/usr/lib/jvm/jdk25/bin/java ./glassfish7/bin/asadmin.java restart-domain 
Server is not running, will attempt to start it...
Waiting until start of domain domain1 completes.. ... finished after 1446 ms.

Successfully started the domain domain1.
  Location: /app/appservers/glassfish7/glassfish/domains/domain1
  Log File: /app/appservers/glassfish7/glassfish/domains/domain1/logs/server.log
  The pid file /app/appservers/glassfish7/glassfish/domains/domain1/config/pid contains pid 2462207.
  Process with pid 2462207 is alive
  Admin Endpoints:
    http://localhost:4848 is reachable.

Command restart-domain executed successfully.

```
