### PR TITLE
Rename com.sun.enterprise.backup.util to org.glassfish.main

### DIFF
--- a/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/BackupManager.java
+++ b/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/BackupManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,8 +17,9 @@
 
 package com.sun.enterprise.backup;
 
-import com.sun.enterprise.backup.util.BackupUtils;
 import com.sun.enterprise.util.io.FileUtils;
+
+import org.glassfish.main.enterprise.backup.util.BackupUtils;
 
 import java.io.File;
 import java.util.Date;

--- a/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/RestoreManager.java
+++ b/appserver/admin/backup/src/main/java/com/sun/enterprise/backup/RestoreManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,9 +16,10 @@
  */
 package com.sun.enterprise.backup;
 
-import com.sun.enterprise.backup.util.BackupUtils;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.util.zip.ZipFile;
+
+import org.glassfish.main.enterprise.backup.util.BackupUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/appserver/admin/backup/src/main/java/org/glassfish/main/enterprise/backup/util/BackupUtils.java
+++ b/appserver/admin/backup/src/main/java/org/glassfish/main/enterprise/backup/util/BackupUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -14,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package com.sun.enterprise.backup.util;
+package org.glassfish.main.enterprise.backup.util;
 
 import com.sun.enterprise.util.OS;
 


### PR DESCRIPTION
First incremental step toward refactoring GlassFish-owned `com.sun.*` packages to `org.glassfish.main`, as discussed in #23627.

### What
Renames `com.sun.enterprise.backup.util.BackupUtils` to `org.glassfish.main.enterprise.backup.util.BackupUtils` and updates the two in-module references (`BackupManager`, `RestoreManager`).

### Why this class first
Per @dmatej's request in the issue, the migration should be iterative and keep every test green at each step. `BackupUtils` is the lowest-risk possible starting point:
- Single class, contained entirely within the `appserver/admin/backup` module.
- Referenced from only two other Java files, both in the same module.
- **No** string/FQCN references in `domain.xml`, `*.conf`, `*.policy`, `*.properties`, `META-INF/services`, or `Class.forName` — so no reflection/config exposure.
- No external-project (EclipseLink/TCK) contract on it.

The intent is to validate the per-package workflow (rename → fix imports → sweep config/string references → compile) on a trivial case before tackling larger, reflection-heavy packages.

### Verification
- `mvn -pl appserver/admin/backup -am compile` succeeds.
- Repo-wide search confirms no remaining references to the old package name.

Refs #23627