### PR TITLE
Upgrade JSF templating to 4.0.5 (7.x)

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -173,7 +173,7 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
 
         <!-- Admin console components -->
-        <jsftemplating.version>4.0.4</jsftemplating.version>
+        <jsftemplating.version>4.0.5</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>6.0.2</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>


### PR DESCRIPTION
Release notes: https://github.com/eclipse-ee4j/glassfish-jsftemplating/releases/tag/4.0.5