### PR TITLE
Guard ManagedConnection cleanup against a torn-down physical connection

### DIFF
--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/main/java/com/sun/gjc/spi/ManagedConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -462,6 +462,15 @@ public class ManagedConnectionImpl
      */
     private void resetConnectionProperties(ManagedConnectionFactoryImpl managedConnectionFactoryImpl) throws ResourceException {
         if (isClean) {
+
+            // cleanup() can be invoked on a ManagedConnection whose physical connection has
+            // already been torn down - for instance one marked for removal whose transaction
+            // has completed. In that case there is no connection to reset; resetIsolation()
+            // already tolerates a null connection, so guard resetAutoCommit() the same way to
+            // avoid a NullPointerException (see issue #24232).
+            if (getActualConnection() == null) {
+                return;
+            }
 
             // If the ManagedConnection is clean, reset the transaction isolation level to
             // what it was when it was when this ManagedConnection was cleaned up depending on

--- a/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/ManagedConnectionImplTest.java
+++ b/appserver/jdbc/jdbc-ra/jdbc-core/src/test/java/com/sun/gjc/spi/ManagedConnectionImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -143,6 +143,32 @@ public class ManagedConnectionImplTest {
         // Close is called on connectionHolder, but it was no longer linked to managedConnection1.
         // Thus connectionCount is not decreased from 1 to 0.
         assertEquals(1, managedConnection1.connectionCount);
+    }
+
+    /**
+     * Reproduces issue #24232: cleanup() can be invoked on a pooled/XA ManagedConnection
+     * whose physical connection has already been torn down (e.g. a connection marked for
+     * removal whose transaction completed and which was then destroyed). In that state both
+     * actualConnection and pooledConnection are null, so resetConnectionProperties() must
+     * not dereference them. Before the fix this threw a NullPointerException from
+     * resetAutoCommit().
+     */
+    @Test
+    public void testCleanupOnTornDownPooledConnectionDoesNotThrow() throws Exception {
+        ManagedConnectionImpl managedConnection = createManagedConnection(new MyPooledConnection(), null);
+        managedConnection.initializeConnectionType(ManagedConnectionImpl.ISPOOLEDCONNECTION);
+
+        // Application changed autoCommit (default is true), so resetConnectionProperties()
+        // would attempt to reset it on the - now absent - physical connection.
+        managedConnection.setLastAutoCommitValue(false);
+
+        // Tear the physical connection down: destroy() closes and nulls both the
+        // pooledConnection and the actualConnection for a pooled connection.
+        managedConnection.destroy();
+        assertNull(managedConnection.getActualConnection());
+
+        // cleanup() runs resetConnectionProperties() on the torn-down connection.
+        assertDoesNotThrow(managedConnection::cleanup);
     }
 
     /**


### PR DESCRIPTION
## Problem

`ManagedConnectionImpl.cleanup()` → `resetConnectionProperties()` resets the transaction isolation level and the auto-commit value so a pooled connection can be safely returned to the pool. `ManagedConnectionFactoryImpl.resetIsolation()` re-fetches the physical connection through `getActualConnection()` and already tolerates a `null` result, but `resetAutoCommit()` dereferenced `actualConnection` directly.

When `cleanup()` runs on a pooled/XA `ManagedConnection` whose physical connection has already been torn down — for instance one marked for removal whose transaction completed (`transactionCompleted()` nulls `actualConnection`) and which was then destroyed (`destroy()` nulls `pooledConnection`) — both fields are `null`. `resetAutoCommit()` then throws:

```
java.lang.NullPointerException: Cannot invoke "java.sql.Connection.setAutoCommit(boolean)" because "this.actualConnection" is null
        at com.sun.gjc.spi.ManagedConnectionImpl.resetAutoCommit(...)
        at com.sun.gjc.spi.ManagedConnectionImpl.resetConnectionProperties(...)
        at com.sun.gjc.spi.ManagedConnectionImpl.cleanup(...)
        at com.sun.enterprise.resource.allocator.AbstractConnectorAllocator.cleanup(...)
```

This is the same code path reported in #24232. The originally reported NPE in `getActualConnection()` itself was already fixed by an earlier guard; this addresses the remaining latent NPE in `resetAutoCommit()` on the same scenario.

## Fix

Guard `resetConnectionProperties()` with the same null-connection check `resetIsolation()` already relies on. When `getActualConnection()` returns `null` there is no physical connection to reset, so cleanup becomes a no-op instead of dereferencing a null connection.

## Test

Adds `ManagedConnectionImplTest.testCleanupOnTornDownPooledConnectionDoesNotThrow`, which destroys a pooled `ManagedConnection` (nulling both connection fields) after the application changed auto-commit, then calls `cleanup()`. The test fails with the exact reported NPE on `main` and passes with this change.

Fixes #24232

🤖 Generated with [Claude Code](https://claude.com/claude-code)