### PR TITLE
Remove outdated OSGi Web Console instructions from the Administration Guide

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/overview.adoc
+++ b/docs/administration-guide/src/main/asciidoc/overview.adoc
@@ -829,22 +829,23 @@ Administer {productName}].
 ==== OSGi Module Management Subsystem
 
 The OSGi module management subsystem that is provided with {productName} is the http://felix.apache.org/[Apache Felix OSGi framework] . To
-administer this framework, use the either of the following tools:
-
-* http://felix.apache.org/documentation/subprojects/apache-felix-remote-shell.html[Apache
+administer this framework, use the
+http://felix.apache.org/documentation/subprojects/apache-felix-remote-shell.html[Apache
 Felix Gogo] remote shell. This shell is provided with {productName}.
 The shell uses the Felix Gogo shell service to interact with the OSGi
 module management subsystem.
-* GlassFish OSGi Administration Console. This console is distributed as
-an add-on component for {productName} or as a set of files from the
-Maven GlassFish repository. In both distributions, the GlassFish OSGi
-Web Console is provided as an extension to the Administration Console
-and as a standalone web application. The GlassFish OSGi Administration
-Console is a customized version of the
-http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html[Apache
-Felix Web Console].
 
-These tools enable you to perform administrative tasks on OSGi bundles
+[NOTE]
+====
+The GlassFish OSGi Web Console is no longer distributed with
+{productName}. Advanced users can install the
+http://felix.apache.org/documentation/subprojects/apache-felix-web-console.html[Apache
+Felix Web Console] manually. See
+https://github.com/eclipse-ee4j/glassfish/issues/24314[issue #24314]
+for a community-described procedure.
+====
+
+The shell enables you to perform administrative tasks on OSGi bundles
 such as:
 
 * Browsing installed OSGi bundles
@@ -1014,119 +1015,6 @@ service.id = 68
 ...
 gogo$
 ----
