### PR TITLE
Generate the embedded HTTPS keystore at runtime so HTTPS works without shipping a private key

### DIFF
--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -43,6 +43,7 @@ import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.embeddable.GlassFishRuntime;
+import org.glassfish.embeddable.GlassFishVariable;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.DuplicatePostProcessor;
 import org.glassfish.main.boot.log.LogFacade;
@@ -147,7 +148,12 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         // The embedded domain.xml declares javax.net.ssl.keyStore/trustStore as jvm-options, but
         // those only take effect when the JVM is forked (standalone GlassFish). For in-process
         // embedded use we set them programmatically here, deferring to the caller's choice if
-        // they've already configured a keystore.
+        // they've already configured a keystore. If the caller set a path but the file does not
+        // exist we log a WARNING up front: SecuritySupport will still substitute an empty
+        // KeyStore (matching its own behaviour), so the handshake will still fail later, but the
+        // log now names the property and the offending path instead of an opaque TLS error.
+        validateConfiguredStorePath(KEYSTORE_FILE);
+        validateConfiguredStorePath(TRUSTSTORE_FILE);
         File embeddedKeyStore = new File(instanceRoot, "config/keystore.p12");
         if (embeddedKeyStore.isFile()) {
             setProperty(KEYSTORE_FILE.getSystemPropertyName(), embeddedKeyStore.getAbsolutePath(), false);
@@ -234,6 +240,16 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         String autoDelete = gfProps.getProperties().getProperty(AUTO_DELETE, "true");
         gfProps.setProperty(AUTO_DELETE, autoDelete);
         return instanceRoot.getAbsolutePath();
+    }
+
+    private static void validateConfiguredStorePath(GlassFishVariable variable) {
+        String configured = System.getProperty(variable.getSystemPropertyName());
+        if (configured != null && !new File(configured).isFile()) {
+            LOG.log(WARNING, "Configured {0}={1} does not exist or is not a regular file;"
+                + " SecuritySupport will fall back to an empty in-memory keystore and"
+                + " TLS handshakes will fail with an opaque error.",
+                new Object[] {variable.getSystemPropertyName(), configured});
+        }
     }
 
     private static void generateEmbeddedKeyPair(File instanceConfigDir) {

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -237,6 +237,11 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
     }
 
     private static void generateEmbeddedKeyPair(File instanceConfigDir) {
+        if (System.getProperty(KEYSTORE_FILE.getSystemPropertyName()) != null) {
+            // The caller already pointed JSSE at a keystore (e.g. via -Djavax.net.ssl.keyStore);
+            // don't generate a dev cert they won't use.
+            return;
+        }
         File keyStore = new File(instanceConfigDir, "keystore.p12");
         File trustStore = new File(instanceConfigDir, "cacerts.p12");
         if (keyStore.isFile() && trustStore.isFile()) {

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -93,7 +93,7 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
             properties.putAll(glassFishProperties.getProperties());
 
             final GlassFishProperties gfProps = new GlassFishProperties(properties);
-            setEnv(gfProps);
+            final OwnedSslProperties ownedSslProps = setEnv(gfProps);
 
             final StartupContext startupContext = new StartupContext(gfProps.getProperties());
             final ModulesRegistry modulesRegistry = AbstractFactory.getInstance().createModulesRegistry();
@@ -103,7 +103,10 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
             final ModuleStartup gfKernel = main.findStartupService(modulesRegistry, serviceLocator, null,
                 startupContext);
 
-            final Consumer<GlassFish> onDispose = gf -> glassFishInstances.remove(gfProps.getInstanceRoot());
+            final Consumer<GlassFish> onDispose = gf -> {
+                glassFishInstances.remove(gfProps.getInstanceRoot());
+                ownedSslProps.clearIfStillOwned();
+            };
             final GlassFish glassFish = new AutoDisposableGlassFish(gfKernel, serviceLocator, gfProps, onDispose);
             glassFishInstances.put(gfProps.getInstanceRoot(), glassFish);
 
@@ -134,7 +137,7 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         }
     }
 
