### PR TITLE
Switch from legacy JVM diagnostic logging to unified logging

### DIFF
--- a/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
+++ b/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
+++ b/appserver/admin/admin-core/src/test/resources/UpgradeTest.xml
@@ -196,8 +196,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -165,7 +165,6 @@
         <jvm-options>-Djdk.xml.totalEntitySizeLimit=50000000</jvm-options>
         <jvm-options>-Djavax.xml.accessExternalSchema=all</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
-        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -367,7 +366,6 @@
              <jvm-options>-Djdk.corba.allowOutputStreamSubclass=true</jvm-options>
              <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
              <jvm-options>-Djdk.xml.totalEntitySizeLimit=50000000</jvm-options>
-             <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
              <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
              <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/appserver/admin/template/src/main/resources/config/domain.xml
+++ b/appserver/admin/template/src/main/resources/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation.
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/connectors/admin/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/admin/src/test/resources/DomainTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/connectors/admin/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/admin/src/test/resources/DomainTest.xml
@@ -132,8 +132,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/DomainTest.xml
@@ -126,8 +126,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
+++ b/appserver/connectors/connectors-internal-api/src/test/resources/PasswordAliasTest.xml
@@ -135,8 +135,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
+++ b/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
@@ -140,8 +140,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
+++ b/appserver/jdbc/jdbc-runtime/src/test/resources/DomainTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
+++ b/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
+++ b/appserver/orb/orb-connector/src/test/resources/DomainTest.xml
@@ -126,8 +126,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/resources/mail/mail-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/mail/mail-connector/src/test/resources/DomainTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/appserver/resources/mail/mail-connector/src/test/resources/DomainTest.xml
+++ b/appserver/resources/mail/mail-connector/src/test/resources/DomainTest.xml
@@ -132,8 +132,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
                 </jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>

--- a/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v3_0_1domain.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v3_0_1domain.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2021 Contributors to the Eclipse Foundation
 

--- a/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v3_0_1domain.xml
+++ b/appserver/tests/appserv-tests/devtests/admin/cli/resources/configs/v3_0_1domain.xml
@@ -152,8 +152,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/docs/administration-guide/src/main/asciidoc/jvm.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jvm.adoc
@@ -98,8 +98,6 @@ This example lists all JVM options.
 ----
 asadmin> list-jvm-options
 -Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
--XX: LogVMOutput
--XX: UnlockDiagnosticVMOptions
 -Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.
 config.serverbeans.AppserverConfigEnvironmentFactory
 -Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12
@@ -114,7 +112,6 @@ config.serverbeans.AppserverConfigEnvironmentFactory
 vaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext${path.se
 parator}${com.sun.aas.derbyRoot}/lib
 -Xmx512m
--XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log
 Command list-jvm-options executed successfully.
 ----
 

--- a/docs/application-development-guide/src/main/asciidoc/debugging-apps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/debugging-apps.adoc
@@ -207,19 +207,20 @@ asadmin create-jvm-options -verbose\:class
 ----
 
 To send the JVM messages to a special JVM log file instead of `stdout`,
-use the following `asadmin create-jvm-options` commands:
+use the following `asadmin create-jvm-options` command to route JVM
+unified logging to a file:
 
 [source]
 ----
-asadmin create-jvm-options -XX\:+LogVMOutput
-asadmin create-jvm-options -XX\:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log
+asadmin create-jvm-options -Xlog\:all\:file=${com.sun.aas.instanceRoot}/logs/jvm.log
 ----
 
 
 [NOTE]
 ====
-These `-XX` options are specific to the OpenJDK (or Hotspot) JVM and do
-not work with the JRockit JVM.
+`-Xlog` is the JVM unified logging option available in the OpenJDK (or
+Hotspot) JVM. It replaces the legacy `-XX:+LogVMOutput` and `-XX:LogFile`
+options.
 ====
 
 

--- a/docs/reference-manual/src/main/asciidoc/list-jvm-options.adoc
+++ b/docs/reference-manual/src/main/asciidoc/list-jvm-options.adoc
@@ -73,8 +73,6 @@ This example lists the options that are used by the Java application launcher.
 ----
 asadmin> list-jvm-options
 -Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
--XX: LogVMOutput
--XX: UnlockDiagnosticVMOptions
 -Dcom.sun.enterprise.config.config_environment_factory_class=
 com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory
 -Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12
@@ -91,7 +89,6 @@ com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}
 /lib/ext${path.separator}${com.sun.aas.derbyRoot}/lib
 -Xmx512m
 -XX:MaxPermSize=192m
--XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log
 Command list-jvm-options executed successfully.
 ----
 

