### PR TITLE
Bundle jersey-cdi-rs-inject to allow @Inject of Jakarta REST artifacts

### DIFF
--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2025 Contributors to Eclipse Foundation.
+    Copyright (c) 2021, 2025, 2026 Contributors to Eclipse Foundation.
     Copyright (c) 2015, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -218,7 +218,9 @@
             </exclusions>
         </dependency>
 
-        <!-- See https://github.com/jakartaee/cdi-tck/issues/474
+        <!-- Allows using @Inject instead of @Context for injection of REST artifacts.
+             Was disabled because of https://github.com/jakartaee/cdi-tck/issues/474,
+             which was resolved by https://github.com/jakartaee/cdi-tck/pull/475 -->
         <dependency>
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-cdi-rs-inject</artifactId>
@@ -229,7 +231,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>

--- a/appserver/tests/tck/rest/pom.xml
+++ b/appserver/tests/tck/rest/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2024, 2026 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,6 +73,54 @@ mvn clean install -Dgroups=security
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
     </properties>
+
+    <!-- The Jakarta REST TCK 4.0.0 is built for JUnit 5. Pin all JUnit artifacts to JUnit 5
+         versions here, because the GlassFish parent manages JUnit 6, which fails at test
+         discovery when mixed with the jupiter-api 5.x required by the TCK. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>5.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-suite-api</artifactId>
+                <version>1.10.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/appserver/tests/tck/rest/pom.xml
+++ b/appserver/tests/tck/rest/pom.xml
@@ -74,54 +74,6 @@ mvn clean install -Dgroups=security
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
     </properties>
 
-    <!-- The Jakarta REST TCK 4.0.0 is built for JUnit 5. Pin all JUnit artifacts to JUnit 5
-         versions here, because the GlassFish parent manages JUnit 6, which fails at test
-         discovery when mixed with the jupiter-api 5.x required by the TCK. -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>5.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>5.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>5.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-commons</artifactId>
-                <version>1.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-engine</artifactId>
-                <version>1.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-launcher</artifactId>
-                <version>1.10.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-suite-api</artifactId>
-                <version>1.10.2</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/appserver/tests/tck/rest_cdi/pom.xml
+++ b/appserver/tests/tck/rest_cdi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation.
+    Copyright (c) 2023, 2024, 2026 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -77,10 +77,12 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!-- Makes @Inject work in ExampleResources -->
+        <!-- Makes @Inject work in ExampleResources.
+             Provided scope: the module is bundled in GlassFish, the war must use the server one. -->
         <dependency>
             <groupId>org.glassfish.jersey.ext.cdi</groupId>
             <artifactId>jersey-cdi-rs-inject</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/docs/application-development-guide/src/main/asciidoc/webapps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/webapps.adoc
@@ -1,19 +1,3 @@
-//
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0, which is available at
-// http://www.eclipse.org/legal/epl-2.0.
-//
-// This Source Code may also be made available under the following Secondary
-// Licenses when the conditions for such availability set forth in the
-// Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
-// version 2 with the GNU Classpath Exception, which is available at
-// https://www.gnu.org/software/classpath/license.html.
-//
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-//
-
 type=page
 status=published
 title=Developing Web Applications

--- a/docs/application-development-guide/src/main/asciidoc/webapps.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/webapps.adoc
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0, which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the
+// Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+// version 2 with the GNU Classpath Exception, which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+//
+
 type=page
 status=published
 title=Developing Web Applications
@@ -1361,6 +1377,67 @@ https://docs.cometd.org/current/reference/#_bayeux[Bayeux Protocol]
 
 For more information about the Dojo toolkit, see
 `http://dojotoolkit.org/`.
+
+[[using-jakarta-rest]]
+
+=== Using Jakarta REST
+
+{productName} implements https://jakarta.ee/specifications/restful-ws/[Jakarta REST]
+with https://eclipse-ee4j.github.io/jersey/[Eclipse Jersey].
+
+[[injecting-jakarta-rest-artifacts-with-cdi]]
+
+==== Injecting Jakarta REST Artifacts with CDI
+
+The Jakarta REST specification requires injection of REST artifacts such as
+`UriInfo`, `Sse`, `SecurityContext`, `HttpHeaders`, `Request` or `Providers`
+via the `@Context` annotation. The `@Context` annotation is deprecated since
+Jakarta REST 3.1 in favor of a future alignment with CDI.
+
+As an extension to the specification, {productName} bundles the Jersey module
+`jersey-cdi-rs-inject`, which already allows injecting these artifacts with the
+standard CDI `@Inject` annotation:
+
+[source,java]
+----
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.sse.Sse;
+
+@Path("example")
+public class ExampleResource {
+
+    @Inject
+    private UriInfo uriInfo;
+
+    @Inject
+    private Sse sse;
+
+    // ...
+}
+----
+
+Unlike `@Context`, which for resources managed by CDI or Enterprise Beans is
+only supported on fields and bean properties, `@Inject` also works for
+constructor injection, following the usual CDI rules:
+
+[source,java]
+----
+@Path("example")
+@ApplicationScoped
+public class ExampleResource {
+
+    private final Sse sse;
+
+    @Inject
+    public ExampleResource(Sse sse) {
+        this.sse = sse;
+    }
+
+    // ...
+}
+----
 
 [[advanced-web-application-features]]
 

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -1,3 +1,19 @@
+//
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0, which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the
+// Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+// version 2 with the GNU Classpath Exception, which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+//
+
 type=page
 status=published
 title={productName} {product-majorVersion} Release Notes
