### PR TITLE
Upgrade Helidon to 4.3.3

### DIFF
--- a/appserver/microprofile/config/pom.xml
+++ b/appserver/microprofile/config/pom.xml
@@ -107,19 +107,17 @@
                             groupId=io.helidon.common;artifactId=helidon-common-context,
                             groupId=io.helidon.common;artifactId=helidon-common-mapper,
                             groupId=io.helidon.common;artifactId=helidon-common-media-type,
-                            groupId=io.helidon.common;artifactId=helidon-common-service-loader,
                             groupId=io.helidon.common;artifactId=helidon-common-types,
-
 
                             groupId=io.helidon.config;artifactId=helidon-config,
                             groupId=io.helidon.config;artifactId=helidon-config-mp,
                             groupId=io.helidon.config;artifactId=helidon-config-yaml,
                             groupId=io.helidon.config;artifactId=helidon-config-yaml-mp,
                             groupId=io.helidon.builder;artifactId=helidon-builder-api,
-                            groupId=io.helidon.inject;artifactId=helidon-inject-api,
                             groupId=io.helidon.logging;artifactId=helidon-logging-common,
                             groupId=io.helidon.service;artifactId=helidon-service-registry,
                             groupId=io.helidon.service;artifactId=helidon-service-metadata,
+                            groupId=io.helidon.metadata;artifactId=helidon-metadata,
                             groupId=io.helidon.metadata;artifactId=helidon-metadata-hson,
 
                             artifactId=snakeyaml,

