### PR TITLE
Enforce duplicate port exclusion in `ServerUtils`

### DIFF
--- a/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/ServerUtils.java
+++ b/nucleus/test-utils/src/main/java/org/glassfish/tests/utils/ServerUtils.java
@@ -89,10 +89,15 @@ public class ServerUtils {
             try (ServerSocket socket = new ServerSocket(0)) {
                 final int port = socket.getLocalPort();
                 socket.setSoTimeout(1);
-                if (excluded.contains(port) && counter >= 20) {
-                    throw new IllegalStateException("Cannot open random port, tried 20 times. Port " + port
-                        + " is excluded and we were not able to find another.");
+
+                if (excluded.contains(port)) {
+                    if (counter >= 20) {
+                        throw new IllegalStateException("Cannot open random port, tried 20 times. Port " + port
+                                + " is excluded and we were not able to find another.");
+                    }
+                    continue;
                 }
+
                 return port;
             } catch (IOException e) {
                 if (counter >= 20) {
@@ -101,7 +106,6 @@ public class ServerUtils {
             }
         }
     }
-
 
     /**
      * @return the IP address of the localhost.


### PR DESCRIPTION
This PR stabilizes a known flaky test in `ClusterITest`. 

Previously, `createInstancesTest` blindly queued ports from `ServerUtils.getFreePorts(20)`, which occasionally contained duplicates from the OS, causing a cascading port collision failure in the CI pipeline.

This patch introduces a private helper method that filters ports through a `Set` within a `while` loop until exactly 20 unique ports are guaranteed, then returns them as a `LinkedList` (Queue). This prevents intermittent CI failures without requiring any refactoring of downstream `.remove()` logic.

Fixes #26048