### PR TITLE
Updated dependencies before release

### DIFF
--- a/appserver/tests/application-tests/pom.xml
+++ b/appserver/tests/application-tests/pom.xml
@@ -61,14 +61,14 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.10.0.Final</version>
+                <version>1.10.1.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.junit5</groupId>
                 <artifactId>arquillian-junit5-container</artifactId>
-                <version>1.10.0.Final</version>
+                <version>1.10.1.Final</version>
                 <scope>test</scope>
             </dependency>
 
@@ -82,13 +82,11 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-                <version>3.3.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-                <version>3.3.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/appserver/tests/embedded/maven-plugin/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/pom.xml
@@ -190,7 +190,7 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.9.11</version>
+                <version>3.9.14</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -35,7 +35,7 @@
     <name>GlassFish Tests</name>
 
     <properties>
-        <testcontainers.version>2.0.3</testcontainers.version>
+        <testcontainers.version>2.0.4</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -105,7 +105,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>11.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -74,7 +74,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>11.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -92,7 +92,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/connectors/pom.xml
+++ b/appserver/tests/tck/connectors/pom.xml
@@ -160,13 +160,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>2.0.17</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/tck/data/data-jpa/pom.xml
+++ b/appserver/tests/tck/data/data-jpa/pom.xml
@@ -65,8 +65,7 @@
             <artifactId>sigtest-maven-plugin</artifactId>
         </dependency>
 
-        <!-- APIs referenced by TCK that do not require implementations for standalone
-        tests -->
+        <!-- APIs referenced by TCK that do not require implementations for standalone tests -->
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>

--- a/appserver/tests/tck/data/data-jpa/pom.xml
+++ b/appserver/tests/tck/data/data-jpa/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main</groupId>

--- a/appserver/tests/tck/data/data-nosql/pom.xml
+++ b/appserver/tests/tck/data/data-nosql/pom.xml
@@ -72,8 +72,7 @@
             <artifactId>sigtest-maven-plugin</artifactId>
         </dependency>
 
-        <!-- APIs referenced by TCK that do not require implementations for standalone
-        tests -->
+        <!-- APIs referenced by TCK that do not require implementations for standalone tests -->
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
@@ -93,6 +92,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main</groupId>

--- a/appserver/tests/tck/data/data-nosql/pom.xml
+++ b/appserver/tests/tck/data/data-nosql/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main</groupId>

--- a/appserver/tests/tck/data/pom.xml
+++ b/appserver/tests/tck/data/pom.xml
@@ -38,40 +38,31 @@
     </modules>
 
     <properties>
-        <jnosql.version>1.1.11</jnosql.version>
         <glassfish.version.main>8</glassfish.version.main>
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.version>${project.version}</glassfish.version>
 
-        <maven.compiler.release>17</maven.compiler.release>
-
         <jakarta.data.tck.version>1.0.1</jakarta.data.tck.version>
 
-        <sigtest.version>2.3</sigtest.version>
-        <weld.version>6.0.3.Final</weld.version>
-        <omnifish.arquillian.version>2.1.1</omnifish.arquillian.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <weld.version>6.0.4.Final</weld.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-<!--            <dependency>
-                <groupId>jakarta.tck</groupId>
-                <artifactId>glassfish-runner-bom</artifactId>
-                <version>11.0.1</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>-->
+            <!--
+                In 1.10.x ArquillianExtension lost handleTestExecutionException method,
+                however StandaloneExtension in the data-tck depends on it.
+                Note that until some test fails, you will not experience it.
+            -->
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.9.4.Final</version>
+                <version>1.9.5.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
 
-            <!-- Test framework -->
             <dependency>
                 <groupId>org.jboss.shrinkwrap</groupId>
                 <artifactId>shrinkwrap-api</artifactId>
