### PR TITLE
MicroProfile Config instance always scoped per application

### DIFF
--- a/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -21,6 +21,7 @@ import io.helidon.common.NativeImageHelper;
 import io.helidon.config.ConfigException;
 import io.helidon.config.mp.MpConfig;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -41,6 +42,7 @@ import jakarta.enterprise.inject.spi.ProcessBean;
 import jakarta.enterprise.inject.spi.ProcessObserverMethod;
 import jakarta.enterprise.inject.spi.ProcessSyntheticObserverMethod;
 import jakarta.enterprise.inject.spi.WithAnnotations;
+import jakarta.interceptor.Interceptor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -71,10 +73,12 @@ import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.inject.ConfigProperties;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.config.spi.Converter;
+import org.glassfish.microprofile.config.ApplicationContext;
 
 import static java.util.Optional.ofNullable;
 
 /**
+ * Must be in the {@link io.helidon.microprofile.config} package because it depends on package private Helidon classes.
  * Extension to enable config injection in CDI container (all of {@link io.helidon.config.Config},
  * {@link org.eclipse.microprofile.config.Config} and {@link ConfigProperty}).
  */
@@ -160,17 +164,17 @@ public class ConfigCdiExtension implements Extension {
     /**
      * Register a config producer bean for each {@link org.eclipse.microprofile.config.inject.ConfigProperty} injection.
      *
-     * @param abd event from CDI container
+     * @param afterBeanDiscovery event from CDI container
      */
-    private void registerConfigProducer(@Observes AfterBeanDiscovery abd) {
+    private void registerConfigProducer(@Observes AfterBeanDiscovery afterBeanDiscovery) {
         // we also must support injection of Config itself
-        abd.addBean()
+        afterBeanDiscovery.addBean()
                 .addTransitiveTypeClosure(org.eclipse.microprofile.config.Config.class)
                 .beanClass(org.eclipse.microprofile.config.Config.class)
                 .scope(ApplicationScoped.class)
                 .createWith(creationalContext -> new SerializableConfig());
 
-        abd.addBean()
+        afterBeanDiscovery.addBean()
                 .addTransitiveTypeClosure(io.helidon.config.Config.class)
                 .beanClass(io.helidon.config.Config.class)
                 .scope(ApplicationScoped.class)
@@ -197,14 +201,14 @@ public class ConfigCdiExtension implements Extension {
                 .collect(Collectors.toSet());
 
         types.forEach(type -> {
-            abd.addBean()
+            afterBeanDiscovery.addBean()
                     .addType(type)
                     .scope(Dependent.class)
                     .addQualifier(CONFIG_PROPERTY_LITERAL)
                     .produceWith(it -> produce(it.select(InjectionPoint.class).get()));
         });
 
-        configBeans.values().forEach(beanDescriptor -> abd.addBean()
+        configBeans.values().forEach(beanDescriptor -> afterBeanDiscovery.addBean()
                 .addType(beanDescriptor.type())
                 .addTransitiveTypeClosure(beanDescriptor.type())
                 // it is non-binding
@@ -213,6 +217,15 @@ public class ConfigCdiExtension implements Extension {
                 .produceWith(it -> beanDescriptor.produce(it.select(InjectionPoint.class).get(), ConfigProvider.getConfig())));
     }
 
+    /**
+     * Register a config producer bean for each {@link org.eclipse.microprofile.config.inject.ConfigProperty} injection.
+     *
+     * @param afterBeanDiscovery event from CDI container
+     */
+    private void defineApplicationContextBean(@Observes @Priority(Interceptor.Priority.LIBRARY_BEFORE) AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+        afterBeanDiscovery.addBean()
+                .read(beanManager.createAnnotatedType(ApplicationContext.class));
+    }
     /**
      * Validate all injection points are valid.
      *

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ApplicationContext.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ApplicationContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@ApplicationScoped
+public class ApplicationContext {
+
+    GlassFishConfigs getConfigs;
+
+    GlassFishConfigs getConfigs() {
+        return getConfigs;
+    }
+
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
@@ -68,6 +68,8 @@ public class ConfigDeployer implements Deployer {
 
     private void enableCdiExtensions(DeploymentContext context) {
         DeploymentImpl deploymentImpl = context.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);
-        deploymentImpl.addExtensions(new ConfigCdiExtension());
+        if (deploymentImpl != null) {
+            deploymentImpl.addExtensions(new ConfigCdiExtension());
+        }
     }
 }

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
@@ -15,6 +15,8 @@
  */
 package org.glassfish.microprofile.config;
 
+import io.helidon.microprofile.config.ConfigCdiExtension;
+
 import java.util.ServiceLoader;
 
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -23,7 +25,10 @@ import org.glassfish.api.deployment.ApplicationContainer;
 import org.glassfish.api.deployment.Deployer;
 import org.glassfish.api.deployment.DeploymentContext;
 import org.glassfish.api.deployment.MetaData;
+import org.glassfish.weld.DeploymentImpl;
 import org.jvnet.hk2.annotations.Service;
+
+import static org.glassfish.weld.WeldDeployer.WELD_DEPLOYMENT;
 
 @Service
 public class ConfigDeployer implements Deployer {
@@ -45,6 +50,8 @@ public class ConfigDeployer implements Deployer {
         final var resolver = ServiceLoader.load(ConfigProviderResolver.class).iterator().next();
         ConfigProviderResolver.setInstance(resolver);
 
+        enableCdiExtensions(deploymentContext);
+
         return new ConfigApplicationContainer(deploymentContext);
     }
 
@@ -57,5 +64,10 @@ public class ConfigDeployer implements Deployer {
     @Override
     public Object loadMetaData(Class aClass, DeploymentContext deploymentContext) {
         return null;
+    }
+
+    private void enableCdiExtensions(DeploymentContext context) {
+        DeploymentImpl deploymentImpl = context.getTransientAppMetaData(WELD_DEPLOYMENT, DeploymentImpl.class);
+        deploymentImpl.addExtensions(new ConfigCdiExtension());
     }
 }

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfig.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfig.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.api.invocation.ComponentInvocation;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.data.ApplicationInfo;
+import org.glassfish.internal.data.ApplicationRegistry;
+import org.glassfish.internal.deployment.Deployment;
+import org.glassfish.microprofile.config.util.LazyProperty;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+class GlassFishConfig implements Config {
+
+    private Supplier<Config> configProducer;
+    private volatile Config defaultConfigDelegate;
+
+    public GlassFishConfig(Supplier<Config> configProducer) {
+        this.configProducer = configProducer;
+    }
+
+    private Config getDefaultConfigDelegate() {
+        return defaultConfigDelegate;
+    }
+
+    private void setDefaultConfigDelegate(Config defaultConfigDelegate) {
+        this.defaultConfigDelegate = defaultConfigDelegate;
+    }
+
+    @Override
+    public <T> T getValue(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getValue(propertyName, propertyType);
+    }
+
+    @Override
+    public ConfigValue getConfigValue(String propertyName) {
+        return getConfigDelegate().getConfigValue(propertyName);
+    }
+
+    @Override
+    public <T> List<T> getValues(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getValues(propertyName, propertyType);
+    }
+
+    @Override
+    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getOptionalValue(propertyName, propertyType);
+    }
+
+    @Override
+    public <T> Optional<List<T>> getOptionalValues(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getOptionalValues(propertyName, propertyType);
+    }
+
+    @Override
+    public Iterable<String> getPropertyNames() {
+        return getConfigDelegate().getPropertyNames();
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources() {
+        return getConfigDelegate().getConfigSources();
+    }
+
+    @Override
+    public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+        return getConfigDelegate().getConverter(forType);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        return getConfigDelegate().unwrap(type);
+    }
+
+    private Config getConfigDelegate() {
+        final ApplicationInfo currentApplicationInfo = getCurrentApplicationInfo();
+        Config config = null;
+        if (currentApplicationInfo != null) {
+            final GlassFishConfigs configs = LazyProperty.getOrSet(currentApplicationInfo, GlassFishConfig::getConfigsFromAppInfo, GlassFishConfigs::new, GlassFishConfig::setConfigsToAppInfo);
+            config = LazyProperty.getOrSet(configs, this::getConfigFromConfigs, configProducer, this::setConfigToConfigs);
+        } else {
+            config = LazyProperty.getOrSet(this, GlassFishConfig::getDefaultConfigDelegate, configProducer, GlassFishConfig::setDefaultConfigDelegate);
+        }
+        return config;
+    }
+
+    private static GlassFishConfigs getConfigsFromAppInfo(ApplicationInfo applicationInfo) {
+        return applicationInfo.getMetaData(GlassFishConfigs.class);
+    }
+
+    private static void setConfigsToAppInfo(ApplicationInfo applicationInfo, GlassFishConfigs configs) {
+        applicationInfo.addMetaData(configs);
+    }
+
+    public Config getConfigFromConfigs(GlassFishConfigs cfgs) {
+        return cfgs.get(this);
+    }
+
+    private void setConfigToConfigs(GlassFishConfigs cfgs, Config cfg) {
+        cfgs.put(this, cfg);
+    }
+
+    private static ApplicationInfo getCurrentApplicationInfo() {
+        final Deployment deploymentService = Globals.get(Deployment.class);
+        DeploymentContext deploymentContext = null;
+        if (deploymentService != null) {
+            deploymentContext = deploymentService.getCurrentDeploymentContext();
+        }
+        if (deploymentContext != null) {
+            // during app deployment, we don't have current invocation, we retrieve it from the deployment
+            return deploymentContext.getModuleMetaData(ApplicationInfo.class);
+        }
+        final ComponentInvocation currentInvocation = Globals.get(InvocationManager.class).getCurrentInvocation();
+        String applicationName = null;
+        if (currentInvocation != null && null != (applicationName = currentInvocation.getAppName())) {
+            ApplicationRegistry applicationRegistry = Globals.get(ApplicationRegistry.class);
+            if (applicationRegistry != null) {
+                // application started
+                return applicationRegistry.get(applicationName);
+            }
+        }
+        // we're not in a context related to an application
+        return null;
+    }
+
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
@@ -18,25 +18,11 @@ package org.glassfish.microprofile.config;
 import io.helidon.config.mp.MpConfigProviderResolver;
 
 import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
-import org.eclipse.microprofile.config.spi.ConfigSource;
-import org.eclipse.microprofile.config.spi.Converter;
-import org.glassfish.api.deployment.DeploymentContext;
-import org.glassfish.api.invocation.ComponentInvocation;
-import org.glassfish.api.invocation.InvocationManager;
-import org.glassfish.internal.api.Globals;
-import org.glassfish.internal.data.ApplicationInfo;
-import org.glassfish.internal.data.ApplicationRegistry;
-import org.glassfish.internal.deployment.Deployment;
+import org.glassfish.microprofile.config.util.LazyProperty;
 
 /**
  *
@@ -49,16 +35,16 @@ public class GlassFishConfigProviderResolver extends ConfigProviderResolver {
     private MpConfigProviderResolver getOrCreateResolverDelegate() {
         return LazyProperty.getOrSet(
                 this,
-                GlassFishConfigProviderResolver::_getResolverDelegate,
+                GlassFishConfigProviderResolver::getResolverDelegate,
                 MpConfigProviderResolver::new,
-                GlassFishConfigProviderResolver::_setResolverDelegate);
+                GlassFishConfigProviderResolver::setResolverDelegate);
     }
 
-    private MpConfigProviderResolver _getResolverDelegate() {
+    private MpConfigProviderResolver getResolverDelegate() {
         return resolverDelegate;
     }
 
-    private void _setResolverDelegate(MpConfigProviderResolver resolverDelegate) {
+    private void setResolverDelegate(MpConfigProviderResolver resolverDelegate) {
         this.resolverDelegate = resolverDelegate;
     }
 
@@ -88,150 +74,6 @@ public class GlassFishConfigProviderResolver extends ConfigProviderResolver {
     }
 }
 
-class LazyProperty {
-
-    static <OBJ, PROP> PROP getOrSet(OBJ object, Function<OBJ, PROP> getter, Supplier<PROP> propertyProducer, BiConsumer<OBJ, PROP> setter) {
-        PROP result = getter.apply(object);
-        if (result == null) {
-            synchronized (object) {
-                result = propertyProducer.get();
-                setter.accept(object, result);
-            }
-        }
-        return result;
-    }
-}
-
 class GlassFishConfigs extends HashMap<GlassFishConfig, Config> {
-
-}
-
-class GlassFishConfig implements Config {
-
-    private Supplier<Config> configProducer;
-    private volatile Config defaultConfigDelegate;
-
-    public GlassFishConfig(Supplier<Config> configProducer) {
-        this.configProducer = configProducer;
-    }
-
-    private Config _getDefaultConfigDelegate() {
-        return defaultConfigDelegate;
-    }
-
-    private void _setDefaultConfigDelegate(Config defaultConfigDelegate) {
-        this.defaultConfigDelegate = defaultConfigDelegate;
-    }
-
-    @Override
-    public <T> T getValue(String propertyName, Class<T> propertyType) {
-        return getConfigDelegate().getValue(propertyName, propertyType);
-    }
-
-    @Override
-    public ConfigValue getConfigValue(String propertyName) {
-        return getConfigDelegate().getConfigValue(propertyName);
-    }
-
-    @Override
-    public <T> List<T> getValues(String propertyName, Class<T> propertyType) {
-        return getConfigDelegate().getValues(propertyName, propertyType);
-    }
-
-    @Override
-    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
-        return getConfigDelegate().getOptionalValue(propertyName, propertyType);
-    }
-
-    @Override
-    public <T> Optional<List<T>> getOptionalValues(String propertyName, Class<T> propertyType) {
-        return getConfigDelegate().getOptionalValues(propertyName, propertyType);
-    }
-
-    @Override
-    public Iterable<String> getPropertyNames() {
-        return getConfigDelegate().getPropertyNames();
-    }
-
-    @Override
-    public Iterable<ConfigSource> getConfigSources() {
-        return getConfigDelegate().getConfigSources();
-    }
-
-    @Override
-    public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
-        return getConfigDelegate().getConverter(forType);
-    }
-
-    @Override
-    public <T> T unwrap(Class<T> type) {
-        return getConfigDelegate().unwrap(type);
-    }
-
-    private Config getConfigDelegate() {
-        final ApplicationInfo currentApplicationInfo = getCurrentApplicationInfo();
-        Config config = null;
-        if (currentApplicationInfo != null) {
-            final GlassFishConfigs configs = LazyProperty.getOrSet(
-                    currentApplicationInfo,
-                    GlassFishConfig::getConfigsFromAppInfo,
-                    GlassFishConfigs::new,
-                    GlassFishConfig::setConfigsToAppInfo
-            );
-            config = LazyProperty.getOrSet(configs,
-                    this::getConfigFromConfigs,
-                    configProducer,
-                    this::setConfigToConfigs);
-        } else {
-            config = LazyProperty.getOrSet(
-                    this,
-                    GlassFishConfig::_getDefaultConfigDelegate,
-                    configProducer,
-                    GlassFishConfig::_setDefaultConfigDelegate
-            );
-        }
-        return config;
-    }
-
-    private static GlassFishConfigs getConfigsFromAppInfo(ApplicationInfo applicationInfo) {
-        return applicationInfo.getMetaData(GlassFishConfigs.class);
-    }
-
-    private static void setConfigsToAppInfo(ApplicationInfo applicationInfo, GlassFishConfigs configs) {
-        applicationInfo.addMetaData(configs);
-    }
-
-    public Config getConfigFromConfigs(GlassFishConfigs cfgs) {
-        return cfgs.get(this);
-    }
-
-    private void setConfigToConfigs(GlassFishConfigs cfgs, Config cfg) {
-        cfgs.put(this, cfg);
-    }
-
-    private static ApplicationInfo getCurrentApplicationInfo() {
-        final Deployment deploymentService = Globals.get(Deployment.class);
-        DeploymentContext deploymentContext = null;
-        if (deploymentService != null) {
-            deploymentContext = deploymentService.getCurrentDeploymentContext();
-        }
-        if (deploymentContext != null) {
-            // during app deployment, we don't have current invocation, we retrieve it from the deployment
-            return deploymentContext.getModuleMetaData(ApplicationInfo.class);
-        }
-
-        final ComponentInvocation currentInvocation = Globals.get(InvocationManager.class)
-                .getCurrentInvocation();
-        String applicationName = null;
-        if (currentInvocation != null && null != (applicationName = currentInvocation.getAppName())) {
-            ApplicationRegistry applicationRegistry = Globals.get(ApplicationRegistry.class);
-            if (applicationRegistry != null) {
-                // application started
-                return applicationRegistry.get(applicationName);
-            }
-        }
-        // we're not in a context related to an application
-        return null;
-    }
 
 }

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config;
+
+import io.helidon.config.mp.MpConfigProviderResolver;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigBuilder;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.glassfish.api.deployment.DeploymentContext;
+import org.glassfish.api.invocation.ComponentInvocation;
+import org.glassfish.api.invocation.InvocationManager;
+import org.glassfish.internal.api.Globals;
+import org.glassfish.internal.data.ApplicationInfo;
+import org.glassfish.internal.data.ApplicationRegistry;
+import org.glassfish.internal.deployment.Deployment;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class GlassFishConfigProviderResolver extends ConfigProviderResolver {
+
+    volatile private MpConfigProviderResolver resolverDelegate;
+
+    private MpConfigProviderResolver getOrCreateResolverDelegate() {
+        return LazyProperty.getOrSet(
+                this,
+                GlassFishConfigProviderResolver::_getResolverDelegate,
+                MpConfigProviderResolver::new,
+                GlassFishConfigProviderResolver::_setResolverDelegate);
+    }
+
+    private MpConfigProviderResolver _getResolverDelegate() {
+        return resolverDelegate;
+    }
+
+    private void _setResolverDelegate(MpConfigProviderResolver resolverDelegate) {
+        this.resolverDelegate = resolverDelegate;
+    }
+
+    @Override
+    public Config getConfig() {
+        return new GlassFishConfig(() -> getOrCreateResolverDelegate().getConfig());
+    }
+
+    @Override
+    public Config getConfig(ClassLoader loader) {
+        return new GlassFishConfig(() -> getOrCreateResolverDelegate().getConfig(loader));
+    }
+
+    @Override
+    public ConfigBuilder getBuilder() {
+        return getOrCreateResolverDelegate().getBuilder();
+    }
+
+    @Override
+    public void registerConfig(Config config, ClassLoader classLoader) {
+        getOrCreateResolverDelegate().registerConfig(config, classLoader);
+    }
+
+    @Override
+    public void releaseConfig(Config config) {
+        getOrCreateResolverDelegate().releaseConfig(config);
+    }
+}
+
+class LazyProperty {
+
+    static <OBJ, PROP> PROP getOrSet(OBJ object, Function<OBJ, PROP> getter, Supplier<PROP> propertyProducer, BiConsumer<OBJ, PROP> setter) {
+        PROP result = getter.apply(object);
+        if (result == null) {
+            synchronized (object) {
+                result = propertyProducer.get();
+                setter.accept(object, result);
+            }
+        }
+        return result;
+    }
+}
+
+class GlassFishConfigs extends HashMap<GlassFishConfig, Config> {
+
+}
+
+class GlassFishConfig implements Config {
+
+    private Supplier<Config> configProducer;
+    private volatile Config defaultConfigDelegate;
+
+    public GlassFishConfig(Supplier<Config> configProducer) {
+        this.configProducer = configProducer;
+    }
+
+    private Config _getDefaultConfigDelegate() {
+        return defaultConfigDelegate;
+    }
+
+    private void _setDefaultConfigDelegate(Config defaultConfigDelegate) {
+        this.defaultConfigDelegate = defaultConfigDelegate;
+    }
+
+    @Override
+    public <T> T getValue(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getValue(propertyName, propertyType);
+    }
+
+    @Override
+    public ConfigValue getConfigValue(String propertyName) {
+        return getConfigDelegate().getConfigValue(propertyName);
+    }
+
+    @Override
+    public <T> List<T> getValues(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getValues(propertyName, propertyType);
+    }
+
+    @Override
+    public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getOptionalValue(propertyName, propertyType);
+    }
+
+    @Override
+    public <T> Optional<List<T>> getOptionalValues(String propertyName, Class<T> propertyType) {
+        return getConfigDelegate().getOptionalValues(propertyName, propertyType);
+    }
+
+    @Override
+    public Iterable<String> getPropertyNames() {
+        return getConfigDelegate().getPropertyNames();
+    }
+
+    @Override
+    public Iterable<ConfigSource> getConfigSources() {
+        return getConfigDelegate().getConfigSources();
+    }
+
+    @Override
+    public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+        return getConfigDelegate().getConverter(forType);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        return getConfigDelegate().unwrap(type);
+    }
+
+    private Config getConfigDelegate() {
+        final ApplicationInfo currentApplicationInfo = getCurrentApplicationInfo();
+        Config config = null;
+        if (currentApplicationInfo != null) {
+            final GlassFishConfigs configs = LazyProperty.getOrSet(
+                    currentApplicationInfo,
+                    GlassFishConfig::getConfigsFromAppInfo,
+                    GlassFishConfigs::new,
+                    GlassFishConfig::setConfigsToAppInfo
+            );
+            config = LazyProperty.getOrSet(configs,
+                    this::getConfigFromConfigs,
+                    configProducer,
+                    this::setConfigToConfigs);
+        } else {
+            config = LazyProperty.getOrSet(
+                    this,
+                    GlassFishConfig::_getDefaultConfigDelegate,
+                    configProducer,
+                    GlassFishConfig::_setDefaultConfigDelegate
+            );
+        }
+        return config;
+    }
+
+    private static GlassFishConfigs getConfigsFromAppInfo(ApplicationInfo applicationInfo) {
+        return applicationInfo.getMetaData(GlassFishConfigs.class);
+    }
+
+    private static void setConfigsToAppInfo(ApplicationInfo applicationInfo, GlassFishConfigs configs) {
+        applicationInfo.addMetaData(configs);
+    }
+
+    public Config getConfigFromConfigs(GlassFishConfigs cfgs) {
+        return cfgs.get(this);
+    }
+
+    private void setConfigToConfigs(GlassFishConfigs cfgs, Config cfg) {
+        cfgs.put(this, cfg);
+    }
+
+    private static ApplicationInfo getCurrentApplicationInfo() {
+        final Deployment deploymentService = Globals.get(Deployment.class);
+        DeploymentContext deploymentContext = null;
+        if (deploymentService != null) {
+            deploymentContext = deploymentService.getCurrentDeploymentContext();
+        }
+        if (deploymentContext != null) {
+            // during app deployment, we don't have current invocation, we retrieve it from the deployment
+            return deploymentContext.getModuleMetaData(ApplicationInfo.class);
+        }
+
+        final ComponentInvocation currentInvocation = Globals.get(InvocationManager.class)
+                .getCurrentInvocation();
+        String applicationName = null;
+        if (currentInvocation != null && null != (applicationName = currentInvocation.getAppName())) {
+            ApplicationRegistry applicationRegistry = Globals.get(ApplicationRegistry.class);
+            if (applicationRegistry != null) {
+                // application started
+                return applicationRegistry.get(applicationName);
+            }
+        }
+        // we're not in a context related to an application
+        return null;
+    }
+
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
@@ -33,7 +33,7 @@ public class GlassFishConfigProviderResolver extends ConfigProviderResolver {
     volatile private MpConfigProviderResolver resolverDelegate;
 
     private MpConfigProviderResolver getOrCreateResolverDelegate() {
-        return LazyProperty.getOrSet(
+        return LazyProperty.getOrCreateAndSet(
                 this,
                 GlassFishConfigProviderResolver::getResolverDelegate,
                 MpConfigProviderResolver::new,

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/util/LazyProperty.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/util/LazyProperty.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.config.util;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class LazyProperty {
+
+    public static <OBJ, PROP> PROP getOrSet(OBJ object, Function<OBJ, PROP> getter, Supplier<PROP> propertyProducer, BiConsumer<OBJ, PROP> setter) {
+        PROP result = getter.apply(object);
+        if (result == null) {
+            synchronized (object) {
+                result = propertyProducer.get();
+                setter.accept(object, result);
+            }
+        }
+        return result;
+    }
+
+}

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/util/LazyProperty.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/util/LazyProperty.java
@@ -20,12 +20,30 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
+ * Utility class for lazy evaluation
  *
  * @author Ondro Mihalyi
  */
-public class LazyProperty {
+public final class LazyProperty {
 
-    public static <OBJ, PROP> PROP getOrSet(OBJ object, Function<OBJ, PROP> getter, Supplier<PROP> propertyProducer, BiConsumer<OBJ, PROP> setter) {
+    private LazyProperty() {
+    }
+
+    /**
+     * Returns a value lazily. Never returns {@code null}. If it would be {@code null}, it creates and sets the value
+     * in a thread-safe way and returns the newly created value.
+     * It's expected that the value set by the {@setter} will be returned by a subsequent call of the {@code getter}.
+     * Therefore subsequent calls to this method would return the value created and set in a previous call.
+     *
+     * @param <OBJ> Type of the object that getter and setter get value from or set value to
+     * @param <PROP> Type of the value to be returned by this method (type of the property to get or set)
+     * @param object Object to get value from or set value to
+     * @param getter Will be used to get the value from the {@code object} argument
+     * @param propertyProducer Produces a new value if {@code getter} returns {@code null}.
+     * @param setter Will be used to set the value produced by {@code propertyProducer} before the value is returned
+     * @return Value returned by {@code getter} or by {@code propertyProducer} if {@code getter} returns {@code null}
+     */
+    public static <OBJ, PROP> PROP getOrCreateAndSet(OBJ object, Function<OBJ, PROP> getter, Supplier<PROP> propertyProducer, BiConsumer<OBJ, PROP> setter) {
         PROP result = getter.apply(object);
         if (result == null) {
             synchronized (object) {

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/util/LazyProperty.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/util/LazyProperty.java
@@ -47,8 +47,10 @@ public final class LazyProperty {
         PROP result = getter.apply(object);
         if (result == null) {
             synchronized (object) {
-                result = propertyProducer.get();
-                setter.accept(object, result);
+                if (result == null) {
+                    result = propertyProducer.get();
+                    setter.accept(object, result);
+                }
             }
         }
         return result;

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,1 +1,0 @@
-io.helidon.microprofile.config.ConfigCdiExtension

--- a/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
+++ b/appserver/microprofile/config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
@@ -1,1 +1,1 @@
-io.helidon.config.mp.MpConfigProviderResolver
+org.glassfish.microprofile.config.GlassFishConfigProviderResolver

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -69,6 +69,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <scope>provided</scope>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/lib/ConfigHolder.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/lib/ConfigHolder.java
@@ -19,7 +19,10 @@ package org.glassfish.main.test.app.mpconfig.lib;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
-public class ConfigHolder {
+public final class ConfigHolder {
+
+    private ConfigHolder() {
+    }
 
     public static final Config config = ConfigProvider.getConfig();
 }

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/lib/ConfigHolder.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/lib/ConfigHolder.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.mpconfig.lib;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+public class ConfigHolder {
+
+    public static final Config config = ConfigProvider.getConfig();
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/webapp/ConfigApplication.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/webapp/ConfigApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.mpconfig.webapp;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import java.util.Set;
+
+@ApplicationPath("")
+public class ConfigApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Set.of(ConfigEndpoint.class);
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/webapp/ConfigEndpoint.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/webapp/ConfigEndpoint.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.mpconfig.webapp;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.glassfish.main.test.app.mpconfig.lib.ConfigHolder;
+
+@Path("/config")
+public class ConfigEndpoint {
+
+    @GET
+    @Path("name")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getName() {
+        return ConfigHolder.config.getValue("name", String.class);
+    }
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpconfig/ApplicationScopedMpConfigTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpconfig/ApplicationScopedMpConfigTest.java
@@ -34,9 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
 
 import static java.lang.System.Logger.Level.INFO;
@@ -45,7 +43,6 @@ import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadmi
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@TestMethodOrder(OrderAnnotation.class)
 public class ApplicationScopedMpConfigTest {
 
     private static final System.Logger LOG = System.getLogger(ApplicationScopedMpConfigTest.class.getName());

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpconfig/ApplicationScopedMpConfigTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpconfig/ApplicationScopedMpConfigTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.mpconfig;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import org.glassfish.common.util.HttpParser;
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.test.app.mpconfig.lib.ConfigHolder;
+import org.glassfish.main.test.app.mpconfig.webapp.ConfigEndpoint;
+import org.glassfish.main.test.app.mpconfig.webapp.ConfigApplication;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.openConnection;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@TestMethodOrder(OrderAnnotation.class)
+public class ApplicationScopedMpConfigTest {
+
+    private static final System.Logger LOG = System.getLogger(ApplicationScopedMpConfigTest.class.getName());
+
+    private static final String SHARED_LIBRARY_NAME = "mpconfig-lib";
+
+    private static final String APP_NAME = "mpconfig-app";
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @TempDir
+    private static File tempDir;
+
+    private static File libraryJar;
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        libraryJar = createLibrary();
+        assertThat(ASADMIN.exec("add-library", libraryJar.getAbsolutePath()), asadminOK());
+    }
+
+    @AfterAll
+    public static void cleanup() {
+        assertThat(ASADMIN.exec("remove-library", libraryJar.getName()), asadminOK());
+    }
+
+    @Test
+    @Order(1)
+    public void testApp1Config() throws IOException {
+        File app1 = createWebApp("app1");
+        final String appName = APP_NAME + "-app1";
+        assertThat(ASADMIN.exec("deploy", "--force", "--contextroot", "app", "--name", appName, app1.getAbsolutePath()), asadminOK());
+
+        String configValue = getConfigName();
+        assertThat(configValue, equalTo("app1"));
+
+        assertThat(ASADMIN.exec("undeploy", appName), asadminOK());
+    }
+
+    @Test
+    @Order(2)
+    public void testApp2Config() throws IOException {
+        File app2 = createWebApp("app2");
+        final String appName = APP_NAME + "-app2";
+        assertThat(ASADMIN.exec("deploy", "--force", "--contextroot", "app", "--name", appName, app2.getAbsolutePath()), asadminOK());
+
+        String configValue = getConfigName();
+        assertThat(configValue, equalTo("app2"));
+
+        assertThat(ASADMIN.exec("undeploy", appName), asadminOK());
+    }
+
+    private String getConfigName() throws IOException {
+        HttpURLConnection connection = openConnection(8080, "/app/config/name");
+        connection.setRequestMethod("GET");
+        try {
+            assertThat(connection.getResponseCode(), equalTo(200));
+            return HttpParser.readResponseInputStream(connection);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    // create a shared library with Config stored in a static field, so that it's shared across applications
+    private static File createLibrary() {
+        JavaArchive library = ShrinkWrap.create(JavaArchive.class, SHARED_LIBRARY_NAME + ".jar")
+            .addClass(ConfigHolder.class);
+
+        LOG.log(INFO, library.toString(true));
+
+        File libraryFile = new File(tempDir, SHARED_LIBRARY_NAME + ".jar");
+        library.as(ZipExporter.class).exportTo(libraryFile, true);
+        return libraryFile;
+    }
+
+    private static File createWebApp(String configValue) {
+        String configProperties = "name=" + configValue;
+
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class)
+            .addClass(ConfigEndpoint.class)
+            .addClass(ConfigApplication.class)
+            .addAsResource(new StringAsset(configProperties), "META-INF/microprofile-config.properties");
+
+        LOG.log(INFO, webApp.toString(true));
+
+        File webAppFile = new File(tempDir, "app-" + configValue + ".war");
+        webApp.as(ZipExporter.class).exportTo(webAppFile, true);
+        return webAppFile;
+    }
+}

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/DeploymentImpl.java
@@ -111,6 +111,7 @@ public class DeploymentImpl implements CDI11Deployment {
     private final Map<ClassLoader, BeanDeploymentArchive> extensionBDAMap = new HashMap<>();
 
     private Iterable<Metadata<Extension>> extensions;
+    private List<Metadata<Extension>> dynamicExtensions = new ArrayList<>();
 
     private final Collection<EjbDescriptor> deployedEjbs = new LinkedList<>();
     private ArchiveFactory archiveFactory;
@@ -304,7 +305,28 @@ public class DeploymentImpl implements CDI11Deployment {
                 extensionsList.add(beanDeploymentArchiveExtension);
             }
         }
+        extensionsList.addAll(dynamicExtensions);
         return extensions = extensionsList;
+    }
+
+    record ExtensionMetadata(Extension extension) implements Metadata<Extension> {
+
+        @Override
+        public Extension getValue() {
+            return extension;
+        }
+
+        @Override
+        public String getLocation() {
+            return extension.toString();
+        }
+
+    }
+
+    public void addExtensions(Extension... extensions) {
+        for (Extension extension : extensions) {
+            dynamicExtensions.add(new ExtensionMetadata(extension));
+        }
     }
 
     @Override

--- a/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationRegistry.java
+++ b/nucleus/common/internal-api/src/main/java/org/glassfish/internal/data/ApplicationRegistry.java
@@ -23,6 +23,7 @@ import jakarta.inject.Singleton;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.glassfish.api.deployment.DeploymentContext;
@@ -71,21 +72,21 @@ public class ApplicationRegistry {
      *
      * @return Information about the current application
      */
-    public ApplicationInfo getCurrentApplicationInfo() {
+    public Optional<ApplicationInfo> getCurrentApplicationInfo() {
         final Deployment deploymentService = deploymentServiceProvider.get();
         DeploymentContext deploymentContext = deploymentService.getCurrentDeploymentContext();
         if (deploymentContext != null) {
             // during app deployment, we don't have current invocation, we retrieve it from the deployment
-            return deploymentContext.getModuleMetaData(ApplicationInfo.class);
+            return Optional.ofNullable(deploymentContext.getModuleMetaData(ApplicationInfo.class));
         }
         final ComponentInvocation currentInvocation = invocationManagerProvider.get().getCurrentInvocation();
         String applicationName = null;
         if (currentInvocation != null && null != (applicationName = currentInvocation.getAppName())) {
             // application started
-            return this.get(applicationName);
+            return Optional.ofNullable(this.get(applicationName));
         }
         // we're not in a context related to an application
-        return null;
+        return Optional.empty();
     }
 
 }


### PR DESCRIPTION
This PR addresses 2 things:

1. Optimization: Disable MicroProfile Config extension if Config is not used in the app, because the CDI beans won't be used
2. An improvement needed for later JNoSQL integration: Enforce MicroProfile Config instance to be unique in different apps at all times

**Background:** 

Normally, MP Config instances are not shared by applications, if the application requests them. But, as I was implementing NoSQL support via JNoSQL I found out, that JNoSQL requests Config and stores it in a static variable. Since, in this context, jNoSQL is going to be an internal GlassFish component, the static variable is shared by all applications and is not released by undeploying the applications.

**Solution:**

Wrap the Config instance into a stateless instance, which retrieves the config from application context and delegates to it. Similar to ApplicationScoped CDI proxies. 

In fact, I also tried to implement it with CDI ApplicationScoped bean and retrieve it via CDI.current(). It worked, but it's even more magic - CDI scans classloaders and tries to determine the beanManager from a classloader that defines the class, by loading the class name via reflection. And I also had to export the CDI bean from the GlassFish Config OSGi package so that Weld can see it. In terms of performance, it looked to me that it was even worse than searching for ApplicationInfo from the current invocation but I didn't measure.