### PR TITLE
Updated Junit, Ant, Postgres and Checkstyle and few maven plugins

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -98,7 +98,7 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
 
         <!-- Admin console components -->
-        <jsftemplating.version>4.1.0-M1</jsftemplating.version>
+        <jsftemplating.version>4.1.0</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>6.0.3</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>

--- a/appserver/tests/jdbc/pom.xml
+++ b/appserver/tests/jdbc/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.8</version>
+            <version>42.7.9</version>
             <scope>test</scope>
         </dependency>
 

--- a/docs/publish/pom.xml
+++ b/docs/publish/pom.xml
@@ -318,7 +318,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.6.3</version>
                         <executions>
                             <execution>
                                 <id>setup-gemfile</id>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -273,8 +273,7 @@
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>
-        <!-- Warning: updating Ant to e.g. 1.10.5 will cause ElementStarITest.testLoadBalancerConfigs to fail -->
-        <ant.version>1.10.2</ant.version>
+        <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.21.0</jackson.version>
         <jackson.version2>2.21</jackson.version2>
@@ -286,8 +285,7 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>5.14.0</junit.version>
-        <junit-platform.version>1.14.0</junit-platform.version>
+        <junit.version>6.0.2</junit.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -839,20 +837,20 @@
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-suite-engine</artifactId>
-                <version>${junit-platform.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-engine</artifactId>
-                <version>${junit-platform.version}</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-commons</artifactId>
-                <version>${junit-platform.version}</version>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-suite-engine</artifactId>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -1194,7 +1192,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>12.2.0</version>
+                            <version>12.3.1</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1239,7 +1237,7 @@
                 <plugin>
                     <groupId>io.github.download-maven-plugin</groupId>
                     <artifactId>download-maven-plugin</artifactId>
-                    <version>2.0.0</version>
+                    <version>2.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
@@ -1259,7 +1257,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.6.3</version>
                     <configuration>
                         <environmentVariables>
                             <AS_JAVA>${java.home}</AS_JAVA>
@@ -1385,7 +1383,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.21.0</version>
                     <executions>
                         <execution>
                             <id>default-cli</id>


### PR DESCRIPTION
- Junit platform started follow junit version numbers
- ElementStarITest passed with 1.10.5
- JsfTemplating 4.1.0 was released right now: https://github.com/eclipse-ee4j/glassfish-jsftemplating/releases/tag/4.1.0
