### PR TITLE
Upgrade Woodstock to 6.0.3 with a security fix for prototype

### DIFF
--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -83,7 +83,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
+            <groupId>org.glassfish.woodstock.external</groupId>
             <artifactId>prototype</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -37,5 +37,5 @@
     </locale-charset-info>
     <class-loader
         delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-${woodstock.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-${woodstock.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -188,10 +188,9 @@
         <!-- Admin console components -->
         <jsftemplating.version>4.1.0-M1</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.0.2</woodstock.version>
+        <woodstock.version>6.0.3</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
         <woodstock-json.version>2.0</woodstock-json.version>
-        <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <!-- Other -->
         <dbschema.version>6.7</dbschema.version>
@@ -682,9 +681,9 @@
                 <version>${woodstock.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
+                <groupId>org.glassfish.woodstock.external</groupId>
                 <artifactId>prototype</artifactId>
-                <version>${woodstock-prototype.version}</version>
+                <version>${woodstock.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>


### PR DESCRIPTION
Woodstock 6.0.3 release notes: https://github.com/eclipse-ee4j/glassfish-woodstock/releases/tag/6.0.3