### PR TITLE
Fixed NPE and noticed NPE in JDK code

### DIFF
--- a/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/managedbean/ManagedBeanManagerImpl.java
+++ b/appserver/common/container-common/src/main/java/com/sun/enterprise/container/common/impl/managedbean/ManagedBeanManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -418,7 +418,9 @@ public class ManagedBeanManagerImpl implements ManagedBeanManager, PostConstruct
 
             // Need to keep track of context in order to destroy properly
             Map<Object, CDIInjectionContext> bundleNonManagedObjs = cdiManagedBeanInstanceMap.get(bundleDescriptor);
-            bundleNonManagedObjs.put(callerObject, cdiContext);
+            if (bundleNonManagedObjs != null) {
+                bundleNonManagedObjs.put(callerObject, cdiContext);
+            }
 
         } else {
             JavaEEInterceptorBuilder interceptorBuilder = (JavaEEInterceptorBuilder) managedBeanDescriptor.getInterceptorBuilder();

--- a/appserver/tests/tck/embedded_ejb_smoke/runner/pom.xml
+++ b/appserver/tests/tck/embedded_ejb_smoke/runner/pom.xml
@@ -60,6 +60,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.main.distributions</groupId>
             <artifactId>glassfish</artifactId>
             <type>zip</type>

--- a/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
+++ b/appserver/tests/tck/embedded_ejb_smoke/runner/src/test/java/com/sun/ts/run/EmbeddedRunnerITest.java
@@ -16,6 +16,7 @@
 package com.sun.ts.run;
 
 import com.sun.ts.lib.harness.ExecTSTestCmd;
+import com.sun.javatest.Status;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -80,13 +81,14 @@ public class EmbeddedRunnerITest {
                 "-Djava.util.logging.config.file=" + System.getProperty("glassfish.home") + "/glassfish/domains/domain1/config/logging.properties",
                 "-Dtest.ejb.stateful.timeout.wait.seconds=180 ",
                 "-Ddeliverable.class=com.sun.ts.lib.deliverable.cts.CTSDeliverable",
-
+                "--module-path", System.getProperty("glassfish.home") + "/glassfish/lib/bootstrap",
+                "--add-modules", "ALL-MODULE-PATH",
                 "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
                 "--add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED",
                 "--add-opens=java.base/java.lang=ALL-UNNAMED",
                 "--add-opens=java.base/java.util=ALL-UNNAMED",
                 "--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED",
-                "--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED")
+                "--add-opens=java.naming/javax.naming.spi=org.glassfish.main.jdke")
             ;
 
         if (System.getProperty("maven.tck.debug") != null && !System.getProperty("maven.tck.debug").isEmpty()) {
@@ -124,10 +126,8 @@ public class EmbeddedRunnerITest {
 
         return String.join(":", List.of(
             localRepository + "/org/glassfish/main/tests/tck/tsharness/" + glassfishVersion + "/tsharness-" + glassfishVersion + ".jar",
-            localRepository + "/org/apache/commons/commons-lang3/3.3.2/commons-lang3-3.3.2.jar",
             System.getProperty("glassfish.home") + "/glassfish/lib/embedded/glassfish-embedded-static-shell.jar",
             copiedEjbJar.toString()
         ));
     }
-
 }


### PR DESCRIPTION
* Embedded tests in the Ant block had BindingException on HTTPS port and failed to start
* Temurin JDK 21

Then embedded had two failures in logs
* NPE in cleaning of thread local references - JDK code, so I just wrapped it with some comment. From time to time we can check the JDK code if it improved somehow. It still should be printed to logs.

<details>
<summary>Stack Trace</summary>

