### PR TITLE
Explicit version of o.g.hk2:osgiversion-m-p

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -871,6 +871,17 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <!--
+                         osgiversion-maven-plugin is used implicitly in modules
+                         of glassfish-jar packaging, as configured by
+                         glassfish-build-maven-plugin (GlassFishJarLifecycle.java).
+                         Managing it here allows its version to be under control.
+                    -->
+                    <groupId>org.glassfish.hk2</groupId>
+                    <artifactId>osgiversion-maven-plugin</artifactId>
+                    <version>${hk2.plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.glassfish.hk2</groupId>
                     <artifactId>consolidatedbundle-maven-plugin</artifactId>
                     <version>${hk2.plugin.version}</version>


### PR DESCRIPTION
Currently, underspecified version (depending on build environment) is being used for `glassfish-jar` packaging (`:compute-osgi-version` bound by extension):
```
[2025-12-04T23:21:48.302Z] [INFO] --- osgiversion:4.0.0-M3:compute-osgi-version (default-compute-osgi-version) @ jsr109-impl ---
[2025-12-04T23:21:52.258Z] [INFO] --- osgiversion:4.0.0-M3:compute-osgi-version (default-compute-osgi-version) @ webservices.security ---
```