@@ -67,6 +83,7 @@ Key new features in {productName} {product-majorVersion} include:
 * xref:embedded-server-guide.adoc#running-from-command-line[Runnable Embedded GlassFish JAR] (since {productName} 7.0.18)
 * xref:administration-guide.adoc#log-executed-admin-commands[Admin Command Logger] (since {productName} 7.0.16)
 * https://github.com/eclipse-ee4j/glassfish/discussions/25343[SSH nodes on Windows] via the native Windows SSH service (since {productName} 7.0.23)
+* xref:application-development-guide.adoc#injecting-jakarta-rest-artifacts-with-cdi[CDI injection of Jakarta REST artifacts] using `@Inject` via the bundled Jersey `jersey-cdi-rs-inject` extension (since {productName} {product-majorVersion}.0.4)
 
 For a complete list of the Jakarta EE technologies included in {productName} {product-currentVersion},
 see xref:#jakarta-ee-support[Jakarta EE Standards Support].

--- a/docs/release-notes/src/main/asciidoc/release-notes.adoc
+++ b/docs/release-notes/src/main/asciidoc/release-notes.adoc
@@ -1,19 +1,3 @@
-//
-// Copyright (c) 2026 Contributors to the Eclipse Foundation
-//
-// This program and the accompanying materials are made available under the
-// terms of the Eclipse Public License v. 2.0, which is available at
-// http://www.eclipse.org/legal/epl-2.0.
-//
-// This Source Code may also be made available under the following Secondary
-// Licenses when the conditions for such availability set forth in the
-// Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
-// version 2 with the GNU Classpath Exception, which is available at
-// https://www.gnu.org/software/classpath/license.html.
-//
-// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-//
-
 type=page
 status=published
 title={productName} {product-majorVersion} Release Notes
@@ -83,7 +67,7 @@ Key new features in {productName} {product-majorVersion} include:
 * xref:embedded-server-guide.adoc#running-from-command-line[Runnable Embedded GlassFish JAR] (since {productName} 7.0.18)
 * xref:administration-guide.adoc#log-executed-admin-commands[Admin Command Logger] (since {productName} 7.0.16)
 * https://github.com/eclipse-ee4j/glassfish/discussions/25343[SSH nodes on Windows] via the native Windows SSH service (since {productName} 7.0.23)
-* xref:application-development-guide.adoc#injecting-jakarta-rest-artifacts-with-cdi[CDI injection of Jakarta REST artifacts] using `@Inject` via the bundled Jersey `jersey-cdi-rs-inject` extension (since {productName} {product-majorVersion}.0.4)
+* xref:application-development-guide.adoc#injecting-jakarta-rest-artifacts-with-cdi[CDI injection of Jakarta REST artifacts] using `@Inject` via the bundled Jersey `jersey-cdi-rs-inject` extension (since {productName} 8.0.4)
 
 For a complete list of the Jakarta EE technologies included in {productName} {product-currentVersion},
 see xref:#jakarta-ee-support[Jakarta EE Standards Support].

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -789,6 +789,12 @@
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
                 <scope>test</scope>

--- a/nucleus/test-utils/pom.xml
+++ b/nucleus/test-utils/pom.xml
@@ -68,7 +68,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <!-- Used in Hk2 junit extension to initialize the HK2 Topic service -->


### PR DESCRIPTION
Restores the Jersey module `org.glassfish.jersey.ext.cdi:jersey-cdi-rs-inject` in the web featureset, so Jakarta REST artifacts (`UriInfo`, `Sse`, `SecurityContext`, ...) can be injected with the standard CDI `@Inject` annotation — including constructor injection, which `@Context` cannot offer for CDI/EJB-managed resources.

As discussed with @OndroMih in #25323, the original reason for removing the module is gone:

- It was pulled after briefly shipping in GlassFish 7.0.6 (#24049), because its `@JerseyContext`-qualified `HttpServletRequest` producer tripped the CDI TCK test `ProcessBeanAttributesNotFiredForBuiltinBean`.
- That TCK test was fixed by jakartaee/cdi-tck#475 (it now only asserts on `@Default`-qualified beans). GlassFish runs CDI TCK 4.1.0, which includes the fix.

### Changes

1. **Re-enable `jersey-cdi-rs-inject`** in `appserver/featuresets/web/pom.xml` (uncommented; the stale comment now explains the history). The module lands in `modules/` of both the full and web-profile distributions.
2. **rest_cdi TCK** now declares the module with `provided` scope, so the test WAR exercises the *server-bundled* module instead of shipping its own copy (verified: the deployed WAR has no `WEB-INF/lib`).
3. **Documentation**: new "Injecting Jakarta REST Artifacts with CDI" section in the Application Development Guide documenting the module as a supported extension, plus a "What's New" bullet in the Release Notes.
4. **REST TCK runner fix**: pin JUnit 5 in `appserver/tests/tck/rest/pom.xml`. The Jakarta REST TCK 4.0.0 artifact is built for JUnit 5; after the parent moved dependency management to JUnit 6, test discovery in this module failed with `NoClassDefFoundError` before any test ran. This pin was needed to be able to run the suite for this PR at all.

### TCK verification (local, Windows, JDK 21)

| Suite | Result |
|---|---|
| CDI TCK 4.1.0 full | **1334/1334 passed** (incl. `ProcessBeanAttributesNotFiredForBuiltinBean`), model + signature passed |
| rest_cdi (internal) | 1/1 passed, using the server-bundled module |
| Jakarta REST TCK 4.0.0 | 2796 run; the only 5 errors are identical **with and without** the module (4 Windows socket-aborts on status-408 tests + a sigtest static-mode classpath-separator issue on Windows; reflection mode passed all packages), so none are caused by this change |

Fixes #25323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
