### PR TITLE
Remove duplicated `jakarta.interceptor-api` dependency

### DIFF
--- a/appserver/featuresets/embedded-web/pom.xml
+++ b/appserver/featuresets/embedded-web/pom.xml
@@ -1049,10 +1049,6 @@
             <artifactId>jakarta.cdi-lang-model-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.interceptor</groupId>
-            <artifactId>jakarta.interceptor-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.main.web</groupId>
             <artifactId>cdi-api-fragment</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Avoid:
```
Some problems were encountered while building the effective model for org.glassfish.main.featuresets:embedded-web:pom:9.0.0-SNAPSHOT
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: jakarta.interceptor:jakarta.interceptor-api:jar -> duplicate declaration of version (?) @ line 1051, column 21
```

