### PR TITLE
Propagate deployment failures and fix CDI/assembly issues in GlassFish Embedded

### DIFF
--- a/appserver/extras/embedded/web/src/assembly/package.xml
+++ b/appserver/extras/embedded/web/src/assembly/package.xml
@@ -31,6 +31,7 @@
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/hk2-locator/*</exclude>
                     <exclude>META-INF/loggerinfo/*</exclude>
+                    <exclude>META-INF/beans.xml</exclude>
                     <exclude>module-info.class</exclude>
                     <exclude>META-INF/versions/*/module-info.class</exclude>
                     <exclude>*.jar</exclude>
@@ -58,6 +59,7 @@
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/hk2-locator/*</exclude>
                     <exclude>META-INF/loggerinfo/*</exclude>
+                    <exclude>META-INF/beans.xml</exclude>
                     <exclude>module-info.class</exclude>
                     <exclude>META-INF/versions/*/module-info.class</exclude>
                     <exclude>*.jar</exclude>

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/PersistenceExtension.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/PersistenceExtension.java
@@ -51,9 +51,17 @@ public class PersistenceExtension implements Extension  {
     private PersistenceUnitDescriptor firstPersistenceUnitDescriptor;
 
     public void afterBean(final @Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager) {
-        var container = Globals.get(InvocationManager.class)
-                                  .getCurrentInvocation()
-                                  .getContainer();
+        if (Globals.getDefaultHabitat() == null) {
+            return;
+        }
+
+        var currentInvocation = Globals.get(InvocationManager.class).getCurrentInvocation();
+
+        if (currentInvocation == null) {
+            return;
+        }
+
+        var container = currentInvocation.getContainer();
 
         if (container instanceof ApplicationInfo applicationInfo) {
 

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/PersistenceExtension.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/persistence/PersistenceExtension.java
@@ -40,6 +40,7 @@ import jakarta.persistence.metamodel.Metamodel;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import org.glassfish.api.invocation.ComponentInvocation;
 import org.glassfish.api.invocation.InvocationManager;
 import org.glassfish.internal.api.Globals;
 import org.glassfish.internal.data.ApplicationInfo;
@@ -55,15 +56,13 @@ public class PersistenceExtension implements Extension  {
             return;
         }
 
-        var currentInvocation = Globals.get(InvocationManager.class).getCurrentInvocation();
+        ComponentInvocation currentInvocation = Globals.get(InvocationManager.class).getCurrentInvocation();
 
         if (currentInvocation == null) {
             return;
         }
 
-        var container = currentInvocation.getContainer();
-
-        if (container instanceof ApplicationInfo applicationInfo) {
+        if (currentInvocation.getContainer() instanceof ApplicationInfo applicationInfo) {
 
             PersistenceUnitsDescriptor persistenceUnits = applicationInfo.getMetaData(PersistenceUnitsDescriptor.class);
 

--- a/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/DeployerImpl.java
+++ b/nucleus/admin/cli/src/main/java/com/sun/enterprise/admin/cli/embeddable/DeployerImpl.java
@@ -117,6 +117,10 @@ public class DeployerImpl implements Deployer {
                 extractPayload(outboundPayload, actionReport, retrieve);
             }
 
+            if (actionReport.hasFailures()) {
+                throw new GlassFishException("Deploy failed: " + actionReport.getMessage(), actionReport.getFailureCause());
+            }
+
             return actionReport.getResultType(String.class);
         } catch (CommandException e) {
             throw new GlassFishException(e);


### PR DESCRIPTION
Extracts the three self-contained product fixes from #25446 (GlassFish Embedded), independent of the TCK runner files still under discussion there. Original author: @Thihup.

## Fixes

- **Embedded deploy failures are now propagated.** `DeployerImpl.deploy(File, ...)` returned normally even when the action report contained failures, so callers could not detect a failed deployment. It now throws `GlassFishException` carrying the report message and failure cause.
- **`PersistenceExtension` no longer NPEs** when there is no default habitat or no active invocation (e.g. GlassFish Embedded). `afterBean()` returns early in those cases instead of dereferencing the current invocation.
- **`META-INF/beans.xml` is excluded** from the `glassfish-embedded-web` assembly (both unpacked dependency sets) so a bundled descriptor doesn't alter CDI bean discovery of the uber jar.

Fixes #26062

🤖 Generated with [Claude Code](https://claude.com/claude-code)
