### PR TITLE
Avoid JAR file locking in `WebappClassLoader`

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/core/StandardContext.java
@@ -271,11 +271,6 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
     private String altDDName;
 
     /**
-     * The antiJARLocking flag for this Context.
-     */
-    private boolean antiJARLocking;
-
-    /**
      * Associated host name.
      */
     private String hostName;
@@ -963,24 +958,6 @@ public class StandardContext extends ContainerBase implements Context, ServletCo
         boolean oldAvailable = this.available;
         this.available = available;
         support.firePropertyChange("available", Boolean.valueOf(oldAvailable), Boolean.valueOf(this.available));
-    }
-
-    /**
-     * @return the antiJARLocking flag for this Context.
-     */
-    public boolean getAntiJARLocking() {
-        return antiJARLocking;
-    }
-
-    /**
-     * Set the antiJARLocking feature for this Context.
-     *
-     * @param antiJARLocking The new flag value
-     */
-    public void setAntiJARLocking(boolean antiJARLocking) {
-        boolean oldAntiJARLocking = this.antiJARLocking;
-        this.antiJARLocking = antiJARLocking;
-        support.firePropertyChange("antiJARLocking", oldAntiJARLocking, this.antiJARLocking);
     }
 
     @Override

--- a/appserver/web/web-core/src/main/java/org/apache/catalina/loader/WebappLoader.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/loader/WebappLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -637,11 +637,6 @@ public class WebappLoader implements Lifecycle, Loader, PropertyChangeListener {
                 setReloadable(((Boolean) event.getNewValue()).booleanValue());
             } catch (NumberFormatException e) {
                 log.log(SEVERE, SET_RELOADABLE_PROPERTY_EXCEPTION, neutralizeForLog(event.getNewValue().toString()));
-            }
-        } else if ("antiJARLocking".equals(propName)) {
-            ClassLoader cloader = Thread.currentThread().getContextClassLoader();
-            if (cloader instanceof WebappClassLoader) {
-                ((WebappClassLoader) cloader).setAntiJARLocking(((Boolean) event.getNewValue()).booleanValue());
             }
         }
     }


### PR DESCRIPTION
The `antiJARlocking` property is always false (is newer set).

 `WebappClassLoader` throws `IllegalStateException` which is swallowing somewhere.

The main idea of this patch is to move the processing of this property from Catalina `StandardContext` to the `WarHandler`. This sets the `antiJARLocking` property before starting webapp class loader and no exception is thrown.