### PR TITLE
Remove thread-context-classloader hack in Weld BDA; rely on per-BDA ResourceLoader SPI

### DIFF
--- a/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/CDILoggerInfo.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/cdi/CDILoggerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -39,9 +39,6 @@ public class CDILoggerInfo {
     public static Logger getLogger() {
         return CDI_LOGGER;
     }
-
-    @LogMessageInfo(message = "Setting Context Class Loader for {0} to {1}.", level = "FINER")
-    public static final String SETTING_CONTEXT_CLASS_LOADER = CDI_LOGMSG_PREFIX + "-00001";
 
     @LogMessageInfo(message = "BeanDeploymentArchiveImpl::addBeanClass - adding {0} to {1}.", level = "FINE")
     public static final String ADD_BEAN_CLASS = CDI_LOGMSG_PREFIX + "-00002";

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/BeanDeploymentArchiveImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -52,7 +52,6 @@ import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.ejb.spi.EjbDescriptor;
 
 import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
@@ -64,7 +63,6 @@ import static org.glassfish.cdi.CDILoggerInfo.PROCESSING_BEANS_XML;
 import static org.glassfish.cdi.CDILoggerInfo.PROCESSING_BECAUSE_SCOPE_ANNOTATION;
 import static org.glassfish.cdi.CDILoggerInfo.PROCESSING_CDI_ENABLED_ARCHIVE;
 import static org.glassfish.cdi.CDILoggerInfo.PROCESSING_WEB_INF_LIB;
-import static org.glassfish.cdi.CDILoggerInfo.SETTING_CONTEXT_CLASS_LOADER;
 import static org.glassfish.weld.WeldDeployer.WELD_BOOTSTRAP;
 import static org.glassfish.weld.connector.WeldUtils.BEANS_XML_FILENAME;
 import static org.glassfish.weld.connector.WeldUtils.CLASS_SUFFIX;
@@ -88,15 +86,15 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
 
     private static final Logger LOG = CDILoggerInfo.getLogger();
 
-    // Workaround: WELD-781
+    // The classloader for this BDA. It is exposed via getModuleClassLoaderForBDA() and
+    // supplied to Weld through the per-BDA ResourceLoader SPI (see WeldDeployer.enable),
+    // so Weld loads classes and resources of this archive with the right classloader.
     private final ClassLoader moduleClassLoaderForBDA;
 
     private String id;
     private String friendlyId = "";
 
     private Collection<String> cdiAnnotatedClassNames;
-
-    private boolean deploymentComplete;
 
     private final List<String> moduleClassNames; // Names of classes in the module
     private final List<String> beanClassNames; // Names of bean classes in the module
@@ -197,18 +195,6 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
 
     @Override
     public Collection<String> getBeanClasses() {
-        // This method is called during BeanDeployment.deployBeans, so this would
-        // be the right time to place the module classloader for the BDA as the TCL
-        if (LOG.isLoggable(FINER)) {
-            LOG.log(FINER, SETTING_CONTEXT_CLASS_LOADER, new Object[] { this.id, this.moduleClassLoaderForBDA });
-        }
-
-        if (!isDeploymentComplete()) {
-            // The TCL is unset at the end of deployment of CDI beans in WeldDeployer.event
-            // XXX: This is a workaround for issue https://issues.jboss.org/browse/WELD-781.
-            // Remove this as soon as the SPI comes in.
-            Thread.currentThread().setContextClassLoader(this.moduleClassLoaderForBDA);
-        }
         return beanClassNames;
     }
 
@@ -723,11 +709,4 @@ public class BeanDeploymentArchiveImpl implements BeanDeploymentArchive {
         return url;
     }
 
-    public boolean isDeploymentComplete() {
-        return deploymentComplete;
-    }
-
-    public void setDeploymentComplete(boolean deploymentComplete) {
-        this.deploymentComplete = deploymentComplete;
-    }
 }

--- a/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
+++ b/appserver/web/weld-integration/src/main/java/org/glassfish/weld/WeldDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2021, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -400,7 +400,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
         addCdiServicesToNonModuleBdas(deploymentImpl.getLibJarRootBdas(), injectionManager);
         addCdiServicesToNonModuleBdas(deploymentImpl.getRarRootBdas(), injectionManager);
 
-        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         invocationManager.pushAppEnvironment(new WeldApplicationEnvironment(appInfo));
         try {
             doBootstrapStartup(appInfo, bootstrap, deploymentImpl);
@@ -410,14 +409,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             throw new DeploymentException(msgPrefix + t.getMessage(), t);
         } finally {
             invocationManager.popAppEnvironment();
-
-            // The TCL is originally the EAR classloader and is reset during Bean deployment to the
-            // corresponding module classloader in BeanDeploymentArchiveImpl.getBeans
-            // for Bean classloading to succeed.
-            //
-            // The TCL is reset to its old value here.
-            Thread.currentThread().setContextClassLoader(originalClassLoader);
-            deploymentComplete(deploymentImpl);
         }
     }
 
@@ -527,12 +518,6 @@ public class WeldDeployer extends SimpleDeployer<WeldContainer, WeldApplicationC
             EjbSupport proxyEjbSupport = (EjbSupport) Proxy.newProxyInstance(EjbSupport.class.getClassLoader(),
                     new Class[] { EjbSupport.class }, handler);
             rootServices.add(EjbSupport.class, proxyEjbSupport);
-        }
-    }
-
-    private void deploymentComplete(DeploymentImpl deploymentImpl) {
-        for (BeanDeploymentArchive oneBda : deploymentImpl.getBeanDeploymentArchives()) {
-            ((BeanDeploymentArchiveImpl) oneBda).setDeploymentComplete(true);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #25593.

`BeanDeploymentArchiveImpl.getBeanClasses()` set the thread context classloader (TCL) to the BDA's module classloader as a side effect — a long-standing workaround for [WELD-781](https://issues.jboss.org/browse/WELD-781), introduced back in #18152, from before Weld offered an SPI to control the classloader per bean deployment archive.

That side effect is fragile: a *getter* mutates global thread state, so it leaks into any caller (e.g. `toString()`), and when a BDA uses a custom classloader the TCL stays set for the rest of the Weld deployment because GlassFish only restores it at the end of `WeldDeployer.enable()`.

The SPI has long since landed and GlassFish already uses it:
- **per-BDA `ResourceLoader`** — registered in `WeldDeployer.enable()` with `getModuleClassLoaderForBDA()`, so Weld loads each archive's classes/resources with the correct classloader;
- **`ProxyServices`** — resolves the bean's own classloader for proxy generation.

The TCL manipulation is therefore redundant.

## Changes

- `BeanDeploymentArchiveImpl.getBeanClasses()` is now a pure getter (no TCL side effect).
- Removed the dependent machinery: the `deploymentComplete` flag and its `is/set` accessors, the `originalClassLoader` save/restore and `deploymentComplete()` call in `WeldDeployer.enable()`, and the now-orphaned `AS-CDI-00001` *"Setting Context Class Loader"* log message.

## Notes / risk

Behavioral change: during Weld bootstrap the TCL is no longer mutated to each BDA's module classloader; it stays as the deployment-time classloader. `ProxyServicesImpl` still falls back to the TCL only for *non-application* beans (e.g. `UserTransaction` proxies), which now resolve against the application classloader — a reasonable choice. As the issue notes there is no functional reproducer today, so correctness rests on the CDI/Weld TCKs (multi-module EARs, RARs, WEB-INF/lib bean archives, built-in-bean proxies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)