### PR TITLE
Upgrade jsftemplating to 4.2.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -90,7 +90,7 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
 
         <!-- Admin console components -->
-        <jsftemplating.version>4.1.0</jsftemplating.version>
+        <jsftemplating.version>4.2.0</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>6.0.3</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>


### PR DESCRIPTION
Release notes: https://github.com/eclipse-ee4j/glassfish-jsftemplating/releases/tag/4.2.0