### PR TITLE
Add link to thread pool page in Admin UI

### DIFF
--- a/appserver/admingui/corba/pom.xml
+++ b/appserver/admingui/corba/pom.xml
@@ -47,4 +47,13 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/appserver/admingui/corba/src/main/resources/orb.jsf
+++ b/appserver/admingui/corba/src/main/resources/orb.jsf
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
     Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -109,6 +110,10 @@
                         selectedOptions="#{pageSession.selectedThreadPools}");
                 />
                 </sun:listbox>
+                <sun:hyperlink id="threadPoolsManageLink" 
+                              text="#{pageSession.selectedThreadPools.length == 1 ? '$resource{i18n_corba.orb.editThreadPool}' : '$resource{i18n_corba.orb.manageThreadPools}'}" 
+                              url="#{pageSession.selectedThreadPools.length == 1 ? request.contextPath.concat('/web/configuration/threadPoolEdit.jsf?name=').concat(pageSession.selectedThreadPools[0]).concat('&configName=').concat(pageSession.configName) : request.contextPath.concat('/web/configuration/threadPools.jsf?configName=').concat(pageSession.configName)}"
+                              style="margin-left: 10px;" />
             </sun:property>
             <sun:property id="MaxMsgSizeProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_corba.orb.maxMsgSizeLabel}" helpText="$resource{i18n_corba.orb.maxMsgSizeHelp}">
                 <sun:dropDown id="MaxMsgSize" selected="#{pageSession.valueMap['messageFragmentSize']}" labels="$pageSession{availableMsgSize}" >

--- a/appserver/admingui/corba/src/main/resources/org/glassfish/corba/admingui/Strings.properties
+++ b/appserver/admingui/corba/src/main/resources/org/glassfish/corba/admingui/Strings.properties
@@ -31,6 +31,8 @@ orb.totalConnsHelp=Maximum number of incoming connections for all IIOP listeners
 orb.iiopClientLabel=IIOP Client Authentication:
 orb.threadPoolIdLabel=Thread Pool ID:
 orb.threadPoolIdHelp=ID for the work queue
+orb.manageThreadPools=Manage
+orb.editThreadPool=Edit
 
 iiopListeners.TableTitle=Listeners
 iiopListeners.ListPageTitle=IIOP Listeners

--- a/appserver/admingui/web/pom.xml
+++ b/appserver/admingui/web/pom.xml
@@ -77,4 +77,14 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/appserver/admingui/web/src/main/resources/configuration/httpListenerAttr.inc
+++ b/appserver/admingui/web/src/main/resources/configuration/httpListenerAttr.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
     Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -63,6 +64,11 @@
                 gf.getChildrenNamesList(endpoint="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/thread-pools/thread-pool" result="#{pageSession.threadPoolList}");
             />
            </sun:dropDown>
+           <sun:hyperlink id="threadPoolEditLink" 
+                          text="$resource{i18n_web.grizzly.networkListener.editThreadPool}" 
+                          url="#{request.contextPath}/web/configuration/threadPoolEdit.jsf?name=#{pageSession.valueMap['threadPool']}&configName=#{pageSession.configName}"
+                          rendered="#{!empty pageSession.valueMap['threadPool']}"
+                          style="margin-left: 10px;" />
         </sun:property>
 
         <sun:property id="ServerNameProp"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.http.serverNameLabel}" helpText="$resource{i18n_web.http.serverNameHelp}" >

--- a/appserver/admingui/web/src/main/resources/grizzly/networkListenerAttr.inc
+++ b/appserver/admingui/web/src/main/resources/grizzly/networkListenerAttr.inc
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
     Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -111,6 +112,11 @@
                 gf.getChildrenNamesList(endpoint="#{sessionScope.REST_URL}/configs/config/#{pageSession.configName}/thread-pools/thread-pool" result="#{pageSession.threadPoolList}");
             />
            </sun:dropDown>
+           <sun:hyperlink id="threadPoolEditLink" 
+                          text="$resource{i18n_web.grizzly.networkListener.editThreadPool}" 
+                          url="#{request.contextPath}/web/configuration/threadPoolEdit.jsf?name=#{pageSession.valueMap['threadpool']}&configName=#{pageSession.configName}"
+                          rendered="#{!empty pageSession.valueMap['threadpool']}"
+                          style="margin-left: 10px;" />
         </sun:property>
 
         <sun:property id="transport"  labelAlign="left" noWrap="#{true}" overlapLabel="#{false}" label="$resource{i18n_web.grizzly.networkListener.transport}" helpText="$resource{i18n_web.grizzly.networkListener.transportHelp}">

--- a/appserver/admingui/web/src/main/resources/grizzly/networkListenerEdit.jsf
+++ b/appserver/admingui/web/src/main/resources/grizzly/networkListenerEdit.jsf
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
     Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -163,6 +164,11 @@
                 gf.getChildrenNamesList(endpoint="#{sessionScope.REST_URL}/configs/config/#{pageSession.encodedConfigName}/thread-pools/thread-pool" result="#{pageSession.threadPoolList}");
             />
            </sun:dropDown>
+           <sun:hyperlink id="threadPoolEditLink" 
+                          text="$resource{i18n_web.grizzly.networkListener.editThreadPool}" 
+                          url="#{request.contextPath}/web/configuration/threadPoolEdit.jsf?name=#{pageSession.valueMap['threadPool']}&configName=#{pageSession.configName}"
+                          rendered="#{!empty pageSession.valueMap['threadPool']}"
+                          style="margin-left: 10px;" />
         </sun:property>
 
     </sun:propertySheetSection>

--- a/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
+++ b/appserver/admingui/web/src/main/resources/org/glassfish/web/admingui/Strings.properties
@@ -130,6 +130,7 @@ grizzly.networkListener.protocol=Protocol:
 grizzly.networkListener.protocolHelp=The protocol associated with the network listener
 grizzly.networkListener.threadPool=Thread Pool:
 grizzly.networkListener.threadPoolHelp=The thread pool associated with the network listener
+grizzly.networkListener.editThreadPool=Edit
 grizzly.networkListener.transport=Transport:
 grizzly.networkListener.transportHelp=The transport associated with the network listener
 grizzly.networkListener.listenerTab=General


### PR DESCRIPTION
Add link next to thread pool selectors to link directly to the thread pool page to edit it.

For the selector in ORB page, which is a multiple choice selector (I don't understand whether and why ORB uses multiple listeners), the link goes to the selected selector if it's only one, or to the thread pool overview page if multiple ones are selected.