### PR TITLE
Bump eclipselink from 4.0.8 to 4.0.9

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -114,8 +114,8 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
-        <eclipselink.version>4.0.8</eclipselink.version>
-        <eclipselink.asm.version>9.8.0</eclipselink.asm.version>
+        <eclipselink.version>4.0.9</eclipselink.version>
+        <eclipselink.asm.version>9.9.0</eclipselink.asm.version>
 
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>


### PR DESCRIPTION
- https://github.com/eclipse-ee4j/eclipselink/releases/tag/4.0.9