--- a/appserver/microprofile/config/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.config.mp;
+
+import java.lang.System.Logger.Level;
+import java.time.Instant;
+import java.util.IdentityHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import io.helidon.common.GenericType;
+import io.helidon.common.config.GlobalConfig;
+import io.helidon.config.ConfigValue;
+import io.helidon.config.MetaConfig;
+import io.helidon.config.spi.ConfigMapper;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * Integration with microprofile config.
+ * This class is an implementation of a java service obtained through ServiceLoader.
+ */
+public class MpConfigProviderResolver extends ConfigProviderResolver {
+    private static final System.Logger LOGGER = System.getLogger(MpConfigProviderResolver.class.getName());
+    private static final Map<ClassLoader, ConfigDelegate> CONFIGS = new IdentityHashMap<>();
+    private static final ReadWriteLock RW_LOCK = new ReentrantReadWriteLock();
+    // specific for native image - we want to replace config provided during build with runtime configuration
+    private static final List<ConfigDelegate> BUILD_CONFIG = new LinkedList<>();
+
+    @Override
+    public Config getConfig() {
+        return getConfig(Thread.currentThread().getContextClassLoader());
+    }
+
+    @Override
+    public Config getConfig(ClassLoader classLoader) {
+        ClassLoader loader;
+        if (classLoader == null) {
+            loader = Thread.currentThread().getContextClassLoader();
+        } else {
+            loader = classLoader;
+        }
+        Lock lock = RW_LOCK.readLock();
+        try {
+            lock.lock();
+            Config config = CONFIGS.get(loader);
+
+            if (null == config) {
+                lock.unlock();
+                lock = RW_LOCK.writeLock();
+                lock.lock();
+                Config c = buildConfig(loader);
+                return doRegisterConfig(c, loader);
+            } else {
+                return config;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private Config buildConfig(ClassLoader loader) {
+        MpConfigBuilder builder = getBuilder();
+        builder.forClassLoader(loader);
+
+        // MP Meta Configuration
+        Optional<io.helidon.config.Config> meta = MpMetaConfig.metaConfig();
+
+        if (meta.isEmpty()){
+            meta = MetaConfig.metaConfig();
+
+            if (meta.isPresent()) {
+                builder.metaConfig(meta.get());
+                LOGGER.log(Level.WARNING, "You are using Helidon SE meta configuration in a Helidon MP application. Some "
+                        + "features work differently, such as environment variable resolving, and mutability");
+            }
+        } else {
+            builder.mpMetaConfig(meta.get());
+        }
+
+        if (meta.isEmpty()) {
+            // no meta configuration, use defaults
+            builder.addDefaultSources();
+            builder.addDiscoveredSources();
+            builder.addDiscoveredConverters();
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public MpConfigBuilder getBuilder() {
+        return new MpConfigBuilder();
+    }
+
+    @Override
+    public void registerConfig(Config config, ClassLoader classLoader) {
+        ClassLoader usedClassloader;
+        if (null == classLoader) {
+            usedClassloader = Thread.currentThread().getContextClassLoader();
+        } else {
+            usedClassloader = classLoader;
+        }
+
+        Lock lock = RW_LOCK.writeLock();
+        try {
+            lock.lock();
+            doRegisterConfig(config, usedClassloader);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * This method should only be called when running within native image, as soon as runtime configuration
+     * is available.
+     *
+     * @param config configuration to use
+     */
+    public static void runtimeStart(Config config) {
+        if (BUILD_CONFIG.isEmpty()) {
+            return;
+        }
+        BUILD_CONFIG.forEach(it -> it.set(config));
+        BUILD_CONFIG.clear();
+    }
+
+    /**
+     * This method should only be called when generating native image, as late in the process as possible.
+     */
+    public static void buildTimeEnd() {
+        Lock lock = RW_LOCK.writeLock();
+        try {
+            lock.lock();
+            CONFIGS.forEach((key, value) -> BUILD_CONFIG.add(value));
+            CONFIGS.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private ConfigDelegate doRegisterConfig(Config config, ClassLoader classLoader) {
+        ConfigDelegate currentConfig = CONFIGS.remove(classLoader);
+
+        if (config instanceof ConfigDelegate delegate) {
+            config = delegate.delegate();
+        }
+
+        if (null != currentConfig) {
+            currentConfig.set(config);
+        }
+
+        ConfigDelegate newConfig = new ConfigDelegate(config);
+        CONFIGS.put(classLoader, newConfig);
+
+        if (classLoader == Thread.currentThread().getContextClassLoader()) {
+            // this should be the default class loader (we do not support classloader magic in Helidon)
+            GlobalConfig.config(() -> newConfig, true);
+        }
+
+        return newConfig;
+    }
+
+    @Override
+    public void releaseConfig(Config config) {
+        // first attempt to find it
+        Lock lock = RW_LOCK.readLock();
+        AtomicReference<ClassLoader> cl = new AtomicReference<>();
+
+        // in case we get our own delegate, we want to remove the exact same instance of delegate
+        try {
+            lock.lock();
+            if (config instanceof ConfigDelegate) {
+                for (Map.Entry<ClassLoader, ConfigDelegate> entry : CONFIGS.entrySet()) {
+                    if (config == entry.getValue()) {
+                        cl.set(entry.getKey());
+                        break;
+                    }
+                }
+            } else {
+                for (Map.Entry<ClassLoader, ConfigDelegate> entry : CONFIGS.entrySet()) {
+                    Config configFromRef = entry.getValue().delegate();
+                    if (config == configFromRef) {
+                        cl.set(entry.getKey());
+                        break;
+                    }
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+
+        // if found, remove it
+        if (cl.get() != null) {
+            lock = RW_LOCK.writeLock();
+            try {
+                lock.lock();
+                CONFIGS.remove(cl.get());
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * A delegate used to allow replacing configuration at runtime for components
+     * that hold a reference to configuration obtained at build time.
+     */
+    static final class ConfigDelegate implements io.helidon.config.Config, Config {
+        private final AtomicReference<Config> delegate = new AtomicReference<>();
+        private final AtomicReference<io.helidon.config.Config> helidonDelegate = new AtomicReference<>();
+
+        private ConfigDelegate(Config delegate) {
+            set(delegate);
+        }
+
+        void set(Config delegate) {
+            this.delegate.set(delegate);
+            if (delegate instanceof io.helidon.config.Config) {
+                this.helidonDelegate.set((io.helidon.config.Config) delegate);
+            } else {
+                this.helidonDelegate.set(MpConfig.toHelidonConfig(delegate));
+            }
+        }
+
+        @Override
+        public org.eclipse.microprofile.config.ConfigValue getConfigValue(String s) {
+            return delegate.get().getConfigValue(s);
+        }
+
+        @Override
+        public <T> Optional<Converter<T>> getConverter(Class<T> aClass) {
+            return delegate.get().getConverter(aClass);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T unwrap(Class<T> aClass) {
+            if (Config.class.equals(aClass)) {
+                return (T) delegate.get();
+            }
+            return delegate.get().unwrap(aClass);
+        }
+
+        private io.helidon.config.Config getCurrent() {
+            var current = helidonDelegate.get().context().last();
+            if (current == this) {
+                // in case there is a bad setup, we may return the same instance, prevent that
+                return helidonDelegate.get();
+            }
+            return current;
+        }
+
+        @Override
+        public Instant timestamp() {
+            return getCurrent().timestamp();
+        }
+
+        @Override
+        public Key key() {
+            return getCurrent().key();
+        }
+
+        @Override
+        public io.helidon.config.Config root() {
+            return getCurrent().root();
+        }
+
+        @Override
+        public io.helidon.config.Config get(Key key) {
+            return getCurrent().get(key);
+        }
+
+        @Override
+        public io.helidon.config.Config detach() {
+            return getCurrent().detach();
+        }
+
+        @Override
+        public Type type() {
+            return getCurrent().type();
+        }
+
+        @Override
+        public boolean hasValue() {
+            return getCurrent().hasValue();
+        }
+
+        @Override
+        public Stream<io.helidon.config.Config> traverse(Predicate<io.helidon.config.Config> predicate) {
+            return getCurrent().traverse();
+        }
+
+        @Override
+        public <T> T convert(Class<T> type, String value) {
+            return getCurrent().convert(type, value);
+        }
+
+        @Override
+        public <T> ConfigValue<T> as(GenericType<T> genericType) {
+            return getCurrent().as(genericType);
+        }
+
+        @Override
+        public <T> ConfigValue<T> as(Class<T> type) {
+            return getCurrent().as(type);
+        }
+
+        @Override
+        public <T> ConfigValue<T> as(Function<io.helidon.config.Config, T> mapper) {
+            return getCurrent().as(mapper);
+        }
+
+        @Override
+        public <T> ConfigValue<List<T>> asList(Class<T> type) {
+            return getCurrent().asList(type);
+        }
+
+        @Override
+        public <T> ConfigValue<List<T>> asList(Function<io.helidon.config.Config, T> mapper) {
+            return getCurrent().asList(mapper);
+        }
+
+        @Override
+        public ConfigValue<List<io.helidon.config.Config>> asNodeList() {
+            return getCurrent().asNodeList();
+        }
+
+        @Override
+        public ConfigValue<Map<String, String>> asMap() {
+            return getCurrent().asMap();
+        }
+
+        @Override
+        public ConfigMapper mapper() {
+            return getCurrent().mapper();
+        }
+
+        @Override
+        public <T> T getValue(String propertyName, Class<T> propertyType) {
+            return delegate.get().getValue(propertyName, propertyType);
+        }
+
+        @Override
+        public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+            return delegate.get().getOptionalValue(propertyName, propertyType);
+        }
+
+        @Override
+        public Iterable<String> getPropertyNames() {
+            return delegate.get().getPropertyNames();
+        }
+
+        @Override
+        public Iterable<ConfigSource> getConfigSources() {
+            return delegate.get().getConfigSources();
+        }
+
+        /**
+         * Get the underlying instance of this delegate pattern.
+         *
+         * @return the instance backing this config delegate
+         */
+        public Config delegate() {
+            return delegate.get();
+        }
+    }
+}

--- a/appserver/microprofile/config/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to Eclipse Foundation.
  * Copyright (c) 2019, 2025 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +17,11 @@
 
 package io.helidon.config.mp;
 
+import io.helidon.common.GenericType;
+import io.helidon.config.ConfigValue;
+import io.helidon.config.MetaConfig;
+import io.helidon.config.spi.ConfigMapper;
+
 import java.lang.System.Logger.Level;
 import java.time.Instant;
 import java.util.IdentityHashMap;
@@ -30,12 +36,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-
-import io.helidon.common.GenericType;
-import io.helidon.common.config.GlobalConfig;
-import io.helidon.config.ConfigValue;
-import io.helidon.config.MetaConfig;
-import io.helidon.config.spi.ConfigMapper;
 
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
@@ -178,11 +178,6 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
 
         ConfigDelegate newConfig = new ConfigDelegate(config);
         CONFIGS.put(classLoader, newConfig);
-
-        if (classLoader == Thread.currentThread().getContextClassLoader()) {
-            // this should be the default class loader (we do not support classloader magic in Helidon)
-            GlobalConfig.config(() -> newConfig, true);
-        }
 
         return newConfig;
     }

--- a/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2018, 2025 Oracle and/or its affiliates.
+ * Copyright (c) 2022, 2026 Contributors to Eclipse Foundation.
+ * Copyright (c) 2018, 2021 Oracle and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +16,42 @@
  */
 
 package io.helidon.microprofile.config;
+
+import io.helidon.common.NativeImageHelper;
+import io.helidon.config.ConfigException;
+import io.helidon.config.mp.MpConfig;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Vetoed;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.AnnotatedField;
+import jakarta.enterprise.inject.spi.AnnotatedMethod;
+import jakarta.enterprise.inject.spi.AnnotatedParameter;
+import jakarta.enterprise.inject.spi.AnnotatedType;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+import jakarta.enterprise.inject.spi.ProcessBean;
+import jakarta.enterprise.inject.spi.ProcessObserverMethod;
+import jakarta.enterprise.inject.spi.ProcessSyntheticObserverMethod;
+import jakarta.enterprise.inject.spi.WithAnnotations;
+import jakarta.inject.Provider;
+import jakarta.interceptor.Interceptor;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.Converter;
 
 import java.lang.System.Logger.Level;
 import java.lang.annotation.Annotation;
@@ -39,39 +76,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import io.helidon.common.NativeImageHelper;
-import io.helidon.config.ConfigException;
-import io.helidon.config.mp.MpConfig;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.event.Observes;
-import jakarta.enterprise.inject.Vetoed;
-import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
-import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
-import jakarta.enterprise.inject.spi.Annotated;
-import jakarta.enterprise.inject.spi.AnnotatedField;
-import jakarta.enterprise.inject.spi.AnnotatedMethod;
-import jakarta.enterprise.inject.spi.AnnotatedParameter;
-import jakarta.enterprise.inject.spi.AnnotatedType;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.enterprise.inject.spi.Extension;
-import jakarta.enterprise.inject.spi.InjectionPoint;
-import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
-import jakarta.enterprise.inject.spi.ProcessBean;
-import jakarta.enterprise.inject.spi.ProcessObserverMethod;
-import jakarta.enterprise.inject.spi.WithAnnotations;
-import jakarta.inject.Provider;
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.ConfigValue;
-import org.eclipse.microprofile.config.inject.ConfigProperties;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.config.spi.Converter;
+import org.glassfish.microprofile.config.ApplicationContext;
 
 /**
+ * Must be in the {@link io.helidon.microprofile.config} package because it depends on package private Helidon classes.
  * Extension to enable config injection in CDI container (all of {@link io.helidon.config.Config},
  * {@link org.eclipse.microprofile.config.Config} and {@link ConfigProperty} and {@link ConfigProperties}).
  */
@@ -128,16 +136,23 @@ public class ConfigCdiExtension implements Extension {
         AnnotatedType<?> annotatedType = event.getAnnotatedType();
         ConfigProperties configProperties = annotatedType.getAnnotation(ConfigProperties.class);
         if (configProperties == null) {
-            // ignore classes that do not have this annotation on class level
+            // Ignore classes that do not have this annotation on class level
             return;
         }
+
         configBeans.put(annotatedType.getJavaClass(), ConfigBeanDescriptor.create(annotatedType, configProperties));
-        // we must veto this annotated type, as we need to create a custom bean to create an instance
+
+        // We must veto this annotated type, as we need to create a custom bean to create an instance
         event.veto();
     }
 
     private <X> void harvestConfigPropertyInjectionPointsFromEnabledObserverMethod(@Observes ProcessObserverMethod<?, X> event,
                                                                                    BeanManager beanManager) {
+        // Synthetic events won't have an annotated method
+        if (event instanceof ProcessSyntheticObserverMethod) {
+            return;
+        }
+
         AnnotatedMethod<X> annotatedMethod = event.getAnnotatedMethod();
         if (annotatedMethod != null && !annotatedMethod.getDeclaringType().isAnnotationPresent(Vetoed.class)) {
             List<AnnotatedParameter<X>> annotatedParameters = annotatedMethod.getParameters();
@@ -163,17 +178,17 @@ public class ConfigCdiExtension implements Extension {
     /**
      * Register a config producer bean for each {@link org.eclipse.microprofile.config.inject.ConfigProperty} injection.
      *
-     * @param abd event from CDI container
+     * @param afterBeanDiscovery event from CDI container
      */
-    private void registerConfigProducer(@Observes AfterBeanDiscovery abd) {
+    private void registerConfigProducer(@Observes AfterBeanDiscovery afterBeanDiscovery) {
         // we also must support injection of Config itself
-        abd.addBean()
+        afterBeanDiscovery.addBean()
                 .addTransitiveTypeClosure(org.eclipse.microprofile.config.Config.class)
                 .beanClass(org.eclipse.microprofile.config.Config.class)
                 .scope(ApplicationScoped.class)
                 .createWith(creationalContext -> new SerializableConfig());
 
-        abd.addBean()
+        afterBeanDiscovery.addBean()
                 .addTransitiveTypeClosure(io.helidon.config.Config.class)
                 .beanClass(io.helidon.config.Config.class)
                 .scope(ApplicationScoped.class)
@@ -202,14 +217,14 @@ public class ConfigCdiExtension implements Extension {
                 .collect(Collectors.toSet());
 
         types.forEach(type -> {
-            abd.addBean()
+            afterBeanDiscovery.addBean()
                     .addType(type)
                     .scope(Dependent.class)
                     .addQualifier(CONFIG_PROPERTY_LITERAL)
                     .produceWith(it -> produce(it.select(InjectionPoint.class).get()));
         });
 
-        configBeans.values().forEach(beanDescriptor -> abd.addBean()
+        configBeans.values().forEach(beanDescriptor -> afterBeanDiscovery.addBean()
                 .addType(beanDescriptor.type())
                 .addTransitiveTypeClosure(beanDescriptor.type())
                 // it is non-binding
@@ -218,6 +233,15 @@ public class ConfigCdiExtension implements Extension {
                 .produceWith(it -> beanDescriptor.produce(it.select(InjectionPoint.class).get(), ConfigProvider.getConfig())));
     }
 
+    /**
+     * Register a config producer bean for each {@link org.eclipse.microprofile.config.inject.ConfigProperty} injection.
+     *
+     * @param afterBeanDiscovery event from CDI container
+     */
+    private void defineApplicationContextBean(@Observes @Priority(Interceptor.Priority.LIBRARY_BEFORE) AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
+        afterBeanDiscovery.addBean()
+                .read(beanManager.createAnnotatedType(ApplicationContext.class));
+    }
     /**
      * Validate all injection points are valid.
      *

--- a/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/microprofile/config/ConfigCdiExtension.java
@@ -45,13 +45,6 @@ import jakarta.enterprise.inject.spi.WithAnnotations;
 import jakarta.inject.Provider;
 import jakarta.interceptor.Interceptor;
 
-import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.ConfigValue;
-import org.eclipse.microprofile.config.inject.ConfigProperties;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.config.spi.Converter;
-
 import java.lang.System.Logger.Level;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -75,6 +68,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.inject.ConfigProperties;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.spi.Converter;
 import org.glassfish.microprofile.config.ApplicationContext;
 
 /**

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/org/glassfish/microprofile/config/GlassFishConfigProviderResolver.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.glassfish.microprofile.config.util.LazyProperty;
 
 /**
+ * This resolver postpones retrieving the resolver when it's actually needed. And when we already have the correct application's threadContext classloader.
  *
  * @author Ondro Mihalyi
  */

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -171,7 +171,7 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1</microprofile.config-api.version>
-        <helidon-config.version>4.2.4</helidon-config.version>
+        <helidon-config.version>4.3.3</helidon-config.version>
 
 
         <!-- MicroProfile Health -->


### PR DESCRIPTION
Upgrades Helidon to 4.3.3: 

* Helidon 4.3.3 release notes: https://github.com/helidon-io/helidon/releases/tag/4.3.3
* Changes since 4.2.4: https://github.com/helidon-io/helidon/compare/4.2.4...4.3.3

If merged before https://github.com/eclipse-ee4j/glassfish/pull/25881, it superceeds it - it contains the same changes plus Helidon upgrade.

Passes MP Config TCK locally.