### PR TITLE
Updated Faces TCK

### DIFF
--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <faces.version>4.0.1</faces.version>
-        <faces.tck.version>4.0.3</faces.tck.version>
+        <faces.tck.version>4.0.4</faces.tck.version>
         <tck.root>${project.build.directory}</tck.root>
         <tck.parentPomFile>${tck.root}/faces-tck-${faces.tck.version}/tck/pom.xml</tck.parentPomFile>
     </properties>
@@ -144,9 +144,9 @@
                                 <pom-replace file="${tck.parentPomFile}"
                                     element="artifactId" value="project" replacement="${project.artifactId}" />
                                 <pom-replace file="${tck.parentPomFile}"
-                                    element="version" value="1.0.7" replacement="${project.version}" />
+                                    element="version" value="1.0.9" replacement="${project.version}" />
                                 <pom-replace file="${tck.parentPomFile}"
-                                    element="version" value="1.4" replacement="${omnifish.arquillian.version}" />
+                                    element="version" value="2.1.2" replacement="${omnifish.arquillian.version}" />
                                 <pom-replace file="${tck.parentPomFile}"
                                     element="version" value="${faces.tck.version}" replacement="${project.parent.version}" />
                                 <replace file="${tck.parentPomFile}">
@@ -165,11 +165,6 @@
                                     <exclude name="pom.xml"/>
                                     <replacetoken><![CDATA[<version>${faces.tck.version}</version>]]></replacetoken>
                                     <replacevalue><![CDATA[<version>${project.version}</version>]]></replacevalue>
-                                </replace>
-                                <replace dir="${tck.root}/faces-tck-${faces.tck.version}/tck">
-                                    <include name="**/pom.xml"/>
-                                    <replacetoken><![CDATA[<groupId>org.omnifaces.arquillian</groupId>]]></replacetoken>
-                                    <replacevalue><![CDATA[<groupId>ee.omnifish.arquillian</groupId>]]></replacevalue>
                                 </replace>
                             </target>
                         </configuration>

--- a/appserver/tests/tck/tck-download/jakarta-faces-tck/pom.xml
+++ b/appserver/tests/tck/tck-download/jakarta-faces-tck/pom.xml
@@ -32,7 +32,7 @@
     <name>TCK: Install Jakarta Faces TCK</name>
 
     <properties>
-        <tck.artifactFileName>jakarta-faces-tck-4.0.3.zip</tck.artifactFileName>
+        <tck.artifactFileName>jakarta-faces-tck-4.0.4.zip</tck.artifactFileName>
         <tck.artifactUrl>https://download.eclipse.org/jakartaee/faces/4.0/${tck.artifactFileName}</tck.artifactUrl>
     </properties>
 


### PR DESCRIPTION
TODO: Release the TCK, so 4.0.4 would not be reachable just from the staging page and update link, but here: https://download.eclipse.org/jakartaee/faces/4.0/

The 4.0.3, 4.0.4 TCK and GF 7.1.0 do not pass with Java25 (these are not OLD tests!), however that does not block us as target for JEE10 is Java17+Java21.
GF8 already has different version, 4.1.1+, I hope it is better there:
```
[ERROR] Failures:  
[ERROR]   Issue4070IT.testLocalDateTime:80->doTestJavaTimeTypes:118 expected:<[2015-05-30T16:14:43]> but was:<[]>
[ERROR]   Issue4087IT.testJavaTimeTypes:100
[ERROR]   Issue4110IT.testLocalDateTime:90->doTestJavaTimeTypes:104 expected:<[2015-05-30T16:14:43]> but was:<[]>
```

The problem is analyzed here:

- https://github.com/jakartaee/faces/pull/2037
- https://github.com/jakartaee/faces/issues/1935

Java 21 passed:
```
[INFO] +--ee.jakarta.tck.faces.test.javaee8.converter.Issue4070IT - 0.848 s
[INFO] |  +-- [OK] testLocalDateTime - 0.077 s
[INFO] |  +-- [OK] testOffsetDateTime - 0.039 s
[INFO] |  +-- [OK] testOffsetTime - 0.037 s
[INFO] |  +-- [OK] testLocalDate - 0.034 s
[INFO] |  +-- [OK] testLocalTime - 0.031 s
[INFO] |  +-- [OK] testInputOutputDiffer - 0.036 s
[INFO] |  '-- [OK] testZonedDateTime - 0.034 s
...
[INFO] +--ee.jakarta.tck.faces.test.javaee8.converter.Issue4087IT - 0.716 s
[INFO] |  '-- [OK] testJavaTimeTypes - 0.070 s
...
[INFO] +--ee.jakarta.tck.faces.test.javaee8.converter.Issue4110IT - 7.841 s
[INFO] |  +-- [OK] testLocalDateTime - 0.801 s
[INFO] |  +-- [OK] testLocalDate - 0.042 s
[INFO] |  '-- [OK] testLocalTime - 0.038 s
```

When we tried to stage and test 4.0.4, we have found that the old tck is not working. That is fixed here:
* https://github.com/jakartaee/faces/pull/2061
* https://github.com/jakartaee/faces/pull/2063

Now, with Java21 and GF 7.1.1-SNAPSHOT in this PR:
```
rm -rf /home/dmatej/.m2/repository/.cache/download-maven-plugin/*
mvn clean install -Ptck -pl :jakarta-faces-tck,:glassfish-external-tck-faces
...
[INFO] 
[INFO] TCK: Install Jakarta Faces TCK ..................... SUCCESS [  4.961 s]
[INFO] TCK: Faces ......................................... SUCCESS [  02:28 h]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:28 h
[INFO] Finished at: 2025-12-15T20:14:08+01:00
```
