### PR TITLE
Upgrade Mojarra to 4.0.15 (7.x branch)

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -88,7 +88,7 @@
 
         <!-- Jakarta Faces -->
         <jakarta.faces-api.version>4.0.1</jakarta.faces-api.version>
-        <mojarra.version>4.0.13</mojarra.version>
+        <mojarra.version>4.0.15</mojarra.version>
 
         <!-- Jakarta WebSocket -->
         <jakarta.websocket-api.version>2.1.1</jakarta.websocket-api.version>


### PR DESCRIPTION
Fixes the websocket regression in Mojarra 4.0.13

Release notes: 
* https://github.com/eclipse-ee4j/mojarra/releases/tag/4.0.14-RELEASE
* https://github.com/eclipse-ee4j/mojarra/releases/tag/4.0.15-RELEASE

Why this version?
❓ 4.0.18 - last version, contains fix of a regression introduced in 4.0.16. Very recent, might introduce other regressions.
✅ 4.0.15 - contains a lot of fixes, none of them introduced a regression reported so far
❎ 4.0.14 - contains a lot of fixes, 2 AJAX regressions fixed in 4.0.15