--- a/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
+++ b/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
+++ b/nucleus/admin/config-api/src/test/resources/ClusterDomain.xml
@@ -99,8 +99,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -225,8 +223,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -351,8 +347,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/DomainTest.xml
+++ b/nucleus/admin/config-api/src/test/resources/DomainTest.xml
@@ -124,8 +124,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.client.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/DomainTest.xml
+++ b/nucleus/admin/config-api/src/test/resources/DomainTest.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1.xml
@@ -143,8 +143,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -267,8 +265,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -397,8 +393,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -527,8 +521,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -657,8 +649,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -787,8 +777,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -917,8 +905,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/c1i1c1i2.xml
@@ -154,8 +154,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -278,8 +276,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -408,8 +404,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -538,8 +532,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -668,8 +660,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -798,8 +788,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -928,8 +916,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/i1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1.xml
@@ -121,8 +121,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -245,8 +243,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -375,8 +371,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
@@ -132,8 +132,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -256,8 +254,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -386,8 +382,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -516,8 +510,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/i1i2.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/noconfigfori1.xml
@@ -121,8 +121,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -245,8 +243,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
@@ -375,8 +371,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-server</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/config-api/src/test/resources/parser/stock.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/stock.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/config-api/src/test/resources/parser/stock.xml
+++ b/nucleus/admin/config-api/src/test/resources/parser/stock.xml
@@ -133,8 +133,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -290,8 +288,6 @@
              <jvm-options>-XX:MaxPermSize=192m</jvm-options>
              <jvm-options>-server</jvm-options>
              <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-             <jvm-options>-XX:+LogVMOutput</jvm-options>
-             <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
              <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
              <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JvmOptions.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JvmOptions.java
