### PR TITLE
Add elements to flattened poms required by Maven Central

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -19,7 +19,7 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -72,7 +72,9 @@
         <module>ant-tasks</module>
     </modules>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false"
+     child.scm.developerConnection.inherit.append.path="false"
+     child.scm.url.inherit.append.path="false">
         <connection>scm:git:git://github.com/eclipse-ee4j/glassfish.git</connection>
         <developerConnection>scm:git:git://github.com/eclipse-ee4j/glassfish.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/glassfish</url>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1273,6 +1273,13 @@
                         <flattenMode>ossrh</flattenMode>
                         <updatePomFile>true</updatePomFile>
                         <flattenedPomFilename>target/.flattened-pom.xml</flattenedPomFilename>
+                        <pomElements>
+                            <name/>
+                            <description/>
+                            <url/>
+                            <scm/>
+                            <developers/>
+                        </pomElements>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
The child.project.url.inherit.append.path="false" settings stops Maven from automatically appending artifact path to the parent's scm url

The attributes on the scm element are needed to stop Maven from doing that for scm urls

See also: https://github.com/apache/maven/issues/7702