@@ -83,12 +74,6 @@
                 <groupId>jakarta.data</groupId>
                 <artifactId>jakarta.data-tck</artifactId>
                 <version>${jakarta.data.tck.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- Signature Test Plugin -->
@@ -103,11 +88,6 @@
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -115,16 +95,7 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
-                    <configuration>
-                        <release>17</release>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
                     <executions>
                         <execution>
                             <id>unpack-glassfish</id>
@@ -147,10 +118,8 @@
                         </execution>
                     </executions>
                 </plugin>
-                <!-- Surefire plugin - Entrypoint for Junit5 -->
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.3</version>
                     <configuration>
                         <dependenciesToScan>
                             <dependency>jakarta.data:jakarta.data-tck</dependency>

--- a/appserver/tests/tck/data/pom.xml
+++ b/appserver/tests/tck/data/pom.xml
@@ -70,14 +70,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <!-- Test framework -->
             <dependency>
                 <groupId>org.jboss.shrinkwrap</groupId>
                 <artifactId>shrinkwrap-api</artifactId>
                 <version>1.2.6</version>
             </dependency>
-            
+
             <!-- The TCK -->
             <dependency>
                 <groupId>jakarta.data</groupId>
@@ -106,7 +106,6 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-jdk14</artifactId>
-                <version>1.7.36</version>
             </dependency>
 
         </dependencies>
@@ -194,7 +193,6 @@
                 <dependency>
                     <groupId>ee.omnifish.arquillian</groupId>
                     <artifactId>arquillian-glassfish-server-managed</artifactId>
-                    <version>2.1.1</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/appserver/tests/tck/enterprise-beans/pom.xml
+++ b/appserver/tests/tck/enterprise-beans/pom.xml
@@ -208,13 +208,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>2.0.17</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/tck/expression-language/pom.xml
+++ b/appserver/tests/tck/expression-language/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/tck/pom.xml
+++ b/appserver/tests/tck/pom.xml
@@ -107,13 +107,13 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-                <version>3.3.4</version>
+                <version>3.3.5</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-                <version>3.3.4</version>
+                <version>3.3.5</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -144,7 +144,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian.junit5</groupId>
                 <artifactId>arquillian-junit5-container</artifactId>
-                <version>1.10.0.Final</version>
+                <version>1.10.1.Final</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -155,13 +155,13 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.11.0</version>
+                <version>7.12.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.10.0.Final</version>
+                <version>1.10.1.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/appserver/webservices/jsr109-impl/pom.xml
+++ b/appserver/webservices/jsr109-impl/pom.xml
@@ -153,6 +153,7 @@
                         <DynamicImport-Package>org.glassfish.flashlight.provider</DynamicImport-Package>
                         <Import-Package>
                             jakarta.ejb;resolution:=optional,
+                            org.glassfish.grizzly.servlet;version="4",
                             *
                         </Import-Package>
                     </instructions>

--- a/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesApplication.java
+++ b/appserver/webservices/jsr109-impl/src/main/java/org/glassfish/webservices/WebServicesApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -36,7 +36,6 @@ import org.glassfish.api.deployment.ApplicationContainer;
 import org.glassfish.api.deployment.ApplicationContext;
 import org.glassfish.api.deployment.DeployCommandParameters;
 import org.glassfish.api.deployment.DeploymentContext;
-import org.glassfish.grizzly.servlet.ServletHandler;
 import org.glassfish.web.deployment.util.WebServerInfo;
 
 /**
@@ -51,7 +50,7 @@ public class WebServicesApplication implements ApplicationContainer<Object> {
 
     private ArrayList<EjbEndpoint> ejbendpoints;
 
-    private final ServletHandler httpHandler;
+    private final EjbWSAdapter httpHandler;
 
     private final RequestDispatcher dispatcher;
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -962,7 +962,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>6.0.0</version>
+                    <version>6.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -235,8 +235,8 @@
         <antlr4.version>4.13.2</antlr4.version>
         <ant.version>1.10.15</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
-        <jackson.version>2.21.1</jackson.version>
-        <jackson.version2>2.21</jackson.version2>
+        <jackson.version>2.21.2</jackson.version>
+        <jackson-annotations.version>2.21</jackson-annotations.version>
         <fasterxml.classmate.version>1.7.3</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.4</jettison.version>
@@ -733,7 +733,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version2}</version>
+                <version>${jackson-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -663,7 +663,7 @@
             <dependency>
                 <groupId>org.jline</groupId>
                 <artifactId>jline</artifactId>
-                <version>3.30.6</version>
+                <version>3.30.9</version>
             </dependency>
 
             <!--3rd party dependencies -->

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -164,7 +164,7 @@
 
         <!-- Jakarta Messaging -->
         <jakarta.messaging-api.version>3.1.0</jakarta.messaging-api.version>
-        <openmq.version>6.7.0</openmq.version>
+        <openmq.version>6.8.0</openmq.version>
 
         <!-- Jakarta Data / NoSQL -->
         <jakarta.data-api.version>1.0.1</jakarta.data-api.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -159,7 +159,7 @@
         <soteria.version>4.0.2</soteria.version>
         <exousia.version>3.0.1</exousia.version>
         <epicyro.version>3.1.1</epicyro.version>
-        <nimbus.version>10.7</nimbus.version>
+        <nimbus.version>10.8</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1414,6 +1414,10 @@
                                                     <type>regex</type>
                                                     <version>.*-RC.*</version>
                                                 </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*payara.*</version>
+                                                </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>
 
@@ -1935,6 +1939,10 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*payara.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -105,8 +105,8 @@
 
         <!-- Jakarta Inject -->
         <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
-        <hk2.version>4.0.0-M3</hk2.version>
-        <hk2.plugin.version>4.0.0-M3</hk2.plugin.version>
+        <hk2.version>4.0.0</hk2.version>
+        <hk2.plugin.version>4.0.0</hk2.plugin.version>
 
         <!-- Jakarta CDI -->
         <jakarta.cdi-api.version>4.1.0</jakarta.cdi-api.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -226,7 +226,7 @@
         <commons-io.version>2.21.0</commons-io.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
-        <jboss.logging.version>3.6.2.Final</jboss.logging.version>
+        <jboss.logging.version>3.6.3.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.9.1</asm.version>
         <jsch.version>2.27.9</jsch.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -239,7 +239,7 @@
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <fasterxml.classmate.version>1.7.3</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
-        <jettison.version>1.5.4</jettison.version>
+        <jettison.version>1.5.5</jettison.version>
         <mimepull.version>1.10.0</mimepull.version>
         <jna.version>5.18.1</jna.version>
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -246,7 +246,7 @@
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>6.0.2</junit.version>
+        <junit.version>6.0.3</junit.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1154,7 +1154,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>12.3.1</version>
+                            <version>13.3.0</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -252,7 +252,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <shrinkwrap.version>3.3.5</shrinkwrap.version>
 
-        <surefire.version>3.5.4</surefire.version>
+        <surefire.version>3.5.5</surefire.version>
         <junit5-surefire-tree-reporter.version>1.5.1</junit5-surefire-tree-reporter.version>
 
         <file.executable.suffix></file.executable.suffix>
@@ -1002,7 +1002,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.9.0</version>
+                    <version>3.10.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.build</groupId>
@@ -1115,7 +1115,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>${surefire.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
@@ -1207,7 +1207,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
                     </configuration>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -229,7 +229,7 @@
         <jboss.logging.version>3.6.2.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.9.1</asm.version>
-        <jsch.version>2.27.7</jsch.version>
+        <jsch.version>2.27.9</jsch.version>
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -250,6 +250,7 @@
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <slf4j.version>2.0.17</slf4j.version>
+        <shrinkwrap.version>3.3.5</shrinkwrap.version>
 
         <surefire.version>3.5.4</surefire.version>
         <junit5-surefire-tree-reporter.version>1.5.1</junit5-surefire-tree-reporter.version>
@@ -855,7 +856,7 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
-                <version>3.3.4</version>
+                <version>${shrinkwrap.version}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
@@ -867,13 +868,13 @@
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-api</artifactId>
-                <version>3.3.4</version>
+                <version>${shrinkwrap.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-api</artifactId>
-                <version>3.3.4</version>
+                <version>${shrinkwrap.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -139,7 +139,7 @@
 
         <!-- Jakarta Faces -->
         <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>
-        <mojarra.version>4.1.6</mojarra.version>
+        <mojarra.version>4.1.7</mojarra.version>
 
         <!-- Jakarta WebSocket -->
         <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -33,7 +33,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>3.5.5</version>
                     <executions>
                         <execution>
                             <id>default-test</id>
@@ -43,7 +43,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                     <executions>
                         <execution>
                             <id>default-testResources</id>


### PR DESCRIPTION
* For now I would avoid JAXB impl 4.0.7 because of https://github.com/eclipse-ee4j/jaxb-ri/releases/tag/4.0.7-RI