### PR TITLE
Resolve @Transactional rollbackOn/dontRollbackOn carried by CDI stereotypes

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -108,20 +108,13 @@ public class TransactionalInterceptorBase implements Serializable {
     }
 
     public Object proceed(InvocationContext ctx) throws Exception {
-        Transactional transactionalAnnotation = ctx.getMethod().getAnnotation(Transactional.class);
+        Transactional transactionalAnnotation = getTransactionalAnnotation(ctx);
         Class<?>[] rollbackOn = null;
         Class<?>[] dontRollbackOn = null;
 
-        if (transactionalAnnotation != null) { //if at method level
+        if (transactionalAnnotation != null) {
             rollbackOn = transactionalAnnotation.rollbackOn();
             dontRollbackOn = transactionalAnnotation.dontRollbackOn();
-        } else { //if not, at class level
-            Class<?> targetClass = ctx.getTarget().getClass();
-            transactionalAnnotation = targetClass.getAnnotation(Transactional.class);
-            if (transactionalAnnotation != null) {
-                rollbackOn = transactionalAnnotation.rollbackOn();
-                dontRollbackOn = transactionalAnnotation.dontRollbackOn();
-            }
         }
 
         Object object;
@@ -188,6 +181,34 @@ public class TransactionalInterceptorBase implements Serializable {
             throw checkedException;
         }
         return object;
+    }
+
+    /**
+     * Resolves the {@link Transactional} annotation that applies to the intercepted invocation, together with its
+     * {@code rollbackOn}/{@code dontRollbackOn} attributes.
+     * <p>
+     * A method-level annotation takes precedence over a class-level one. When {@code @Transactional} is not declared
+     * directly, it is looked up from the interceptor bindings of the invocation via
+     * {@link InvocationContext#getInterceptorBinding(Class)}. Unlike {@link Class#getAnnotation(Class)}, which does not
+     * traverse meta-annotations, the binding set includes {@code @Transactional} contributed through CDI stereotypes (at
+     * any nesting depth) as well as bindings added dynamically by CDI extensions. A direct class-level lookup is kept as
+     * a final fallback for invocation contexts that do not expose interceptor bindings.
+     *
+     * @param ctx the current invocation context
+     * @return the applicable {@link Transactional} annotation, or {@code null} if none can be resolved
+     */
+    private Transactional getTransactionalAnnotation(InvocationContext ctx) {
+        Transactional transactionalAnnotation = ctx.getMethod().getAnnotation(Transactional.class);
+        if (transactionalAnnotation != null) {
+            return transactionalAnnotation;
+        }
+
+        transactionalAnnotation = ctx.getInterceptorBinding(Transactional.class);
+        if (transactionalAnnotation != null) {
+            return transactionalAnnotation;
+        }
+
+        return ctx.getTarget().getClass().getAnnotation(Transactional.class);
     }
 
     /**

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/transaction/TransactionalInterceptorBase.java
@@ -187,23 +187,26 @@ public class TransactionalInterceptorBase implements Serializable {
      * Resolves the {@link Transactional} annotation that applies to the intercepted invocation, together with its
      * {@code rollbackOn}/{@code dontRollbackOn} attributes.
      * <p>
-     * A method-level annotation takes precedence over a class-level one. When {@code @Transactional} is not declared
-     * directly, it is looked up from the interceptor bindings of the invocation via
-     * {@link InvocationContext#getInterceptorBinding(Class)}. Unlike {@link Class#getAnnotation(Class)}, which does not
-     * traverse meta-annotations, the binding set includes {@code @Transactional} contributed through CDI stereotypes (at
-     * any nesting depth) as well as bindings added dynamically by CDI extensions. A direct class-level lookup is kept as
-     * a final fallback for invocation contexts that do not expose interceptor bindings.
+     * The interceptor binding resolved by the container via {@link InvocationContext#getInterceptorBinding(Class)} is
+     * consulted first. Unlike {@link Class#getAnnotation(Class)}, which does not traverse meta-annotations, the binding
+     * set includes {@code @Transactional} contributed through CDI stereotypes (at any nesting depth) as well as bindings
+     * added or disabled dynamically by CDI extensions; it already reflects method-over-class precedence. This also
+     * covers the edge case where an extension disables the binding on the method but keeps it on the class, in which
+     * case the class-level annotation is the one that applies.
+     * <p>
+     * Direct reflection on the method and then the target class is used only as a fallback for invocation contexts that
+     * do not expose interceptor bindings (for example when the interceptor is not driven by a CDI container).
      *
      * @param ctx the current invocation context
      * @return the applicable {@link Transactional} annotation, or {@code null} if none can be resolved
      */
     private Transactional getTransactionalAnnotation(InvocationContext ctx) {
-        Transactional transactionalAnnotation = ctx.getMethod().getAnnotation(Transactional.class);
+        Transactional transactionalAnnotation = ctx.getInterceptorBinding(Transactional.class);
         if (transactionalAnnotation != null) {
             return transactionalAnnotation;
         }
 
-        transactionalAnnotation = ctx.getInterceptorBinding(Transactional.class);
+        transactionalAnnotation = ctx.getMethod().getAnnotation(Transactional.class);
         if (transactionalAnnotation != null) {
             return transactionalAnnotation;
         }

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TestInvocationContext.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TestInvocationContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,8 @@
 
 package org.glassfish.cdi.transaction;
 
+import jakarta.interceptor.InvocationContext;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -23,12 +26,12 @@ import java.util.Map;
 /**
  * User: paulparkinson Date: 12/12/12 Time: 1:12 PM
  */
-public class InvocationContext implements jakarta.interceptor.InvocationContext {
+public class TestInvocationContext implements InvocationContext {
     Method method;
     Exception exceptionFromProceed;
     TestInvocationContextTarget testInvocationContextTarget = new TestInvocationContextTarget();
 
-    public InvocationContext(Method method, Exception exceptionFromProceed) {
+    public TestInvocationContext(Method method, Exception exceptionFromProceed) {
         this.method = method;
         this.exceptionFromProceed = exceptionFromProceed;
     }

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionalAnnotationTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionalAnnotationTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,6 +18,7 @@
 package org.glassfish.cdi.transaction;
 
 import jakarta.enterprise.inject.Stereotype;
+import jakarta.interceptor.InvocationContext;
 import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.TransactionRequiredException;
@@ -50,7 +51,7 @@ public class TransactionalAnnotationTest {
         TransactionalInterceptorMandatory transactionalInterceptorMANDATORY = new TransactionalInterceptorMandatory();
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
-        jakarta.interceptor.InvocationContext ctx = new InvocationContext(BeanMandatory.class.getMethod("foo", String.class), null);
+        InvocationContext ctx = new TestInvocationContext(BeanMandatory.class.getMethod("foo", String.class), null);
         try {
             transactionalInterceptorMANDATORY.transactional(ctx);
             fail("should have thrown TransactionRequiredException due to " + "transactionalInterceptorMANDATORY and no tx in place");
@@ -74,7 +75,7 @@ public class TransactionalAnnotationTest {
         TransactionalInterceptorNever transactionalInterceptorNEVER = new TransactionalInterceptorNever();
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
-        jakarta.interceptor.InvocationContext ctx = new InvocationContext(BeanNever.class.getMethod("foo", String.class), null);
+        InvocationContext ctx = new TestInvocationContext(BeanNever.class.getMethod("foo", String.class), null);
         transactionalInterceptorNEVER.transactional(ctx);
         transactionManager.begin();
         try {
@@ -92,7 +93,7 @@ public class TransactionalAnnotationTest {
         TransactionalInterceptorNotSupported transactionalInterceptorNOT_SUPPORTED = new TransactionalInterceptorNotSupported();
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
-        jakarta.interceptor.InvocationContext ctx = new InvocationContext(BeanNotSupported.class.getMethod("foo", String.class), null);
+        InvocationContext ctx = new TestInvocationContext(BeanNotSupported.class.getMethod("foo", String.class), null);
         transactionalInterceptorNOT_SUPPORTED.transactional(ctx);
     }
 
@@ -100,7 +101,7 @@ public class TransactionalAnnotationTest {
         TransactionalInterceptorRequired transactionalInterceptorREQUIRED = new TransactionalInterceptorRequired();
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
-        jakarta.interceptor.InvocationContext ctx = new InvocationContext(BeanRequired.class.getMethod("foo", String.class), null);
+        InvocationContext ctx = new TestInvocationContext(BeanRequired.class.getMethod("foo", String.class), null);
         transactionalInterceptorREQUIRED.transactional(ctx);
         transactionManager.begin();
         transactionalInterceptorREQUIRED.transactional(ctx);
@@ -112,7 +113,7 @@ public class TransactionalAnnotationTest {
         TransactionalInterceptorRequiresNew transactionalInterceptorREQUIRES_NEW = new TransactionalInterceptorRequiresNew();
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
-        jakarta.interceptor.InvocationContext ctx = new InvocationContext(BeanRequiresNew.class.getMethod("foo", String.class), null);
+        InvocationContext ctx = new TestInvocationContext(BeanRequiresNew.class.getMethod("foo", String.class), null);
         transactionalInterceptorREQUIRES_NEW.transactional(ctx);
         transactionManager.begin();
         transactionalInterceptorREQUIRES_NEW.transactional(ctx);
@@ -124,7 +125,7 @@ public class TransactionalAnnotationTest {
         TransactionalInterceptorSupports transactionalInterceptorSUPPORTS = new TransactionalInterceptorSupports();
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
-        jakarta.interceptor.InvocationContext ctx = new InvocationContext(BeanSupports.class.getMethod("foo", String.class), null);
+        InvocationContext ctx = new TestInvocationContext(BeanSupports.class.getMethod("foo", String.class), null);
         transactionalInterceptorSUPPORTS.transactional(ctx);
         transactionManager.begin();
         transactionalInterceptorSUPPORTS.transactional(ctx);
@@ -136,7 +137,7 @@ public class TransactionalAnnotationTest {
         jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
         TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
         {
-            jakarta.interceptor.InvocationContext ctx = new InvocationContext(
+            InvocationContext ctx = new TestInvocationContext(
                 BeanSpecExampleOfRollbackDontRollback.class.getMethod("throwSQLException"), null) {
 
                 @Override
@@ -155,7 +156,7 @@ public class TransactionalAnnotationTest {
         }
         {
             // Now with a child of SQLException
-            InvocationContext ctx = new InvocationContext(
+            InvocationContext ctx = new TestInvocationContext(
                 BeanSpecExampleOfRollbackDontRollback.class.getMethod("throwSQLException"), null) {
 
                 @Override
@@ -175,7 +176,7 @@ public class TransactionalAnnotationTest {
         {
 
             // now with a child of SQLException but one that is specified as dontRollback
-            InvocationContext ctx = new InvocationContext(
+            InvocationContext ctx = new TestInvocationContext(
                 BeanSpecExampleOfRollbackDontRollback.class.getMethod("throwSQLWarning"), null) {
 
                 @Override
@@ -204,7 +205,7 @@ public class TransactionalAnnotationTest {
             //        SQLException isAssignableFrom SQLWarning
             //        SQLWarning isAssignableFrom SQLWarningExtensionExtension
             //        SQLWarningExtensionExtension isAssignableFrom SQLWarningExtension
-            InvocationContext ctx = new InvocationContext(
+            InvocationContext ctx = new TestInvocationContext(
                 BeanSpecExampleOfRollbackDontRollbackExtension.class.getMethod("throwSQLWarning"), null) {
 
                 @Override
@@ -223,7 +224,7 @@ public class TransactionalAnnotationTest {
         }
         {
             // same as above test but with extension just to show continued inheritance...
-            InvocationContext ctx = new InvocationContext(
+            InvocationContext ctx = new TestInvocationContext(
                 BeanSpecExampleOfRollbackDontRollbackExtension.class.getMethod("throwSQLWarning"), null) {
 
                 @Override
@@ -259,7 +260,7 @@ public class TransactionalAnnotationTest {
         Transactional transactionalFromStereotype = StereotypeWithTransactional.class.getAnnotation(Transactional.class);
         Set<Annotation> interceptorBindings = Set.of(transactionalFromStereotype);
 
-        InvocationContext ctx = new InvocationContext(
+        InvocationContext ctx = new TestInvocationContext(
             StereotypedBean.class.getMethod("doSomething"), null) {
 
             @Override

--- a/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionalAnnotationTest.java
+++ b/appserver/web/weld-integration/src/test/java/org/glassfish/cdi/transaction/TransactionalAnnotationTest.java
@@ -17,17 +17,24 @@
 
 package org.glassfish.cdi.transaction;
 
+import jakarta.enterprise.inject.Stereotype;
 import jakarta.transaction.InvalidTransactionException;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.TransactionRequiredException;
 import jakarta.transaction.Transactional;
 import jakarta.transaction.TransactionalException;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import static java.lang.annotation.ElementType.TYPE;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -233,6 +240,64 @@ public class TransactionalAnnotationTest {
             transactionManager.begin();
             assertThrows(SQLWarningExtensionExtension.class, () -> transactionalInterceptorREQUIRED.transactional(ctx));
             assertThrows(RollbackException.class, transactionManager::commit);
+        }
+    }
+
+    /**
+     * Reproduces issue #26017: when {@code @Transactional(rollbackOn = ...)} is carried by a CDI stereotype rather than
+     * declared directly on the bean, its {@code rollbackOn} must still trigger a rollback for the listed checked
+     * exceptions. The resolved binding (including those contributed by stereotypes) is exposed through
+     * {@link jakarta.interceptor.InvocationContext#getInterceptorBinding(Class)}, which the interceptor consults.
+     */
+    @Test
+    public void testRollbackOnFromStereotypeCheckedException() throws Exception {
+        TransactionalInterceptorRequired transactionalInterceptorREQUIRED = new TransactionalInterceptorRequired();
+        jakarta.transaction.TransactionManager transactionManager = new TransactionManager();
+        TransactionalInterceptorBase.setTestTransactionManager(transactionManager);
+
+        // @Transactional is meta-annotated on the stereotype, not on the bean itself.
+        Transactional transactionalFromStereotype = StereotypeWithTransactional.class.getAnnotation(Transactional.class);
+        Set<Annotation> interceptorBindings = Set.of(transactionalFromStereotype);
+
+        InvocationContext ctx = new InvocationContext(
+            StereotypedBean.class.getMethod("doSomething"), null) {
+
+            @Override
+            public Object getTarget() {
+                return new StereotypedBean();
+            }
+
+            @Override
+            public Set<Annotation> getInterceptorBindings() {
+                return interceptorBindings;
+            }
+
+            @Override
+            public Object proceed() throws Exception {
+                throw new StereotypeCheckedException();
+            }
+        };
+
+        transactionManager.begin();
+        assertThrows(StereotypeCheckedException.class, () -> transactionalInterceptorREQUIRED.transactional(ctx));
+        assertThrows(RollbackException.class, transactionManager::commit);
+    }
+
+    static class StereotypeCheckedException extends Exception {
+        private static final long serialVersionUID = 1L;
+    }
+
+    @Transactional(rollbackOn = StereotypeCheckedException.class)
+    @Stereotype
+    @Target(TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface StereotypeWithTransactional {
+    }
+
+    @StereotypeWithTransactional
+    static class StereotypedBean {
+        public void doSomething() throws StereotypeCheckedException {
+            throw new StereotypeCheckedException();
         }
     }
 


### PR DESCRIPTION
## Problem

When `@Transactional` is declared inside a CDI `@Stereotype` applied to a bean, the interceptor binding is honored (the transaction starts), but its `rollbackOn`/`dontRollbackOn` attributes are silently ignored. Checked exceptions listed in `rollbackOn` do not trigger a rollback — only the default `RuntimeException` behavior applies.

Fixes #26017

## Root cause

`TransactionalInterceptorBase.proceed()` resolved the annotation purely with `Class#getAnnotation` on the method and target class. That call only sees annotations **directly present** (plus `@Inherited` superclass ones) — it does not traverse meta-annotations. A stereotype is an annotation meta-annotated with `@Transactional`, so the lookup returned `null` for a stereotyped bean and both `rollbackOn`/`dontRollbackOn` stayed `null`.

## Fix

Resolve `@Transactional` from the invocation's interceptor bindings via the standard `InvocationContext#getInterceptorBinding(Class)` (Jakarta Interceptors 2.2). That binding set includes `@Transactional` contributed through CDI stereotypes (at any nesting depth) and bindings added dynamically by CDI extensions. Method-level annotations still take precedence, and a direct class-level lookup is kept as a fallback for non-Weld invocation contexts.

This follows the approach suggested by the maintainers in the issue discussion (using the resolved interceptor bindings rather than manual reflection), using the now-standardized API instead of the deprecated Weld-specific one.

## Test

Adds `TransactionalAnnotationTest.testRollbackOnFromStereotypeCheckedException`, which exercises a stereotype-borne `@Transactional(rollbackOn = ...)` throwing a checked exception and asserts the transaction is marked for rollback. Verified the test fails without the production change and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)