### PR TITLE
Several optimizations of Embedded GlassFish startup

### DIFF
--- a/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
+++ b/nucleus/admin/config-api/src/main/java/org/glassfish/config/support/TranslatedConfigView.java
@@ -101,7 +101,6 @@ public class TranslatedConfigView implements ConfigView {
                     }
                 }
             }
-
             // Perform property substitution in the value
             // The loop limit is imposed to prevent infinite looping to values
             // such as a=${a} or a=foo ${b} and b=bar {$a}

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
@@ -24,9 +24,11 @@ import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -35,7 +37,9 @@ import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.main.boot.impl.GlassFishImpl;
 import org.glassfish.main.jdke.props.SystemProperties;
 
@@ -63,6 +67,7 @@ class AutoDisposableGlassFish extends GlassFishImpl {
         // If there are custom configurations like http.port, https.port, jmx.port then configure them.
         CommandRunner commandRunner = null;
         Set<String> knownPropertyPrefixes = new HashSet<>();
+        ArrayList<String> configPropertiesToSet = new ArrayList<>();
         for (String key : gfProps.getPropertyNames()) {
             String propertyName = key;
             if (key.startsWith(GENERAL_CONFIG_PROP_PREFIX)) {
@@ -92,10 +97,12 @@ class AutoDisposableGlassFish extends GlassFishImpl {
                     continue;
                 }
             }
-            CommandResult result = commandRunner.run("set", propertyName + "=" + propertyValue);
-            if (result.getExitStatus() != CommandResult.ExitStatus.SUCCESS) {
-                throw new GlassFishException(result.getOutput(), result.getFailureCause());
-            }
+            configPropertiesToSet.add(propertyName + "=" + propertyValue);
+        }
+
+        CommandResult result = commandRunner.run("set", configPropertiesToSet.toArray(String[]::new));
+        if (result.getExitStatus() != CommandResult.ExitStatus.SUCCESS) {
+            throw new GlassFishException(result.getOutput(), result.getFailureCause());
         }
     }
 

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/AutoDisposableGlassFish.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -37,9 +36,7 @@ import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
-import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.main.boot.impl.GlassFishImpl;
 import org.glassfish.main.jdke.props.SystemProperties;
 

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -35,15 +35,20 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+import org.glassfish.embeddable.CommandRunner;
 import org.glassfish.embeddable.GlassFish;
 import org.glassfish.embeddable.GlassFishException;
 import org.glassfish.embeddable.GlassFishProperties;
 import org.glassfish.embeddable.GlassFishRuntime;
+import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.DuplicatePostProcessor;
 import org.glassfish.main.boot.log.LogFacade;
 
@@ -89,18 +94,25 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
             properties.putAll(glassFishProperties.getProperties());
 
             final GlassFishProperties gfProps = new GlassFishProperties(properties);
-            setEnv(gfProps);
+            final CompletableFuture<Void> setEnvFuture = setEnv(gfProps);
 
             final StartupContext startupContext = new StartupContext(gfProps.getProperties());
             final ModulesRegistry modulesRegistry = AbstractFactory.getInstance().createModulesRegistry();
+             // Building the serviceLocator takes about 600ms, around 1/5
             final ServiceLocator serviceLocator = main.createServiceLocator(modulesRegistry, startupContext,
                 List.of(new EmbeddedInhabitantsParser(), new DuplicatePostProcessor()), null);
+
+            preloadEssentialServicesInBackground(serviceLocator);
 
             final ModuleStartup gfKernel = main.findStartupService(modulesRegistry, serviceLocator, null,
                 startupContext);
 
             final Consumer<GlassFish> onDispose = gf -> glassFishInstances.remove(gfProps.getInstanceRoot());
-            final GlassFish glassFish = new AutoDisposableGlassFish(gfKernel, serviceLocator, gfProps, onDispose);
+
+            // We need to complete the setup before creating AutoDisposableGlassFish
+            setEnvFuture.join();
+
+            final GlassFish glassFish = new AutoDisposableGlassFish(gfKernel, serviceLocator, gfProps, onDispose); // takes 900ms
             glassFishInstances.put(gfProps.getInstanceRoot(), glassFish);
 
             return glassFish;
@@ -109,6 +121,26 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         } catch (Exception e) {
             throw new GlassFishException(e);
         }
+    }
+
+    // Preloads some services in background. They will always be needed during startup.
+    // Instead of loading them lazily in the main thread, we load them immediately in background so that they are loaded sooner
+    private void preloadEssentialServicesInBackground(final ServiceLocator serviceLocator) {
+        // Preload command runner. AutoDisposableGlassFish always needs to run it
+        // - first load preloads all the singleton dependencies which take about 500ms to initialize.
+        // It's typically not loaded in time before it's needed on the main thread but it still decreases
+        // the time the main thread needs to wait until the initialization completes by about 2/3, to about 150ms
+        ForkJoinPool.commonPool().submit(() -> serviceLocator.getService(CommandRunner.class));
+
+        // Preload the service for the set command (name="set") in a background thread.
+        // AutoDisposableGlassFish always needs to run it so it can retrieve it faster
+        // - we load the singleton GetSetModularityHelper dependency heere eagerly because it takes about 250ms to initialize
+        // Again, it doesn't load completely in time before it's needed on the main thread but decreases the wait time on the main to about 80ms
+        ForkJoinPool.commonPool().submit(() -> {
+            final ActiveDescriptor<?> setCommandDescriptor = serviceLocator.getBestDescriptor(BuilderHelper.createNameFilter("set"));
+            serviceLocator.getServiceHandle(setCommandDescriptor)
+                    .getService();
+        });
     }
 
     @Override
