### PR TITLE
Fixed ConfigProfileResolver service selection

### DIFF
--- a/appserver/extras/embedded/all/src/assembly/package.xml
+++ b/appserver/extras/embedded/all/src/assembly/package.xml
@@ -28,6 +28,8 @@
                     <exclude>META-INF/loggerinfo/*</exclude>
                     <exclude>module-info.class</exclude>
                     <exclude>META-INF/versions/*/module-info.class</exclude>
+                    <!-- Helidon's impl is sometimes first -->
+                    <exclude>META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver</exclude>
                     <exclude>*.jar</exclude>
                 </excludes>
             </unpackOptions>
@@ -69,6 +71,13 @@
         </file>
     </files>
     <fileSets>
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <includes>
+                <include>META-INF/services/*</include>
+            </includes>
+            <outputDirectory></outputDirectory>
+        </fileSet>
         <fileSet>
             <directory>target/jars/glassfish/lib</directory>
             <includes>

--- a/appserver/extras/embedded/all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
+++ b/appserver/extras/embedded/all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
@@ -1,0 +1,1 @@
+org.glassfish.microprofile.config.GlassFishConfigProviderResolver

--- a/appserver/extras/embedded/tests/pom.xml
+++ b/appserver/extras/embedded/tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -27,8 +27,7 @@
         <version>8.0.2-SNAPSHOT</version>
     </parent>
 
-    <artifactId>tests-embedded</artifactId>
-
+    <artifactId>embedded-tests-extras</artifactId>
     <name>GlassFish Embedded Modules - Tests</name>
 
     <properties>

--- a/appserver/featuresets/microprofile/pom.xml
+++ b/appserver/featuresets/microprofile/pom.xml
@@ -35,28 +35,15 @@
     <description>This pom defines the set of packages that provide all the supported MicroProfile features</description>
 
     <dependencies>
-        <!-- MicroProfile Glassfish Connectors -->
-        <dependency>
-            <groupId>org.glassfish.main.microprofile</groupId>
-            <artifactId>microprofile-connectors</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <!-- MicroProfile Config -->
-        <dependency>
-            <groupId>org.eclipse.microprofile.config</groupId>
-            <artifactId>microprofile-config-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.glassfish.main.microprofile</groupId>
             <artifactId>microprofile-config</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <!-- MicroProfile Health -->
         <dependency>
-            <groupId>org.eclipse.microprofile.health</groupId>
-            <artifactId>microprofile-health-api</artifactId>
+            <groupId>org.glassfish.main.microprofile</groupId>
+            <artifactId>microprofile-connectors</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.microprofile</groupId>
@@ -67,6 +54,15 @@
             <groupId>org.glassfish.main.microprofile</groupId>
             <artifactId>microprofile-health-service</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
         </dependency>
 
         <!-- MicroProfile JWT -->
@@ -109,6 +105,5 @@
             <artifactId>reactive-streams</artifactId>
             <version>${reactive-streams.version}</version>
         </dependency>
-
     </dependencies>
 </project>

--- a/appserver/microprofile/config/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
+++ b/appserver/microprofile/config/src/main/java/io/helidon/config/mp/MpConfigProviderResolver.java
@@ -71,7 +71,7 @@ public class MpConfigProviderResolver extends ConfigProviderResolver {
             lock.lock();
             Config config = CONFIGS.get(loader);
 
-            if (null == config) {
+            if (config == null) {
                 lock.unlock();
                 lock = RW_LOCK.writeLock();
                 lock.lock();

--- a/appserver/tests/embedded/microprofile/config/pom.xml
+++ b/appserver/tests/embedded/microprofile/config/pom.xml
@@ -5,12 +5,12 @@
 
     <parent>
         <groupId>org.glassfish.tests.embedded</groupId>
-        <artifactId>microprofile</artifactId>
+        <artifactId>microprofile-tests</artifactId>
         <version>8.0.2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.tests.embedded.microprofile</groupId>
-    <artifactId>config</artifactId>
+    <artifactId>microprofile-config-test</artifactId>
     <name>Test MicroProfile Config</name>
 
     <dependencies>

--- a/appserver/tests/embedded/microprofile/config/pom.xml
+++ b/appserver/tests/embedded/microprofile/config/pom.xml
@@ -34,7 +34,7 @@
 
     <profiles>
         <profile>
-            <id>run-with-uber-jar</id>
+            <id>embedded-all</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -46,13 +46,7 @@
             </dependencies>
         </profile>
         <profile>
-            <id>run-with-uber-jar-web</id>
-            <activation>
-                <property>
-                    <name>build</name>
-                    <value>uber-jar-web</value>
-                </property>
-            </activation>
+            <id>embedded-web</id>
             <dependencies>
                 <dependency>
                     <groupId>org.glassfish.main.extras</groupId>
@@ -61,21 +55,14 @@
             </dependencies>
         </profile>
         <profile>
-            <id>run-with-shell-jar</id>
-            <activation>
-                <property>
-                    <name>build</name>
-                    <value>static-shell</value>
-                </property>
-            </activation>
+            <id>embedded-static-shell-jar</id>
             <dependencies>
                 <dependency>
                     <groupId>org.glassfish.main.extras</groupId>
                     <artifactId>glassfish-embedded-static-shell</artifactId>
                     <version>${project.version}</version>
                     <scope>system</scope>
-                    <systemPath>${env.S1AS_HOME}/lib/embedded/glassfish-embedded-static-shell.jar
-                    </systemPath>
+                    <systemPath>${env.S1AS_HOME}/lib/embedded/glassfish-embedded-static-shell.jar</systemPath>
                 </dependency>
             </dependencies>
         </profile>

--- a/appserver/tests/embedded/microprofile/config/src/test/java/org/glassfish/tests/embedded/microprofile/config/MicroProfileConfigIT.java
+++ b/appserver/tests/embedded/microprofile/config/src/test/java/org/glassfish/tests/embedded/microprofile/config/MicroProfileConfigIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Path;
 
 import org.glassfish.embeddable.Deployer;
 import org.glassfish.embeddable.GlassFish;
@@ -37,9 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test MicroProfile Config functionality in embedded GlassFish
  */
