### PR TITLE
Restore support of domain lib/ext jars by adding them to the server classpath (Fixes #26058)

### DIFF
--- a/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
@@ -64,8 +64,13 @@ Table 2-1 {productName} Class Loaders
 provided by the JVM software.
 
 |Extension |The Extension class loader loads classes from JAR files
-present in the system extensions directory, domain-dir``/lib/ext``. It is
-parent to the Public API class loader. See xref:#using-the-java-optional-package-mechanism[Using the Java
+present in the system extensions directory, domain-dir``/lib/ext``.
+Because Java 9 removed the JVM extension mechanism (`java.ext.dirs`),
+{productName} instead adds the JAR files in domain-dir``/lib/ext`` to the
+front of the server classpath, immediately after any JAR files added with
+the `classpath-prefix` option, so that they retain their former
+precedence. It is parent to the Public API class loader. See
+xref:#using-the-java-optional-package-mechanism[Using the Java
 Optional Package Mechanism].
 
 |Public API |The Public API class loader makes available all classes
@@ -168,14 +173,12 @@ domain-dir``/lib/ext`` directory, or use the `asadmin add-library` command
 with the `--type ext` option, then restart the server. For more
 information about the `asadmin add-library` command, see the {productName} Reference Manual.
 
-For more information, see
-http://docs.oracle.com/javase/8/docs/technotes/guides/extensions/extensions.html[Optional
-Packages - An Overview]
-(`http://docs.oracle.com/javase/8/docs/technotes/guides/extensions/extensions.html`)
-and
-http://download.oracle.com/javase/tutorial/ext/basics/load.html[Understanding
-Extension Class Loading]
-(`http://docs.oracle.com/javase/tutorial/ext/basics/load.html`).
+Java 9 removed the original JVM extension mechanism (`java.ext.dirs`).
+{productName} therefore adds the JAR files found in domain-dir``/lib/ext``
+to the front of the server classpath, immediately after any JAR files
+added with the `classpath-prefix` option. This restores the familiar
+drop-in behavior for JAR files that must be visible on the JVM system
+classpath, such as a statically registered `java.security.Provider` (JCA).
 
 [[using-the-endorsed-standards-override-mechanism]]
 

--- a/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
@@ -60,18 +60,17 @@ Table 2-1 {productName} Class Loaders
 [width="100%",cols="20%,80%",options="header",]
 |===
 |Class Loader |Description
-|Bootstrap |The Bootstrap class loader loads the basic runtime classes
-provided by the JVM software.
+|JVM a|
+The JVM class loaders load the basic runtime classes provided by the JVM
+software and internal {productName} classes.
 
-|Extension |The Extension class loader loads classes from JAR files
-present in the system extensions directory, domain-dir``/lib/ext``.
-Because Java 9 removed the JVM extension mechanism (`java.ext.dirs`),
-{productName} instead adds the JAR files in domain-dir``/lib/ext`` to the
-front of the server classpath, immediately after any JAR files added with
-the `classpath-prefix` option, so that they retain their former
-precedence. It is parent to the Public API class loader. See
-xref:#using-the-java-optional-package-mechanism[Using the Java
-Optional Package Mechanism].
+It is possible to provide additional JARs to the JVM classpath by
+dropping them into the domain-dir``/lib/ext`` directory. {productName}
+adds all JARs in that directory to the front of the JVM classpath,
+immediately after any JAR files added with the `classpath-prefix`
+option, so that they take precedence over the internal {productName}
+classes. See xref:#using-the-java-optional-package-mechanism[Using the
+Java Optional Package Mechanism].
 
 |Public API |The Public API class loader makes available all classes
 specifically exported by the {productName} runtime for use by

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
@@ -547,8 +547,8 @@ class GlassFishMainLauncher extends GFLauncher {
         all.addAll(domainXMLJavaConfigProfiler.getClasspath());
         all.addAll(domainXMLjavaConfig.getSystemClasspath());
         all.addAll(domainXMLjavaConfig.getEnvClasspath());
-        all.addAll(domainXMLjavaConfig.getSuffixClasspath());
         all.addAll(getExtensionJars(instanceRootDir));
+        all.addAll(domainXMLjavaConfig.getSuffixClasspath());
         return all.toArray(File[]::new);
     }
 