@@ -130,7 +162,15 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         }
     }
 
-    private void setEnv(GlassFishProperties gfProps) throws Exception {
+    /*
+       Unpacks the domain directory and sets up the properties related to the environment
+
+       Asynchronously completes tasks that aren't essential during startup to move them from the main thread.
+       The returned future should be joined before creating AutoDisposableGlassFish, which applies properties
+       that might depend on having the environment completely set up.
+    */
+    private CompletableFuture<Void> setEnv(GlassFishProperties gfProps) throws Exception {
+        CompletableFuture<Void> asyncResult = CompletableFuture.completedFuture(null);
         String instanceRootValue = gfProps.getInstanceRoot();
         if (instanceRootValue == null) {
             instanceRootValue = createTempInstanceRoot(gfProps);
@@ -145,7 +185,8 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         if (installRootValue == null) {
             installRootValue = instanceRoot.getAbsolutePath();
             gfProps.setProperty("-type", "EMBEDDED");
-            JarUtil.extractRars(installRootValue);
+            final String installRootFinalValue = installRootValue;
+            asyncResult = asyncResult.thenRun(() -> JarUtil.extractRars(installRootFinalValue));
         }
         JarUtil.setEnv(installRootValue);
 
@@ -159,6 +200,8 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         // StartupContext requires the installRoot to be set in the GlassFishProperties.
         gfProps.setProperty(INSTALL_ROOT.getPropertyName(), installRoot.getAbsolutePath());
         gfProps.setProperty(BootstrapKeys.INSTALL_ROOT_URI_PROP_NAME, installRoot.toURI().toString());
+
+        return asyncResult;
     }
 
     private String createTempInstanceRoot(GlassFishProperties gfProps) throws Exception {

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/embedded/EmbeddedGlassFishRuntime.java
@@ -23,6 +23,7 @@ import com.sun.enterprise.module.bootstrap.Main;
 import com.sun.enterprise.module.bootstrap.ModuleStartup;
 import com.sun.enterprise.module.bootstrap.StartupContext;
 import com.sun.enterprise.module.common_impl.AbstractFactory;
+import com.sun.enterprise.util.Utility;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -130,16 +131,25 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
         // - first load preloads all the singleton dependencies which take about 500ms to initialize.
         // It's typically not loaded in time before it's needed on the main thread but it still decreases
         // the time the main thread needs to wait until the initialization completes by about 2/3, to about 150ms
-        ForkJoinPool.commonPool().submit(() -> serviceLocator.getService(CommandRunner.class));
+        runAsynchWithThreadContext(() -> serviceLocator.getService(CommandRunner.class), Thread.currentThread());
 
         // Preload the service for the set command (name="set") in a background thread.
         // AutoDisposableGlassFish always needs to run it so it can retrieve it faster
         // - we load the singleton GetSetModularityHelper dependency heere eagerly because it takes about 250ms to initialize
         // Again, it doesn't load completely in time before it's needed on the main thread but decreases the wait time on the main to about 80ms
+        runAsynchWithThreadContext(
+                () -> {
+                    final ActiveDescriptor<?> setCommandDescriptor = serviceLocator.getBestDescriptor(BuilderHelper.createNameFilter("set"));
+                    serviceLocator.getServiceHandle(setCommandDescriptor)
+                            .getService();
+                },
+                Thread.currentThread());
+    }
+
+    private static void runAsynchWithThreadContext(Utility.RunnableWithException action, Thread spawningThread) {
+        final ClassLoader contextClassLoader = spawningThread.getContextClassLoader();
         ForkJoinPool.commonPool().submit(() -> {
-            final ActiveDescriptor<?> setCommandDescriptor = serviceLocator.getBestDescriptor(BuilderHelper.createNameFilter("set"));
-            serviceLocator.getServiceHandle(setCommandDescriptor)
-                    .getService();
+            Utility.runWithContextClassLoader(contextClassLoader, action);
         });
     }
 
@@ -186,7 +196,12 @@ class EmbeddedGlassFishRuntime extends GlassFishRuntime {
             installRootValue = instanceRoot.getAbsolutePath();
             gfProps.setProperty("-type", "EMBEDDED");
             final String installRootFinalValue = installRootValue;
-            asyncResult = asyncResult.thenRun(() -> JarUtil.extractRars(installRootFinalValue));
+            final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            asyncResult = asyncResult.thenRunAsync(
+                    () -> {
+                        Utility.runWithContextClassLoader(contextClassLoader,
+                                () -> JarUtil.extractRars(installRootFinalValue));
+                    });
         }
         JarUtil.setEnv(installRootValue);
 


### PR DESCRIPTION
Reduces startup time by about 300ms, from 2.2s to 2.0s, about 10%

Things done:
- set multiple properties in a single command (not so significant but might help)
- preload some work in background ASAP
- load some non-essential things in background (unpacking RARs to the domain)
- do not initialize alias store if it's not needed
