### PR TITLE
Improve diagnostics for unresolved ejb-ref JNDI lookups

### DIFF
--- a/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/JavaURLContext.java
+++ b/appserver/common/glassfish-naming/src/main/java/com/sun/enterprise/naming/impl/JavaURLContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -180,6 +180,10 @@ public final class JavaURLContext implements Context, Cloneable {
                 return obj;
             }
         }
+        // All strategies failed. The collector carries the cause of each attempt as a suppressed
+        // exception; log them here so the reason is available even when callers only report the
+        // top-level "No object bound" message.
+        LOG.log(Level.DEBUG, () -> "No naming strategy could resolve '" + name + "'.", e);
         throw e;
     }
 

--- a/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EjbNamingReferenceManagerImpl.java
+++ b/appserver/ejb/ejb-container/src/main/java/com/sun/ejb/EjbNamingReferenceManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -150,9 +150,19 @@ public class EjbNamingReferenceManagerImpl implements EjbNamingReferenceManager 
 
             } catch(Exception e) {
                 // Important to make the real underlying lookup name part of the exception.
-                NamingException ne = new NamingException("Exception resolving Ejb for '" +
-                    ejbRefDesc + "' .  Actual (possibly internal) Remote JNDI name used for lookup is '" +
-                    remoteJndiName + "'");
+                StringBuilder msg = new StringBuilder("Exception resolving Ejb for '").append(ejbRefDesc)
+                    .append("'.  Actual (possibly internal) Remote JNDI name used for lookup is '")
+                    .append(remoteJndiName).append('\'');
+                if (ejbRefDesc.isLinked() && !ejbRefDesc.hasJndiName() && !ejbRefDesc.hasLookupName()) {
+                    // With no jndi-name or lookup-name, the remote name above degenerates to just
+                    // the '#<interface>' suffix, which is never bound. Spell out the real cause
+                    // rather than leaving a cryptic NameNotFoundException for that name.
+                    msg.append(". The reference is resolved only by ejb-link '").append(ejbRefDesc.getLinkName())
+                        .append("', but that link was not mapped to a bound JNDI name. Add a lookup-name")
+                        .append(" (or jndi-name) to the reference, or make sure the linked bean is part of")
+                        .append(" the same application so the ejb-link can be resolved.");
+                }
+                NamingException ne = new NamingException(msg.toString());
                 ne.initCause(e);
                 throw ne;
             } finally {


### PR DESCRIPTION
## Problem

When a remote appclient `ejb-ref` is resolved only by `ejb-link` (no `jndi-name` and no `lookup-name`), the lookup fails with a cryptic `NameNotFoundException: #<interface> not found`, and the real reason is not surfaced. Reported in #25190 from EE 11 Persistence TCK runs.

The `#<interface>` name comes from `EJBUtils.getRemoteEjbJndiName` → `checkFullyQualifiedJndiName("", "#" + interface)`: with an empty jndi-name the result degenerates to just the `#<interface>` suffix, which is never bound. On top of that, `JavaURLContext.lookup` tries several strategies via `lookupOrCollectException`, attaching each failure as a **suppressed** exception on a single `NameNotFoundException("No object bound for …")` and discarding the whole collector if any later strategy succeeds — so the actual cause is only present as a suppressed exception on the terminal throw and is never logged.

## Change

Diagnostics only — lookup behavior is unchanged.

- **`EjbNamingReferenceManagerImpl`**: when the failing ejb-ref is link-only (`isLinked() && !hasJndiName() && !hasLookupName()`), the resolution exception now names the `ejb-link` and states that it was not mapped to a bound JNDI name, with the concrete remedies (add a `lookup-name`/`jndi-name`, or keep the linked bean in the same application), instead of leaving a bare `#<interface>` not-found.
- **`JavaURLContext`**: log the terminal lookup failure (after all strategies have been tried) at `DEBUG`, including the per-attempt causes carried as suppressed exceptions, so the reason is available even when callers only report the top-level "No object bound" message.

Logging is intentionally placed only at the terminal failure, not inside `resolveEjbReference`, because the collect-and-retry pattern means an earlier attempt failing is not itself an error when a later strategy succeeds. `DEBUG` (not `WARNING`) is used because `NameNotFoundException` is frequently an expected, caller-handled outcome.

## Scope

This addresses the diagnostics request in the issue title. The underlying `ejb-link` → jndi-name binding regression (link-only appclient ejb-refs no longer binding as they did in EE 10) is a separate, larger DOL/appclient fix and is intentionally **not** part of this PR; the issue is kept open for it.

Refs #25190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
