### PR TITLE
Generate real javadoc and sources Maven artifacts for embedded distributions (#24278)

### DIFF
--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -213,24 +213,95 @@
 
     <profiles>
         <profile>
-            <!-- generate empty javadoc jar -->
+            <!--
+                Generate real sources and javadoc JARs aggregated from the bundled
+                modules, so that the javadoc can be published on javadoc.io and IDEs
+                can attach sources (issue #24278).
+            -->
             <id>oss-release</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
+                    <!-- Collect the sources of all bundled modules into one source tree. -->
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-source-dependencies</id>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <classifier>sources</classifier>
+                                    <!-- Not every (third-party) dependency publishes a sources JAR. -->
+                                    <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                                    <includeScope>compile</includeScope>
+                                    <includeScope>runtime</includeScope>
+                                    <includeTypes>jar,glassfish-jar</includeTypes>
+                                    <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                                    <includes>**/*.java</includes>
+                                    <!-- A stray module-info.java puts javac into module mode and breaks the run. -->
+                                    <excludes>**/module-info.java</excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Build the javadoc JAR from the collected sources. -->
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <sourcepath>${project.build.directory}/sources</sourcepath>
+                            <!-- Best-effort: keep going on the inevitable warnings/errors in aggregated sources. -->
+                            <failOnError>false</failOnError>
+                            <failOnWarnings>false</failOnWarnings>
+                            <doclint>none</doclint>
+                            <detectLinks>false</detectLinks>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <quiet>true</quiet>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                        The inherited 'source' profile would attach an empty sources JAR
+                        (this module has no src/main/java); disable it in favour of the
+                        aggregated sources JAR built below.
+                    -->
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Build the sources JAR from the collected sources. -->
                     <plugin>
                         <artifactId>maven-jar-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>create-empty-javadoc-jar</id>
+                                <id>create-sources-jar</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
-                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/sources</classesDirectory>
+                                    <classifier>sources</classifier>
                                 </configuration>
                             </execution>
                         </executions>

--- a/appserver/extras/embedded/web/pom.xml
+++ b/appserver/extras/embedded/web/pom.xml
@@ -237,24 +237,95 @@
 
     <profiles>
         <profile>
-            <!-- generate empty javadoc jar -->
+            <!--
+                Generate real sources and javadoc JARs aggregated from the bundled
+                modules, so that the javadoc can be published on javadoc.io and IDEs
+                can attach sources (issue #24278).
+            -->
             <id>oss-release</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>
+                    <!-- Collect the sources of all bundled modules into one source tree. -->
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-source-dependencies</id>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <classifier>sources</classifier>
+                                    <!-- Not every (third-party) dependency publishes a sources JAR. -->
+                                    <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                                    <includeScope>compile</includeScope>
+                                    <includeScope>runtime</includeScope>
+                                    <includeTypes>jar,glassfish-jar</includeTypes>
+                                    <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                                    <includes>**/*.java</includes>
+                                    <!-- A stray module-info.java puts javac into module mode and breaks the run. -->
+                                    <excludes>**/module-info.java</excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Build the javadoc JAR from the collected sources. -->
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <sourcepath>${project.build.directory}/sources</sourcepath>
+                            <!-- Best-effort: keep going on the inevitable warnings/errors in aggregated sources. -->
+                            <failOnError>false</failOnError>
+                            <failOnWarnings>false</failOnWarnings>
+                            <doclint>none</doclint>
+                            <detectLinks>false</detectLinks>
+                            <detectOfflineLinks>false</detectOfflineLinks>
+                            <quiet>true</quiet>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                        The inherited 'source' profile would attach an empty sources JAR
+                        (this module has no src/main/java); disable it in favour of the
+                        aggregated sources JAR built below.
+                    -->
+                    <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Build the sources JAR from the collected sources. -->
                     <plugin>
                         <artifactId>maven-jar-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>create-empty-javadoc-jar</id>
+                                <id>create-sources-jar</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <classesDirectory>${project.build.directory}/javadoc</classesDirectory>
-                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.build.directory}/sources</classesDirectory>
+                                    <classifier>sources</classifier>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
## Problem

The `glassfish-embedded-all` and `glassfish-embedded-web` artifacts on Maven Central ship a **javadoc JAR and a sources JAR that are empty**:

- the javadoc JAR was fabricated by a `maven-jar-plugin` `create-empty-javadoc-jar` hack pointing at a never-populated directory;
- the sources JAR comes from the inherited `source` profile, but these modules have no `src/main/java`, so it only contains the POM.

As a result no Javadoc is published at javadoc.io (so the glassfish.org site cannot link to it), and IDEs cannot attach sources. See #24278.

## Change

In the `oss-release` profile of both embedded modules:

1. **Collect sources** of all bundled modules into a single source tree via `maven-dependency-plugin:unpack-dependencies` (sources classifier, `failOnMissingClassifierArtifact=false` since not every third-party dependency publishes sources, `module-info.java` excluded so javac does not switch into module mode).
2. **Build a real javadoc JAR** from that tree with `maven-javadoc-plugin` (`sourcepath` = collected sources, best-effort: `doclint=none`, `failOnError/Warnings=false`, offline-link detection off).
3. **Build a real sources JAR** from the same tree, and disable the inherited empty `attach-sources` execution so only one `sources` artifact is attached.

The dependency classes are already on the module's compile/runtime classpath, so javadoc resolves the bundled APIs.

## Verification

- `help:effective-pom -P oss-release,source` confirms the new executions are wired, the inherited `attach-sources` is overridden to phase `none`, and exactly one `sources`-classifier artifact is attached (no duplicate-classifier conflict).
- A standalone proof-of-concept feeding aggregated sources JARs through `maven-javadoc-plugin` produced a complete, cross-linked Javadoc (unified `index.html`), confirming the approach generates non-empty output when the dependency classes are on the classpath.

Full content is produced by the release reactor build (where each component's sources JAR is built with the `oss-release`/`source` profiles).

## Notes

The Full and Web distributions (`distributions/glassfish`, `distributions/web`, `nucleus/distributions`) still ship empty/missing javadoc & sources artifacts; they additionally skip javadoc and are zip-assembly modules, so they are left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)