### PR TITLE
Fix MP Config packaging

### DIFF
--- a/appserver/extras/embedded/all/src/assembly/package.xml
+++ b/appserver/extras/embedded/all/src/assembly/package.xml
@@ -9,6 +9,11 @@
     <includeBaseDirectory>false</includeBaseDirectory>
 
     <dependencySets>
+        <!--
+            microprofile-config contains GlassFish-specific overrides of Helidon resources. 
+            It must be unpacked before all other jars so its classes take precedence.
+            Note that the default behavior of assembly plugin is that it skips duplicates, first occurence wins.
+        -->
         <dependencySet>
             <unpack>true</unpack>
             <outputDirectory></outputDirectory>
@@ -28,14 +33,47 @@
                     <exclude>META-INF/loggerinfo/*</exclude>
                     <exclude>module-info.class</exclude>
                     <exclude>META-INF/versions/*/module-info.class</exclude>
-                    <!-- Helidon's impl is sometimes first -->
-                    <exclude>META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver</exclude>
                     <exclude>*.jar</exclude>
+                </excludes>
+            </unpackOptions>
+            <includes>
+                <include>org.glassfish.main.microprofile:microprofile-config</include>
+            </includes>
+        </dependencySet>
+
+        <!-- All jars except microprofile-config, which must be unpacked first (see above) -->
+        <dependencySet>
+            <unpack>true</unpack>
+            <outputDirectory></outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <useStrictFiltering>true</useStrictFiltering>
+            <scope>compile</scope>
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/NOTICE</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/*.inf</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/hk2-locator/*</exclude>
+                    <exclude>META-INF/loggerinfo/*</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
+                    <exclude>*.jar</exclude>
+                    <!-- Service files from microprofile-config should be excluded, not merged -->
+                    <exclude>META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver</exclude>
+                    <exclude>META-INF/services/org.eclipse.microprofile.config.spi.Converter</exclude>
+                    <!-- End of Service files from microprofile-config -->
                 </excludes>
             </unpackOptions>
             <includes>
                 <include>*:*:jar:*</include>
             </includes>
+            <excludes>
+                <exclude>org.glassfish.main.microprofile:microprofile-config</exclude>
+            </excludes>
         </dependencySet>
     </dependencySets>
 

--- a/appserver/extras/embedded/all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
+++ b/appserver/extras/embedded/all/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver
@@ -1,1 +1,0 @@
-org.glassfish.microprofile.config.GlassFishConfigProviderResolver

--- a/appserver/extras/embedded/web/src/assembly/package.xml
+++ b/appserver/extras/embedded/web/src/assembly/package.xml
@@ -9,6 +9,11 @@
     <includeBaseDirectory>false</includeBaseDirectory>
 
     <dependencySets>
+        <!--
+            microprofile-config contains GlassFish-specific overrides of Helidon resources. 
+            It must be unpacked before all other jars so its classes take precedence.
+            Note that the default behavior of assembly plugin is that it skips duplicates, first occurence wins.
+        -->
         <dependencySet>
             <unpack>true</unpack>
             <outputDirectory></outputDirectory>
@@ -32,10 +37,43 @@
                 </excludes>
             </unpackOptions>
             <includes>
-                <include>*:*:jar:*</include>
+                <include>org.glassfish.main.microprofile:microprofile-config</include>
             </includes>
         </dependencySet>
 
+        <!-- All jars except microprofile-config, which must be unpacked first (see above) -->        <dependencySet>
+            <unpack>true</unpack>
+            <outputDirectory></outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <useStrictFiltering>true</useStrictFiltering>
+            <scope>compile</scope>
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/NOTICE</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/*.inf</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
+                    <exclude>META-INF/hk2-locator/*</exclude>
+                    <exclude>META-INF/loggerinfo/*</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/*/module-info.class</exclude>
+                    <exclude>*.jar</exclude>
+                    <!-- Service files from microprofile-config should be excluded, not merged -->
+                    <exclude>META-INF/services/org.eclipse.microprofile.config.spi.ConfigProviderResolver</exclude>
+                    <exclude>META-INF/services/org.eclipse.microprofile.config.spi.Converter</exclude>
+                    <!-- End of Service files from microprofile-config -->
+                </excludes>
+            </unpackOptions>
+            <includes>
+                <include>*:*:jar:*</include>
+            </includes>
+            <excludes>
+                <exclude>org.glassfish.main.microprofile:microprofile-config</exclude>
+            </excludes>
+        </dependencySet>
     </dependencySets>
 
     <files>


### PR DESCRIPTION
Refactors Embedded GF All distribution module to avoid duplicating the patched Helidon class.

Fixes Embedded GF Web, which didn't prevent Helidon's service file occasionally win over the patched file.

There's still a warning from MP Config OSGi bundle build about split packages. I don't know how to fix it. Our bundle overrides/patches a few classes in the packages that those 2 modules export and bundle plugin complains about split packages provided by both our module and the Helidon artifacts. I tried `-split-package:=merge-first` but it didn't help. Probably the only way to fix it is to remove those 2 modules from the manifest and copy over classes from them to our bundle and then overwrite them with our classes. But I'm not going to do it in this PR.