### PR TITLE
Support for graceful socket closes when checking server endpoint listening via the admin CLI

### DIFF
--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLIConstants.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/CLIConstants.java
@@ -37,6 +37,7 @@ public final class CLIConstants {
     public static final String EOL = System.lineSeparator();
 
     public static final Duration WAIT_FOR_DAS_TIME_MS = getEnv(TIMEOUT_START_SERVER);
+    public static final Duration WAIT_FOR_DAS_POLLING_INTERVAL = Duration.ofMillis(100);
     public static final int RESTART_NORMAL = 10;
     public static final int RESTART_DEBUG_ON = 11;
     public static final int RESTART_DEBUG_OFF = 12;

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ServerLifeSignChecker.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/cli/ServerLifeSignChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,7 @@
 
 package com.sun.enterprise.admin.servermgmt.cli;
 
+import com.sun.enterprise.admin.cli.CLIConstants;
 import com.sun.enterprise.admin.servermgmt.util.CommandAction;
 import com.sun.enterprise.universal.process.ProcessUtils;
 import com.sun.enterprise.util.HostAndPort;
@@ -126,7 +127,7 @@ public class ServerLifeSignChecker {
             }
             return true;
         };
-        return ProcessUtils.waitFor(signOfFinishedStartup, timeout, verbose);
+        return ProcessUtils.waitFor(signOfFinishedStartup, timeout, CLIConstants.WAIT_FOR_DAS_POLLING_INTERVAL, verbose);
     }
 
     private ServerLifeSigns createTimeoutReport(final ServerLifeSigns signs) {

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StartInstanceCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -70,6 +70,7 @@ import static org.glassfish.embeddable.GlassFishVariable.TIMEOUT_START_SERVER;
         })
 })
 public class StartInstanceCommand implements AdminCommand {
+    private static final Duration PORT_CHECK_SLEEP = Duration.ofMillis(100);
     @Inject
     ServiceLocator locator;
 
@@ -197,7 +198,7 @@ public class StartInstanceCommand implements AdminCommand {
 
         if (report.getActionExitCode() == ActionReport.ExitCode.SUCCESS) {
             // Make sure instance is listening
-            if (ProcessUtils.waitFor(instance::isListeningOnAdminPort, getTimeout(timeout), false)) {
+            if (ProcessUtils.waitFor(instance::isListeningOnAdminPort, getTimeout(timeout), PORT_CHECK_SLEEP, false)) {
                 return;
             }
             report.setMessage(Strings.get("start.instance.timeout", instanceName));

--- a/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopInstanceCommand.java
+++ b/nucleus/cluster/admin/src/main/java/com/sun/enterprise/v3/admin/cluster/StopInstanceCommand.java
@@ -86,7 +86,7 @@ import static org.glassfish.embeddable.GlassFishVariable.TIMEOUT_STOP_SERVER;
         })
 })
 public class StopInstanceCommand extends StopServer implements AdminCommand {
-
+    private static final Duration PORT_CHECK_SLEEP = Duration.ofMillis(100);
     @Inject
     private ServiceLocator locator;
     @Inject
@@ -296,7 +296,7 @@ public class StopInstanceCommand extends StopServer implements AdminCommand {
 
     private boolean pollForDeath() {
         Supplier<Boolean> supplier = () -> !instance.isListeningOnAdminPort();
-        return ProcessUtils.waitFor(supplier, getTimeout(timeout), false);
+        return ProcessUtils.waitFor(supplier, getTimeout(timeout), PORT_CHECK_SLEEP, false);
     }
 
 

--- a/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
+++ b/nucleus/common/common-util/src/main/java/com/sun/enterprise/universal/process/ProcessUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -166,7 +166,7 @@ public final class ProcessUtils {
         final Supplier<Boolean> action = () -> {
             try (Socket server = new Socket()) {
                 // Force RST on close
-                server.setSoLinger(true, 0);
+                server.setSoLinger(true, 1);
                 server.setSoTimeout(timeout == null ? 0 : (int) timeout.toMillis());
                 try {
                     server.connect(endpoint.toInetSocketAddress(), SOCKET_CONNECT_TIMEOUT);
@@ -214,7 +214,7 @@ public final class ProcessUtils {
     public static boolean isListening(HostAndPort endpoint) {
         try (Socket socket = new Socket()) {
             // Force RST on close
-            socket.setSoLinger(true, 0);
+            socket.setSoLinger(true, 1);
             socket.connect(endpoint.toInetSocketAddress(), SOCKET_CONNECT_TIMEOUT);
             return true;
         } catch (IOException e) {
@@ -274,15 +274,36 @@ public final class ProcessUtils {
      * @return true if the sign returned true before timeout.
      */
     public static boolean waitFor(Supplier<Boolean> sign, Duration timeout, boolean printDots) {
-        LOG.log(DEBUG, "waitFor(sign={0}, timeout={1}, printDots={2})", sign, timeout, printDots);
+        return waitFor(sign, timeout, null, printDots);
+    }
+
+    /**
+     * @param sign logic defining what we are waiting for.
+     * @param timeout can be null to wait indefinitely.
+     * @param interval interval for polling until the timeout. can be null to poll without an interval.
+     * @param printDots print dot each second and new line in the end.
+     * @return true if the sign returned true before timeout.
+     */
+    public static boolean waitFor(Supplier<Boolean> sign, Duration timeout, Duration interval, boolean printDots) {
+        LOG.log(DEBUG, "waitFor(sign={0}, timeout={1}, interval={2}, printDots={3})", sign, timeout, interval, printDots);
         final Instant start = Instant.now();
         final Instant deadline = timeout == null ? null : start.plus(timeout);
         final Supplier<Boolean> action = () -> {
-            while (deadline == null || Instant.now().isBefore(deadline)) {
+            Instant current = null;
+            while (deadline == null || (current = Instant.now()).isBefore(deadline)) {
                 if (sign.get()) {
                     return true;
                 }
-                Thread.onSpinWait();
+                final Duration pollingInterval = calculatePollingInterval(interval, deadline, current);
+                if (pollingInterval != null) {
+                    try {
+                        Thread.sleep(interval);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    Thread.onSpinWait();
+                }
             }
             return false;
         };
@@ -293,6 +314,23 @@ public final class ProcessUtils {
         LOG.log(DEBUG,
             () -> "Waiting finished after " + millis + " ms. Action " + (result ? "succeeded." : "timed out."));
         return result;
+    }
+
+
+    private static Duration calculatePollingInterval(final Duration interval, final Instant deadline, Instant current) {
+        if (interval == null) {
+            return null;
+        }
+        if (deadline == null) {
+            return interval;
+        }
+        if (current == null) {
+            current = Instant.now();
+        }
+        if (current.isAfter(deadline)) {
+            return null;
+        }
+        return current.plus(interval).isBefore(deadline) ? interval : Duration.between(current, deadline);
     }
 
 


### PR DESCRIPTION
For macOS, immediately closing a client socket results in an incomplete socket state on the server, causing unnecessary server errors. Please refer to the issue below:

- https://github.com/eclipse-ee4j/glassfish-grizzly/issues/2285