### PR TITLE
Multirelease tests updated from 11+17 to 21+25

### DIFF
--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/MultiReleaseTestBase.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/MultiReleaseTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,9 +44,9 @@ import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ARETURN;
 import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.RETURN;
-import static org.objectweb.asm.Opcodes.V11;
-import static org.objectweb.asm.Opcodes.V17;
 import static org.objectweb.asm.Opcodes.V1_8;
+import static org.objectweb.asm.Opcodes.V21;
+import static org.objectweb.asm.Opcodes.V25;
 
 public class MultiReleaseTestBase {
 
@@ -59,8 +59,8 @@ public class MultiReleaseTestBase {
             .setManifest(generateManifest())
             .addClass(Version.class)
             .add(generateVersionClass(V1_8), packageJarEntryFor(VersionImpl.class, V1_8), classFileNameFor(VersionImpl.class))
-            .add(generateVersionClass(V11), packageJarEntryFor(VersionImpl.class, V11), classFileNameFor(VersionImpl.class))
-            .add(generateVersionClass(V17), packageJarEntryFor(VersionImpl.class, V17), classFileNameFor(VersionImpl.class));
+            .add(generateVersionClass(V21), packageJarEntryFor(VersionImpl.class, V21), classFileNameFor(VersionImpl.class))
+            .add(generateVersionClass(V25), packageJarEntryFor(VersionImpl.class, V25), classFileNameFor(VersionImpl.class));
     }
 
     protected static File createFileFor(Archive<?> archive, String applicationName) throws IOException {
@@ -88,11 +88,11 @@ public class MultiReleaseTestBase {
     private static String packageJarEntryFor(Class<?> c, int version) {
         StringBuilder jarTarget = new StringBuilder();
         switch (version) {
-            case V11:
-                jarTarget.append("META-INF/versions/11/");
+            case V21:
+                jarTarget.append("META-INF/versions/21/");
                 break;
-            case V17:
-                jarTarget.append("META-INF/versions/17/");
+            case V25:
+                jarTarget.append("META-INF/versions/25/");
                 break;
             default:
                 break;

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/ear/MultiReleaseEnterpriseApplicationLibraryTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/ear/MultiReleaseEnterpriseApplicationLibraryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,11 +42,11 @@ import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadmi
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.condition.JRE.JAVA_11;
-import static org.junit.jupiter.api.condition.JRE.JAVA_16;
-import static org.junit.jupiter.api.condition.JRE.JAVA_17;
-import static org.objectweb.asm.Opcodes.V11;
-import static org.objectweb.asm.Opcodes.V17;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
+import static org.junit.jupiter.api.condition.JRE.JAVA_24;
+import static org.junit.jupiter.api.condition.JRE.JAVA_25;
+import static org.objectweb.asm.Opcodes.V21;
+import static org.objectweb.asm.Opcodes.V25;
 
 public class MultiReleaseEnterpriseApplicationLibraryTest extends MultiReleaseTestBase {
 
@@ -80,8 +80,8 @@ public class MultiReleaseEnterpriseApplicationLibraryTest extends MultiReleaseTe
     }
 
     @Test
-    @EnabledForJreRange(min = JAVA_11, max = JAVA_16)
-    public void testMultiReleaseEarLibProcessingJdk11(TestInfo testInfo) throws IOException {
+    @EnabledForJreRange(min = JAVA_21, max = JAVA_24)
+    public void testMultiReleaseEarLibProcessingJdk21(TestInfo testInfo) throws IOException {
         LOG.log(INFO, "Run test method {0}", testInfo.getTestMethod().orElseThrow().getName());
         HttpURLConnection connection = GlassFishTestEnvironment.openConnection(8080, CONTEXT_ROOT);
         connection.setRequestMethod("GET");
@@ -89,7 +89,7 @@ public class MultiReleaseEnterpriseApplicationLibraryTest extends MultiReleaseTe
             assertAll(
                 () -> assertThat(connection.getResponseCode(), equalTo(200)),
                 // Check version of loaded class file
-                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V11))
+                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V21))
             );
         } finally {
             connection.disconnect();
@@ -97,8 +97,8 @@ public class MultiReleaseEnterpriseApplicationLibraryTest extends MultiReleaseTe
     }
 
     @Test
-    @EnabledForJreRange(min = JAVA_17)
-    public void testMultiReleaseEarLibProcessingJdk17(TestInfo testInfo) throws IOException {
+    @EnabledForJreRange(min = JAVA_25)
+    public void testMultiReleaseEarLibProcessingJdk25(TestInfo testInfo) throws IOException {
         LOG.log(INFO, "Run test method {0}", testInfo.getTestMethod().orElseThrow().getName());
         HttpURLConnection connection = GlassFishTestEnvironment.openConnection(8080, CONTEXT_ROOT);
         connection.setRequestMethod("GET");
@@ -106,7 +106,7 @@ public class MultiReleaseEnterpriseApplicationLibraryTest extends MultiReleaseTe
             assertAll(
                 () -> assertThat(connection.getResponseCode(), equalTo(200)),
                 // Check version of loaded class file
-                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V17))
+                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V25))
             );
         } finally {
             connection.disconnect();

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/servlet/MultiReleaseServletContainerInitializerTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/servlet/MultiReleaseServletContainerInitializerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,11 +41,11 @@ import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadmi
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.condition.JRE.JAVA_11;
-import static org.junit.jupiter.api.condition.JRE.JAVA_16;
-import static org.junit.jupiter.api.condition.JRE.JAVA_17;
-import static org.objectweb.asm.Opcodes.V11;
-import static org.objectweb.asm.Opcodes.V17;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
+import static org.junit.jupiter.api.condition.JRE.JAVA_24;
+import static org.junit.jupiter.api.condition.JRE.JAVA_25;
+import static org.objectweb.asm.Opcodes.V21;
+import static org.objectweb.asm.Opcodes.V25;
 
 public class MultiReleaseServletContainerInitializerTest extends MultiReleaseTestBase {
 
@@ -77,8 +77,8 @@ public class MultiReleaseServletContainerInitializerTest extends MultiReleaseTes
     }
 
     @Test
-    @EnabledForJreRange(min = JAVA_11, max = JAVA_16)
-    public void testServletContainerInitializerJdk11(TestInfo testInfo) throws IOException {
+    @EnabledForJreRange(min = JAVA_21, max = JAVA_24)
+    public void testServletContainerInitializerJdk21(TestInfo testInfo) throws IOException {
         LOG.log(INFO, "Run test method {0}", testInfo.getTestMethod().orElseThrow().getName());
         HttpURLConnection connection = GlassFishTestEnvironment.openConnection(8080, CONTEXT_ROOT);
         connection.setRequestMethod("GET");
@@ -86,7 +86,7 @@ public class MultiReleaseServletContainerInitializerTest extends MultiReleaseTes
             assertAll(
                 () -> assertThat(connection.getResponseCode(), equalTo(200)),
                 // Check version of loaded class file
-                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection).trim()), equalTo(V11))
+                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection).trim()), equalTo(V21))
             );
         } finally {
             connection.disconnect();
@@ -94,8 +94,8 @@ public class MultiReleaseServletContainerInitializerTest extends MultiReleaseTes
     }
 
     @Test
