### PR TITLE
MicroProfile JWT injection as Jakarta Security authentication mechanism

### DIFF
--- a/appserver/featuresets/microprofile/pom.xml
+++ b/appserver/featuresets/microprofile/pom.xml
@@ -78,6 +78,11 @@
             <groupId>org.omnifaces</groupId>
             <artifactId>microprofile-jwt-auth</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.microprofile</groupId>
+            <artifactId>glassfish-microprofile-jwt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- MicroProfile REST Client -->
         <dependency>

--- a/appserver/microprofile/jwt/pom.xml
+++ b/appserver/microprofile/jwt/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.microprofile</groupId>
+        <artifactId>microprofile-parent</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>glassfish-microprofile-jwt</artifactId>
+    <packaging>glassfish-jar</packaging>
+
+    <name>GlassFish MicroProfile JWT</name>
+
+    <dependencies>
+        <!-- APIs -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <!-- Internal Dependencies -->
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>glassfish-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.omnifaces</groupId>
+            <artifactId>microprofile-jwt-auth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <supportedProjectTypes>
+                        <supportedProjectType>glassfish-jar</supportedProjectType>
+                    </supportedProjectTypes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>osgi-bundle</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>dev</id>
+            <properties>
+                <copy.modules.to.distribution.skip>false</copy.modules.to.distribution.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/appserver/microprofile/jwt/src/main/java/org/glassfish/microprofile/jwt/MpJwtCdiExtension.java
+++ b/appserver/microprofile/jwt/src/main/java/org/glassfish/microprofile/jwt/MpJwtCdiExtension.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.microprofile.jwt;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+
+import org.eclipse.microprofile.auth.LoginConfig;
+import org.glassfish.api.security.jwt.MicroProfileJwtAuthenticationMechanism;
+import org.omnifaces.jwt.cdi.CdiExtension;
+import org.omnifaces.jwt.eesecurity.JWTAuthenticationMechanism;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+public class MpJwtCdiExtension implements Extension {
+
+    public void addQualifiedBean(@Observes @Priority(1000) AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+        CdiExtension omnifacesExtension = beanManager.getExtension(CdiExtension.class);
+
+        if (omnifacesExtension.isAddJWTAuthenticationMechanism()) {
+            afterBeanDiscovery.addBean()
+                    .scope(ApplicationScoped.class)
+                    .beanClass(HttpAuthenticationMechanism.class)
+                    .qualifiers(MicroProfileJwtAuthenticationMechanism.Literal.INSTANCE)
+                    .types(Object.class, HttpAuthenticationMechanism.class, JWTAuthenticationMechanism.class)
+                    .id("mechanism " + LoginConfig.class)
+                    .createWith(e -> new JWTAuthenticationMechanism());
+        }
+    }
+}

--- a/appserver/microprofile/jwt/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/appserver/microprofile/jwt/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.glassfish.microprofile.jwt.MpJwtCdiExtension

--- a/appserver/microprofile/pom.xml
+++ b/appserver/microprofile/pom.xml
@@ -37,5 +37,6 @@
         <module>health</module>
         <module>health-glassfish</module>
         <module>connectors</module>
+        <module>jwt</module>
     </modules>
 </project>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2025 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2026 Contributors to Eclipse Foundation.
     Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -161,7 +161,6 @@
         <stax2-api.version>4.2.2</stax2-api.version>
 
         <!-- Jakarta CDI -->
-        <jakarta.cdi-api.version>4.1.0</jakarta.cdi-api.version>
         <weld.version>6.0.3.Final</weld.version>
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
@@ -550,18 +549,6 @@
                 <version>${jakarta.jaxb-impl.version}</version>
             </dependency>
 
