### PR TITLE
Document class loader delegation exceptions and the useBundledJsf property

### DIFF
--- a/docs/application-deployment-guide/src/main/asciidoc/dd-elements.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/dd-elements.adoc
@@ -1218,11 +1218,15 @@ Servlet specification and looks in its class loader before looking in
 the parent class loader. It's safe to set this to `false` only for a web
 module that does not interact with any other modules.
 
-For a number of packages, including `java.*` and `javax.*`, symbol
-resolution is always delegated to the parent class loader regardless of
-the delegate setting. This prevents applications from overriding core
-Java runtime classes or changing the API versions of specifications that
-are part of the Jakarta EE platform.
+For a number of packages, including `java.*`, `javax.*`, `jakarta.*`,
+and the Jakarta Faces implementation (`com.sun.faces.*` and
+`jakarta.faces.*`), symbol resolution is always delegated to the parent
+class loader regardless of the delegate setting. This prevents
+applications from overriding core Java runtime classes or changing the
+API versions of specifications that are part of the Jakarta EE platform.
+To use a Jakarta Faces implementation bundled in the application instead
+of the one provided by the {productName}, set the `useBundledJsf`
+property described in xref:#gcfjs[Table C-24].
 
 |`dynamic-reload-interval` | |(optional) Not implemented. Included
 for backward compatibility with previous Oracle Web Server versions.
@@ -1262,6 +1266,20 @@ Table C-24 `class-loader` Properties
 |`ignoreHiddenJarFiles` |`false` |If `true`, specifies that all JAR and
 ZIP files in the `WEB-INF/lib` directory that start with a period (`.`)
 are ignored by the class loader.
+
+|`useBundledJsf` |`false` a|
+If `true`, the web module uses the Jakarta Faces implementation that is
+bundled in its `WEB-INF/lib` directory instead of the Mojarra
+implementation provided by the {productName}.
+
+By default, the `jakarta.faces.*` API and the `com.sun.faces.*`
+implementation are always loaded from the {productName}, regardless of
+the `delegate` attribute. Set this property to `true` (together with
+`delegate="false"`) when the application bundles its own version of
+Jakarta Faces and must use it.
+
+The `useMyFaces` property is a synonym for `useBundledJsf` and has the
+same effect.
 |===
 
 

--- a/docs/application-deployment-guide/src/main/asciidoc/dd-elements.adoc
+++ b/docs/application-deployment-guide/src/main/asciidoc/dd-elements.adoc
@@ -1218,15 +1218,18 @@ Servlet specification and looks in its class loader before looking in
 the parent class loader. It's safe to set this to `false` only for a web
 module that does not interact with any other modules.
 
-For a number of packages, including `java.*`, `javax.*`, `jakarta.*`,
-and the Jakarta Faces implementation (`com.sun.faces.*` and
-`jakarta.faces.*`), symbol resolution is always delegated to the parent
-class loader regardless of the delegate setting. This prevents
-applications from overriding core Java runtime classes or changing the
-API versions of specifications that are part of the Jakarta EE platform.
-To use a Jakarta Faces implementation bundled in the application instead
-of the one provided by the {productName}, set the `useBundledJsf`
-property described in xref:#gcfjs[Table C-24].
+For a number of packages, symbol resolution is always delegated to the
+parent class loader regardless of the delegate setting: `jakarta.*`,
+`javax.*`, `sun.*`, `org.xml.sax.*`, `org.w3c.dom.*`,
+`org.eclipse.microprofile.*`, and the {productName} Jakarta Faces
+(Mojarra) and JSP standard tag library implementations (`com.sun.faces.*`
+and `org.glassfish.wasp.taglibs.standard.*`). Classes in the `java.*`
+namespace are always loaded by the JVM bootstrap class loader. This
+prevents applications from overriding core Java runtime classes or
+changing the API versions of specifications that are part of the Jakarta
+EE platform. To use a Jakarta Faces implementation bundled in the
+application instead of the one provided by the {productName}, set the
+`useBundledJsf` property described in xref:#gcfjs[Table C-24].
 
 |`dynamic-reload-interval` | |(optional) Not implemented. Included
 for backward compatibility with previous Oracle Web Server versions.

