### PR TITLE
Remove broken JDBC connection from pool on local-transaction connection errors

### DIFF
--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListener.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListener.java
@@ -88,6 +88,23 @@ public class LocalTxConnectionEventListener extends ConnectionEventListener {
     public synchronized void connectionErrorOccurred(ConnectionEvent evt) {
         resource.setConnectionErrorOccurred();
 
+        if (resource.getResourceState().isEnlisted()) {
+            // The connection error was detected while the resource is still enlisted in a
+            // transaction, for example during local-transaction begin/commit/rollback (see issue
+            // #25930). Removing the resource from the pool now would make the transaction
+            // completion path (ConnectionPool.transactionCompleted) re-process an already removed
+            // handle, because the resource is still tracked in the transaction's resource set (see
+            // PoolTxHelper). The setConnectionErrorOccurred() flag set above already guarantees the
+            // connection is discarded on the next checkout - ConnectionPool checks
+            // hasConnectionErrorOccurred() before any validation, so "validate-atmost-once" cannot
+            // keep it alive. Keep this listener attached so the normal connection-close /
+            // transaction-completion path returns the resource to the pool, where it is then
+            // removed. Defer pool removal.
+            LOG.log(DEBUG, () -> "connectionErrorOccurred while enlisted, deferring pool removal for resource="
+                + resource + ", this=" + this);
+            return;
+        }
+
         // ManagedConnection instance is now invalid and unusable. Remove this event listener.
         ManagedConnection mc = (ManagedConnection) evt.getSource();
         mc.removeConnectionEventListener(this);

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListener.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -88,18 +88,17 @@ public class LocalTxConnectionEventListener extends ConnectionEventListener {
     public synchronized void connectionErrorOccurred(ConnectionEvent evt) {
         resource.setConnectionErrorOccurred();
 
-        if (resource.getResourceState().isEnlisted()) {
-            // The connection error was detected while the resource is still enlisted in a
-            // transaction, for example during local-transaction begin/commit/rollback (see issue
-            // #25930). Removing the resource from the pool now would make the transaction
-            // completion path (ConnectionPool.transactionCompleted) re-process an already removed
-            // handle, because the resource is still tracked in the transaction's resource set (see
-            // PoolTxHelper). The setConnectionErrorOccurred() flag set above already guarantees the
-            // connection is discarded on the next checkout - ConnectionPool checks
-            // hasConnectionErrorOccurred() before any validation, so "validate-atmost-once" cannot
-            // keep it alive. Keep this listener attached so the normal connection-close /
-            // transaction-completion path returns the resource to the pool, where it is then
-            // removed. Defer pool removal.
+        if (resource.isEnlisted()) {
+            // The resource is still enlisted in a transaction, so it is still in use and still
+            // tracked in that transaction's resource set (see PoolTxHelper). Removing it from the
+            // pool now would make ConnectionPool.transactionCompleted re-process an already removed
+            // handle. Defer the removal: the flag set above makes ConnectionPool discard the
+            // connection on the next checkout, where hasConnectionErrorOccurred() is checked before
+            // any validation, so "validate-atmost-once" cannot keep it alive (issue #25930).
+            // Keeping this listener attached lets the normal connection-close /
+            // transaction-completion path return the resource to the pool exactly once.
+            // Note: ConnectionPool.resourceErrorOccurred is not reached in this case, so a pool
+            // configured with "fail-all-connections" is not flushed until the transaction completed.
             LOG.log(DEBUG, () -> "connectionErrorOccurred while enlisted, deferring pool removal for resource="
                 + resource + ", this=" + this);
             return;

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListenerTest.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListenerTest.java
@@ -22,6 +22,7 @@ import com.sun.enterprise.resource.ResourceHandle;
 import com.sun.enterprise.resource.ResourceSpec;
 
 import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ConnectionEvent;
 import jakarta.resource.spi.ManagedConnection;
 
 import java.util.Map;
@@ -30,10 +31,13 @@ import org.glassfish.api.naming.SimpleJndiName;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LocalTxConnectionEventListenerTest {
 
@@ -79,9 +83,37 @@ public class LocalTxConnectionEventListenerTest {
         assertEquals(0, associatedHandlesAndClearMap.size());
     }
 
+    /**
+     * Issue #25930: a connection error signalled while the resource is still enlisted in a
+     * transaction must flag the resource but defer pool removal (and keep the listener attached),
+     * so the transaction-completion path does not later re-process an already removed handle.
+     */
+    @Test
+    public void connectionErrorWhileEnlistedDefersPoolRemoval() throws ResourceException {
+        ManagedConnection managedConnection = createMock(ManagedConnection.class);
+        // Strict mock with no recorded calls: removeConnectionEventListener must NOT be invoked.
+        replay(managedConnection);
+
+        ResourceHandle resourceHandle = createResourceHandle(managedConnection, 1);
+        resourceHandle.getResourceState().setEnlisted(true);
+
+        LocalTxConnectionEventListener listener = new LocalTxConnectionEventListener(resourceHandle);
+        listener.connectionErrorOccurred(new ConnectionEvent(managedConnection, ConnectionEvent.CONNECTION_ERROR_OCCURRED));
+
+        // The connection is flagged, so the pool discards it on the next checkout regardless of
+        // the validate-atmost-once period...
+        assertTrue(resourceHandle.hasConnectionErrorOccurred());
+        // ...but while still enlisted the listener is kept and pool removal is deferred.
+        verify(managedConnection);
+    }
+
     private ResourceHandle createResourceHandle(int i) throws ResourceException {
         ManagedConnection managedConnection = createNiceMock(ManagedConnection.class);
         replay();
+        return new ResourceHandle(managedConnection, new ResourceSpec(new SimpleJndiName("testResource" + i), 0), null);
+    }
+
+    private ResourceHandle createResourceHandle(ManagedConnection managedConnection, int i) {
         return new ResourceHandle(managedConnection, new ResourceSpec(new SimpleJndiName("testResource" + i), 0), null);
     }
 }

--- a/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListenerTest.java
+++ b/appserver/connectors/connectors-runtime/src/test/java/com/sun/enterprise/resource/listener/LocalTxConnectionEventListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/LocalTransactionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/LocalTransactionImpl.java
@@ -22,6 +22,8 @@ import jakarta.resource.ResourceException;
 import jakarta.resource.spi.LocalTransactionException;
 
 import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.FINEST;
@@ -65,6 +67,7 @@ public class LocalTransactionImpl implements jakarta.resource.spi.LocalTransacti
                 _logger.finest("Exception during begin() : " + sqle);
             }
 
+            notifyConnectionErrorIfFatal(sqle);
             throw new LocalTransactionException(sqle.getMessage(), sqle);
         }
     }
@@ -84,6 +87,7 @@ public class LocalTransactionImpl implements jakarta.resource.spi.LocalTransacti
                 _logger.finest("Exception during commit() : " + sqle);
             }
 
+            notifyConnectionErrorIfFatal(sqle);
             throw new LocalTransactionException(sqle.getMessage(), sqle);
         } finally {
             managedConnectionImpl.transactionCompleted();
@@ -105,10 +109,62 @@ public class LocalTransactionImpl implements jakarta.resource.spi.LocalTransacti
                 _logger.finest("Exception during rollback() : " + sqle);
             }
 
+            notifyConnectionErrorIfFatal(sqle);
             throw new LocalTransactionException(sqle.getMessage(), sqle);
         } finally {
             managedConnectionImpl.transactionCompleted();
         }
