### PR TITLE
(7.0) Upgrade woodstock to 6.0.3 (dojo.js to 1.16.5, prototype.js to a fixed version)

### DIFF
--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -78,7 +78,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
+            <groupId>org.glassfish.woodstock.external</groupId>
             <artifactId>prototype</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -73,8 +73,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.woodstock.dependlibs</groupId>
-            <artifactId>dojo-ajax-nodemo</artifactId>
+            <groupId>org.glassfish.woodstock.external</groupId>
+            <artifactId>dojo</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -126,7 +126,7 @@
                             <outputDirectory>${dependencies.extra.directory}</outputDirectory>
                             <includeArtifactIds>
                                 commons-io,
-                                dojo-ajax-nodemo,prototype,
+                                dojo,prototype,
                                 woodstock-webui-jsf,woodstock-webui-jsf-suntheme
                             </includeArtifactIds>
                             <includeScope>provided</includeScope>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -37,5 +37,5 @@
     </locale-charset-info>
     <class-loader
         delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-ajax-nodemo-${woodstock-dojo-ajax-nodemo.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-${woodstock.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
 </sun-web-app>

--- a/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
+++ b/appserver/admingui/war/src/main/webapp/WEB-INF/sun-web.xml
@@ -37,5 +37,5 @@
     </locale-charset-info>
     <class-loader
         delegate="true"
-        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-${woodstock.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock-prototype.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
+        extra-class-path="WEB-INF/extra/woodstock-webui-jsf-suntheme-${woodstock.version}.jar:WEB-INF/extra/dojo-${woodstock.version}.jar:WEB-INF/extra/woodstock-webui-jsf-${woodstock.version}.jar:WEB-INF/extra/prototype-${woodstock.version}.jar:WEB-INF/extra/commons-io-${commons-io.version}.jar" />
 </sun-web-app>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -165,9 +165,8 @@
         <!-- Admin console components -->
         <jsftemplating.version>4.0.5</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.0.2</woodstock.version>
+        <woodstock.version>6.0.3</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
-        <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <!-- Other -->
         <dbschema.version>6.7</dbschema.version>
@@ -605,9 +604,9 @@
                 <version>${woodstock.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
+                <groupId>org.glassfish.woodstock.external</groupId>
                 <artifactId>prototype</artifactId>
-                <version>${woodstock-prototype.version}</version>
+                <version>${woodstock.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -165,9 +165,8 @@
         <!-- Admin console components -->
         <jsftemplating.version>4.0.5</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.0.1</woodstock.version>
+        <woodstock.version>6.1.0-SNAPSHOT</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
-        <woodstock-dojo-ajax-nodemo.version>1.12.4</woodstock-dojo-ajax-nodemo.version>
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 
         <!-- Other -->
@@ -601,9 +600,9 @@
                 <version>${woodstock-json.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.sun.woodstock.dependlibs</groupId>
-                <artifactId>dojo-ajax-nodemo</artifactId>
-                <version>${woodstock-dojo-ajax-nodemo.version}</version>
+                <groupId>org.glassfish.woodstock.external</groupId>
+                <artifactId>dojo</artifactId>
+                <version>${woodstock.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.woodstock.dependlibs</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -165,7 +165,7 @@
         <!-- Admin console components -->
         <jsftemplating.version>4.0.5</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
-        <woodstock.version>6.1.0-SNAPSHOT</woodstock.version>
+        <woodstock.version>6.0.2</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
         <woodstock-prototype.version>1.7.3</woodstock-prototype.version>
 


### PR DESCRIPTION
Backport from main, addresses 2 CVEs 