### PR TITLE
Replace hard-coded version references in docs with existing properties defined in pom.xml

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -81,93 +81,6 @@
     <properties>
         <glassfish.version>${project.version}</glassfish.version>
 
-        <!-- Jakarta EE platform -->
-        <jakartaee>11</jakartaee>
-        <jakarta.platform.version>11.0.0</jakarta.platform.version>
-
-        <!-- Jakarta API Versions -->
-
-        <!-- Jakarta Faces -->
-        <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>
-        <mojarra.version>4.1.6</mojarra.version>
-
-        <!-- Jakarta WebSocket -->
-        <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
-        <tyrus.version>2.2.2</tyrus.version>
-
-        <!-- Jakarta Concurrency -->
-        <jakarta.concurrent-api.version>3.1.1</jakarta.concurrent-api.version>
-        <concurro.version>3.1.0</concurro.version>
-
-        <!-- Jakarta Interceptors -->
-        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
-
-        <!-- Jakarta Security + Authentication/Authorization -->
-        <!-- APIs -->
-        <jakarta.security-api.version>4.0.0</jakarta.security-api.version>
-        <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
-        <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
-        <!-- Implementations -->
-        <soteria.version>4.0.2</soteria.version>
-        <exousia.version>3.0.1</exousia.version>
-        <epicyro.version>3.1.1</epicyro.version>
-        <nimbus.version>10.7</nimbus.version>
-        <jcip.version>1.0.2</jcip.version>
-
-        <!-- Jakarta Messaging -->
-        <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.7.0</openmq.version>
-
-        <!-- Jakarta Data / NoSQL -->
-        <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
-        <jakarta.data.spec.version>1.0</jakarta.data.spec.version>
-        <jakarta.nosql-api.version>1.0.1</jakarta.nosql-api.version>
-        <jakarta.nosql.spec.version>1.0.1</jakarta.nosql.spec.version>
-        <jnosql.version>1.1.12</jnosql.version>
-
-        <!-- Jakarta Persistence -->
-        <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-        <eclipselink.version>5.0.0-B13</eclipselink.version>
-        <eclipselink.asm.version>9.9.0</eclipselink.asm.version>
-
-        <!-- Jakarta Transactions -->
-        <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-
-        <!-- Jakarta Connectors -->
-        <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
-
-        <!-- Jakarta Batch -->
-        <jakarta.batch-api.version>2.1.1</jakarta.batch-api.version>
-        <jbatch.version>2.1.1</jbatch.version>
-
-        <!-- Jakarta Enterprise beans -->
-        <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
-
-        <!-- Jakarta JSON -->
-        <jakarta.jsonp-api.version>2.1.3</jakarta.jsonp-api.version>
-        <parsson.version>1.1.7</parsson.version>
-        <parsson-media.version>1.1.7</parsson-media.version>
-        <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
-        <yasson.version>3.0.4</yasson.version>
-
-        <!-- Jakarta Pages and Jakarta Standard Tag Library -->
-        <jakarta.pages-api.version>4.0.0</jakarta.pages-api.version>
-        <jstl-api.version>3.0.2</jstl-api.version>
-        <wasp.version>4.0.0</wasp.version>
-
-        <!-- Used for Jakarta SOAP (XML Web Services) -->
-        <xmlsec.version>4.0.4</xmlsec.version>
-        <woodstox.version>7.1.1</woodstox.version>
-        <stax2-api.version>4.2.2</stax2-api.version>
-
-        <!-- Jakarta CDI -->
-        <weld.version>6.0.4.Final</weld.version>
-        <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
-
-        <!-- Jakarta MVC -->
-        <jakarta.mvc-api.version>3.0.0</jakarta.mvc-api.version>
-        <krazo.version>4.0.1</krazo.version>
-
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1</microprofile.config-api.version>
         <helidon-config.version>4.3.3</helidon-config.version>
@@ -810,11 +723,11 @@
                             <artifact>
                                 <groupId>jakarta.activation</groupId>
                                 <artifactId>jakarta.activation-api</artifactId>