-public class MicroProfileConfigTest {
+public class MicroProfileConfigIT {
 
-    private static final String PROJECT_DIR = System.getProperty("basedir", System.getProperty("user.dir"));
+    private static final Path PROJECT_DIR = detectBasedir();
     private static final int HTTP_PORT = 8080;
     private static final String APP_NAME = "config";
 
@@ -53,10 +54,8 @@ public class MicroProfileConfigTest {
         glassfish = GlassFishRuntime.bootstrap().newGlassFish(props);
         glassfish.start();
 
-        File classesDir = new File(PROJECT_DIR, "target/classes");
-
         ScatteredArchive sa = new ScatteredArchive(APP_NAME, ScatteredArchive.Type.WAR);
-        sa.addClassPath(classesDir);
+        sa.addClassPath(PROJECT_DIR.resolve(Path.of("target", "classes")).toFile());
         URI warURI = sa.toURI();
 
         Deployer deployer = glassfish.getDeployer();
@@ -65,13 +64,14 @@ public class MicroProfileConfigTest {
 
     @Test
     void testConfigValueInjection() throws Exception {
-        URL servlet = new URL("http://localhost:" + HTTP_PORT + "/" + APP_NAME + "/config");
+        URL servlet = URI.create("http://localhost:" + HTTP_PORT + "/" + APP_NAME + "/config").toURL();
         URLConnection connection = servlet.openConnection();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        String response = reader.readLine();
-        reader.close();
-
+        String response;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            response = reader.readLine();
+        }
         assertEquals("Hello MicroProfile,Injected", response);
+
     }
 
     @AfterAll
@@ -83,4 +83,19 @@ public class MicroProfileConfigTest {
             glassfish.dispose();
         }
     }
+
+    private static Path detectBasedir() {
+        // Maven would set this property.
+        final String basedir = System.getProperty("basedir");
+        if (basedir != null) {
+            return new File(basedir).toPath().toAbsolutePath();
+        }
+        // Maybe we are standing in the basedir.
+        final File target = new File("target");
+        if (target.exists()) {
+            return target.toPath().toAbsolutePath().getParent();
+        }
+        // Eclipse IDE sometimes uses target as the current dir.
+        return new File(".").toPath().toAbsolutePath().getParent();
+   }
 }

--- a/appserver/tests/embedded/microprofile/pom.xml
+++ b/appserver/tests/embedded/microprofile/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <groupId>org.glassfish.tests.embedded</groupId>
-    <artifactId>microprofile</artifactId>
+    <artifactId>microprofile-tests</artifactId>
     <packaging>pom</packaging>
     <name>MicroProfile Tests</name>
 


### PR DESCRIPTION
- The order suddenly changed just by changing the version number to 8.0.1
- Sometimes our resolver was even missing, not sure why 
- Changing order of dependencies still did not ensure order of resolvers, so I excluded the service and explicitly set the one we want.

In the future we should write our own descriptor handler instead of usage `metaInf-services` which merges all it can see, but cannot filter them or order them.

https://maven.apache.org/plugins/maven-assembly-plugin/examples/single/using-container-descriptor-handlers.html