### PR TITLE
Generate test keystore in jsptest and multipleApps so HTTPS tests pass standalone

### DIFF
--- a/appserver/tests/embedded/maven-plugin/jsptest/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/jsptest/pom.xml
@@ -41,10 +41,22 @@
                 </property>
             </activation>
             <build>
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                        <includes>
+                            <include>*.properties</include>
+                        </includes>
+                        <filtering>true</filtering>
+                    </testResource>
+                </testResources>
                 <plugins>
                     <plugin>
                         <groupId>org.glassfish.embedded</groupId>
                         <artifactId>maven-embedded-glassfish-plugin</artifactId>
+                        <configuration>
+                            <systemPropertiesFile>${project.build.testOutputDirectory}/system.properties</systemPropertiesFile>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>
@@ -77,6 +89,18 @@
         <dependency>
             <groupId>org.glassfish.main</groupId>
             <artifactId>glassfish-jul-extension</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>glassfish-jdk-extensions</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/embedded/maven-plugin/jsptest/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
+++ b/appserver/tests/embedded/maven-plugin/jsptest/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
@@ -18,9 +18,11 @@
 package org.glassfish.tests.embedded.jsptest;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
@@ -29,8 +31,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.glassfish.main.jdke.security.KeyTool;
+import org.glassfish.tests.utils.junit.JUnitSystem;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static com.sun.enterprise.util.SystemPropertyConstants.KEYSTORE_PASSWORD_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JspTest {
@@ -38,6 +44,14 @@ public class JspTest {
     private static final int EXPECTED_COUNT = 3;
 
     private String contextPath = "test";
+
+    @BeforeAll
+    public static void createKeyStore() throws Exception {
+        // Path matches javax.net.ssl.keyStore in src/test/resources/system.properties.
+        File keystore = JUnitSystem.detectBasedir().resolve(Path.of("target", "testkeystore.p12")).toFile();
+        KeyTool keyTool = new KeyTool(keystore, KEYSTORE_PASSWORD_DEFAULT.toCharArray());
+        keyTool.generateKeyPair("s1as", "CN=localhost", "RSA", 1);
+    }
 
     @Test
     public void testWeb() throws Exception {

--- a/appserver/tests/embedded/maven-plugin/jsptest/src/test/resources/system.properties
+++ b/appserver/tests/embedded/maven-plugin/jsptest/src/test/resources/system.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Contributors to the Eclipse Foundation.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+javax.net.ssl.keyStore=${project.build.directory}/testkeystore.p12
+javax.net.ssl.trustStore=${project.build.directory}/testtruststore.p12

--- a/appserver/tests/embedded/maven-plugin/multipleApps/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/multipleApps/pom.xml
@@ -41,10 +41,22 @@
                 </property>
             </activation>
             <build>
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                        <includes>
+                            <include>*.properties</include>
+                        </includes>
+                        <filtering>true</filtering>
+                    </testResource>
+                </testResources>
                 <plugins>
                     <plugin>
                         <groupId>org.glassfish.embedded</groupId>
                         <artifactId>maven-embedded-glassfish-plugin</artifactId>
+                        <configuration>
+                            <systemPropertiesFile>${project.build.testOutputDirectory}/system.properties</systemPropertiesFile>
+                        </configuration>
                         <executions>
                             <!-- Start embedded GlassFish -->
                             <execution>
@@ -134,6 +146,18 @@
         <dependency>
             <groupId>org.glassfish.main</groupId>
             <artifactId>glassfish-jul-extension</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.common</groupId>
+            <artifactId>glassfish-jdk-extensions</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/embedded/maven-plugin/multipleApps/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
+++ b/appserver/tests/embedded/maven-plugin/multipleApps/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
@@ -18,9 +18,11 @@
 package org.glassfish.tests.embedded.jsptest;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
@@ -29,8 +31,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.glassfish.main.jdke.security.KeyTool;
+import org.glassfish.tests.utils.junit.JUnitSystem;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static com.sun.enterprise.util.SystemPropertyConstants.KEYSTORE_PASSWORD_DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JspTest {
@@ -38,6 +44,14 @@ public class JspTest {
     private static final int EXPECTED_COUNT = 3;
 
     private String contextPath = "test";
+
+    @BeforeAll
+    public static void createKeyStore() throws Exception {
+        // Path matches javax.net.ssl.keyStore in src/test/resources/system.properties.
+        File keystore = JUnitSystem.detectBasedir().resolve(Path.of("target", "testkeystore.p12")).toFile();
+        KeyTool keyTool = new KeyTool(keystore, KEYSTORE_PASSWORD_DEFAULT.toCharArray());
+        keyTool.generateKeyPair("s1as", "CN=localhost", "RSA", 1);
+    }
 
     @Test
     public void testWeb() throws Exception {

--- a/appserver/tests/embedded/maven-plugin/multipleApps/src/test/resources/system.properties
+++ b/appserver/tests/embedded/maven-plugin/multipleApps/src/test/resources/system.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Contributors to the Eclipse Foundation.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+javax.net.ssl.keyStore=${project.build.directory}/testkeystore.p12
+javax.net.ssl.trustStore=${project.build.directory}/testtruststore.p12


### PR DESCRIPTION
Since 6b062d0d27 ("Removed nonexisting keystore.jks and cacerts.jks", Jun 2025) the embedded GlassFish artifacts no longer ship the s1as keystore. The maven-plugin embedded HTTPS tests therefore have no usable server keypair: SecuritySupport falls back to an empty in-memory KeyStore, JSSE cannot present a certificate for the s1as alias, and the TLS 1.3 handshake aborts with HANDSHAKE_FAILURE. The client (jsptest, multipleApps) sees "Remote host terminated the handshake".

CI masked this for ~10 months because secureWebApp runs first in the shared Maven JVM and its src/test/resources/system.properties sets javax.net.ssl.keyStore to a pre-generated testkeystore.p12 via the embedded plugin's <systemPropertiesFile>. The system property leaks into the same JVM and rescues every later embedded HTTPS test - but only when they run together. Running jsptest or multipleApps standalone fails.

Fix: give each affected module its own keystore the same way secureWebApp already does it.

  - src/test/resources/system.properties points javax.net.ssl.keyStore and trustStore at target/testkeystore.p12, with property filtering so ${project.build.directory} expands.
  - pom.xml wires the file into the embedded plugin via <systemPropertiesFile> and pulls in glassfish-jdk-extensions and test-utils as test deps for KeyTool / JUnitSystem.
  - JspTest.createKeyStore() generates a fresh PKCS12 s1as keypair under @BeforeAll, mirroring SecureWebAppTest.createKeyStore.

Supersedes PR #26031, which attempted to fix the same handshake failure by generating an s1as keypair inside EmbeddedGlassFishRuntime at every embedded JVM start. Reviewers pushed back on auto-generating certificates in the runtime: embedded GlassFish should not ship or synthesize a private key, production users are expected to supply their own keystore, and a CN=localhost self-signed cert is worthless anyway. Confining the fix to the test modules that actually need it leaves the runtime untouched and matches the existing convention in secureWebApp.
