### PR TITLE
Fixed missing new line in the output.

### DIFF
--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/StartServerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -133,7 +133,7 @@ public final class StartServerHelper {
         if (!terse) {
             if (launcher.isSuspendEnabled()) {
                 // If the server starts suspended, user needs to see this before it happens.
-                System.out.print("Debugging is configured to listen on port " + launcher.getDebugPort()
+                System.out.println("Debugging is configured to listen on port " + launcher.getDebugPort()
                     + ". Server's JVM is set to suspend.");
             }
         }


### PR DESCRIPTION
Original output - the text starting with `Waiting until` should be on a new line:
```
/usr/lib/jvm/jdk25/bin/java /app/appservers/glassfish8/bin/asadmin.java start-domain --server-output=true --debug --suspend
Debugging is configured to listen on port 9009. Server's JVM is set to suspend.Waiting until start of domain domain1 completes............................................................................................................... ... finished after 110264 ms.

Successfully started the domain domain1.
  Location: /app/appservers/glassfish8/glassfish/domains/domain1
  Log File: /app/appservers/glassfish8/glassfish/domains/domain1/logs/server.log
  Debugging is configured to listen on port 9009. Server's JVM is set to suspend.
  The pid file /app/appservers/glassfish8/glassfish/domains/domain1/config/pid contains pid 1068702.
  Process with pid 1068702 is alive
  Admin Endpoints:
    http://localhost:4848 is reachable.

The output of the process until we stopped watching:

**********
Listening for transport dt_socket at address: 9009

```