### PR TITLE
Upgrade Jersey to 3.1.12 (7.0 branch)

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -101,7 +101,7 @@
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>3.1.0</jakarta.rest-api.version>
-        <jersey.version>3.1.11</jersey.version>
+        <jersey.version>3.1.12</jersey.version>
 
         <!-- Jakarta Mail -->
         <jakarta.mail-api.version>2.1.3</jakarta.mail-api.version>


### PR DESCRIPTION
## Summary
- upgrade Jersey from 3.1.11 to 3.1.12 in nucleus parent

## Release notes
- https://github.com/eclipse-ee4j/jersey/releases/tag/3.1.12
- https://github.com/eclipse-ee4j/jersey/compare/3.1.11...3.1.12