@@ -183,11 +183,10 @@ class JvmOptions {
 
     private List<String> postProcessOrdering(List<String> unsorted) {
         /*
-         * (1) JVM has one known order dependency. If these 3 are here, then unlock MUST appear first in the list
-         * -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:LogFile=D:/as/domains/domain1/logs/jvm.log
-         *
-         * June 2012 http://java.net/jira/browse/GLASSFISH-18777 JFR needs UnlockCommercialFeatures -- it is also
-         * order-dependent. New algorithm -- put -XX:+Unlock* first
+         * (1) JVM has one known order dependency. The -XX:+Unlock* options (e.g. -XX:+UnlockDiagnosticVMOptions,
+         * -XX:+UnlockCommercialFeatures) unlock other -XX options and therefore MUST appear before any option they
+         * unlock. June 2012 http://java.net/jira/browse/GLASSFISH-18777 JFR needs UnlockCommercialFeatures -- it is
+         * also order-dependent. Algorithm -- put -XX:+Unlock* first.
          *
          * (2) TODO Get the name of the instance early. We no longer send in the instanceRoot as an arg so -- ????
          */

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JvmOptions.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/JvmOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domain1/config/domain.xml
@@ -140,8 +140,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.client.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
+++ b/nucleus/admin/launcher/src/test/resources/domains/domainNoLog/config/domain.xml
@@ -137,8 +137,6 @@
       <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="${com.sun.aas.installRoot}/lib/appserv-launch.jar" classpath-suffix="">
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.server.gcInterval=3600000</jvm-options>
         <jvm-options>-Dsun.rmi.dgc.client.gcInterval=3600000</jvm-options>

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/V2ToV3ConfigUpgrade.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/V2ToV3ConfigUpgrade.java
@@ -140,10 +140,9 @@ public class V2ToV3ConfigUpgrade implements ConfigurationUpgrade, PostConstruct 
     private final List<String> newJvmOptions = new ArrayList<String>();
     private static final String[] BASE_REMOVAL_LIST = new String[] { "-Djavax.management.builder.initial",
             "-Dsun.rmi.dgc.server.gcInterval", "-Dsun.rmi.dgc.client.gcInterval", "-Dcom.sun.enterprise.taglibs",
-            "-Dcom.sun.enterprise.taglisteners", "-XX:LogFile", };
+            "-Dcom.sun.enterprise.taglisteners", "-XX:+LogVMOutput", "-XX:LogFile", };
     // these are added to all configs
-    private static final String[] ADD_LIST = new String[] { "-XX:+UnlockDiagnosticVMOptions", "-XX:+LogVMOutput",
-            "-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log", "-Djava.awt.headless=true", "-DANTLR_USE_DIRECT_CLASS_LOADING=true",
+    private static final String[] ADD_LIST = new String[] { "-Djava.awt.headless=true", "-DANTLR_USE_DIRECT_CLASS_LOADING=true",
             "-Dosgi.shell.telnet.maxconn=1", "-Dosgi.shell.telnet.ip=127.0.0.1", "-Dgosh.args=--nointeractive",
             "-Dfelix.fileinstall.dir=${com.sun.aas.installRoot}/modules/autostart/", "-Dfelix.fileinstall.poll=5000",
             "-Dfelix.fileinstall.debug=3", "-Dfelix.fileinstall.bundles.new.start=true", "-Dfelix.fileinstall.bundles.startTransient=true",

--- a/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/V2ToV3ConfigUpgrade.java
+++ b/nucleus/admin/server-mgmt/src/main/java/com/sun/enterprise/admin/servermgmt/V2ToV3ConfigUpgrade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -136,7 +136,6 @@
         <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
         <jvm-options>-Djdk.xml.totalEntitySizeLimit=50000000</jvm-options>
         <jvm-options>-Djavax.management.builder.initial=com.sun.enterprise.v3.admin.AppServerMBeanServerBuilder</jvm-options>
-        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
@@ -293,7 +292,6 @@
              <jvm-options>-Djava.awt.headless=true</jvm-options>
              <jvm-options>-Djdk.tls.rejectClientInitiatedRenegotiation=true</jvm-options>
              <jvm-options>-Djdk.xml.totalEntitySizeLimit=50000000</jvm-options>
-             <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
              <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
              <jvm-options>-Dcom.sun.enterprise.security.httpsOutboundKeyAlias=s1as</jvm-options>
              <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/admin/template/src/main/resources/config/domain.xml
+++ b/nucleus/admin/template/src/main/resources/config/domain.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2024 Contributors to the Eclipse Foundation.
+    Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/common/common-util/src/test/resources/big.xml
+++ b/nucleus/common/common-util/src/test/resources/big.xml
@@ -138,8 +138,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/big.xml
+++ b/nucleus/common/common-util/src/test/resources/big.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
@@ -138,8 +138,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringFalse.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/common/common-util/src/test/resources/monitoringNone.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringNone.xml
@@ -138,8 +138,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/monitoringNone.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringNone.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
@@ -138,8 +138,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
+++ b/nucleus/common/common-util/src/test/resources/monitoringTrue.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/common/common-util/src/test/resources/olddomain.xml
+++ b/nucleus/common/common-util/src/test/resources/olddomain.xml
@@ -1,5 +1,6 @@
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/nucleus/common/common-util/src/test/resources/olddomain.xml
+++ b/nucleus/common/common-util/src/test/resources/olddomain.xml
@@ -120,8 +120,6 @@
         <jvm-options>-XX:MaxPermSize=192m</jvm-options>
         <jvm-options>-client</jvm-options>
         <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
-        <jvm-options>-XX:+LogVMOutput</jvm-options>
-        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
         <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
         <jvm-options>-Xmx512m</jvm-options>
         <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>

--- a/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/list-jvm-options.1
+++ b/nucleus/core/kernel/src/main/manpages/com/sun/enterprise/v3/admin/commands/list-jvm-options.1
@@ -53,8 +53,6 @@ EXAMPLES
 
                asadmin> list-jvm-options
                -Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf
-               -XX: LogVMOutput
-               -XX: UnlockDiagnosticVMOptions
                -Dcom.sun.enterprise.config.config_environment_factory_class=
                com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory
                -Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.jks
@@ -68,7 +66,6 @@ EXAMPLES
                /lib/ext${path.separator}${com.sun.aas.derbyRoot}/lib
                -Xmx512m
                -XX:MaxPermSize=192m
-               -XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log
                Command list-jvm-options executed successfully.
 
 EXIT STATUS


### PR DESCRIPTION
Fixes #24064

Removes the legacy JVM diagnostic-logging options (`-XX:+LogVMOutput`, `-XX:LogFile=...`) and the now-orphaned `-XX:+UnlockDiagnosticVMOptions` from the codebase.

## Changes
- **Templates** (`nucleus` + `appserver` `domain.xml`): remove the orphaned `-XX:+UnlockDiagnosticVMOptions` (the `LogVMOutput`/`LogFile` options it used to unlock were already gone; nothing else needed it).
- **`V2ToV3ConfigUpgrade`**: stop adding the legacy logging trio to upgraded configs (`ADD_LIST`), and add `-XX:+LogVMOutput` to `BASE_REMOVAL_LIST` so an upgrade actively strips it (alongside the existing `-XX:LogFile` removal).
- **Cleanup**: refresh the misleading `LogVMOutput` comment in `JvmOptions` (its `-XX:+Unlock*` ordering logic is retained).
- **Test fixtures**: remove the legacy logging options from domain.xml test fixtures. `-XX:+UnlockDiagnosticVMOptions` is **kept** in fixtures (it is a valid, non-deprecated diagnostic-unlock flag) where `GFLauncherTest` relies on it as a jvm-option pass-through marker.

## Testing
- `nucleus/admin/launcher`: 8/8 tests pass.
- `nucleus/common/common-util` `MiniXmlParserTest`: 22/22 pass (validates the changed fixtures parse correctly).
- `nucleus/admin/server-mgmt`: compiles.

## Why no `-Xlog` replacement
The legacy options were already vestigial: default domains no longer route VM diagnostic output to `jvm.log`. There is therefore nothing to replace with `-Xlog` — this change removes the dead legacy configuration. Anyone who wants JVM unified logging can still add a standard `-Xlog:...` JVM option to their domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