+    }
+
+    /**
+     * Signals a connection error to the <code>ManagedConnection</code> when the given
+     * <code>SQLException</code> indicates that the underlying physical connection is broken.
+     * <p>
+     * Local transaction operations (begin/commit/rollback) are the place where a connection
+     * that died while in the pool is first detected (for example after a request timeout
+     * interrupts a statement and leaves the connection closed). Without raising a
+     * CONNECTION_ERROR_OCCURRED event the broken connection is never removed from the pool and,
+     * when "validate-atmost-once-period-in-seconds" is greater than zero, it is also never
+     * re-validated on checkout, so it stays broken forever. Raising the event lets the pool
+     * discard the connection, mirroring how the XA path reacts in
+     * {@link ManagedConnectionImpl#XAStartOccurred()} / {@link ManagedConnectionImpl#XAEndOccurred()}.
+     *
+     * @param sqle the exception thrown by the physical connection
+     */
+    private void notifyConnectionErrorIfFatal(SQLException sqle) {
+        if (isConnectionError(sqle)) {
+            managedConnectionImpl.connectionErrorOccurred(sqle, null);
+        }
+    }
+
+    /**
+     * Determines whether the given <code>SQLException</code> (or any exception in its
+     * {@link SQLException#getNextException() next} or {@link Throwable#getCause() cause} chain)
+     * represents a fatal connection error, as opposed to a transient or data related failure that
+     * leaves the connection usable. Detection is driver agnostic: it relies on the standard
+     * connection-exception subclasses and on SQLState class "08" (connection exception) defined by
+     * the SQL standard. For example Oracle reports ORA-17008 ("Closed connection") with SQLState
+     * "08003" and a socket read interrupted by a request timeout as a
+     * <code>SQLRecoverableException</code>.
+     *
+     * @param sqle the exception to inspect
+     * @return true if the exception indicates the physical connection is no longer usable
+     */
+    static boolean isConnectionError(SQLException sqle) {
+        for (SQLException current = sqle; current != null; current = current.getNextException()) {
+            for (Throwable t = current; t != null; t = t.getCause()) {
+                if (t instanceof SQLRecoverableException || t instanceof SQLNonTransientConnectionException) {
+                    return true;
+                }
+                if (t instanceof SQLException) {
+                    String sqlState = ((SQLException) t).getSQLState();
+                    if (sqlState != null && sqlState.startsWith("08")) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/LocalTransactionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/LocalTransactionImpl.java
@@ -125,9 +125,12 @@ public class LocalTransactionImpl implements jakarta.resource.spi.LocalTransacti
      * interrupts a statement and leaves the connection closed). Without raising a
      * CONNECTION_ERROR_OCCURRED event the broken connection is never removed from the pool and,
      * when "validate-atmost-once-period-in-seconds" is greater than zero, it is also never
-     * re-validated on checkout, so it stays broken forever. Raising the event lets the pool
-     * discard the connection, mirroring how the XA path reacts in
-     * {@link ManagedConnectionImpl#XAStartOccurred()} / {@link ManagedConnectionImpl#XAEndOccurred()}.
+     * re-validated on checkout, so it stays broken forever. Raising the event flags the resource
+     * with hasConnectionErrorOccurred(), which makes the pool discard the connection on the next
+     * checkout regardless of the validate-atmost-once period. The actual pool removal is handled by
+     * the connection event listener, which defers it until the transaction completes when the
+     * resource is still enlisted (see
+     * com.sun.enterprise.resource.listener.LocalTxConnectionEventListener).
      *
      * @param sqle the exception thrown by the physical connection
      */

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/LocalTransactionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/LocalTransactionImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,6 +25,9 @@ import jakarta.resource.spi.LocalTransactionException;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.FINEST;
@@ -127,10 +131,14 @@ public class LocalTransactionImpl implements jakarta.resource.spi.LocalTransacti
      * when "validate-atmost-once-period-in-seconds" is greater than zero, it is also never
      * re-validated on checkout, so it stays broken forever. Raising the event flags the resource
      * with hasConnectionErrorOccurred(), which makes the pool discard the connection on the next
-     * checkout regardless of the validate-atmost-once period. The actual pool removal is handled by
-     * the connection event listener, which defers it until the transaction completes when the
-     * resource is still enlisted (see
-     * com.sun.enterprise.resource.listener.LocalTxConnectionEventListener).
+     * checkout regardless of the validate-atmost-once period.
+     * <p>
+     * The actual pool removal is handled by
+     * com.sun.enterprise.resource.listener.LocalTxConnectionEventListener. During begin() the
+     * resource is not enlisted yet, because the transaction manager enlists it only after
+     * XAResource.start() returned, so the connection is removed from the pool right away. During
+     * commit() and rollback() the resource is still enlisted and the removal is deferred until the
+     * transaction completes.
      *
      * @param sqle the exception thrown by the physical connection
      */
@@ -154,8 +162,11 @@ public class LocalTransactionImpl implements jakarta.resource.spi.LocalTransacti
      * @return true if the exception indicates the physical connection is no longer usable
      */
     static boolean isConnectionError(SQLException sqle) {
-        for (SQLException current = sqle; current != null; current = current.getNextException()) {
-            for (Throwable t = current; t != null; t = t.getCause()) {
+        // Both chains are built by the driver and are not guaranteed to be acyclic, so the already
+        // inspected exceptions are tracked to keep the iteration finite.
+        Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (SQLException current = sqle; current != null && !visited.contains(current); current = current.getNextException()) {
+            for (Throwable t = current; t != null && visited.add(t); t = t.getCause()) {
                 if (t instanceof SQLRecoverableException || t instanceof SQLNonTransientConnectionException) {
                     return true;
                 }

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/LocalTransactionImplTest.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/LocalTransactionImplTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.gjc.spi;
+
+import java.sql.SQLDataException;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the connection-error detection used by {@link LocalTransactionImpl} to decide whether a
+ * failed local transaction operation should remove the connection from the pool (see issue #25930).
+ */
+public class LocalTransactionImplTest {
+
+    @Test
+    public void recoverableExceptionIsConnectionError() {
+        // e.g. Oracle "ORA-18730: Interrupted IO error" after a request timeout interrupts a read
+        assertTrue(LocalTransactionImpl.isConnectionError(new SQLRecoverableException("Socket read interrupted")));
+    }
+
+    @Test
+    public void nonTransientConnectionExceptionIsConnectionError() {
+        assertTrue(LocalTransactionImpl.isConnectionError(new SQLNonTransientConnectionException("gone")));
+    }
+
+    @Test
+    public void sqlState08IsConnectionError() {
+        // e.g. Oracle "ORA-17008: Closed connection" is reported with SQLState 08003
+        assertTrue(LocalTransactionImpl.isConnectionError(new SQLException("Closed connection", "08003")));
+    }
+
+    @Test
+    public void dataExceptionIsNotConnectionError() {
+        // A constraint violation / data error must NOT discard a still usable connection
+        assertFalse(LocalTransactionImpl.isConnectionError(new SQLDataException("bad value", "22003")));
+        assertFalse(LocalTransactionImpl.isConnectionError(new SQLException("constraint violated", "23000")));
+    }
+
+    @Test
+    public void connectionErrorDetectedInNextExceptionChain() {
+        SQLException head = new SQLException("wrapper", "HY000");
+        head.setNextException(new SQLException("Closed connection", "08003"));
+        assertTrue(LocalTransactionImpl.isConnectionError(head));
+    }
+
+    @Test
+    public void connectionErrorDetectedInCauseChain() {
+        SQLException head = new SQLException("wrapper", "HY000");
+        head.initCause(new SQLRecoverableException("Socket read interrupted"));
+        assertTrue(LocalTransactionImpl.isConnectionError(head));
+    }
+
+    @Test
+    public void nullSqlStateIsNotConnectionError() {
+        assertFalse(LocalTransactionImpl.isConnectionError(new SQLException("no state")));
+    }
+}

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/LocalTransactionImplTest.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/LocalTransactionImplTest.java
@@ -73,4 +73,30 @@ public class LocalTransactionImplTest {
     public void nullSqlStateIsNotConnectionError() {
         assertFalse(LocalTransactionImpl.isConnectionError(new SQLException("no state")));
     }
+
+    @Test
+    public void cyclicNextExceptionChainTerminates() {
+        SQLException first = new SQLException("first", "HY000");
+        SQLException second = new SQLException("second", "HY000");
+        first.setNextException(second);
+        second.setNextException(first);
+        assertFalse(LocalTransactionImpl.isConnectionError(first));
+    }
+
+    @Test
+    public void cyclicCauseChainTerminates() {
+        SQLException head = new SQLException("head", "HY000");
+        SQLException cause = new SQLException("cause", "HY000");
+        head.initCause(cause);
+        cause.initCause(head);
+        assertFalse(LocalTransactionImpl.isConnectionError(head));
+    }
+
+    @Test
+    public void connectionErrorDetectedDeeperInNextExceptionChain() {
+        SQLException head = new SQLException("first", "HY000");
+        head.setNextException(new SQLException("second", "HY000"));
+        head.setNextException(new SQLException("Closed connection", "08003"));
+        assertTrue(LocalTransactionImpl.isConnectionError(head));
+    }
 }


### PR DESCRIPTION
## Problem

Fixes #25930.

A pooled JDBC connection that breaks while in use (e.g. an HTTP `request-timeout-seconds` interrupts a statement and leaves the Oracle connection closed) is never removed from the pool when `validate-atmost-once-period-in-seconds` is greater than `0`, so the application keeps getting the dead connection forever:

```
RAR5031:System Exception
jakarta.resource.spi.LocalTransactionException: ORA-17008: Closed connection
```

Setting the period to `0` "fixes" it only because that forces validation on every checkout.

## Root cause

`LocalTransactionImpl.begin()/commit()/rollback()` caught the `SQLException` from the physical connection and rethrew it as a `LocalTransactionException` **without** raising a `CONNECTION_ERROR_OCCURRED` event. As a result `ResourceHandle.setConnectionErrorOccurred()` was never set and the pool never discarded the connection.

The only remaining safety net was validation-on-checkout (`ConnectionPool.isConnectionValid`), and `validate-atmost-once-period-in-seconds > 0` deliberately skips that while the period has not elapsed — so a connection that broke shortly after its last validation stays broken indefinitely.

## Fix

**1. Detect the error (RA, `LocalTransactionImpl`).** Raise `ManagedConnectionImpl.connectionErrorOccurred()` from the local-transaction operations when the failure is a genuine connection error, so the resource gets flagged with `hasConnectionErrorOccurred()`. The pool checks that flag **before** validation on every checkout, so the dead connection is discarded regardless of the validate-atmost-once setting.

Detection is driver-agnostic and conservative:
- `SQLRecoverableException` / `SQLNonTransientConnectionException` subclasses, and
- SQLState class `08` (connection exception),
- walking both the `getNextException()` and `getCause()` chains.

Data/transient failures (e.g. constraint violations, SQLState `22`/`23`) do **not** discard the connection. Oracle reports `ORA-17008` with SQLState `08003` and the interrupted read as `SQLRecoverableException`, so both symptoms are covered.

**2. Remove it cleanly (`LocalTxConnectionEventListener`).** A connection error during begin/commit/rollback happens while the resource is **still enlisted** in the transaction. Removing it from the pool immediately would make the JTA transaction-completion path (`ConnectionPool.transactionCompleted`, driven by the connector's own resource set in `PoolTxHelper`) re-process an already-removed handle, causing redundant cleanup and monitoring-counter drift. So when the resource is still enlisted, the listener sets the error flag but **defers** pool removal to the normal connection-close / transaction-completion path; the connection is then removed exactly once at the next checkout.

This second change is scoped to **local-tx, non-XA** resources only — XA resources use a different listener (`ConnectorAllocator.ConnectionListenerImpl`), so XA behavior is unchanged.

## Tests

`LocalTransactionImplTest` covers the connection-error detection logic (recoverable, non-transient-connection, SQLState `08003`, next-exception/cause chains, and negative cases for data errors / null SQLState).

> Note: I could not run a full Maven build locally (this environment's Maven 3.8.6 is incompatible with the repo's `glassfishbuild-maven-plugin:4.1.0`, which needs Maven 3.9+); relying on CI to validate the build and the connector/transaction integration paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)