### PR TITLE
Fixed stopping domain - we have to bound to 4848 before we ask server to stop

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/RestartDomainCommand.java
@@ -106,8 +106,8 @@ public class RestartDomainCommand extends StopDomainCommand {
 
         final Duration timeout = getRestartTimeout();
         final Duration startTimeout;
-        if (isLocal()) {
-            startTimeout = step(null, timeout, () -> waitForStop(oldPid, null, timeout));
+        if (isLocal() && oldPid != null) {
+            startTimeout = step(null, timeout, () -> waitForStop(oldPid, timeout));
         } else {
             startTimeout = timeout;
         }

--- a/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/RestartLocalInstanceCommand.java
+++ b/nucleus/cluster/cli/src/main/java/com/sun/enterprise/admin/cli/cluster/RestartLocalInstanceCommand.java
@@ -75,8 +75,8 @@ public class RestartLocalInstanceCommand extends StopLocalInstanceCommand {
 
         final Duration timeout = getRestartTimeout();
         final Duration startTimeout;
-        if (isLocal()) {
-            startTimeout = step(null, timeout, () -> waitForStop(oldPid, null, timeout));
+        if (isLocal() && oldPid != null) {
+            startTimeout = step(null, timeout, () -> waitForStop(oldPid, timeout));
         } else {
             startTimeout = timeout;
         }


### PR DESCRIPTION
Broken in 7.1.0, the command sometimes waits shorter time than needed.
