### PR TITLE
Do not set fixed values for MP TCKs via Arquillian XML

### DIFF
--- a/appserver/tests/tck/microprofile/arquillian.xml
+++ b/appserver/tests/tck/microprofile/arquillian.xml
@@ -9,11 +9,7 @@
 
     <container qualifier="arquillian-glassfish">
         <configuration>
-            <property name="debug">true</property>
             <property name="allowConnectingToRunningServer">false</property>
-            <property name="adminHost">localhost</property>
-            <property name="adminPort">4848</property>
-            <property name="enableDerby">${enableDerby:false}</property>
             <property name="outputToConsole">true</property>
         </configuration>
     </container>


### PR DESCRIPTION
Don't need to fix the port explicitly to the default

