### PR TITLE
Fix #25852 The --target option of asadmin delete-jdbc-resource command is ignored

### DIFF
--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/DeleteJdbcResource.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/DeleteJdbcResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -39,8 +39,6 @@ import org.glassfish.hk2.api.PerLookup;
 import org.glassfish.resourcebase.resources.api.ResourceStatus;
 import org.jvnet.hk2.annotations.Service;
 
-import static com.sun.enterprise.util.SystemPropertyConstants.DAS_SERVER_NAME;
-
 /**
  * Delete JDBC Resource command
  */
@@ -64,8 +62,6 @@ public class DeleteJdbcResource implements AdminCommand {
     @Param(name = "jdbc_resource_name", primary = true)
     private String jndiName;
 
-    // FIXME: unused, when removing, do the same in Create* and all asadmin commands used in tests
-    @Deprecated
     @Param(optional = true, defaultValue = CommandTarget.TARGET_SERVER)
     private String target;
 
@@ -86,7 +82,7 @@ public class DeleteJdbcResource implements AdminCommand {
 
         final ActionReport report = context.getActionReport();
         try {
-            ResourceStatus rs = jdbcResMgr.delete(domain.getResources(), SimpleJndiName.of(jndiName), DAS_SERVER_NAME);
+            ResourceStatus rs = jdbcResMgr.delete(domain.getResources(), SimpleJndiName.of(jndiName), target);
             if(rs.getMessage() != null){
                 report.setMessage(rs.getMessage());
             }

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCResourceManager.java
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/JDBCResourceManager.java
@@ -232,6 +232,7 @@ public class JDBCResourceManager implements ResourceManager {
             String msg = I18N.getLocalString("delete.jdbc.resource.system-all-req.object-type",
                     "The jdbc resource [ {0} ] cannot be deleted as it is required to be configured in the system.",
                     jndiName);
+            return new ResourceStatus(FAILURE, msg);
         }
 
         if (environment.isDas()) {
@@ -241,8 +242,16 @@ public class JDBCResourceManager implements ResourceManager {
                             "jdbc-resource [ {0} ] is referenced in an " +
                                     "instance/cluster target, Use delete-resource-ref on appropriate target",
                             jndiName);
+                    return new ResourceStatus(FAILURE, msg);
                 }
             } else {
+                if (!resourceUtil.isResourceRefInTarget(jndiName, target)) {
+                    String msg = I18N.getLocalString("delete.jdbc.resource.no.resource-ref",
+                            "jdbc-resource [ {0} ] is not referenced in target [ {1} ]",
+                            jndiName, target);
+                    return new ResourceStatus(FAILURE, msg);
+                }
+
                 if (resourceUtil.getTargetsReferringResourceRef(jndiName).size() > 1) {
                     String msg = I18N.getLocalString("delete.jdbc.resource.multiple.resource-refs",
                             "jdbc resource [ {0} ] is referenced in multiple " +
@@ -256,7 +265,7 @@ public class JDBCResourceManager implements ResourceManager {
         try {
 
             // delete resource-ref
-            if (!TARGET_DOMAIN.equals(target) && resourceUtil.isResourceRefInTarget(jndiName, target)) {
+            if (!TARGET_DOMAIN.equals(target)) {
                 resourceUtil.deleteResourceRef(jndiName, target);
             }
 

--- a/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/LocalStrings.properties
+++ b/appserver/jdbc/admin/src/main/java/org/glassfish/jdbc/admin/cli/LocalStrings.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
 # Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -36,6 +36,7 @@ delete.jdbc.resource.fail=Command create-jdbc-resource failed.
 delete.jdbc.resource.notfound=A JDBC resource named {0} does not exist.
 delete.jdbc.resource.resource-ref.exist=jdbc-resource [ {0} ] is referenced in an instance/cluster target, Use delete-resource-ref on appropriate target.
 delete.jdbc.resource.multiple.resource-refs=jdbc-resource [ {0} ] is referenced in multiple instance/cluster targets, Use delete-resource-ref on appropriate target
+delete.jdbc.resource.no.resource-ref=jdbc-resource [ {0} ] is not referenced in target [ {1} ]
 delete.jdbc.resource.system-all-req.object-type=The jdbc resource [ {0} ] cannot be deleted as it is required to be configured in the system.
 list.jdbc.resources=List all JDBC resources.
 list.jdbc.resources.success=Command list-jdbc-resources executed successfully.


### PR DESCRIPTION
Fixes #25852.
This should also fix #24459.

According to discussion in #24171,
- the target option of the {create,delete}-jdbc-connection-pool command is deprecated and ignored, whereas
- the target option of the {create,delete}-jdbc-resource command is necessary for resource reference (mapping between a JNDI name and the target).

Based on the above, this pull request makes the `target` option of the `delete-jdbc-resource` command work again.
Since this will also resolve #24459, we can restore validations for the resource reference targets, which were deleted in #24460 and subsequent pull requests as a workaround.