### PR TITLE
Fix NetUtilsIT to detect the actual container IP at runtime

### DIFF
--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/net/NetUtilsIT.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/net/NetUtilsIT.java
@@ -317,9 +317,16 @@ public class NetUtilsIT {
     }
 
     private String getContainerHostIP() {
-        // FIXME: The following call is unstable, randomly returns an empty string.
-//        return container.getContainerInfo().getNetworkSettings().getGlobalIPv6Address();
-        return "172.17.";
+        var networkSettings = container.getContainerInfo().getNetworkSettings();
+        String ip = networkSettings.getIpAddress();
+        if (ip != null && !ip.isEmpty()) {
+            return ip;
+        }
+        return networkSettings.getNetworks().values().stream()
+            .map(network -> network.getIpAddress())
+            .filter(addr -> addr != null && !addr.isEmpty())
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Container has no IPv4 address assigned"));
     }
 
     private static String filterMethodIsLocal(String template, String address) {


### PR DESCRIPTION
getContainerHostIP() was hard-coded to the default Docker bridge prefix "172.17.". On machines where Docker assigns containers from a different subnet (e.g. 172.26.0.0/16, which happens when 172.17.0.0/16 is already in use by a VPN or pre-existing network), every assertion using stringContainsInOrder(getContainerHostIP(), ...) fails because the expected substring never appears in the actual IP string.

Replace the hard-coded prefix with a live lookup via testcontainers' NetworkSettings.getIpAddress() after the container has started, falling back to iterating the networks map if the primary IP is empty (the original FIXME's complaint about getGlobalIPv6Address() returning blank).
