### PR TITLE
Add test-only Jdbc40ObjectsFactory stub to silence RAR7118 warning in jdbc-core tests

### DIFF
--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/jdbc40/Jdbc40ObjectsFactory.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/jdbc40/Jdbc40ObjectsFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.gjc.spi.jdbc40;
+
+import com.sun.gjc.spi.JdbcObjectsFactory;
+import com.sun.gjc.spi.ManagedConnectionFactoryImpl;
+import com.sun.gjc.spi.ManagedConnectionImpl;
+import com.sun.gjc.spi.base.ConnectionHolder;
+import com.sun.gjc.util.SQLTraceDelegator;
+
+import jakarta.resource.spi.ConnectionManager;
+import jakarta.resource.spi.ConnectionRequestInfo;
+
+import java.sql.Connection;
+
+import javax.sql.DataSource;
+
+/**
+ * Test stub for the real {@code com.sun.gjc.spi.jdbc40.Jdbc40ObjectsFactory},
+ * which lives in the separate {@code jdbc40} module and is therefore not on the
+ * test classpath of {@code jdbc-core}.
+ *
+ * <p>{@link JdbcObjectsFactory#getInstance()} loads that class by name via
+ * {@code Class.forName(...)}. Without this stub the lookup fails with a
+ * {@code ClassNotFoundException} that is logged as a {@code RAR7118} warning
+ * (with a stack trace) during the {@code jdbc-core} unit tests. Providing this
+ * stub on the test classpath lets the lookup succeed so the tests run without
+ * the misleading warning.
+ */
+public class Jdbc40ObjectsFactory extends JdbcObjectsFactory {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public DataSource getDataSourceInstance(ManagedConnectionFactoryImpl mcfObject, ConnectionManager cmObject) {
+        return null;
+    }
+
+    @Override
+    public ConnectionHolder getConnection(Connection conObject, ManagedConnectionImpl mcObject,
+            ConnectionRequestInfo criObject, boolean statementWrapping, SQLTraceDelegator sqlTraceDelegator) {
+        return null;
+    }
+}


### PR DESCRIPTION
## Problem

When running the `jdbc-core` unit tests (`ConnectionHolderTest`, `ManagedConnectionImplTest`), the tests pass but a misleading warning with a stack trace is logged:

```
WARNING ... RAR7118: Unable to load jdbc objects factory
java.lang.ClassNotFoundException: com.sun.gjc.spi.jdbc40.Jdbc40ObjectsFactory
	at com.sun.gjc.spi.JdbcObjectsFactory.getInstance(JdbcObjectsFactory.java:57)
	at com.sun.gjc.spi.ManagedConnectionFactoryImpl.<init>(ManagedConnectionFactoryImpl.java:117)
	...
```

## Root cause

`ManagedConnectionFactoryImpl` initializes its factory field via `JdbcObjectsFactory.getInstance()`, which loads `com.sun.gjc.spi.jdbc40.Jdbc40ObjectsFactory` by name with `Class.forName(...)`.

That class lives in the separate **`jdbc40`** Maven module, which *depends on* `jdbc-core` — not the other way around. So during `jdbc-core`'s own test phase the class is not on the classpath, the lookup fails with `ClassNotFoundException`, and it is caught and logged as the `RAR7118` warning. The tests still pass because the `null` factory is never dereferenced by the exercised code paths, and in a real GlassFish runtime the `jdbc40` module is on the classpath so the warning never appears.

## Fix

Add a minimal **test-scoped** stub of `com.sun.gjc.spi.jdbc40.Jdbc40ObjectsFactory` under `jdbc-core/src/test/java` so the `Class.forName` lookup resolves during tests and the noisy warning is no longer logged.

- No production behavior changes.
- Adding a test-scoped dependency on the `jdbc40` module is **not** an option — it would create a circular Maven dependency (`jdbc40` → `jdbc-core`).

## Verification

Ran both affected test classes (Maven 3.9.14, JDK 21):

```
mvn -Dtest=com.sun.gjc.spi.ConnectionHolderTest test     -> Tests run: 1, Failures: 0, Errors: 0; 0 RAR7118 warnings
mvn -Dtest=com.sun.gjc.spi.ManagedConnectionImplTest test -> Tests run: 3, Failures: 0, Errors: 0; 0 RAR7118 warnings
```

Fixes #25803

🤖 Generated with [Claude Code](https://claude.com/claude-code)