-            <!-- Jakarta CDI -->
-            <dependency>
-                <groupId>jakarta.enterprise</groupId>
-                <artifactId>jakarta.enterprise.cdi-api</artifactId>
-                <version>${jakarta.cdi-api.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.inject</groupId>
-                        <artifactId>jakarta.inject</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.lang-model</artifactId>

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -74,6 +74,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <scope>provided</scope>

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpjwt/webapp/JwtApplication.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpjwt/webapp/JwtApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.mpjwt.webapp;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import org.eclipse.microprofile.auth.LoginConfig;
+
+@LoginConfig(authMethod = "MP-JWT", realmName = "test")
+@ApplicationPath("")
+@ApplicationScoped
+public class JwtApplication extends Application {
+
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpjwt/webapp/JwtClaimEndpoint.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpjwt/webapp/JwtClaimEndpoint.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.main.test.app.mpjwt.webapp;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.jwt.Claim;
+
+@Path("/claim")
+@RequestScoped
+public class JwtClaimEndpoint {
+
+    // Inject the 'sub' (subject) claim from the JWT token
+    @Inject
+    @Claim("sub")
+    String subject;
+
+    @GET
+    @Path("subject")
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed("user")
+    public String getSubject() {
+        return subject;
+    }
+}

--- a/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpjwt/webapp/JwtCustomAuthMechanismHandler.java
+++ b/appserver/tests/application/src/main/java/org/glassfish/main/test/app/mpjwt/webapp/JwtCustomAuthMechanismHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.mpjwt.webapp;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import jakarta.interceptor.Interceptor;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.glassfish.api.security.jwt.MicroProfileJwtAuthenticationMechanism;
+
+/**
+ *
+ * @author Ondro Mihalyi
+ */
+@BasicAuthenticationMechanismDefinition
+@ApplicationScoped
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION)
+public class JwtCustomAuthMechanismHandler implements HttpAuthenticationMechanismHandler {
+
+    @Inject
+    @MicroProfileJwtAuthenticationMechanism
+    HttpAuthenticationMechanism jwtAuthentication;
+
+    @Inject
+    @BasicAuthenticationMechanismDefinition.BasicAuthenticationMechanism
+    HttpAuthenticationMechanism basicAuthentication;
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext messageContext) throws AuthenticationException {
+        return jwtAuthentication.validateRequest(request, response, messageContext);
+    }
+
+}

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpjwt/MpJwtClaimInjectionTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpjwt/MpJwtClaimInjectionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.main.test.app.mpjwt;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import org.glassfish.common.util.HttpParser;
+import org.glassfish.main.itest.tools.GlassFishTestEnvironment;
+import org.glassfish.main.itest.tools.asadmin.Asadmin;
+import org.glassfish.main.test.app.mpjwt.webapp.JwtApplication;
+import org.glassfish.main.test.app.mpjwt.webapp.JwtClaimEndpoint;
+import org.glassfish.main.test.app.mpjwt.webapp.JwtCustomAuthMechanismHandler;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.System.Logger.Level.INFO;
+import static org.glassfish.main.itest.tools.GlassFishTestEnvironment.openConnection;
+import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadminOK;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MpJwtClaimInjectionTest {
+
+    private static final System.Logger LOG = System.getLogger(MpJwtClaimInjectionTest.class.getName());
+
+    private static final String APP_NAME = "mpjwt-app";
+
+    private static final Asadmin ASADMIN = GlassFishTestEnvironment.getAsadmin();
+
+    @TempDir
+    private static File tempDir;
+
+    @Test
+    void testJwtClaimInjection() throws IOException {
+        File app = createWebApp();
+        assertThat(ASADMIN.exec("deploy", "--force", "--contextroot", "app", "--name", APP_NAME, app.getAbsolutePath()), asadminOK());
+
+        try {
+            // Test that the endpoint is accessible (even without valid JWT, it should deploy successfully)
+            HttpURLConnection connection = openConnection(8080, "/app/claim/subject");
+            connection.setRequestMethod("GET");
+            // Without JWT, we expect 401 Unauthorized, which means JWT security is working
+            int responseCode = connection.getResponseCode();
+            // Either 401 (unauthorized) or 403 (forbidden) indicates JWT security is active
+            assertThat("JWT security should be active", responseCode == 401 || responseCode == 403, equalTo(true));
+            connection.disconnect();
+        } finally {
+            assertThat(ASADMIN.exec("undeploy", APP_NAME), asadminOK());
+        }
+    }
+
+    private String getJwtClaim() throws IOException {
+        HttpURLConnection connection = openConnection(8080, "/app/claim/subject");
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("Authorization", "Bearer " + createTestJwt());
+        try {
+            assertThat(connection.getResponseCode(), equalTo(200));
+            return HttpParser.readResponseInputStream(connection);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private String createTestJwt() {
+        // Minimal JWT for testing - in real scenario this would be properly signed
+        return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6InRlc3QiLCJhdWQiOiJ0ZXN0In0.test";
+    }
+
+    private static File createWebApp() {
+        String jwtConfig = """
+            mp.jwt.verify.issuer=https://server.example.com
+            mp.jwt.verify.publickey.location=/publicKey.pem
+            """;
+
+        String publicKey = """
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlivFI8qB4D0y2jy0CfEq
+            Fyy46R0o7S8TKpsx5xbHKoU1VWg6QkQm+ntyIv1p4kE1sPEQO73+HY8+Bzs75XwR
+            TYL1BmR1w8J5hmjVWjc6R2BTBGAYRPFRhor3kpM6ni2SPmNNhurEAHw7TaqszP5e
+            UF/F9+KEBWkwVta+PZ37bwqSE4sCb1soZFrVz/UT/LF4tYpuVYt3YbqToZ3pZOZ9
+            AX2o1GCG3xwOjkc4x0W7ezbQZdC9iftPxVHR8irOijJRRjcPDtA6vPKpzLl6CyYn
+            sIYPd99ltwxTHjr3npfv/3Lw50bAkbT4HeLFxTx4flEoZLKO/g0bAoV2uqBhkA9x
+            nQIDAQAB
+            -----END PUBLIC KEY-----
+            """;
+
+        WebArchive webApp = ShrinkWrap.create(WebArchive.class)
+                .addClass(JwtClaimEndpoint.class)
+                .addClass(JwtApplication.class)
+                .addClass(JwtCustomAuthMechanismHandler.class)
+                .addAsResource(new StringAsset(jwtConfig), "META-INF/microprofile-config.properties")
+                .addAsResource(new StringAsset(publicKey), "publicKey.pem");
+
+        LOG.log(INFO, webApp.toString(true));
+
+        File webAppFile = new File(tempDir, "jwt-app.war");
+        webApp.as(ZipExporter.class).exportTo(webAppFile, true);
+        return webAppFile;
+    }
+}

--- a/docs/application-development-guide/src/main/asciidoc/glassfish-api.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/glassfish-api.adoc
@@ -57,11 +57,11 @@ import org.glassfish.api.security.jwt.MicroProfileJwtAuthenticationMechanism;
 
 @ApplicationScoped
 public class SecurityService {
-    
+
     @Inject
     @MicroProfileJwtAuthenticationMechanism
     private HttpAuthenticationMechanism jwtAuthMechanism;
-    
+
     // Use the JWT authentication mechanism directly
 }
 ```

--- a/docs/application-development-guide/src/main/asciidoc/glassfish-api.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/glassfish-api.adoc
@@ -40,6 +40,64 @@ In Maven project, you can add it as the following dependency:
 
 This will already add `scattered-archive-api.jar` as a transitive dependency.
 
+[[microprofile-jwt-integration]]
+#### MicroProfile JWT Integration
+
+The GlassFish API includes CDI qualifiers for integrating with built-in security mechanisms.
+
+[[microprofile-jwt-qualifier]]
+##### @MicroProfileJwtAuthenticationMechanism Qualifier
+
+The `@MicroProfileJwtAuthenticationMechanism` qualifier allows direct injection of the GlassFish built-in MicroProfile JWT authentication mechanism:
+
+```java
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import org.glassfish.api.security.jwt.MicroProfileJwtAuthenticationMechanism;
+
+@ApplicationScoped
+public class SecurityService {
+    
+    @Inject
+    @MicroProfileJwtAuthenticationMechanism
+    private HttpAuthenticationMechanism jwtAuthMechanism;
+    
+    // Use the JWT authentication mechanism directly
+}
+```
+
+This qualifier provides:
+
+* **Direct Access**: Direct access to the GlassFish JWT authentication mechanism
+* **CDI Integration**: Seamless integration with CDI dependency injection
+* **Type Safety**: Uses the standard `HttpAuthenticationMechanism` interface
+
+The `@MicroProfileJwtAuthenticationMechanism` qualifier is complementary to the qualifiers for the standard Jakarta Security mechanisms like the Basic authentication mechanism. It can be combined with the other standard mechanisms in the same `HttpAuthenticationMechanismHandler`.
+
+Example:
+
+```
+@ApplicationScoped
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION)
+public class CustomAuthenticationHandler implements HttpAuthenticationMechanismHandler {
+
+    @Inject
+    @MicroProfileJwtAuthenticationMechanism
+    HttpAuthenticationMechanism jwtAuthentication;
+
+    @Inject
+    @BasicAuthenticationMechanismDefinition.BasicAuthenticationMechanism
+    HttpAuthenticationMechanism basicAuthentication;
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext messageContext) throws AuthenticationException {
+        // delegate to one of the two mechanisms
+    }
+
+}
+```
+
 [[glassfish-ee-api]]
 ### GlassFish EE API
 

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -50,6 +50,8 @@ view the most up-to-date product information.
 Key new features in {productName} {product-majorVersion} include:
 
 * Support for both https://jakarta.ee/specifications/persistence/[Jakarta Persistence] entities and https://jakarta.ee/specifications/nosql/[Jakarta NoSQL] entities in xref:application-development-guide.adoc#using-jakarta-data-repositories[Jakarta Data repositories]
+* xref:application-development-guide.adoc#microprofile-jwt-qualifier[@MicroProfileJwtAuthenticationMechanism CDI qualifier] for direct injection of the built-in MicroProfile JWT authentication mechanism (see xref:application-development-guide.adoc#microprofile-jwt-integration[MicroProfile JWT Integration])
+* Enhanced virtual threads support with Java 21+ for improved concurrency performance
 * Java 21+ minimum requirement with support up to JDK 25 (see xref:#required-jdk-versions[Required JDK Versions])
 * MicroProfile APIs expanded to Web Profile and Embedded GlassFish (since {productName} 7.1.0) (see xref:#microprofile-support[MicroProfile Standards Support])
 * Monitoring via JMX supported in Embedded {productName}
@@ -641,6 +643,16 @@ Table 1-4 Jakarta EE Standards Implementations in {productName} {product-current
 
 |https://jakarta.ee/specifications/platform/10/[Jakarta EE Specification]
 |{jakartaee}
+|X
+|X
+
+|https://jakarta.ee/specifications/data/[Jakarta Data]
+|{jakarta-data-api-version}
+|X
+|X
+
+|https://jakarta.ee/specifications/nosql/[Jakarta NoSQL]
+|{jakarta-nosql-api-version}
 |X
 |X
 

--- a/nucleus/common/glassfish-api/pom.xml
+++ b/nucleus/common/glassfish-api/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>glassfish-corba-omgapi</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-server</artifactId>
         </dependency>

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/security/jwt/MicroProfileJwtAuthenticationMechanism.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/security/jwt/MicroProfileJwtAuthenticationMechanism.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.api.security.jwt;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * CDI qualifier for injecting the GlassFish built-in MicroProfile JWT
+ * Jakarta Security Authentication mechanism.
+ * 
+ * <p>This qualifier allows direct injection of the GlassFish built-in MicroProfile JWT authentication mechanism.</p>
+ * 
+ * <h3>Basic Usage</h3>
+ * <pre>{@code
+ * @ApplicationScoped
+ * public class SecurityService {
+ *     
+ *     @Inject
+ *     @MicroProfileJwtAuthenticationMechanism
+ *     private HttpAuthenticationMechanism jwtAuthMechanism;
+ *     
+ *     // Use the JWT authentication mechanism directly
+ * }
+ * }</pre>
+ * 
+ * <h3>Features</h3>
+ * <ul>
+ * <li><strong>Direct Access:</strong> Direct access to the GlassFish JWT authentication mechanism</li>
+ * <li><strong>CDI Integration:</strong> Seamless integration with CDI dependency injection</li>
+ * <li><strong>Type Safety:</strong> Uses the standard {@link jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism} interface</li>
+ * </ul>
+ * 
+ * <h3>Combining with Other Mechanisms</h3>
+ * <p>The {@code @MicroProfileJwtAuthenticationMechanism} qualifier is complementary to the qualifiers for the standard Jakarta Security 
+ * mechanisms like the Basic authentication mechanism. It can be combined with the other standard mechanisms 
+ * in the same {@code HttpAuthenticationMechanismHandler}.</p>
+ * 
+ * <pre>{@code
+ * @ApplicationScoped
+ * @Alternative
+ * @Priority(Interceptor.Priority.APPLICATION)
+ * public class CustomAuthenticationHandler implements HttpAuthenticationMechanismHandler {
+ * 
+ *     @Inject
+ *     @MicroProfileJwtAuthenticationMechanism
+ *     HttpAuthenticationMechanism jwtAuthentication;
+ * 
+ *     @Inject
+ *     @BasicAuthenticationMechanismDefinition.BasicAuthenticationMechanism
+ *     HttpAuthenticationMechanism basicAuthentication;
+ * 
+ *     @Override
+ *     public AuthenticationStatus validateRequest(HttpServletRequest request, 
+ *                                               HttpServletResponse response, 
+ *                                               HttpMessageContext messageContext) 
+ *                                               throws AuthenticationException {
+ *         // delegate to one of the two mechanisms
+ *     }
+ * }
+ * }</pre>
+ * 
+ * @since GlassFish 8.0
+ * @see jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism
+ * @see org.eclipse.microprofile.jwt.JsonWebToken
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+@Documented
+public @interface MicroProfileJwtAuthenticationMechanism {
+    
+    public static final class Literal extends AnnotationLiteral<MicroProfileJwtAuthenticationMechanism> 
+            implements MicroProfileJwtAuthenticationMechanism {
+        public static final Literal INSTANCE = new Literal();
+    }
+}

--- a/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/security/jwt/MicroProfileJwtAuthenticationMechanism.java
+++ b/nucleus/common/glassfish-api/src/main/java/org/glassfish/api/security/jwt/MicroProfileJwtAuthenticationMechanism.java
@@ -32,58 +32,58 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * CDI qualifier for injecting the GlassFish built-in MicroProfile JWT
  * Jakarta Security Authentication mechanism.
- * 
+ *
  * <p>This qualifier allows direct injection of the GlassFish built-in MicroProfile JWT authentication mechanism.</p>
- * 
+ *
  * <h3>Basic Usage</h3>
  * <pre>{@code
  * @ApplicationScoped
  * public class SecurityService {
- *     
+ *
  *     @Inject
  *     @MicroProfileJwtAuthenticationMechanism
  *     private HttpAuthenticationMechanism jwtAuthMechanism;
- *     
+ *
  *     // Use the JWT authentication mechanism directly
  * }
  * }</pre>
- * 
+ *
  * <h3>Features</h3>
  * <ul>
  * <li><strong>Direct Access:</strong> Direct access to the GlassFish JWT authentication mechanism</li>
  * <li><strong>CDI Integration:</strong> Seamless integration with CDI dependency injection</li>
  * <li><strong>Type Safety:</strong> Uses the standard {@link jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism} interface</li>
  * </ul>
- * 
+ *
  * <h3>Combining with Other Mechanisms</h3>
- * <p>The {@code @MicroProfileJwtAuthenticationMechanism} qualifier is complementary to the qualifiers for the standard Jakarta Security 
- * mechanisms like the Basic authentication mechanism. It can be combined with the other standard mechanisms 
+ * <p>The {@code @MicroProfileJwtAuthenticationMechanism} qualifier is complementary to the qualifiers for the standard Jakarta Security
+ * mechanisms like the Basic authentication mechanism. It can be combined with the other standard mechanisms
  * in the same {@code HttpAuthenticationMechanismHandler}.</p>
- * 
+ *
  * <pre>{@code
  * @ApplicationScoped
  * @Alternative
  * @Priority(Interceptor.Priority.APPLICATION)
  * public class CustomAuthenticationHandler implements HttpAuthenticationMechanismHandler {
- * 
+ *
  *     @Inject
  *     @MicroProfileJwtAuthenticationMechanism
  *     HttpAuthenticationMechanism jwtAuthentication;
- * 
+ *
  *     @Inject
  *     @BasicAuthenticationMechanismDefinition.BasicAuthenticationMechanism
  *     HttpAuthenticationMechanism basicAuthentication;
- * 
+ *
  *     @Override
- *     public AuthenticationStatus validateRequest(HttpServletRequest request, 
- *                                               HttpServletResponse response, 
- *                                               HttpMessageContext messageContext) 
+ *     public AuthenticationStatus validateRequest(HttpServletRequest request,
+ *                                               HttpServletResponse response,
+ *                                               HttpMessageContext messageContext)
  *                                               throws AuthenticationException {
  *         // delegate to one of the two mechanisms
  *     }
  * }
  * }</pre>
- * 
+ *
  * @since GlassFish 8.0
  * @see jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism
  * @see org.eclipse.microprofile.jwt.JsonWebToken
@@ -93,9 +93,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({TYPE, METHOD, FIELD, PARAMETER})
 @Documented
 public @interface MicroProfileJwtAuthenticationMechanism {
-    
-    public static final class Literal extends AnnotationLiteral<MicroProfileJwtAuthenticationMechanism> 
+
+    /**
+     * Literal implementation for programmatic use.
+     */
+    final class Literal extends AnnotationLiteral<MicroProfileJwtAuthenticationMechanism>
             implements MicroProfileJwtAuthenticationMechanism {
+
+        /**
+         * Singleton instance of the literal.
+         */
         public static final Literal INSTANCE = new Literal();
     }
 }

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -117,6 +117,9 @@
         <hk2.version>4.0.0-M3</hk2.version>
         <hk2.plugin.version>4.0.0-M3</hk2.plugin.version>
 
+        <!-- Jakarta CDI -->
+        <jakarta.cdi-api.version>4.1.0</jakarta.cdi-api.version>
+
         <!-- Jakarta XML Binding -->
         <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
         <jakarta.jaxb-impl.version>4.0.6</jakarta.jaxb-impl.version>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -94,6 +94,23 @@
         <glassfishbuild-maven-plugin.assemblyInputDirectory>${project.build.outputDirectory}</glassfishbuild-maven-plugin.assemblyInputDirectory>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Jakarta CDI -->
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.cdi-api.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.inject</groupId>
+                        <artifactId>jakarta.inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <repositories>
         <repository>
             <id>central</id>


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/25475

Example better than words:

Just add the following dependency at compile time with version matching your target GlassFish:

```
<dependency>
    <groupId>org.glassfish.main.common</groupId>
    <artifactId>glassfish-api</artifactId>
    <version>${glassfish.version}</version>
</dependency>
```

And then you can decide whether to use JWT (e.g. for REST endpoints) or something else (e.g. OpenId or Basic for websites):

```
@BasicAuthenticationMechanismDefinition
@ApplicationScoped
@Alternative
@Priority(Interceptor.Priority.APPLICATION)
public class JwtCustomAuthMechanismHandler implements HttpAuthenticationMechanismHandler {

    @Inject
    @MicroProfileJwtAuthenticationMechanism
    HttpAuthenticationMechanism jwtAuthentication;

    @Inject
    @BasicAuthenticationMechanismDefinition.BasicAuthenticationMechanism
    HttpAuthenticationMechanism basicAuthentication;

    @Override
    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext messageContext) throws AuthenticationException {
        return isRest(request)
              ? jwtAuthentication.validateRequest(request, response, messageContext)
              : basicAuthentication.validateRequest(request, response, messageContext);
             
    }

}
```