@@ -566,7 +566,8 @@ class GlassFishMainLauncher extends GFLauncher {
      */
     private List<File> getExtensionJars(File instanceRootDir) {
         File extDir = new File(new File(instanceRootDir, "lib"), "ext");
-        File[] jars = extDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
+        File[] jars = extDir.listFiles(
+            file -> file.isFile() && file.getName().toLowerCase(Locale.ROOT).endsWith(".jar"));
         if (jars == null || jars.length == 0) {
             return emptyList();
         }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
@@ -544,10 +544,12 @@ class GlassFishMainLauncher extends GFLauncher {
     private File[] createClasspath(File instanceRootDir) {
         List<File> all = new ArrayList<>();
         all.addAll(domainXMLjavaConfig.getPrefixClasspath());
+        // lib/ext jars replace the old extension mechanism, so they go at the front of
+        // the classpath (right after classpath-prefix) to keep their former precedence.
+        all.addAll(getExtensionJars(instanceRootDir));
         all.addAll(domainXMLJavaConfigProfiler.getClasspath());
         all.addAll(domainXMLjavaConfig.getSystemClasspath());
         all.addAll(domainXMLjavaConfig.getEnvClasspath());
-        all.addAll(getExtensionJars(instanceRootDir));
         all.addAll(domainXMLjavaConfig.getSuffixClasspath());
         return all.toArray(File[]::new);
     }

--- a/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
+++ b/nucleus/admin/launcher/src/main/java/com/sun/enterprise/admin/launcher/GlassFishMainLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -239,7 +240,7 @@ class GlassFishMainLauncher extends GFLauncher {
 
         final Path installRoot = new File(asenvProps.get(INSTALL_ROOT.getPropertyName())).toPath();
         modulepath = installRoot.resolve(Path.of("lib", "bootstrap")).toAbsolutePath().normalize().toFile();
-        classpath = createClasspath();
+        classpath = createClasspath(callerParameters.getInstanceRootDir());
         setCommandLine(prepareCommandLine(callerParameters));
 
         // if no <network-config> element, we need to upgrade this domain
@@ -540,14 +541,38 @@ class GlassFishMainLauncher extends GFLauncher {
 
 
     /** create a list of all the classpath pieces in the right order */
-    private File[] createClasspath() {
+    private File[] createClasspath(File instanceRootDir) {
         List<File> all = new ArrayList<>();
         all.addAll(domainXMLjavaConfig.getPrefixClasspath());
         all.addAll(domainXMLJavaConfigProfiler.getClasspath());
         all.addAll(domainXMLjavaConfig.getSystemClasspath());
         all.addAll(domainXMLjavaConfig.getEnvClasspath());
         all.addAll(domainXMLjavaConfig.getSuffixClasspath());
+        all.addAll(getExtensionJars(instanceRootDir));
         return all.toArray(File[]::new);
+    }
+
+
+    /**
+     * Returns the jars found in the instance's <code>lib/ext</code> directory.
+     * <p>
+     * Java&nbsp;9 removed the extension mechanism (<code>java.ext.dirs</code> /
+     * <code>lib/ext</code>), so jars dropped there - typically a statically registered
+     * {@link java.security.Provider} (JCA) - are no longer picked up automatically. Adding
+     * them to the server classpath restores the familiar drop-in behavior.
+     *
+     * @param instanceRootDir the domain or instance root directory
+     * @return jars in <code>lib/ext</code>, sorted by name; empty if the directory is absent
+     */
+    private List<File> getExtensionJars(File instanceRootDir) {
+        File extDir = new File(new File(instanceRootDir, "lib"), "ext");
+        File[] jars = extDir.listFiles(file -> file.isFile() && file.getName().endsWith(".jar"));
+        if (jars == null || jars.length == 0) {
+            return emptyList();
+        }
+        Arrays.sort(jars);
+        LOG.log(INFO, () -> "Adding " + jars.length + " jar(s) from " + extDir + " to the server classpath.");
+        return Arrays.asList(jars);
     }
 
 

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherTest.java
@@ -179,7 +179,8 @@ public class GFLauncherTest {
      */
     @Test
     public void libExtJarOnClasspath() throws Exception {
-        File extDir = new File(domainsDir, "domain2/lib/ext");
+        File libDir = new File(domainsDir, "domain2/lib");
+        File extDir = new File(libDir, "ext");
         File extJar = new File(extDir, "test-provider.jar");
         assertTrue(extDir.mkdirs() || extDir.isDirectory(), "could not create " + extDir);
         try {
@@ -192,6 +193,7 @@ public class GFLauncherTest {
         } finally {
             extJar.delete();
             extDir.delete();
+            libDir.delete();
         }
     }
 

--- a/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherTest.java
+++ b/nucleus/admin/launcher/src/test/java/com/sun/enterprise/admin/launcher/GFLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -21,6 +21,7 @@ import com.sun.enterprise.universal.xml.MiniXmlParserException;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.glassfish.api.admin.RuntimeType;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -169,5 +171,35 @@ public class GFLauncherTest {
         launcher.setup();
         launcher.launch();
         assertThat(launcher.getCommandLine(), hasItems("-Dorg.glassfish.job-manager.drop-interrupted-commands=true"));
+    }
+
+    /**
+     * A jar dropped into the domain's {@code lib/ext} directory must be added to the
+     * server classpath (issue #26058 - drop-in support for static JCA providers).
+     */
+    @Test
+    public void libExtJarOnClasspath() throws Exception {
+        File extDir = new File(domainsDir, "domain2/lib/ext");
+        File extJar = new File(extDir, "test-provider.jar");
+        assertTrue(extDir.mkdirs() || extDir.isDirectory(), "could not create " + extDir);
+        try {
+            assertTrue(extJar.createNewFile() || extJar.isFile(), "could not create " + extJar);
+            launchParams.setDomainName("domain2");
+            launcher.setup();
+            launcher.launch();
+            assertThat(getClasspath(launcher.getCommandLine()),
+                containsString(extJar.getAbsolutePath()));
+        } finally {
+            extJar.delete();
+            extDir.delete();
+        }
+    }
+
+    /** @return the value of the {@code -cp} argument */
+    private static String getClasspath(CommandLine cmdline) {
+        List<String> command = cmdline.toList();
+        int cpIndex = command.indexOf("-cp");
+        assertTrue(cpIndex >= 0 && cpIndex + 1 < command.size(), "no -cp argument in " + command);
+        return command.get(cpIndex + 1);
     }
 }


### PR DESCRIPTION
## Summary

Java 9 removed the extension mechanism (`java.ext.dirs` / `lib/ext`), so jars dropped into a domain's `lib/ext` directory — typically a statically registered `java.security.Provider` (JCA) — are no longer picked up automatically. This restores the familiar drop-in behavior by scanning `<instanceRoot>/lib/ext` at launch and appending any jars found there to the server classpath.

## Details

- `createClasspath(...)` now also includes the jars returned by a new `getExtensionJars(instanceRootDir)` helper, appended after the existing prefix/profiler/system/env/suffix classpath entries.
- `getExtensionJars` lists `lib/ext/*.jar`, sorts by name for deterministic ordering, logs how many jars were added, and returns an empty list when the directory is absent or empty.
- The "Java 9+" condition from the issue title is effectively unconditional in practice, since GlassFish already requires Java 11+.

## Testing

- Added `GFLauncherTest.libExtJarOnClasspath`, which drops a jar into a test domain's `lib/ext` and asserts it appears in the launched `-cp` argument.
- `mvn -pl nucleus/admin/launcher test` passes (Maven 3.9.x): 9 tests, 0 failures.

Fixes #26058
