### PR TITLE
Fixed deployment of cyclonedx files, alternative deployments, updated parent project

### DIFF
--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
         <relativePath />
     </parent>
 

--- a/appserver/tests/v2-tests/appserv-tests/util/reportbuilder/pom.xml
+++ b/appserver/tests/v2-tests/appserv-tests/util/reportbuilder/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.devtests</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -266,6 +266,7 @@
         <project.build.commonResourcesDirectory>${project.build.directory}/common-resources</project.build.commonResourcesDirectory>
         <legal.doc.source>${project.build.commonResourcesDirectory}/legal</legal.doc.source>
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
+        <cyclonedx.skip>true</cyclonedx.skip>
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>
 
@@ -2476,19 +2477,6 @@
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>command-security-maven-plugin</artifactId>
             </plugin>
-            <!-- Disables sbom generation inherited from parent -->
-            <plugin>
-                <groupId>org.cyclonedx</groupId>
-                <artifactId>cyclonedx-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase></phase>
-                        <goals>
-                            <goal>makeAggregateBom</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -2511,6 +2499,7 @@
                 <release.projectName>Eclipse GlassFish</release.projectName>
                 <release.autoPublish>false</release.autoPublish>
                 <release.waitUntil>published</release.waitUntil>
+                <cyclonedx.skip>false</cyclonedx.skip>
             </properties>
         </profile>
         <profile>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
         <relativePath />
     </parent>
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1307,7 +1307,8 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.4</version>
                     <configuration>
-                        <deployAtEnd>true</deployAtEnd>
+                        <!-- true would disable alternative deployment as the last module has deployment disabled -->
+                        <deployAtEnd>false</deployAtEnd>
                         <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
                         <skip>${deploy.skip}</skip>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <packaging>pom</packaging>
 
     <name>Eclipse GlassFish Aggregator POM</name>
+    <description>Root POM of the GlassFish project</description>
     <url>https://projects.eclipse.org/projects/ee4j.glassfish</url>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 
     <properties>
         <project.build.outputTimestamp>2026-05-05T00:17:58Z</project.build.outputTimestamp>
+        <cyclonedx.skip>true</cyclonedx.skip>
     </properties>
 
     <build>
@@ -95,19 +96,6 @@
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- Disables sbom generation inherited from parent -->
-            <plugin>
-                <groupId>org.cyclonedx</groupId>
-                <artifactId>cyclonedx-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase></phase>
-                        <goals>
-                            <goal>makeAggregateBom</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -181,6 +169,22 @@
                 <module>appserver</module>
                 <module>docs</module>
                 <module>docs/publish</module>
+            </modules>
+        </profile>
+
+        <!--
+        Override cyclonedx skip
+        -->
+        <profile>
+            <id>oss-release</id>
+            <properties>
+                <cyclonedx.skip>false</cyclonedx.skip>
+            </properties>
+            <modules>
+                <module>qa</module>
+                <module>nucleus</module>
+                <module>appserver</module>
+                <module>docs</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
* Relates to https://github.com/eclipse-ee4j/ee4j/pull/128 which would make this much easier, basically we could remove all those `cyclonedx.skip` properties because the plugin execution would align with release profiles.
* For now we use the `cyclonedx.skip` to ask the plugin to do or not to do the work, while in the future it would or would not be in the reactor.
* The added `oss-profile` with modules must be there until that because there's a default profile which would be disabled by enabling this one.
* If https://github.com/eclipse-ee4j/ee4j/pull/128 would be released before 8.0.3, we can simplify this asap.
