### PR TITLE
Fix: Add graceful validation handling for invalid MDB ActivationConfigProperty types

### DIFF
--- a/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/ConnectorMessageBeanClient.java
+++ b/appserver/connectors/connectors-inbound-runtime/src/main/java/com/sun/enterprise/connectors/inbound/ConnectorMessageBeanClient.java
@@ -137,7 +137,6 @@ public final class ConnectorMessageBeanClient implements MessageBeanClient, Mess
         ActiveInboundResourceAdapter aira = getActiveResourceAdapter(resourceAdapterMid);
         aira.updateMDBRuntimeInfo(descriptor, this.messageBeanPM.getPoolDescriptor());
 
-        // the resource adapter this MDB client is deployed to
         ResourceAdapter ra = aira.getResourceAdapter();
         if (ra == null) {
             String i18nMsg = localStrings.getString("msg-bean-client.ra.class.not.specified", resourceAdapterMid);
@@ -155,11 +154,16 @@ public final class ConnectorMessageBeanClient implements MessageBeanClient, Mess
             throw new IllegalStateException("Unsupported message listener type");
         }
 
-        if (logger.isLoggable(FINEST)) {
-            logger.log(FINEST, "ActivationSpecClassName = " + activationSpecClassName);
-        }
         try {
-            ActivationSpec activationSpec = getActivationSpec(aira, activationSpecClassName);
+            ActivationSpec activationSpec;
+            try {
+                activationSpec = getActivationSpec(aira, activationSpecClassName);
+            } catch (IllegalArgumentException ex) {
+                String errorMsg = localStrings.getString("msg-bean-client.activation.invalid.property", descriptor.getName());
+                logger.log(Level.SEVERE, errorMsg, ex);
+                throw new ConnectorRuntimeException(errorMsg, ex);
+            }
+
             activationSpec.setResourceAdapter(ra);
 
             // at this stage, activation-spec is created, config properties merged with ejb-descriptor.
@@ -171,9 +175,12 @@ public final class ConnectorMessageBeanClient implements MessageBeanClient, Mess
             this.myState = BLOCKED;
             ra.endpointActivation(this, activationSpec);
             aira.addEndpointFactoryInfo(beanID_, new MessageEndpointFactoryInfo(this, activationSpec));
+
+        } catch (ConnectorRuntimeException cre) {
+            throw cre;
         } catch (Exception ex) {
             logger.log(Level.WARNING, "endpoint.activation.failure",
-                new Object[] {resourceAdapterMid, activationSpecClassName, ex});
+            new Object[] {resourceAdapterMid, activationSpecClassName, ex});
             throw new ConnectorRuntimeException("Setup failed.", ex);
         }
     }

--- a/appserver/connectors/connectors-inbound-runtime/src/main/resources/com/sun/enterprise/connectors/inbound/LocalStrings.properties
+++ b/appserver/connectors/connectors-inbound-runtime/src/main/resources/com/sun/enterprise/connectors/inbound/LocalStrings.properties
@@ -19,3 +19,4 @@ msg-bean-client.multiple-ras-supporting-message-listener=The 'resource-adapter-m
 msg-bean-client.defaulting.message-listener.supporting.rar=No 'resource-adapter-mid' specified, defaulting to the resource-adapter [ {0} ] that supports the requested 'message-listener' [ {1} ]
 msg-bean-client.ra.class.not.specified=<resourceadapter-class> must be specified for the resource-adapter [ {0} ] having inbound (<inbound-resourceadapter> or its equivalent annotation) artifacts
 msg-bean-client.could-not-derive-ra-mid=Unable to determine resourceAdapterMid for descriptor [ {0} ]
+msg-bean-client.activation.invalid.property=Deployment failed for MDB [ {0} ]: Invalid type provided for ActivationConfigProperty.


### PR DESCRIPTION
This PR addresses issue #26040 by adding graceful error handling inside `ConnectorMessageBeanClient.setup()`. 

Previously, if an invalid property (such as `resourceAdapter`) was passed via `@ActivationConfigProperty`, the `EnvironmentProperty.getObjectFromString()` method would throw an `IllegalArgumentException` during reflection. Because this was only caught by a generic `Exception` block, it propagated the root cause up, printing a raw reflection stack trace and a generic "Setup failed" error.

This patch intercepts the `IllegalArgumentException` specifically, outputting a clean `SEVERE` validation message indicating which MDB failed and why the property type was invalid. By not passing the root exception up to the `ConnectorRuntimeException`, it prevents the raw reflection stack trace from bleeding into `server.log`, drastically improving the Developer Experience (DX) for annotation misconfigurations.

Fixes #26040