-
-[[to-download-and-install-the-glassfish-osgi-web-console]]
-
-===== To Download and Install the GlassFish OSGi Web Console
-
-The GlassFish OSGi Web Console is distributed as follows:
-
-* As an add-on component for {productName}
-* As a set of files from the https://maven.java.net[GlassFish Maven
-repository]
-
-In both distributions, the GlassFish OSGi Web Console is provided as an
-extension to the Administration Console and as a standalone web
-application.
-
-1. Perform one of the following sets of steps, depending on how you are
-obtaining the GlassFish OSGi Web Console.
-* If you are obtaining the console as an add-on component, install the
-GlassFish OSGi Admin Console component.
-* If you are obtaining the console from the Maven repository, download
-and unzip the required files.
-2. Download the following files to the parent of the `glassfish8`
-directory of your {productName} installation.
-http://maven.glassfish.org/content/groups/glassfish/org/glassfish/packager/glassfish-osgi-http/3.1.2/glassfish-osgi-http-3.1.2.zip[`glassfish-osgi-http-3.1.2.zip`]
-+
-http://maven.glassfish.org/content/groups/glassfish/org/glassfish/packager/glassfish-osgi-gui/3.1.2/glassfish-osgi-gui-3.1.2.zip[`glassfish-osgi-gui-3.1.2.zip`]
-3. Unzip the files that you downloaded.
-+
-The contents of the files are added to the
-as-install``/modules/autostart`` directory of your {productName}
-installation.
-4. Restart the DAS. For instructions, see xref:domains.adoc#to-restart-a-domain[To Restart a Domain].
-
-[[GSADG797]]
-
-Next Steps
-
-After downloading and installing the GlassFish OSGi Web Console, you can
-access the console as explained in the following sections:
-
-* xref:#to-access-the-glassfish-osgi-web-console-through-the-glassfish-server-administration-console[To Access the GlassFish OSGi Web Console Through the
-{productName} Administration Console]
-* <<To Access the GlassFish OSGi Web Console as a Standalone Web Application>>
-
-[[to-access-the-glassfish-osgi-web-console-through-the-glassfish-server-administration-console]]
-
-===== To Access the GlassFish OSGi Web Console Through the {productName} Administration Console
-
-A tab for the GlassFish OSGi Web Console is provided for the DAS and for
-every {productName} instance in a domain.
-
-1. Ensure that the DAS and the instance for which you want to access
-the GlassFish OSGi Web Console are running.
-
-2. Start the {productName} Administration Console.
-For instructions, see <<Administration Console>>.
-
-3. Open the Administration Console page for the DAS or instance for
-which you are accessing the GlassFish OSGi Web Console.
-* For the DAS, in the navigation tree, select the server (Admin Server) node.
-* For a standalone instance, perform these steps:
-.. In the navigation tree, expand the Standalone Instances node.
-.. Under the Standalone Instances node, select the instance.
-* For a clustered instance, perform these steps:
-.. In the navigation tree, expand the Clusters node.
-.. Under the Clusters node, select the cluster that contains the instance.
-   The General Information page for the cluster opens.
-.. In the General Information page for the cluster, click the Instances tab.
-   The Clustered Server Instances page for the cluster opens.
-.. In the Server Instances table on the Clustered Server Instances
-   page, select the instance.
-
-4. On the Administration Console page for the DAS or instance, click
-the OSGi Console tab. You are prompted for the user name and password of the administrative
-user of the GlassFish OSGi Web Console.
-
-5. In response to the prompt, provide the user name and password of the
-administrative user of the GlassFish OSGi Web Console.
-The user name and password of this user are both preset to `admin`.
-The GlassFish OSGi Web Console page opens.
-
-[[to-access-the-glassfish-osgi-web-console-as-a-standalone-web-application]]
-
-===== To Access the GlassFish OSGi Web Console as a Standalone Web Application
-
-1. Ensure that the DAS or the instance for which you want to access the
-GlassFish OSGi Web Console is running.
-
-2. In a web browser, open the following location:
-+
-[source]
-----
-http://host:http-port/osgi/system/console/
-----
-host::
-  The host where the DAS or instance is running.
-http-port::
-  The port on which {productName} listens for HTTP requests.
-  The default is 8080.
-
-+
-For example, if the DAS is running on the local host and {productName} listens
-  for HTTP requests on the default port, open the following location:
-+
-[source]
-----
-http://localhost:8080/osgi/system/console/
-----
-
-3. When prompted, provide the user name and password of the
-administrative user of the GlassFish OSGi Web Console.
-+
-The user name and password of this user are both preset to `admin`.
 
 [[keytool-utility]]
 


### PR DESCRIPTION
The Administration Guide still instructed users to download the GlassFish OSGi Web Console packaging (`glassfish-osgi-http-3.1.2.zip` / `glassfish-osgi-gui-3.1.2.zip`) from `maven.glassfish.org`, a host that no longer exists. That packaging was part of pre-Eclipse GlassFish and was never donated to the Eclipse Foundation (latest Maven Central version is 5.0 from 2017), so the links cannot be fixed.

As agreed with @OndroMih in https://github.com/eclipse-ee4j/glassfish/pull/25649#issuecomment-4670193940, this PR:

- removes the three outdated subsections from the Administration Guide ("To Download and Install the GlassFish OSGi Web Console" and the two "To Access…" ones), plus the Web Console bullet in the OSGi subsystem tools list;
- replaces them with a short note stating the Web Console is no longer distributed with GlassFish, linking to #24314 where a manual installation procedure for advanced users is described;
- keeps all Apache Felix Gogo shell documentation (`asadmin osgi` / `osgi-shell`) unchanged, as the shell is still fully supported.

Verified by building the `administration-guide` module: HTML/PDF generate cleanly, the guide now mentions the Web Console only in the new note, and no `maven.glassfish.org` references remain.

Supersedes #25649 — credit to @Ariho-Seth, whose removal this builds on (kept as co-author on the commit). The accidental whitespace changes in `asadmin-subcommands.adoc` and `loe.adoc` from that PR are not carried over.

Fixes #24314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
