### PR TITLE
Diagnose test errors: Print Derby log when DB not started

### DIFF
--- a/appserver/tests/appserv-tests/config/common.xml
+++ b/appserver/tests/appserv-tests/config/common.xml
@@ -1473,11 +1473,38 @@ AS_ADMIN_MASTERPASSWORD=${master.password}
 
 <!-- start Derby Database -->
 <target name="startDerby">
+    <echo message="Checking if Derby port ${db.port} is available before starting..."/>
+    <condition property="port.occupied.before">
+        <socket server="localhost" port="${db.port}"/>
+    </condition>
+    <echo message="Port ${db.port} occupied before start: ${port.occupied.before}"/>
+
     <condition property="darwin">
         <os name="Mac OS X" />
     </condition>
     <antcall target="startDerbyNonMac" />
     <antcall target="startDerbyMac" />
+
+    <echo message="Verifying Derby is listening on port ${db.port}..."/>
+    <waitfor maxwait="30" maxwaitunit="second" checkevery="2" checkeveryunit="second" timeoutproperty="derby.start.timeout">
+        <socket server="localhost" port="${db.port}"/>
+    </waitfor>
+
+    <antcall target="derby-startup-failed"/>
+
+    <echo message="Derby successfully started and listening on port ${db.port}"/>
+</target>
+
+<target name="derby-startup-failed" if="derby.start.timeout">
+    <echo message="Derby failed to start on port ${db.port} within 30 seconds"/>
+    <echo message="=== Derby Log (last 50 lines) ==="/>
+    <loadfile property="derby.log.content" srcFile="${env.S1AS_HOME}/databases/derby.log" failonerror="false">
+        <filterchain>
+            <tailfilter lines="50"/>
+        </filterchain>
+    </loadfile>
+    <echo message="${derby.log.content}"/>
+    <fail message="Derby failed to start on port ${db.port}. See Derby logs above."/>
 </target>
 
 <target name="startDerbyNonMac" depends="init-common" unless="darwin">

--- a/appserver/tests/appserv-tests/devtests/jdbc/JdbcCommon.xml
+++ b/appserver/tests/appserv-tests/devtests/jdbc/JdbcCommon.xml
@@ -360,8 +360,33 @@
    </condition>
 
    <target name="start-derby" depends="init-common">
+       <echo message="Checking if port 1527 is available before starting Derby..."/>
+       <condition property="port.occupied.before">
+           <socket server="localhost" port="1527"/>
+       </condition>
+       <echo message="Port 1527 occupied before start: ${port.occupied.before}"/>
+
        <antcall target="start-derby-aix"/>
        <antcall target="start-derby-nonaix"/>
+
+       <echo message="Verifying Derby is listening on port 1527..."/>
+       <waitfor maxwait="30" maxwaitunit="second" checkevery="2" checkeveryunit="second" timeoutproperty="derby.start.timeout">
+           <socket server="localhost" port="1527"/>
+       </waitfor>
+
+       <sequential if:set="derby.start.timeout">
+           <echo message="Derby failed to start on port 1527 within 30 seconds"/>
+           <echo message="=== Derby Log (last 50 lines) ==="/>
+           <loadfile property="derby.log.content" srcFile="${env.S1AS_HOME}/databases/derby.log" failonerror="false">
+               <filterchain>
+                   <tailfilter lines="50"/>
+               </filterchain>
+           </loadfile>
+           <echo message="${derby.log.content}"/>
+           <fail message="Derby failed to start on port 1527. See Derby logs above."/>
+       </sequential>
+
+       <echo message="Derby successfully started and listening on port 1527"/>
    </target>
 
    <target name="start-derby-aix" if="aix">


### PR DESCRIPTION
To find out what's happening when we get errors like this about failing to connect to Derby DB more than 15 seconds after it was supposed to start: https://ci.eclipse.org/glassfish/job/glassfish_build-and-test-using-jenkinsfile/job/PR-25936/7/stages/