### PR TITLE
Upgrade Jersey to 3.1.12 (7.x)

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -123,7 +123,7 @@
 
         <!-- Jakarta REST -->
         <jakarta.rest-api.version>3.1.0</jakarta.rest-api.version>
-        <jersey.version>3.1.11</jersey.version>
+        <jersey.version>3.1.12</jersey.version>
 
         <!-- Jakarta Mail -->
         <jakarta.mail-api.version>2.1.5</jakarta.mail-api.version>


### PR DESCRIPTION
## Summary
- Upgrade Jersey from 3.1.11 to 3.1.12 in `nucleus/parent/pom.xml`

## Release Notes
- https://github.com/eclipse-ee4j/jersey/releases/tag/3.1.12

## Compare
- https://github.com/eclipse-ee4j/jersey/compare/3.1.11...3.1.12