```
00:47:21.479       [java] WARNING: Failed to check for ThreadLocal references for web application [sample]
00:47:21.479       [java] java.lang.reflect.InvocationTargetException
00:47:21.479       [java] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:115)
00:47:21.479       [java] 	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
00:47:21.479       [java] 	at org.glassfish.web.loader.ReferenceCleaner.checkThreadLocalsForLeaks(ReferenceCleaner.java:137)
00:47:21.479       [java] 	at org.glassfish.web.loader.ReferenceCleaner.clearReferences(ReferenceCleaner.java:75)
00:47:21.479       [java] 	at org.glassfish.web.loader.WebappClassLoader.close(WebappClassLoader.java:1149)
00:47:21.479       [java] 	at org.glassfish.web.loader.WebappClassLoader.preDestroy(WebappClassLoader.java:1208)
00:47:21.479       [java] 	at org.glassfish.deployment.common.DeploymentContextImpl.getClassLoader(DeploymentContextImpl.java:252)
00:47:21.479       [java] 	at org.glassfish.deployment.common.DeploymentContextImpl.getClassLoader(DeploymentContextImpl.java:204)
00:47:21.479       [java] 	at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:517)
00:47:21.479       [java] 	at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:256)
00:47:21.479       [java] 	at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:475)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:549)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:545)
00:47:21.479       [java] 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
00:47:21.479       [java] 	at java.base/javax.security.auth.Subject.doAs(Subject.java:453)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:545)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:574)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:566)
00:47:21.479       [java] 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
00:47:21.479       [java] 	at java.base/javax.security.auth.Subject.doAs(Subject.java:453)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:566)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1441)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:187)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:166)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:159)
00:47:21.479       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:49)
00:47:21.479       [java] 	at com.sun.enterprise.admin.cli.embeddable.DeployerImpl.deploy(DeployerImpl.java:114)
00:47:21.479       [java] 	at org.glassfish.ejb.embedded.EJBContainerImpl.deploy(EJBContainerImpl.java:119)
00:47:21.479       [java] 	at org.glassfish.ejb.embedded.EJBContainerProviderImpl.createEJBContainer(EJBContainerProviderImpl.java:125)
00:47:21.479       [java] 	at jakarta.ejb.embeddable.EJBContainer.createEJBContainer(EJBContainer.java:91)
00:47:21.479       [java] 	at com.acme.Client.testREST(Client.java:111)
00:47:21.479       [java] 	at com.acme.Client.main(Client.java:57)
00:47:21.479       [java] Caused by: java.lang.NullPointerException: Cannot assign field "value" because "tab[staleSlot]" is null
00:47:21.479       [java] 	at java.base/java.lang.ThreadLocal$ThreadLocalMap.expungeStaleEntry(ThreadLocal.java:674)
00:47:21.479       [java] 	at java.base/java.lang.ThreadLocal$ThreadLocalMap.expungeStaleEntries(ThreadLocal.java:797)
00:47:21.479       [java] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
00:47:21.479       [java] 	... 31 more
```
</details>

* NPE in ManagedBeanManagerImpl - probably easy to fix, however it might not be everything.

<details>
<summary>Stack Trace</summary>