-    private void setEnv(GlassFishProperties gfProps) throws Exception {
+    private OwnedSslProperties setEnv(GlassFishProperties gfProps) throws Exception {
         String instanceRootValue = gfProps.getInstanceRoot();
         if (instanceRootValue == null) {
             instanceRootValue = createTempInstanceRoot(gfProps);
@@ -155,13 +158,10 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         validateConfiguredStorePath(KEYSTORE_FILE);
         validateConfiguredStorePath(TRUSTSTORE_FILE);
         File embeddedKeyStore = new File(instanceRoot, "config/keystore.p12");
-        if (embeddedKeyStore.isFile()) {
-            setProperty(KEYSTORE_FILE.getSystemPropertyName(), embeddedKeyStore.getAbsolutePath(), false);
-        }
+        String ownedKeyStore = setStoreSystemPropertyIfUnset(KEYSTORE_FILE, embeddedKeyStore);
         File embeddedTrustStore = new File(instanceRoot, "config/cacerts.p12");
-        if (embeddedTrustStore.isFile()) {
-            setProperty(TRUSTSTORE_FILE.getSystemPropertyName(), embeddedTrustStore.getAbsolutePath(), false);
-        }
+        String ownedTrustStore = setStoreSystemPropertyIfUnset(TRUSTSTORE_FILE, embeddedTrustStore);
+        OwnedSslProperties ownedSslProps = new OwnedSslProperties(ownedKeyStore, ownedTrustStore);
 
         String installRootValue = System.getProperty("org.glassfish.embeddable.installRoot");
         if (installRootValue == null) {
@@ -181,6 +181,44 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         // StartupContext requires the installRoot to be set in the GlassFishProperties.
         gfProps.setProperty(INSTALL_ROOT.getPropertyName(), installRoot.getAbsolutePath());
         gfProps.setProperty(BootstrapKeys.INSTALL_ROOT_URI_PROP_NAME, installRoot.toURI().toString());
+
+        return ownedSslProps;
+    }
+
+    /**
+     * Sets the JSSE store system property to {@code embeddedStore} only if it is unset and the
+     * file exists, returning the path so the caller can clear it again on dispose. Tracking
+     * ownership is what keeps a dangling path from leaking into the next embedded GlassFish
+     * instance started in the same JVM: when the temp instanceRoot is auto-deleted, leaving the
+     * system property pointing at it would later defeat both {@link #generateEmbeddedKeyPair}'s
+     * bail-out (which trusts the property) and the maven-embedded-glassfish-plugin's
+     * setSystemProperties (which skips already-set keys).
+     */
+    private static String setStoreSystemPropertyIfUnset(GlassFishVariable variable, File embeddedStore) {
+        if (!embeddedStore.isFile() || System.getProperty(variable.getSystemPropertyName()) != null) {
+            return null;
+        }
+        setProperty(variable.getSystemPropertyName(), embeddedStore.getAbsolutePath(), false);
+        return embeddedStore.getAbsolutePath();
+    }
+
+    /**
+     * The JSSE store system property paths that this GlassFish instance set on startup and is
+     * therefore responsible for clearing on dispose. A null path means the property was already
+     * set by the caller (or not set at all) and is not ours to touch.
+     */
+    private record OwnedSslProperties(String keyStorePath, String trustStorePath) {
+
+        void clearIfStillOwned() {
+            clear(KEYSTORE_FILE, keyStorePath);
+            clear(TRUSTSTORE_FILE, trustStorePath);
+        }
+
+        private static void clear(GlassFishVariable variable, String ownedPath) {
+            if (ownedPath != null && ownedPath.equals(System.getProperty(variable.getSystemPropertyName()))) {
+                System.clearProperty(variable.getSystemPropertyName());
+            }
+        }
     }
 
     private String createTempInstanceRoot(GlassFishProperties gfProps) throws Exception {

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -46,6 +46,7 @@ import org.glassfish.embeddable.GlassFishRuntime;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.DuplicatePostProcessor;
 import org.glassfish.main.boot.log.LogFacade;
+import org.glassfish.main.jdke.security.KeyTool;
 
 import static com.sun.enterprise.glassfish.bootstrap.cfg.BootstrapKeys.AUTO_DELETE;
 import static java.util.logging.Level.FINER;
@@ -53,6 +54,8 @@ import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
 import static org.glassfish.embeddable.GlassFishVariable.INSTANCE_ROOT;
+import static org.glassfish.embeddable.GlassFishVariable.KEYSTORE_FILE;
+import static org.glassfish.embeddable.GlassFishVariable.TRUSTSTORE_FILE;
 import static org.glassfish.main.jdke.props.SystemProperties.setProperty;
 
 /**
@@ -141,6 +144,19 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         setProperty(INSTANCE_ROOT.getSystemPropertyName(), instanceRoot.getAbsolutePath(), true);
         setProperty(BootstrapKeys.INSTANCE_ROOT_URI_PROP_NAME, instanceRoot.toURI().toString(), true);
 
+        // The embedded domain.xml declares javax.net.ssl.keyStore/trustStore as jvm-options, but
+        // those only take effect when the JVM is forked (standalone GlassFish). For in-process
+        // embedded use we set them programmatically here, deferring to the caller's choice if
+        // they've already configured a keystore.
+        File embeddedKeyStore = new File(instanceRoot, "config/keystore.p12");
+        if (embeddedKeyStore.isFile()) {
+            setProperty(KEYSTORE_FILE.getSystemPropertyName(), embeddedKeyStore.getAbsolutePath(), false);
+        }
+        File embeddedTrustStore = new File(instanceRoot, "config/cacerts.p12");
+        if (embeddedTrustStore.isFile()) {
+            setProperty(TRUSTSTORE_FILE.getSystemPropertyName(), embeddedTrustStore.getAbsolutePath(), false);
+        }
+
         String installRootValue = System.getProperty("org.glassfish.embeddable.installRoot");
         if (installRootValue == null) {
             installRootValue = instanceRoot.getAbsolutePath();
@@ -204,6 +220,13 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
             if(configFileURI != null) {
                 copy(configFileURI.toURL(), new File(instanceConfigDir, "domain.xml"), true);
             }
+
+            // Generate a self-signed s1as keypair for the embedded HTTPS listener. Each embedded
+            // JVM gets its own fresh private key, so the private key is never shipped in the jar.
+            // The embedded domain.xml expects keystore.p12 + cacerts.p12 in config/, and JSSE
+            // loads them via the system properties set in setEnv. Users replace the cert by
+            // providing a custom instanceRoot or domain.xml.
+            generateEmbeddedKeyPair(instanceConfigDir);
         } catch (Exception ex) {
             LOG.log(SEVERE, "Failed to create instanceRoot", ex);
         }
@@ -211,6 +234,29 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         String autoDelete = gfProps.getProperties().getProperty(AUTO_DELETE, "true");
         gfProps.setProperty(AUTO_DELETE, autoDelete);
         return instanceRoot.getAbsolutePath();
+    }
+
+    private static void generateEmbeddedKeyPair(File instanceConfigDir) {
+        File keyStore = new File(instanceConfigDir, "keystore.p12");
+        File trustStore = new File(instanceConfigDir, "cacerts.p12");
+        if (keyStore.isFile() && trustStore.isFile()) {
+            return;
+        }
+        try {
+            char[] password = "changeit".toCharArray();
+            KeyTool keyTool = new KeyTool(keyStore, "PKCS12", password);
+            keyTool.generateKeyPair("s1as", "CN=localhost,OU=GlassFish,O=Eclipse Foundation", "RSA", 3650);
+            keyTool.copyCertificate("s1as", trustStore);
+            LOG.log(WARNING,
+                "Generated a self-signed s1as keypair for the embedded HTTPS listener at {0}."
+                + " This certificate is for development and testing only; replace it with a"
+                + " CA-issued certificate (or supply your own keystore via a custom domain.xml"
+                + " or the javax.net.ssl.keyStore system property) before exposing this server"
+                + " to untrusted networks.",
+                keyStore.getAbsolutePath());
+        } catch (Exception ex) {
+            LOG.log(WARNING, "Failed to generate embedded s1as keypair; HTTPS listener will be unusable.", ex);
+        }
     }
 
     private static void copy(URL url, File destFile, boolean overwrite) {


### PR DESCRIPTION
Commit 6b062d0d27 ("Removed nonexisting keystore.jks and cacerts.jks", Jun 2025) deliberately stopped shipping the s1as keystore inside kernel.jar / glassfish-embedded-all.jar so the published artifacts would not leak a publicly-known private key. That was the right call, but no runtime replacement was wired up: `EmbeddedGlassFishRuntime.createTempInstanceRoot()` now creates an instance root with no keystore at all. The embedded domain.xml still declares `-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12`, but those `<jvm-options>` only take effect when the JVM is forked - in-process they are ignored. `SecuritySupport` reads `javax.net.ssl.keyStore` as null and falls back to an empty `KeyStore`. JSSE logs `"s1as is not a private key entry"` and the TLS 1.3 handshake aborts with `HANDSHAKE_FAILURE (No available authentication scheme)`; the `HttpURLConnection` client sees `"Remote host terminated the handshake"`.

The CI build masked this for ~10 months because the nine maven-plugin test modules that run before `secureWebApp` each invoke the embedded plugin in the same Maven JVM. The first of them sets `javax.net.ssl.keyStore` to its own pre-generated test keystore, and every subsequent module's GlassFish silently inherits that JVM-wide property - giving `jsptest`, `multipleApps`, and others a usable keystore. `secureWebApp` itself was also a victim: `maven-embedded-glassfish-plugin.setSystemProperties` only sets a key when `System.getProperty` returns null, so `secureWebApp`'s own `systemPropertiesFile` (which would have wired in its `testkeystore.p12`) was silently skipped, and the dangling pointer from the very first module won. Run any of these tests standalone and the handshake fails; run `mvn clean install` from the repo root and `secureWebApp`'s https test fails too, once a later commit on this PR makes the leaked property point at a now-deleted instanceRoot.

All four commits live in `EmbeddedGlassFishRuntime` and preserve the original intent of not shipping a private key:

1. **Generate the keystore at runtime** — `createTempInstanceRoot` now calls `generateEmbeddedKeyPair`, which creates a fresh self-signed `s1as` PKCS12 keystore and matching `cacerts` truststore under `${instanceRoot}/config/` using the existing `KeyTool` utility. A new key pair is generated for every embedded JVM, so `kernel.jar` and `glassfish-embedded-all.jar` still contain no key material - nothing is leaked through the build artifacts. A WARNING log states clearly that the auto-generated cert is for development and testing only, and points to the supported override paths (custom domain.xml, `javax.net.ssl.keyStore` system property, custom instanceRoot). `setEnv` sets `javax.net.ssl.keyStore` and `javax.net.ssl.trustStore` to the generated files with `force=false`, so JSSE in the embedded JVM actually picks them up. Pre-set values from the caller are respected.

2. **Skip generation when the caller already configured one** — if `javax.net.ssl.keyStore` is set on the JVM before `bootstrap()` (typical when wiring in a production cert), `generateEmbeddedKeyPair` bails out early. Avoids ~1s of spurious `keytool` work and suppresses the dev-cert WARNING in scenarios where JSSE never loads the auto-generated keystore.

3. **Log a warning when a configured `javax.net.ssl.keyStore` / `javax.net.ssl.trustStore` is missing** — if the caller pointed JSSE at a path that does not exist, `SecuritySupport.getKeyStore` silently substitutes an empty `KeyStore` and the misconfiguration only surfaces later as an opaque handshake failure. `setEnv` now logs a WARNING up front naming the property and the offending path, mirroring the existing pattern in `SecuritySupport.getKeyStore` that also warns and falls back.

4. **Clear the JSSE properties on dispose** — `setEnv` now returns an `OwnedSslProperties` record listing the paths it set for `javax.net.ssl.keyStore` / `javax.net.ssl.trustStore`. The `onDispose` lambda in `newGlassFish` clears those properties when the instance shuts down, *only* if they still equal the path we set - so a caller's later override is never clobbered. Without this, the embedded instanceRoot is auto-deleted on dispose but the system property keeps pointing at the now-missing `keystore.p12`; the next embedded GlassFish in the same JVM then sees a non-null `javax.net.ssl.keyStore`, `generateEmbeddedKeyPair` bails out (per `#2` above), `setEnv`'s `force=false` preserves the dangling value, and `SecuritySupport` silently substitutes an empty keystore. This is exactly the chain that breaks `secureWebApp` under `mvn clean install` from the repo root, and it's also what restores the plugin's per-module `setSystemProperties` so `secureWebApp`'s `testkeystore.p12` actually gets wired in.

The embedded https-listener remains opt-in (`enabled="false"` in domain.xml); this change only makes it functional when the user does opt in.
