### PR TITLE
Start CDI container before MP Config container

### DIFF
--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/ConfigDeployer.java
@@ -17,8 +17,11 @@ package org.glassfish.microprofile.config;
 
 import io.helidon.microprofile.config.ConfigCdiExtension;
 
+import jakarta.enterprise.inject.spi.CDI;
+
 import java.util.ServiceLoader;
 
+import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.glassfish.api.container.Container;
 import org.glassfish.api.deployment.ApplicationContainer;
@@ -35,7 +38,7 @@ public class ConfigDeployer implements Deployer {
 
     @Override
     public MetaData getMetaData() {
-        return null;
+        return new MetaData(true, new Class[] {Config.class}, new Class[] {CDI.class});
     }
 
     @Override

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/webapp/ConfigEndpoint.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpconfig/webapp/ConfigEndpoint.java
@@ -16,15 +16,24 @@
 
 package org.glassfish.main.test.app.mpconfig.webapp;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.glassfish.main.test.app.mpconfig.lib.ConfigHolder;
 
 @Path("/config")
+@ApplicationScoped
 public class ConfigEndpoint {
+
+    // Inject a property to verify that injection works
+    @Inject
+    @ConfigProperty(name = "name")
+    String name;
 
     @GET
     @Path("name")

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -29,6 +29,7 @@ import com.sun.enterprise.deployment.util.DOLUtils;
 import com.sun.enterprise.deployment.web.ServletFilterMapping;
 
 import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.CDI;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.InjectionTarget;
 import jakarta.inject.Inject;
@@ -183,7 +184,7 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
 
     @Override
     public MetaData getMetaData() {
-        return new MetaData(true, null, new Class[] { Application.class });
+        return new MetaData(true, new Class[] {CDI.class}, new Class[] { Application.class });
     }
 
     @Override

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/ApplicationLifecycle.java
@@ -953,7 +953,6 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
         if (results.contains(deployer)) {
             return;
         }
-        results.add(deployer);
         if (deployer.getMetaData() != null) {
             for (Class<?> required : deployer.getMetaData().requires()) {
                 if (dc.getModuleMetaData(required) != null) {
@@ -976,17 +975,17 @@ public class ApplicationLifecycle implements Deployment, PostConstruct {
                 }
             }
         }
+        results.add(deployer);
     }
 
     private void addRecursively(LinkedList<ApplicationMetaDataProvider<?>> results,
             Map<Class<?>, ApplicationMetaDataProvider<?>> providers, ApplicationMetaDataProvider<?> provider) {
-        results.addFirst(provider);
-
         for (Class<?> type : provider.getMetaData().requires()) {
             if (providers.containsKey(type)) {
                 addRecursively(results, providers, providers.get(type));
             }
         }
+        results.addFirst(provider);
     }
 
     @Override

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/SnifferManagerImpl.java
@@ -161,8 +161,8 @@ public class SnifferManagerImpl implements SnifferManager {
         }
         for (String annotationName : annotationNames) {
             Type type = types.getBy(annotationName);
-            if (type instanceof AnnotationType) {
-                Collection<AnnotatedElement> elements = ((AnnotationType) type).allAnnotatedTypes();
+            if (type instanceof AnnotationType annotationType) {
+                Collection<AnnotatedElement> elements = annotationType.allAnnotatedTypes();
                 for (AnnotatedElement element : elements) {
                     if (checkPath) {
                         final Type t = getDeclaringType(element);


### PR DESCRIPTION
Mark CDI container as a dependency of Config container. Fix loading of dependencies - load dependencies first, not after.

Fixes error introduced in https://github.com/eclipse-ee4j/glassfish/pull/25818:

```
Error occurred during deployment: Exception while loading the app : CDI deployment failure: WELD-001408: Unsatisfied dependencies for type Optional<String> with qualifiers @ConfigProperty
```

- caused because Config container couldn't register CDI extension because Weld container was starting later