-    @EnabledForJreRange(min = JAVA_17)
-    public void testServletContainerInitializerJdk17(TestInfo testInfo) throws IOException {
+    @EnabledForJreRange(min = JAVA_25)
+    public void testServletContainerInitializerJdk25(TestInfo testInfo) throws IOException {
         LOG.log(INFO, "Run test method {0}", testInfo.getTestMethod().orElseThrow().getName());
         HttpURLConnection connection = GlassFishTestEnvironment.openConnection(8080, CONTEXT_ROOT);
         connection.setRequestMethod("GET");
@@ -103,7 +103,7 @@ public class MultiReleaseServletContainerInitializerTest extends MultiReleaseTes
             assertAll(
                 () -> assertThat(connection.getResponseCode(), equalTo(200)),
                 // Check version of loaded class file
-                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection).trim()), equalTo(V17))
+                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection).trim()), equalTo(V25))
             );
         } finally {
             connection.disconnect();

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/webapp/MultiReleaseWebApplicationTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mrjar/webapp/MultiReleaseWebApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,11 +39,11 @@ import static org.glassfish.main.itest.tools.asadmin.AsadminResultMatcher.asadmi
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.condition.JRE.JAVA_11;
-import static org.junit.jupiter.api.condition.JRE.JAVA_16;
-import static org.junit.jupiter.api.condition.JRE.JAVA_17;
-import static org.objectweb.asm.Opcodes.V11;
-import static org.objectweb.asm.Opcodes.V17;
+import static org.junit.jupiter.api.condition.JRE.JAVA_21;
+import static org.junit.jupiter.api.condition.JRE.JAVA_24;
+import static org.junit.jupiter.api.condition.JRE.JAVA_25;
+import static org.objectweb.asm.Opcodes.V21;
+import static org.objectweb.asm.Opcodes.V25;
 
 public class MultiReleaseWebApplicationTest extends MultiReleaseTestBase {
 
@@ -73,8 +73,8 @@ public class MultiReleaseWebApplicationTest extends MultiReleaseTestBase {
     }
 
     @Test
-    @EnabledForJreRange(min = JAVA_11, max = JAVA_16)
-    public void testMultiReleaseJarProcessingJdk11(TestInfo testInfo) throws IOException {
+    @EnabledForJreRange(min = JAVA_21, max = JAVA_24)
+    public void testMultiReleaseJarProcessingJdk21(TestInfo testInfo) throws IOException {
         LOG.log(INFO, "Run test method {0}", testInfo.getTestMethod().orElseThrow().getName());
         HttpURLConnection connection = GlassFishTestEnvironment.openConnection(8080, CONTEXT_ROOT);
         connection.setRequestMethod("GET");
@@ -82,7 +82,7 @@ public class MultiReleaseWebApplicationTest extends MultiReleaseTestBase {
             assertAll(
                 () -> assertThat(connection.getResponseCode(), equalTo(200)),
                 // Check version of loaded class file
-                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V11))
+                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V21))
             );
         } finally {
             connection.disconnect();
@@ -90,8 +90,8 @@ public class MultiReleaseWebApplicationTest extends MultiReleaseTestBase {
     }
 
     @Test
-    @EnabledForJreRange(min = JAVA_17)
-    public void testMultiReleaseJarProcessingJdk17(TestInfo testInfo) throws IOException {
+    @EnabledForJreRange(min = JAVA_25)
+    public void testMultiReleaseJarProcessingJdk25(TestInfo testInfo) throws IOException {
         LOG.log(INFO, "Run test method {0}", testInfo.getTestMethod().orElseThrow().getName());
         HttpURLConnection connection = GlassFishTestEnvironment.openConnection(8080, CONTEXT_ROOT);
         connection.setRequestMethod("GET");
@@ -99,7 +99,7 @@ public class MultiReleaseWebApplicationTest extends MultiReleaseTestBase {
             assertAll(
                 () -> assertThat(connection.getResponseCode(), equalTo(200)),
                 // Check version of loaded class file
-                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V17))
+                () -> assertThat(Integer.parseInt(HttpParser.readResponseInputStream(connection)), equalTo(V25))
             );
         } finally {
             connection.disconnect();


### PR DESCRIPTION
GlassFish 8 upgraded JDK versions, so these tests should follow.
