### PR TITLE
Sync domain-passwords.p12 to instances after PKCS12 migration

### DIFF
--- a/docs/ha-administration-guide/src/main/asciidoc/instances.adoc
+++ b/docs/ha-administration-guide/src/main/asciidoc/instances.adoc
@@ -1665,7 +1665,7 @@ configuration files:
 * `cacerts.jks`
 * `default-web.xml`
 * `domain.xml`
-* `domain-passwords`
+* `domain-passwords.p12`
 * `keyfile`
 * `keystore.p12`
 * `keystore.jks`
@@ -1705,7 +1705,7 @@ admin-keyfile
 cacerts.p12
 default-web.xml
 domain.xml
-domain-passwords
+domain-passwords.p12
 keyfile
 keystore.p12
 server.policy

--- a/nucleus/cluster/admin/src/main/resources/META-INF/config-files
+++ b/nucleus/cluster/admin/src/main/resources/META-INF/config-files
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2026 Contributors to the Eclipse Foundation.
 # Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -22,7 +23,7 @@ admin-keyfile
 cacerts.p12
 client-jnlp-config.properties
 default-web.xml
-domain-passwords
+domain-passwords.p12
 glassfish-acc.xml
 keyfile
 keystore.p12


### PR DESCRIPTION
## Problem

This is a regression introduced in 7.1.0. Please backport also to 7.1.x stream (7.x branch).

Password aliases stored in `domain-passwords.p12` are not synchronized to clustered instances on startup (regression in 7.1.0 / 8.0.x; 7.0.25 and earlier are fine). As a result, any instance-side use of an alias fails, e.g. a JDBC connection pool whose password is `${ALIAS=...}`:

```
There is no such alias [mssql-pwd] ... defined in the default store for this domain.
```

## Root cause

The list of config files synced to instances is hardcoded in `nucleus/cluster/admin/src/main/resources/META-INF/config-files`. It still named the alias keystore `domain-passwords` — the old JKS/JCEKS filename. Commit 096ace25 ("Switching from JKS and JCEKS to PKCS12") renamed it to `domain-passwords.p12` (`PasswordAdapter.PASSWORD_ALIAS_KEYSTORE`). The stale entry no longer matches any file, so the keystore is never propagated.

## Fix

- Update the sync list entry to `domain-passwords.p12`.
- Fix the matching stale references in the HA Administration Guide (`instances.adoc`).

## Notes

This restores the 7.0.x behavior. Reported and root-caused by @cluisquijada; triage/fix confirmed by @OndroMih in the issue.

Fixes #26093

🤖 Generated with [Claude Code](https://claude.com/claude-code)