-                                <version>${activation.version}</version>
+                                <version>${jakarta.activation-api.version}</version>
                             </artifact>
                             <jarType>api</jarType>
                             <specVersion>2.1</specVersion>
-                            <specImplVersion>${activation.version}</specImplVersion>
+                            <specImplVersion>${jakarta.activation-api.version}</specImplVersion>
                             <apiPackage>jakarta.activation</apiPackage>
                         </spec>
                         <spec>

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -657,7 +657,7 @@ Table 1-4 Jakarta EE Standards Implementations in {productName} {product-current
 |X
 
 |https://jakarta.ee/specifications/activation/[Activation]
-|2.1
+|{jakarta-activation-api-version}
 |X
 |-
 

--- a/docs/troubleshooting-guide/src/main/asciidoc/overview.adoc
+++ b/docs/troubleshooting-guide/src/main/asciidoc/overview.adoc
@@ -113,7 +113,7 @@ be to figure out why something isn't working.
 Lists and forums are extremely helpful resources, and are accessed as follows:
 
 * GlassFish mailing lists: `https://accounts.eclipse.org/mailing-list/glassfish-dev`
-* GlassFish user forum: `https://www.eclipse.org/forums/index.php/f/419/`
+* GlassFish user forum: `https://github.com/eclipse-ee4j/glassfish/discussions`
 
 [[gathering-information]]
 

--- a/nucleus/distributions/nucleus-common/pom.xml
+++ b/nucleus/distributions/nucleus-common/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -38,6 +39,7 @@
                 <filtering>false</filtering>
                 <excludes>
                     <exclude>config/osgi.properties</exclude>
+                    <exclude>docs/*.html</exclude>
                 </excludes>
             </resource>
             <resource>
@@ -45,6 +47,7 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>config/osgi.properties</include>
+                    <include>docs/*.html</include>
                 </includes>
             </resource>
         </resources>
@@ -63,6 +66,22 @@
                         <delimiter>@</delimiter>
                     </delimiters>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>parse-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <propertyPrefix>product</propertyPrefix>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/nucleus/distributions/nucleus-common/src/main/resources/docs/about.html
+++ b/nucleus/distributions/nucleus-common/src/main/resources/docs/about.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <!--
 
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -46,7 +46,7 @@ cellspacing="4" cellpadding="2">
 <td align="right" valign="top"> <a href="https://glassfish.org">glassfish.org</a> </td>
 </tr>
 <tr>
-<td align="left" valign="top" bgcolor="#587993"> <font color="#ffffff"><b>GlassFish Server 7</b></font></td>
+<td align="left" valign="top" bgcolor="#587993"> <font color="#ffffff"><b>GlassFish Server ${product.majorVersion}</b></font></td>
 </tr>
 </tbody>
 </table> <h1>GlassFish Server - Installation Complete</h1>
@@ -65,12 +65,12 @@ the GlassFish Server, including up-to-date release notes. </li>
 <li><b><a href="https://eclipse-ee4j.github.io/jakartaee-firstcup">Your First Cup: An Introduction to the Jakarta EE Platform</a>:</b> Follow this short tutorial
 for beginning Jakarta EE programmers that shows how to develop a simple enterprise application from scratch. The sample application is a web application that
 consists of an Jakarta Enterprise Beans bean, a Jakarta RESTful Web Services service, and a Jakarta Faces Facelet web front end.</li>
-<li><b><a href="https://eclipse-ee4j.github.io/jakartaee-tutorial">The Jakarta EE Tutorial</a>:</b> Learn more about the Jakarta EE standards by following this
+<li><b><a href="https://jakarta.ee/learn/docs/jakartaee-tutorial/current/index.html">The Jakarta EE Tutorial</a>:</b> Learn more about the Jakarta EE standards by following this
 beginner's guide to developing enterprise applications for the GlassFish Server. It includes working examples and step-by-step instructions for creating Jakarta
 EE applications with these technologies: Jakarta XML Web Services, Jakarta Servlet, Jakarta Server Pages, Jakarta Standard Tag Library,
 Jakarta Enterprise Beans, Java Messaging, and Jakarta Connectors.</li>
-<li><b><a href="https://jakarta.ee/specifications/platform/10/apidocs">Jakarta EE Platform API online documentation</i>:</a></b> View the
+<li><b><a href="https://jakarta.ee/specifications/platform/${jakartaee}/apidocs">Jakarta EE Platform API online documentation</i>:</a></b> View the
 API reference documentation for the GlassFish Server packages and related APIs. This documentation is generated from the source code by the Javadoc&trade;
 tool.</li>
-<hr style="width: 80%; height: 2px;"> <p class="copy">Copyright &copy; 2023 Eclipse Foundation &nbsp;&nbsp;|&nbsp;&nbsp; <a
+<hr style="width: 80%; height: 2px;"> <p class="copy">Copyright &copy; 2026 Eclipse Foundation &nbsp;&nbsp;|&nbsp;&nbsp; <a
 href="./copyright.html">Legal Notices</a></p></body></html>

--- a/nucleus/distributions/nucleus-common/src/main/resources/docs/copyright.html
+++ b/nucleus/distributions/nucleus-common/src/main/resources/docs/copyright.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <!--
 
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,14 +36,14 @@
 	a:visited{color:#917E9C}
 	a:hover {text-decoration:underline}
 </style>
-<title>GlassFish Server 7</title>
+<title>GlassFish Server ${product.majorVersion}</title>
 </head>
 <body><table width="100%" border="0" cellspacing="4" cellpadding="2">
 <tbody>
-<tr><td align="left" valign="top" bgcolor="#587993"> <font color="#ffffff">&nbsp;&nbsp;<b> GlassFish Server 7</b></font>&nbsp; </td></tr>
+<tr><td align="left" valign="top" bgcolor="#587993"> <font color="#ffffff">&nbsp;&nbsp;<b> GlassFish Server ${product.majorVersion}</b></font>&nbsp; </td></tr>
 </tbody>
 </table><!--startindex-->
-<p>Copyright &copy; 2023 Eclipse Foundation and/or its affiliates. All rights reserved.</p>
+<p>Copyright &copy; 2026 Eclipse Foundation and/or its affiliates. All rights reserved.</p>
  
 <p>This program and the accompanying materials are made available under the terms of the Eclipse Public License v. 2.0, which is available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.</p>
  

--- a/nucleus/distributions/nucleus-common/src/main/resources/docs/features.html
+++ b/nucleus/distributions/nucleus-common/src/main/resources/docs/features.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <!--
 
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,66 +37,66 @@
   a:visited{color:#917E9C}
   a:hover {text-decoration:underline}
 </style>
-<title>GlassFish Server 7 - Features and Resources</title>
+<title>GlassFish Server ${product.majorVersion} - Features and Resources</title>
 </head>
 <body bgcolor="#ffffff" text="#000000" link="#594fbf" vlink="#1005fb" alink="#333366">
 <table width="100%" border="0" cellspacing="4" cellpadding="2">
 <tbody>
 <tr><td align="right" valign="top"><a href="https://glassfish.org/">glassfish.org</a></td></tr>
-<tr><td align="left" valign="top" bgcolor="#587993"><font color="#ffffff"><b>GlassFish Server 7</b></font>&nbsp;</td></tr>
+<tr><td align="left" valign="top" bgcolor="#587993"><font color="#ffffff"><b>GlassFish Server ${product.majorVersion}</b></font>&nbsp;</td></tr>
 </tbody>
 </table>  <h1>Features and Resources </h1>
-<p>GlassFish Server 7 provides a server for the development and
+<p>GlassFish Server ${product.majorVersion} provides a server for the development and
 deployment of Jakarta EE Platform and dynamic, scalable HTML5 applications.
-Key features include Servlet 6.0 to support HTTP/2, support for Java SE 11 and
+Key features include Servlet ${jakarta.servlet-api.version} to support HTTP/2, support for Java SE ${java.version.max-supported}+ and
 updates to some important web standards.</p>
 <p>This page contains the following topics:</p>
 <ul><li><a href="#key-features">Key Features</a></li>
 <li><a href="#resources">Resources</a></li></ul>
 <h2><a name="key-features"></a>Key Features</h2>
 <h3>Jakarta EE Support</h3>
-<p>GlassFish Server supports Jakarta EE Platform 10, which provides the foundation
-for delivering dynamic, scalable HTML5 applications. Jakarta EE 10 augments
+<p>GlassFish Server supports Jakarta EE Platform ${jakartaee}, which provides the foundation
+for delivering dynamic, scalable HTML5 applications. Jakarta EE ${jakartaee} augments
 support for HTML5 applications by adding support for server-sent events,
 standardized binding between JSON text and Java objects, HTTP/2 support
 and improvements to the Jakarta WebSocket and the Jakarta JSON
-Processing. Jakarta EE 10 aligns with JDK11 so that developers will be
+Processing. Jakarta EE ${jakartaee} aligns with JDK${java.version.jakartaee.required} so that developers will be
 able to take advantage of new features such as repeating annotations,
 lambda expressions, the Date/Time API, type annotations, Completable Futures etc.</p>
-<p>Jakarta EE 10 and GlassFish Server 7 include the following new and updated Java EE standards:</p>
+<p>Jakarta EE ${jakartaee} and GlassFish Server ${product.majorVersion} include the following new and updated Java EE standards:</p>
 <dl><dt><b>Platform Updates</b></dt><dd><ul>
 <li>Jakarta EE Core Profile</li>
 </ul></dd>
 <dt><b>New or Significant Updates</b></dt><dd><ul>
-<li>Jakarta Contexts and Dependency Injection 4.0 (CDI Lite section)</li>
+<li>Jakarta Contexts and Dependency Injection ${jakarta.cdi-api.version} (CDI Lite section)</li>
 </ul></dd>
 <dt><b>Updated</b></dt><dd><ul>
-<li>Jakarta JSON Binding 3.0</li>
-<li>Jakarta Security 3.0</li>
-<li>Jakarta Servlet 6.0</li>
-<li>Jakarta RESTful Web Services 3.1</li>
-<li>Jakarta JSON Processing 2.1</li>
-<li>Jakarta Authorization 2.1</li>
-<li>Jakarta Authentication 3.0</li>
-<li>Jakarta Activation 2.1</li>
-<li>Jakarta Batch 2.1</li>
-<li>Jakarta Faces 4.0</li>
-<li>Jakarta Interceptors 2.1</li>
-<li>Jakarta Persistence 3.1</li>
-<li>Jakarta Mail 2.1</li>
-<li>Jakarta Connectors 2.1</li>
-<li>Jakarta Messaging 3.1</li>
-<li>Jakarta Expression Language 5.0</li>
-<li>Jakarta Concurrency 3.0</li>
-<li>Jakarta Standard Tag Library 3.0</li>
-<li>Jakarta Server Pages 3.1</li>
-<li>Jakarta WebSocket 2.1</li>
-<li>Jakarta Annotations 2.1</li>
+<li>Jakarta JSON Binding ${jakarta.json.bind-api.version}</li>
+<li>Jakarta Security ${jakarta.security-api.version}</li>
+<li>Jakarta Servlet ${jakarta.servlet-api.version}</li>
+<li>Jakarta RESTful Web Services ${jakarta.rest-api.version}</li>
+<li>Jakarta JSON Processing ${jakarta.jsonp-api.version}</li>
+<li>Jakarta Authorization ${jakarta.authorization-api.version}</li>
+<li>Jakarta Authentication ${jakarta.authentication-api.version}</li>
+<li>Jakarta Activation ${jakarta.activation-api.version}</li>
+<li>Jakarta Batch ${jakarta.batch-api.version}</li>
+<li>Jakarta Faces ${jakarta.faces-api.version}</li>
+<li>Jakarta Interceptors ${jakarta.interceptor-api.version}</li>
+<li>Jakarta Persistence ${jakarta.persistence-api.version}</li>
+<li>Jakarta Mail ${jakarta.mail-api.version}</li>
+<li>Jakarta Connectors ${jakarta.resource-api.version}</li>
+<li>Jakarta Messaging ${jakarta.messaging-api.version}</li>
+<li>Jakarta Expression Language ${jakarta.el-api.version}</li>
+<li>Jakarta Concurrency ${jakarta.concurrent-api.version}</li>
+<li>Jakarta Standard Tag Library ${jstl-api.version}</li>
+<li>Jakarta Server Pages ${jakarta.pages-api.version}</li>
+<li>Jakarta WebSocket ${jakarta.websocket-api.version}</li>
+<li>Jakarta Annotations ${jakarta.annotation-api.version}</li>
 </ul></dd></dl>
 <p>For a complete list of the Jakarta EE technologies included, see
 the <a href="https://glassfish.org/docs/latest/release-notes.html"><cite>Release Notes</cite></a>.</p>
 <p>Discussion within the GlassFish community is conducted through the
-<a href="https://www.eclipse.org/forums/index.php/f/419/">GlassFish Community Forum</a>.</p>
+<a href="https://github.com/eclipse-ee4j/glassfish/discussions">GlassFish Community Forum</a>.</p>
 <h2><a name="resources"></a>Resources</h2>
 <h3>GlassFish Community</h3>
 <p>GlassFish Server is based on the source code that is developed
@@ -115,11 +115,5 @@ the Jakarta EE platform.</p>
 <p>The <cite>Release Notes, Installation Guide</cite>,
 and other product documentation are available on the
 <a href="https://glassfish.org/documentation">GlassFish Product Documentation</a> page.</p>
-<!--
-<p>Data sheets, news, white papers, and other information are available at the
-<a href="http://www.oracle.com/us/products/middleware/cloud-app-foundation/glassfish-server/overview/index.html">Oracle GlassFish Server</a> product page.</p>
-<hr style="width: 80%; height: 2px;">
-<p class="copy"><a href="http://www.oracle.com/corporate/">Company Info</a> &nbsp;&nbsp;|&nbsp;&nbsp; <a href="http://www.oracle.com/corporate/contact/">Contact</a> &nbsp;&nbsp;|&nbsp;&nbsp; Copyright &copy; 2010, 2017 Oracle Corporation &nbsp;&nbsp;|&nbsp;&nbsp; <a href="./copyright.html">Legal Notices</a></p>
--->
 </body>
 </html>

--- a/nucleus/distributions/nucleus-common/src/main/resources/docs/quickstart.html
+++ b/nucleus/distributions/nucleus-common/src/main/resources/docs/quickstart.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <!--
 
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,7 +36,7 @@
   a:visited{color:#917E9C}
   a:hover {text-decoration:underline}
 </style>
-<title>GlassFish Server 7 Quick Start Guide</title>
+<title>GlassFish Server ${product.majorVersion} Quick Start Guide</title>
 </head>
 <body style="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);"
 link="#594fbf" vlink="#1005fb" alink="#333366"><table width="100%" border="0"
@@ -46,13 +46,13 @@ cellspacing="4" cellpadding="2">
 <td align="right" valign="top"> <a href="https://glassfish.org/">glassfish.org</a> </td>
 </tr>
 <tr>
-<td align="left" valign="top" bgcolor="#587993"> <font color="#ffffff"><b>GlassFish Server 7</b></font></td>
+<td align="left" valign="top" bgcolor="#587993"> <font color="#ffffff"><b>GlassFish Server ${product.majorVersion}</b></font></td>
 </tr>
 </tbody>
 </table><div class="maincontent">
-<a name="aboaa"></a><h1>GlassFish Server 7 Quick Start Guide</h1>
+<a name="aboaa"></a><h1>GlassFish Server ${product.majorVersion} Quick Start Guide</h1>
 <p>GlassFish Server provides a server for the development and deployment of Jakarta EE Platform applications
-and web technologies based on Java technology. GlassFish Server 7 provides the following:</p>
+and web technologies based on Java technology. GlassFish Server ${product.majorVersion} provides the following:</p>
 <ul>
 <li><p>A lightweight and extensible core based on OSGi Alliance standards</p></li>
 <li><p>A web container</p></li>
@@ -67,15 +67,15 @@ and web technologies based on Java technology. GlassFish Server 7 provides the f
 <li><p><a href="#gglmh">Starting and Stopping the Database Server</a></p></li>
 <li><p><a href="#ggllq">Starting the Administration Console</a></p></li>
 <li><p><a href="#geyvr">Deploying and Undeploying Applications</a></p></li>
-<li><p><a href="#ghgqg">Removing GlassFish Server 7 Software</a></p></li>
+<li><p><a href="#ghgqg">Removing GlassFish Server ${product.majorVersion} Software</a></p></li>
 <li><p><a href="#ggkzh">For More Information</a></p></li>
 </ul>
 <a id="ghgpe" name="ghgpe"></a><a id="GSQSG00030" name="GSQSG00030"></a>
 <h2>About This Quick Start Guide</h2>
 <p>This <i>Quick Start Guide</i> demonstrates key features of GlassFish Server and enables you to quickly learn the basics.
 Step-by-step procedures introduce you to product features and enable you to use them immediately.</p>
-<p>This guide assumes that you have already obtained and installed the GlassFish Server 7 software. For more information
-about installing GlassFish Server 7, see the <a href="https://glassfish.org/docs/latest/installation-guide.html"><cite>Installation Guide</cite></a>.</p>
+<p>This guide assumes that you have already obtained and installed the GlassFish Server ${product.majorVersion} software. For more information
+about installing GlassFish Server ${product.majorVersion}, see the <a href="https://glassfish.org/docs/latest/installation-guide.html"><cite>Installation Guide</cite></a>.</p>
 <p>Instructions and examples in this guide that apply to all supported operating systems use the forward slash character
 (<code>/</code>) as path separators in all file names and commands. Ensure that you use the correct character for the
 system on which GlassFish Server is installed. For example:</p>
@@ -87,9 +87,9 @@ system on which GlassFish Server is installed. For example:</p>
 other entities mentioned in this guide, see <a href="#ggkzh">For More Information</a>.</p>
 <p>To review additional details about this release before you begin using the software,
 see the <a href="https://glassfish.org/docs/latest/release-notes.html"><cite>Release Notes</cite></a>.
-The <i>Release Notes</i> provide important information about the GlassFish Server 7 release,
+The <i>Release Notes</i> provide important information about the GlassFish Server ${product.majorVersion} release,
 including details about new features, information about known issues and possible workarounds,
-and tips for installing and working with GlassFish Server 7 software.</p>
+and tips for installing and working with GlassFish Server ${product.majorVersion} software.</p>
 
 
 <a id="ghpfg" name="ghpfg"></a><a id="GSQSG00031" name="GSQSG00031"></a>
@@ -644,7 +644,7 @@ For this example, use the default domain, <code>domain1</code>, in the default <
 
 <a id="ghgqg" name="ghgqg"></a><a id="GSQSG00039" name="GSQSG00039"></a>
 
-<h2>Removing GlassFish Server 7 Software</h2>
+<h2>Removing GlassFish Server ${product.majorVersion} Software</h2>
 <p>Before removing the GlassFish Server software, stop the following processes:</p>
 <ul>
 <li><p>All domains and other related processes</p></li>
@@ -658,7 +658,7 @@ For this example, use the default domain, <code>domain1</code>, in the default <
 <a id="ggkzh" name="ggkzh"></a><a id="GSQSG00040" name="GSQSG00040"></a>
 
 <h2>For More Information</h2>
-<p>Additional resources are available to help you learn more about GlassFish Server 7 and related technologies.</p>
+<p>Additional resources are available to help you learn more about GlassFish Server ${product.majorVersion} and related technologies.</p>
 <p>The following resources are described here:</p>
 <ul>
 <li><p><a href="#ghhir">Product Documentation</a></p></li>
@@ -682,14 +682,14 @@ For this example, use the default domain, <code>domain1</code>, in the default <
 
 <h3>GlassFish Community</h3>
 <ul>
-<li><p><a href="https://www.eclipse.org/forums/index.php/f/419/">GlassFish Forum</a>: Public online discussion forum that provides community support and tips for working with GlassFish Server.</p></li>
+<li><p><a href="https://github.com/eclipse-ee4j/glassfish/discussions">GlassFish Forum</a>: Public online discussion forum that provides community support and tips for working with GlassFish Server.</p></li>
 </ul>
 
 
 <a id="giyjo" name="giyjo"></a><a id="GSQSG00052" name="GSQSG00052"></a>
 
 <h3>Tutorials</h3>
-<p>The following tutorials provide working examples and detailed instructions for creating enterprise applications for the Jakarta EE Platform 10.</p>
+<p>The following tutorials provide working examples and detailed instructions for creating enterprise applications for the Jakarta EE Platform ${jakartaee}.</p>
 <ul>
 <li><p><a href="https://eclipse-ee4j.github.io/jakartaee-firstcup">Your First Cup: An Introduction to the Jakarta EE Platform</a>: Provides a short tutorial for beginning Jakarta EE programmers that shows how to develop a simple enterprise application from scratch. The sample application consists of four main components: a Jakarta RESTful web service, an enterprise bean, a Jakarta Persistence entity, and a web application created with Jakarta Faces Facelets technology.</p></li>
 <li><p><a href="https://eclipse-ee4j.github.io/jakartaee-tutorial">The Jakarta EE Tutorial</a>: Provides a beginner's guide to developing enterprise applications for GlassFish Server. The tutorial includes working examples and instructions for creating applications with Jakarta EE technologies, including Jakarta Servlets, Jakarta Faces Facelets, Jakarta RESTful Web Services, Jakarta Enterprise Beans, Jakarta Persistence, Jakarta Contexts and Dependency Injection for the Jakarta EE Platform, and more.</p></li>
@@ -706,5 +706,5 @@ For this example, use the default domain, <code>domain1</code>, in the default <
 <h3>GlassFish Samples</h3>
 <p>The sample applications that are delivered with older Java EE SDK. The samples are available from the <a href="https://github.com/eclipse-ee4j/glassfish-samples">GlassFish samples downloads page</a>.</p>
 </div> <hr style="width: 80%; height: 2px;"> <p
-class="copy">Copyright &copy; 2023 Eclipse Foundation &nbsp;&nbsp;|&nbsp;&nbsp; <a
+class="copy">Copyright &copy; 2026 Eclipse Foundation &nbsp;&nbsp;|&nbsp;&nbsp; <a
 href="./copyright.html">Legal Notices</a></p></body></html>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -116,6 +116,16 @@
     </repositories>
 
     <properties>
+
+        <!-- Supported Java versions -->
+        <java.version.required>21</java.version.required>
+        <java.version.max-supported>25</java.version.max-supported>
+        <java.version.jakartaee.required>17</java.version.jakartaee.required>
+
+        <!-- Jakarta EE platform -->
+        <jakartaee>11</jakartaee>
+        <jakarta.platform.version>11.0.0</jakarta.platform.version>
+
         <!-- Jakarta Expression Language -->
         <jakarta.el-api.version>6.0.1</jakarta.el-api.version>
         <expressly.version>6.0.0</expressly.version>
@@ -140,6 +150,8 @@
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.1.0</jakarta.cdi-api.version>
+        <weld.version>6.0.4.Final</weld.version>
+        <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta XML Binding -->
         <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
@@ -151,17 +163,89 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
+        <eclipselink.version>5.0.0-B13</eclipselink.version>
+        <eclipselink.asm.version>9.9.0</eclipselink.asm.version>
 
         <!-- Jakarta Mail -->
         <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>
         <angus.mail.version>2.0.5</angus.mail.version>
 
         <!-- Jakarta Activation -->
-        <activation.version>2.1.4</activation.version>
+        <jakarta.activation-api.version>2.1.4</jakarta.activation-api.version>
         <angus.activation.version>2.0.3</angus.activation.version>
 
         <!-- Jakarta Annotations -->
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+
+        <!-- Jakarta Faces -->
+        <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>
+        <mojarra.version>4.1.6</mojarra.version>
+
+        <!-- Jakarta WebSocket -->
+        <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
+        <tyrus.version>2.2.2</tyrus.version>
+
+        <!-- Jakarta Concurrency -->
+        <jakarta.concurrent-api.version>3.1.1</jakarta.concurrent-api.version>
+        <concurro.version>3.1.0</concurro.version>
+
+        <!-- Jakarta Interceptors -->
+        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>
+
+        <!-- Jakarta Security + Authentication/Authorization -->
+        <jakarta.security-api.version>4.0.0</jakarta.security-api.version>
+        <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
+        <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
+        <soteria.version>4.0.2</soteria.version>
+        <exousia.version>3.0.1</exousia.version>
+        <epicyro.version>3.1.1</epicyro.version>
+        <nimbus.version>10.7</nimbus.version>
+        <jcip.version>1.0.2</jcip.version>
+
+        <!-- Jakarta Messaging -->
+        <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
+        <openmq.version>6.7.0</openmq.version>
+
+        <!-- Jakarta Data / NoSQL -->
+        <jakarta.data-api.version>1.0.1</jakarta.data-api.version>
+        <jakarta.data.spec.version>1.0</jakarta.data.spec.version>
+        <jakarta.nosql-api.version>1.0.1</jakarta.nosql-api.version>
+        <jakarta.nosql.spec.version>1.0.1</jakarta.nosql.spec.version>
+        <jnosql.version>1.1.12</jnosql.version>
+
+        <!-- Jakarta Transactions -->
+        <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
+
+        <!-- Jakarta Connectors -->
+        <jakarta.resource-api.version>2.1.0</jakarta.resource-api.version>
+
+        <!-- Jakarta Batch -->
+        <jakarta.batch-api.version>2.1.1</jakarta.batch-api.version>
+        <jbatch.version>2.1.1</jbatch.version>
+
+        <!-- Jakarta Enterprise beans -->
+        <jakarta.ejb-api.version>4.0.1</jakarta.ejb-api.version>
+
+        <!-- Jakarta JSON -->
+        <jakarta.jsonp-api.version>2.1.3</jakarta.jsonp-api.version>
+        <parsson.version>1.1.7</parsson.version>
+        <parsson-media.version>1.1.7</parsson-media.version>
+        <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
+        <yasson.version>3.0.4</yasson.version>
+
+        <!-- Jakarta Pages and Jakarta Standard Tag Library -->
+        <jakarta.pages-api.version>4.0.0</jakarta.pages-api.version>
+        <jstl-api.version>3.0.2</jstl-api.version>
+        <wasp.version>4.0.0</wasp.version>
+
+        <!-- Jakarta MVC -->
+        <jakarta.mvc-api.version>3.0.0</jakarta.mvc-api.version>
+        <krazo.version>4.0.1</krazo.version>
+
+        <!-- Jakarta SOAP (XML Web Services) -->
+        <xmlsec.version>4.0.4</xmlsec.version>
+        <woodstox.version>7.1.1</woodstox.version>
+        <stax2-api.version>4.2.2</stax2-api.version>
 
         <!-- GlassFish Components -->
         <grizzly.version>5.0.0</grizzly.version>
@@ -390,7 +474,7 @@
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
-                <version>${activation.version}</version>
+                <version>${jakarta.activation-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.angus</groupId>


### PR DESCRIPTION
Moved some properties from appserver/pom.xml to nucleus parent so that they are available in nucleus docs.

Will conflict with https://github.com/eclipse-ee4j/glassfish/pull/25906, which just updates hard-coded values. But doesn't replace it completely.