### PR TITLE
Updated dependencies (Helidon Config to 4.4.1, Nimbus JWT to 10.9,  JNoSQL to 1.1.13, JSch to 2.28.0, StAX 2 API to 4.3.0

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -695,7 +695,7 @@
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>
                             <artifactId>plexus-utils</artifactId>
-                            <version>4.0.2</version>
+                            <version>4.0.3</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -75,7 +75,7 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1</microprofile.config-api.version>
-        <helidon-config.version>4.4.0</helidon-config.version>
+        <helidon-config.version>4.4.1</helidon-config.version>
 
 
         <!-- MicroProfile Health -->

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-maven-plugin</artifactId>
-                <version>4.0.3</version>
+                <version>4.0.4</version>
                 <executions>
                     <execution>
                         <id>jaxws-generate</id>

--- a/appserver/tests/embedded/maven-plugin/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/pom.xml
@@ -190,7 +190,7 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>3.9.14</version>
+                <version>3.9.15</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/appserver/tests/quicklook/testng/testng_full_profile.xml
+++ b/appserver/tests/quicklook/testng/testng_full_profile.xml
@@ -19,7 +19,7 @@
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="QuickLookTests" verbose="-1">
+<suite name="QuickLookTests" verbose="10">
 
     <parameter name="admin.url" value="http://localhost:4848/__asadmin" />
     <parameter name="admin.user" value="admin" />

--- a/appserver/tests/quicklook/testng/testng_web_profile.xml
+++ b/appserver/tests/quicklook/testng/testng_web_profile.xml
@@ -23,7 +23,7 @@
     Tests for "WD" (Web Distribution, aka Jakarta EE Web Profile)
 
  -->
-<suite name="QuickLookTests" verbose="-1">
+<suite name="QuickLookTests" verbose="10">
 
     <parameter name="admin.url" value="http://localhost:4848/__asadmin" />
     <parameter name="admin.user" value="admin" />

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -114,8 +114,8 @@
         <jboss.classfilewriter.version>1.3.1.Final</jboss.classfilewriter.version>
 
         <!-- Jakarta XML Binding -->
-        <jakarta.xml.bind-api.version>4.0.4</jakarta.xml.bind-api.version>
-        <jakarta.jaxb-impl.version>4.0.6</jakarta.jaxb-impl.version>
+        <jakarta.xml.bind-api.version>4.0.5</jakarta.xml.bind-api.version>
+        <jakarta.jaxb-impl.version>4.0.7</jakarta.jaxb-impl.version>
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>4.0.0</jakarta.rest-api.version>
@@ -159,7 +159,7 @@
         <soteria.version>4.0.2</soteria.version>
         <exousia.version>3.0.1</exousia.version>
         <epicyro.version>3.1.1</epicyro.version>
-        <nimbus.version>10.8</nimbus.version>
+        <nimbus.version>10.9</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->
@@ -205,7 +205,7 @@
         <!-- Jakarta SOAP (XML Web Services) -->
         <xmlsec.version>4.0.4</xmlsec.version>
         <woodstox.version>7.1.1</woodstox.version>
-        <stax2-api.version>4.2.2</stax2-api.version>
+        <stax2-api.version>4.3.0</stax2-api.version>
 
         <!-- GlassFish Components -->
         <grizzly.version>5.0.0</grizzly.version>
@@ -232,11 +232,11 @@
         <jboss.logging.version>3.6.3.Final</jboss.logging.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <asm.version>9.9.1</asm.version>
-        <jsch.version>2.27.9</jsch.version>
+        <jsch.version>2.28.0</jsch.version>
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>
-        <ant.version>1.10.15</ant.version>
+        <ant.version>1.10.16</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.21.2</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
@@ -919,7 +919,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-launcher</artifactId>
-                <version>1.10.15</version>
+                <version>1.10.16</version>
             </dependency>
             <dependency>
                 <groupId>com.github.mwiede</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1374,7 +1374,7 @@
                 <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
-                    <version>9.0.2</version>
+                    <version>10.0.0</version>
                     <executions>
                         <execution>
                             <id>get-the-git-infos</id>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -171,7 +171,7 @@
         <jakarta.data.spec.version>1.0</jakarta.data.spec.version>
         <jakarta.nosql-api.version>1.0.1</jakarta.nosql-api.version>
         <jakarta.nosql.spec.version>1.0.1</jakarta.nosql.spec.version>
-        <jnosql.version>1.1.12</jnosql.version>
+        <jnosql.version>1.1.13</jnosql.version>
 
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
@@ -236,7 +236,7 @@
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>
-        <ant.version>1.10.16</ant.version>
+        <ant.version>1.10.17</ant.version>
         <ant.external.version>1.10.2</ant.external.version>
         <jackson.version>2.21.2</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
@@ -919,7 +919,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant-launcher</artifactId>
-                <version>1.10.16</version>
+                <version>${ant.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.mwiede</groupId>

--- a/runtests.sh
+++ b/runtests.sh
@@ -38,6 +38,7 @@ install_bundles() {
   install_dependency "org.glassfish.main.distributions:glassfish:${GF_VERSION}:zip"
   install_dependency "org.glassfish.main.distributions:web:${GF_VERSION}:zip"
   install_dependency "org.jacoco:org.jacoco.agent:0.8.12:jar:runtime"
+  ls -la "${BUNDLES_DIR}/"
 }
 
 ####################################
@@ -89,9 +90,6 @@ else
    unset GLASSFISH_SUSPEND
 fi
 
-echo GF_VERSION=$GF_VERSION
-echo GLASSFISH_SUSPEND=$GLASSFISH_SUSPEND
-
 export JACOCO_ENABLED="true"
 export WORKSPACE="${WORKSPACE:-$(pwd)/target}"
 export BUNDLES_DIR="${BUNDLES_DIR:-${WORKSPACE}/bundles}"
@@ -115,4 +113,5 @@ rm -f ./appserver/tests/appserv-tests/test_resultsValid.xml
 rm -f ./appserver/tests/appserv-tests/test_results.xml
 
 ./appserver/tests/gftest.sh run_test "${test}"
-
+# QuickLook tests don't stop the domain.
+"${S1AS_HOME}"/bin/asadmin stop-domain --kill=true --force=true domain1 || true;


### PR DESCRIPTION
Note: JAX-B reverted back to 4.0.6 later with: https://github.com/eclipse-ee4j/glassfish/pull/26016 because of issues that failed some automated tests.

Upgrades:
* Helidon Config from 4.4.0 to 4.4.1
* JAX-B Impl from 4.0.6 to 4.0.7
* Nimbus JOSE JWT from 10.8 to 10.9
* JNoSQL from 1.1.12 to 1.1.13
* StAX 2 API from 4.2.2 to 4.3.0
* JSch from 2.27.9 to 2.28.0

Summary of changes

* Backported few changes from 9.0
* Updated dependencies
* Discovered issue of HK2 BOM, will be fixed here: https://github.com/eclipse-ee4j/glassfish-hk2/pull/1292
* Discovered issue of new Checkstyle blocking the upgrade
  * I have reported the issue here: https://github.com/checkstyle/checkstyle/issues/19712
  * I will try to fix issues for us here https://github.com/eclipse-ee4j/glassfish/pull/25992 - if someone wants to help me, I can assign the PR to him and he can take over my work and continue.
  * It has pros and cons, good is that it enforces us to fix all javadocs, at least to avoid the reported problem :-D
  * For now I did not do the upgrade, but I fixed few modules. In general the problem comes when Checkstyle fails to parse Javadocs. I have found that Eclipse IDE fails to process such javadocs too, so we will have to fix them too. However still Checkstyle should not crash on them.
* Resolved/improved few issues with QuickLook tests
