### PR TITLE
Remove superfluous parameter from Admin GUI downloads

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/ClientStubsContentSource.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/ClientStubsContentSource.java
@@ -60,12 +60,11 @@ public class ClientStubsContentSource  implements DownloadServlet.ContentSource 
         // Get appName
         HttpServletRequest request = (HttpServletRequest) ctx.getServletRequest();
         String appName = request.getParameter("appName");
-        String restUrl = request.getParameter("restUrl");
 
         // Create the tmpFile
         InputStream tmpFile = null;
         try {
-            String endpoint = restUrl + "/applications/application/" + appName + "/get-client-stubs";
+            String endpoint = request.getSession().getAttribute("REST_URL") + "/applications/application/" + appName + "/get-client-stubs";
             DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
             Date date = new Date();
             Map attrsMap = new HashMap();

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/LBConfigContentSource.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/LBConfigContentSource.java
@@ -69,12 +69,11 @@ public class LBConfigContentSource  implements DownloadServlet.ContentSource {
         // Get appName
         HttpServletRequest request = (HttpServletRequest) ctx.getServletRequest();
         String lbName = request.getParameter("lbName");
-        String restUrl = request.getParameter("restUrl");
 
         // Create the tmpFile
         InputStream tmpFile = null;
         try {
-            String endpoint = restUrl + "/load-balancers/load-balancer/" + lbName + "/export-http-lb-config";
+            String endpoint = request.getSession().getAttribute("REST_URL") + "/load-balancers/load-balancer/" + lbName + "/export-http-lb-config";
             DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
             Date date = new Date();
             Map attrsMap = new HashMap();

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/LogFilesContentSource.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/LogFilesContentSource.java
@@ -60,12 +60,11 @@ public class LogFilesContentSource  implements DownloadServlet.ContentSource {
         // Get appName
         HttpServletRequest request = (HttpServletRequest) ctx.getServletRequest();
         String target = request.getParameter("target");
-        String restUrl = request.getParameter("restUrl");
 
         // Create the tmpFile
         InputStream tmpFile = null;
         try {
-            String endpoint = restUrl + "/collect-log-files";
+            String endpoint = request.getSession().getAttribute("REST_URL") + "/collect-log-files";
             DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
             Date date = new Date();
             Map attrsMap = new HashMap();

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/LogViewerContentSource.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/servlet/LogViewerContentSource.java
@@ -56,14 +56,13 @@ public class LogViewerContentSource  implements DownloadServlet.ContentSource {
 
         HttpServletRequest request = (HttpServletRequest) ctx.getServletRequest();
         //http://localhost:4848/management/domain/view-log/?start=180427&instanceName=server
-        String restUrl = request.getParameter("restUrl");
         String start = request.getParameter("start");
         String instanceName = request.getParameter("instanceName");
 
         // Create the tmpFile
         InputStream tmpFile = null;
         try {
-            String endpoint = restUrl + "/view-log/";
+            String endpoint = request.getSession().getAttribute("REST_URL") + "/view-log/";
             Map<String, Object> attrsMap = new HashMap<String, Object>();
             attrsMap.put("start", start);
             attrsMap.put("instanceName", instanceName);

--- a/appserver/admingui/common/src/main/resources/appServer/domainLogs.jsf
+++ b/appserver/admingui/common/src/main/resources/appServer/domainLogs.jsf
@@ -114,7 +114,7 @@
             if (event.preventDefault) {
               event.preventDefault();
             }
-            var url = '#{request.contextPath}/download/log-files-' + $('#{targetNameId}').value + '.zip?contentSourceId=LogFiles&target=' + $('#{targetNameId}').value + '&restUrl=#{sessionScope.REST_URL}';
+            var url = '#{request.contextPath}/download/log-files-' + $('#{targetNameId}').value + '.zip?contentSourceId=LogFiles&target=' + $('#{targetNameId}').value;
             if(location.protocol != 'https:' &&
               navigator.appName.indexOf("Internet Explorer") != -1 &&
               navigator.appVersion.indexOf("MSIE 10") != -1) {

--- a/appserver/admingui/common/src/main/resources/applications/subComponentTable.inc
+++ b/appserver/admingui/common/src/main/resources/applications/subComponentTable.inc
@@ -59,7 +59,7 @@ println("sectionDetail =  $attribute{sectionDetail}");
                 url="#{request.contextPath}/common/applications/appclientLaunch.jsf?appName=#{appName}&moduleName=#{td.value.moduleName}"/>
             />
             <sun:hyperlink id="downloadStubs" rendered="#{td.value.hasAppClientStub}" text="$resource{i18n.deployTable.downloadStubs}"
-                onClick="window.location = '#{request.contextPath}/download/client-stubs.zip?contentSourceId=ClientStubs&appName=#{appName}&restUrl=#{sessionScope.REST_URL}'; return false; "
+                onClick="window.location = '#{request.contextPath}/download/client-stubs.zip?contentSourceId=ClientStubs&appName=#{appName}'; return false; "
                            />
         </sun:tableColumn>
 

--- a/appserver/admingui/common/src/main/resources/logViewer/logViewerRaw.jsf
+++ b/appserver/admingui/common/src/main/resources/logViewer/logViewerRaw.jsf
@@ -40,7 +40,7 @@
 	<h:outputScript name="faces.js" library="jakarta.faces" target="head" />
     <sun:script url="$resource{i18nc.adminjsf.url}" />
 </sun:head>
-<sun:body onLoad="javascript: logViewerRaw('/download/log/?contentSourceId=LogViewer&start=0&instanceName=#{pageSession.encodedInstanceName}&restUrl=' + encodeURIComponent('#{sessionScope.REST_URL}'))" id="body3">
+<sun:body onLoad="javascript: logViewerRaw('/download/log/?contentSourceId=LogViewer&start=0&instanceName=#{pageSession.encodedInstanceName}')" id="body3">
 <sun:form id="propertyForm">
 #include "/common/shared/alertMsg_1.inc"
     <!-- Page Title -->


### PR DESCRIPTION
The query parameters weren't necessary, because the parameter is present in the session anyway.

Builds fine and functionality is same as it was before - DAS logs work, standalone instance logs not so much, but that's not the issue this PR is trying to address.