```
00:47:22.538       [java] in flushAll , creating new testSuiteHash
00:47:22.538       [java] Dec 02, 2025 11:47:22 PM org.apache.catalina.core.ContainerBase addChildInternal
00:47:22.538       [java] SEVERE: ContainerBase.addChild: start: 
00:47:22.538       [java] org.apache.catalina.LifecycleException: java.lang.IllegalArgumentException: jakarta.servlet.ServletException: com.sun.enterprise.container.common.spi.util.InjectionException: Error creating managed object for class: class org.jboss.weld.module.web.servlet.WeldListener
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.start(StandardContext.java:4457)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebModule.start(WebModule.java:549)
00:47:22.538       [java] 	at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:935)
00:47:22.538       [java] 	at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:917)
00:47:22.538       [java] 	at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:653)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebContainer.loadWebModule(WebContainer.java:1804)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebContainer.loadWebModule(WebContainer.java:1484)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebApplication.start(WebApplication.java:88)
00:47:22.538       [java] 	at org.glassfish.internal.data.EngineRef.start(EngineRef.java:97)
00:47:22.538       [java] 	at org.glassfish.internal.data.ModuleInfo.start(ModuleInfo.java:278)
00:47:22.538       [java] 	at org.glassfish.internal.data.ApplicationInfo.start(ApplicationInfo.java:344)
00:47:22.538       [java] 	at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:532)
00:47:22.538       [java] 	at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:256)
00:47:22.538       [java] 	at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:475)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:549)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:545)
00:47:22.538       [java] 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
00:47:22.538       [java] 	at java.base/javax.security.auth.Subject.doAs(Subject.java:453)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:545)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:574)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:566)
00:47:22.538       [java] 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
00:47:22.538       [java] 	at java.base/javax.security.auth.Subject.doAs(Subject.java:453)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:566)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1441)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:187)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:166)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:159)
00:47:22.538       [java] 	at com.sun.enterprise.v3.admin.CommandRunnerExecutionContext.execute(CommandRunnerExecutionContext.java:49)
00:47:22.538       [java] 	at com.sun.enterprise.admin.cli.embeddable.DeployerImpl.deploy(DeployerImpl.java:114)
00:47:22.538       [java] 	at org.glassfish.ejb.embedded.EJBContainerImpl.deploy(EJBContainerImpl.java:119)
00:47:22.538       [java] 	at org.glassfish.ejb.embedded.EJBContainerProviderImpl.createEJBContainer(EJBContainerProviderImpl.java:125)
00:47:22.538       [java] 	at jakarta.ejb.embeddable.EJBContainer.createEJBContainer(EJBContainer.java:91)
00:47:22.538       [java] 	at com.acme.Client.testREST(Client.java:111)
00:47:22.538       [java] 	at com.acme.Client.main(Client.java:57)
00:47:22.538       [java] Caused by: java.lang.IllegalArgumentException: jakarta.servlet.ServletException: com.sun.enterprise.container.common.spi.util.InjectionException: Error creating managed object for class: class org.jboss.weld.module.web.servlet.WeldListener
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.addListener(StandardContext.java:2420)
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.addApplicationListener(StandardContext.java:1784)
00:47:22.538       [java] 	at com.sun.enterprise.web.TomcatDeploymentConfig.configureApplicationListener(TomcatDeploymentConfig.java:220)
00:47:22.538       [java] 	at com.sun.enterprise.web.TomcatDeploymentConfig.configureWebModule(TomcatDeploymentConfig.java:103)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebModuleContextConfig.start(WebModuleContextConfig.java:209)
00:47:22.538       [java] 	at org.apache.catalina.startup.ContextConfig.lifecycleEvent(ContextConfig.java:323)
00:47:22.538       [java] 	at org.apache.catalina.util.LifecycleSupport.fireLifecycleEvent(LifecycleSupport.java:121)
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.start(StandardContext.java:4455)
00:47:22.538       [java] 	... 34 more
00:47:22.538       [java] Caused by: jakarta.servlet.ServletException: com.sun.enterprise.container.common.spi.util.InjectionException: Error creating managed object for class: class org.jboss.weld.module.web.servlet.WeldListener
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.createListener(StandardContext.java:2515)
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.loadListener(StandardContext.java:3995)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebModule.loadListener(WebModule.java:1575)
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.addListener(StandardContext.java:2418)
00:47:22.538       [java] 	... 41 more
00:47:22.538       [java] Caused by: com.sun.enterprise.container.common.spi.util.InjectionException: Error creating managed object for class: class org.jboss.weld.module.web.servlet.WeldListener
00:47:22.538       [java] 	at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl.createManagedObject(InjectionManagerImpl.java:256)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebContainer.createListenerInstance(WebContainer.java:695)
00:47:22.538       [java] 	at com.sun.enterprise.web.WebModule.createListenerInstance(WebModule.java:1901)
00:47:22.538       [java] 	at org.apache.catalina.core.StandardContext.createListener(StandardContext.java:2513)
00:47:22.538       [java] 	... 44 more
00:47:22.538       [java] Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.put(Object, Object)" because "bundleNonManagedObjs" is null
00:47:22.538       [java] 	at com.sun.enterprise.container.common.impl.managedbean.ManagedBeanManagerImpl.createManagedBean(ManagedBeanManagerImpl.java:421)
00:47:22.538       [java] 	at com.sun.enterprise.container.common.impl.managedbean.ManagedBeanManagerImpl.createManagedBean(ManagedBeanManagerImpl.java:370)
00:47:22.538       [java] 	at com.sun.enterprise.container.common.impl.util.InjectionManagerImpl.createManagedObject(InjectionManagerImpl.java:244)
00:47:22.538       [java] 	... 47 more
```
</details>