### PR TITLE
Handle bnd SNAPSHOT version-mismatch warnings centrally in the parent pom

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -2322,6 +2322,42 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <!--
+                        Compute bnd.version.mismatch.level used by the maven-bundle-plugin
+                        _fixupmessages instruction (see below): 'ignore' for -SNAPSHOT builds,
+                        'error' otherwise, so a release never ships a truncated SNAPSHOT package
+                        version. regex-property does not overwrite an already-set property, so this
+                        is done in two steps with a fresh property rather than a predefined default.
+                        See issue #26004.
+                    -->
+                    <execution>
+                        <id>bnd-version-mismatch-level-snapshot</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>bnd.version.mismatch.level</name>
+                            <value>${project.version}</value>
+                            <regex>.*-SNAPSHOT</regex>
+                            <replacement>ignore</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>bnd-version-mismatch-level-release</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>bnd.version.mismatch.level</name>
+                            <value>${bnd.version.mismatch.level}</value>
+                            <regex>^(?!ignore$).+</regex>
+                            <replacement>error</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -2409,6 +2445,16 @@
                         <_include>-osgi.bundle</_include>
                         <_noimportjava>true</_noimportjava>
                         <_runee>JavaSE-21</_runee>
+                        <!--
+                            A package version derived from a Maven SNAPSHOT (e.g. 5.0.2-SNAPSHOT)
+                            is not a valid OSGi version, so bnd truncates it (5.0.2) in the manifest
+                            and reports a "Version for package ... set to different values" warning.
+                            This is harmless during SNAPSHOT development but must not happen in a
+                            release. Promote that warning to ${bnd.version.mismatch.level}, which is
+                            'error' by default and relaxed to 'ignore' for -SNAPSHOT builds by the
+                            build-helper regex-property executions above. See issue #26004.
+                        -->
+                        <_fixupmessages>"Version for package * is set to different values*";restrict:=warning;is:=${bnd.version.mismatch.level}</_fixupmessages>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
@
## Problem

Many bundle modules export packages whose version is derived from a Maven SNAPSHOT (e.g. `5.0.2-SNAPSHOT`). That is not a valid OSGi version, so bnd truncates it in the manifest and warns:

```
Version for package org.glassfish.grizzly.comet is set to different values in the
source (5.0.2-SNAPSHOT) and in the manifest (5.0.2) ...
```

As @dmatej noted, this is a known issue spread across many modules, so a per-module fix is not ideal.

## Fix (per @OndroMihs suggestion, applied in `nucleus/parent/pom.xml`)

* **maven-bundle-plugin**: a `_fixupmessages` instruction promotes that specific warning to `${bnd.version.mismatch.level}`.
* **build-helper-maven-plugin**: `regex-property` sets `bnd.version.mismatch.level` to `ignore` for `-SNAPSHOT` builds and `error` otherwise — so SNAPSHOT development stays quiet, while a **release** build fails if it would ship a truncated SNAPSHOT-derived package version.

One deviation from the original snippet: the level is computed in **two** `regex-property` steps with a fresh property, because `regex-property` does not overwrite an already-set property — a predefined `error` default would never be relaxed to `ignore` (verified). 

## Verification

Built `glassfish-grizzly-extra-all` (unchanged, still using explicit `${grizzly.version}` / `${project.version}` exports) against the patched parent:
* `mvn package` → **BUILD SUCCESS**, **0** "Version for package" warnings.
* Manifest keeps valid OSGi versions, e.g. `org.glassfish.extras.grizzly;version="8.0.3.SNAPSHOT"`.

Fixes #26004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@