--- a/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
@@ -149,11 +149,40 @@ You must use `delegate="true"` for a web application that accesses EJB
 components or that acts as a web service client or endpoint. For details
 about `glassfish-web.xml`, see the xref:application-deployment-guide.adoc#GSDPG[{productName} Application Deployment Guide].
 
-For a number of packages, including `java.*` and `javax.*`, symbol
-resolution is always delegated to the parent class loader regardless of
-the `delegate` setting. This prevents applications from overriding core
-Java runtime classes or changing the API versions of specifications that
-are part of the Jakarta EE platform.
+For a number of packages, symbol resolution is always delegated to the
+parent class loader regardless of the `delegate` setting. This prevents
+applications from overriding core Java runtime classes or changing the
+API versions of specifications that are part of the Jakarta EE platform.
+The always-delegated packages are:
+
+* `java.*` and `javax.*` - Java runtime and Java extension classes
+* `jakarta.*` - Jakarta EE specification APIs
+* `sun.*` - JRE internal classes
+* `org.xml.sax.*` and `org.w3c.dom.*` - SAX and DOM classes provided by
+the JRE
+* `org.eclipse.microprofile.*` - MicroProfile specification APIs
+* `com.sun.faces.*` and `org.glassfish.wasp.taglibs.standard.*` - the
+Jakarta Faces (Mojarra) implementation and JSP standard tag library
+bundled with the {productName}
+
+As a result, setting `delegate="false"` alone does not cause an
+application to use a Jakarta Faces implementation bundled in its
+`WEB-INF/lib` directory; the `jakarta.faces.*` API and the
+`com.sun.faces.*` implementation are still loaded from the server.
+To make the application use its own bundled Jakarta Faces implementation
+instead of the one provided by the {productName}, set the
+`useBundledJsf` property to `true` in the `class-loader` element of the
+`glassfish-web.xml` file:
+
+[source,xml]
+----
+<glassfish-web-app error-url="">
+  <class-loader delegate="false"/>
+  <property name="useBundledJsf" value="true"/>
+</glassfish-web-app>
+----
+
+For details, see "xref:application-deployment-guide.adoc#class-loader[class-loader]" in {productName} Application Deployment Guide.
 
 [[using-the-java-optional-package-mechanism]]
 

--- a/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
+++ b/docs/application-development-guide/src/main/asciidoc/class-loaders.adoc
@@ -155,7 +155,7 @@ applications from overriding core Java runtime classes or changing the
 API versions of specifications that are part of the Jakarta EE platform.
 The always-delegated packages are:
 
-* `java.*` and `javax.*` - Java runtime and Java extension classes
+* `javax.*` - Java extension classes
 * `jakarta.*` - Jakarta EE specification APIs
 * `sun.*` - JRE internal classes
 * `org.xml.sax.*` and `org.w3c.dom.*` - SAX and DOM classes provided by
@@ -164,6 +164,9 @@ the JRE
 * `com.sun.faces.*` and `org.glassfish.wasp.taglibs.standard.*` - the
 Jakarta Faces (Mojarra) implementation and JSP standard tag library
 bundled with the {productName}
+
+In addition, classes in the `java.*` namespace are always loaded by the
+JVM bootstrap class loader and can never be overridden by an application.
 
 As a result, setting `delegate="false"` alone does not cause an
 application to use a Jakarta Faces implementation bundled in its


### PR DESCRIPTION
## Problem

As reported in #24808, setting `<class-loader delegate="false"/>` in `glassfish-web.xml` does not make GlassFish use a Jakarta Faces implementation bundled in the application — the server's Mojarra is used instead. This is by design: a fixed set of packages is always delegated to the server regardless of the `delegate` setting, including the Faces API (`jakarta.faces.*`) and implementation (`com.sun.faces.*`). The documented workaround (the `useBundledJsf` property) was not actually documented, and the always-delegated package set was described only as "`java.*` and `javax.*`".

## Changes (docs only)

- **Application Development Guide → Class Loaders → Delegation**: list the full set of always-delegated packages (matching `WebappClassLoader.DELEGATED_PACKAGES`) and explain the `useBundledJsf` workaround with an example.
- **Application Deployment Guide → `class-loader` descriptor reference**: document the previously-undocumented `useBundledJsf` property (and its `useMyFaces` synonym) in the properties table, and expand the `delegate` attribute description to mention the Faces exception.

No behavior change.

Refs #24808

🤖 Generated with [Claude Code](https://claude.com/claude-code)