### PR TITLE
Fix MP JWT integration

### DIFF
--- a/appserver/microprofile/jwt/src/main/java/org/glassfish/microprofile/jwt/MpJwtCdiExtension.java
+++ b/appserver/microprofile/jwt/src/main/java/org/glassfish/microprofile/jwt/MpJwtCdiExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,9 +18,11 @@ package org.glassfish.microprofile.jwt;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Extension;
+import jakarta.interceptor.Interceptor;
 import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
 
 import org.eclipse.microprofile.auth.LoginConfig;
@@ -41,7 +43,9 @@ public class MpJwtCdiExtension implements Extension {
             afterBeanDiscovery.addBean()
                     .scope(ApplicationScoped.class)
                     .beanClass(HttpAuthenticationMechanism.class)
-                    .qualifiers(MicroProfileJwtAuthenticationMechanism.Literal.INSTANCE)
+                    .qualifiers(MicroProfileJwtAuthenticationMechanism.Literal.INSTANCE, Default.Literal.INSTANCE)
+                    .priority(Interceptor.Priority.PLATFORM_BEFORE)
+                    .alternative(true)
                     .types(Object.class, HttpAuthenticationMechanism.class, JWTAuthenticationMechanism.class)
                     .id("mechanism " + LoginConfig.class)
                     .createWith(e -> new JWTAuthenticationMechanism());

--- a/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpjwt/MpJwtClaimInjectionTest.java
+++ b/appserver/tests/application/src/test/java/org/glassfish/main/test/app/mpjwt/MpJwtClaimInjectionTest.java
@@ -50,8 +50,17 @@ public class MpJwtClaimInjectionTest {
     private static File tempDir;
 
     @Test
-    void testJwtClaimInjection() throws IOException {
-        File app = createWebApp();
+    void testJwtClaimInjectionWithoutHandler() throws IOException {
+        testJwtClaimInjection(false);
+    }
+
+    @Test
+    void testJwtClaimInjectionWithHandler() throws IOException {
+        testJwtClaimInjection(true);
+    }
+
+    void testJwtClaimInjection(boolean withHandler) throws IOException {
+        File app = createWebApp(withHandler);
         assertThat(ASADMIN.exec("deploy", "--force", "--contextroot", "app", "--name", APP_NAME, app.getAbsolutePath()), asadminOK());
 
         try {
@@ -85,7 +94,7 @@ public class MpJwtClaimInjectionTest {
         return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0dXNlciIsImlzcyI6InRlc3QiLCJhdWQiOiJ0ZXN0In0.test";
     }
 
-    private static File createWebApp() {
+    private static File createWebApp(boolean withHandler) {
         String jwtConfig = """
             mp.jwt.verify.issuer=https://server.example.com
             mp.jwt.verify.publickey.location=/publicKey.pem
@@ -106,9 +115,12 @@ public class MpJwtClaimInjectionTest {
         WebArchive webApp = ShrinkWrap.create(WebArchive.class)
                 .addClass(JwtClaimEndpoint.class)
                 .addClass(JwtApplication.class)
-                .addClass(JwtCustomAuthMechanismHandler.class)
                 .addAsResource(new StringAsset(jwtConfig), "META-INF/microprofile-config.properties")
                 .addAsResource(new StringAsset(publicKey), "publicKey.pem");
+
+        if (withHandler) {
+            webApp = webApp.addClass(JwtCustomAuthMechanismHandler.class);
+        }
 
         LOG.log(INFO, webApp.toString(true));
 


### PR DESCRIPTION
In case the app relies on the default auth handler and doesn't provide a custom one, the problem was that GlassFish defined a new MP JWT mechanism bean but the original provided by Omni JWT remained, causing ambiguous dependency because the default Soteria handler searches for any mechanism, by @Any qualifier.

The fix is to define the new bean as alternative and enable it using priority, so that it replaces the original bean instead of just adding a new bean. Plus add the `@Default` qualifier which is used by the original bean.

The defect introduced in GlassFish 8.0.0 by  https://github.com/eclipse-ee4j/glassfish/pull/25880