### PR TITLE
Move JSFTemplate to GlassFish adminui

### DIFF
--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -46,6 +46,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.main.admingui</groupId>
+            <artifactId>jsftemplating</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.admingui</groupId>
+            <artifactId>jsftemplating-dt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
             <groupId>org.glassfish.main.admin</groupId>
             <artifactId>rest-client</artifactId>
             <version>${project.version}</version>
@@ -70,39 +81,7 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-
-
-        <dependency>
-            <groupId>org.glassfish.expressly</groupId>
-            <artifactId>expressly</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.mojarra</groupId>
-            <artifactId>mojarra</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating-dt</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
+        
         <dependency>
             <groupId>jakarta.authentication</groupId>
             <artifactId>jakarta.authentication-api</artifactId>
@@ -131,6 +110,27 @@
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.mojarra</groupId>
+            <artifactId>mojarra</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/appserver/admingui/common/pom.xml
+++ b/appserver/admingui/common/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>jsftemplating-dt</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.glassfish.main.admin</groupId>
             <artifactId>rest-client</artifactId>
@@ -81,7 +81,7 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>jakarta.authentication</groupId>
             <artifactId>jakarta.authentication-api</artifactId>

--- a/appserver/admingui/core/src/main/resources/templates/bareLayout.xhtml
+++ b/appserver/admingui/core/src/main/resources/templates/bareLayout.xhtml
@@ -25,20 +25,32 @@
     }
     getPluginIdFromViewId(viewId="#{facesContext.viewRoot.viewId}", pluginId="#{pluginId}");
 </ui:event>
+
 <event>
     <!-- Before Create must be inside a component, cannot be at page-level -->
     <ui:event type="beforeCreate">
         setPartialRequest("false");
     </ui:event>
+    
     <ui:event type="beforeEncode">
         <!-- Set request-scoped restart flag to compare w/ session -->
         if (!$session{supportCluster}) {
-            gf.restRequest(endpoint="#{sessionScope.REST_URL}/_get-restart-required", method="get", result="#{requestScope.result}");
-            setSessionAttribute(key="restartRequired", value="#{requestScope.result.data.extraProperties.entity.restartRequired}");
-            setSessionAttribute(key="unprocessedChanges", value="#{requestScope.result.data.extraProperties.entity.unprocessedChanges}");
+            gf.restRequest(
+                endpoint="#{sessionScope.REST_URL}/_get-restart-required", 
+                method="get", result="#{requestScope.result}");
+            
+            setSessionAttribute(
+                key="restartRequired", 
+                value="#{requestScope.result.data.extraProperties.entity.restartRequired eq true}");
+                
+            setSessionAttribute(
+                key="unprocessedChanges", 
+                value="#{requestScope.result.data.extraProperties.entity.unprocessedChanges}");
         }
         if($session{supportCluster}) {
-            setSessionAttribute(key="restartRequired" value="$boolean{false}");
+            setSessionAttribute(
+                key="restartRequired" 
+                value="$boolean{false}");
         }
 
         gf.restRequest(endpoint="#{request.scheme}://#{sessionScope.serverName}:#{sessionScope.serverPort}/management/domain/anonymous-user-enabled"
@@ -81,6 +93,7 @@
         Content Missing!
     </insert>
 "</div>
+
 <f:verbatim>
 <script type="text/javascript">
     var loc = top.window.location.href;

--- a/appserver/admingui/core/src/main/resources/templates/baseLayout.xhtml
+++ b/appserver/admingui/core/src/main/resources/templates/baseLayout.xhtml
@@ -132,20 +132,31 @@
                             <event id="restartCheck">
                                 <ui:event type="beforeEncode">
                                     if ("!$session{supportCluster}") {
-                                        gf.restRequest(endpoint="#{sessionScope.REST_URL}/_get-restart-required", method="get", result="#{requestScope.result}");
-                                        setSessionAttribute(key="restartRequired", value="#{requestScope.result.data.extraProperties.entity.restartRequired}");
-                                        setSessionAttribute(key="unprocessedChanges", value="#{requestScope.result.data.extraProperties.entity.unprocessedChanges}");
+                                        gf.restRequest(
+                                            endpoint="#{sessionScope.REST_URL}/_get-restart-required", 
+                                            method="get", 
+                                            result="#{requestScope.result}");
+                                        
+                                        setSessionAttribute(
+                                            key="restartRequired", 
+                                            value="#{requestScope.result.data.extraProperties.entity.restartRequired eq true}");
+                                        
+                                        setSessionAttribute(
+                                            key="unprocessedChanges", 
+                                            value="#{requestScope.result.data.extraProperties.entity.unprocessedChanges}");
                                     }
                                     if("$session{supportCluster}") {
                                         setSessionAttribute(key="restartRequired" value="$boolean{false}");
                                     }
                                 </ui:event>
+                                
                                 <!-- Masthead Integration Point -->
                                 <ui:event type="afterCreate">
                                     includeFirstIntegrationPoint(type="org.glassfish.admingui:masthead" root="$this{component}");
                                     includeFirstIntegrationPoint(type="org.glassfish.admingui:favicon" root="#{view}");
                                 </ui:event>
                             </event>
+                            
                             <h:commandButton id="execButton" text="na" style="display:none;">
                                 <ui:event type="command">
                                     <!-- Ok to use #{param} here -->

--- a/appserver/admingui/jca/pom.xml
+++ b/appserver/admingui/jca/pom.xml
@@ -48,7 +48,6 @@
             <groupId>org.glassfish.main.admingui</groupId>
             <artifactId>console-common</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/appserver/admingui/pom.xml
+++ b/appserver/admingui/pom.xml
@@ -80,6 +80,7 @@
     </developers>
 
     <modules>
+        <module>vdl</module>
         <module>dataprovider</module>
         <module>plugin-service</module>
         <module>common</module>
@@ -106,16 +107,6 @@
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
-            <artifactId>jsftemplating-dt</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -162,6 +153,7 @@
           </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>dev</id>

--- a/appserver/admingui/vdl/jsftemplating/jsft/pom.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsft/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
+    Copyright (c) 2014, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.admingui</groupId>
+        <artifactId>jsftemplating-parent</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jsft</artifactId>
+
+    <name>jsft</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.main.admingui</groupId>
+            <artifactId>jsftemplating</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.faces</groupId>
+            <artifactId>jakarta.faces-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Export-Package>*</Export-Package>
+                                <Import-Package>
+                                    com.sun.jsft.commands",
+                                    com.sun.jsft.event",
+                                    com.sun.jsft.facelets",
+                                    com.sun.jsft.util",
+                                    jakarta.el;version="5",
+                                    jakarta.faces;version="4",
+                                    jakarta.faces.application;version="4",
+                                    jakarta.faces.component;version="4",
+                                    jakarta.faces.context;version="4",
+                                    jakarta.faces.event;version="4",
+                                    jakarta.faces.view.facelets;version="4",
+                                    *
+                                </Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/commands/JSFTCommands.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/commands/JSFTCommands.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *  UtilCommands.java
+ *
+ *  Created  April 2, 2011
+ *  @author  Ken Paulsen (kenapaulsen@gmail.com)
+ */
+package com.sun.jsft.commands;
+
+import com.sun.jsft.event.Command;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class contains methods that perform common utility-type functionality.
+ * </p>
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+@ApplicationScoped
+@Named("jsft")
+public class JSFTCommands {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public JSFTCommands() {
+    }
+
+    /**
+     * <p>
+     * This command conditionally executes its child commands.
+     * </p>
+     */
+    public void _if(boolean condition) {
+        Command command = (Command) FacesContext.getCurrentInstance().getExternalContext().getRequestMap().get(Command.COMMAND_KEY);
+        if (condition) {
+            command.invokeChildCommands();
+        } else {
+            command = command.getElseCommand();
+            if (command != null) {
+                command.invoke();
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This command iterates over the given List and sets given
+     */
+    public void foreach(String var, List list) {
+        // Get the Request Map
+        Map<String, Object> reqMap = FacesContext.getCurrentInstance().getExternalContext().getRequestMap();
+
+        // Get the Current Command...
+        Command command = (Command) reqMap.get(Command.COMMAND_KEY);
+
+        // Iterate over each item in the List
+        List<Command> childCommands = null;
+        for (Object item : list) {
+            // Set the item in the request scope under the given key
+            reqMap.put(var, item);
+
+            // Invoke all the child commands
+            childCommands = command.getChildCommands();
+            if (childCommands != null) {
+                for (Command childCommand : childCommands) {
+                    childCommand.invoke();
+                }
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This command sets a requestScope attribute with the given <code>key</code> and <code>value</code>.
+     * </p>
+     */
+    public void setAttribute(String key, Object value) {
+        FacesContext.getCurrentInstance().getExternalContext().getRequestMap().put(key, value);
+    }
+
+    /**
+     * <p>
+     * This command writes output using <code>System.out.println</code>. It requires <code>value</code> to be supplied.
+     * </p>
+     */
+    public void println(String value) {
+        System.out.println(value);
+    }
+
+    /**
+     * <p>
+     * This command writes using <code>FacesContext.getResponseWriter()</code>.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    public static void write(String text) {
+        if (text == null) {
+            text = "";
+        }
+        try {
+            FacesContext.getCurrentInstance().getResponseWriter().write(text);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * <p>
+     * This command marks the response complete. This means that no additional response will be sent. This is useful if
+     * you've provided a response already and you don't want JSF to do it again (it may cause problems to do it 2x).
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    public static void responseComplete() {
+        FacesContext.getCurrentInstance().responseComplete();
+    }
+
+    /**
+     * <p>
+     * This command indicates to JSF that the request should proceed immediately to the render response phase. It will be
+     * ignored if rendering has already begun. This is useful if you want to stop processing and jump to the response. This
+     * is often the case when an error ocurrs or validation fails. Typically the page the user is on will be reshown
+     * (although if navigation has already occurred, the new page will be shown.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    public void renderResponse() {
+        FacesContext.getCurrentInstance().renderResponse();
+    }
+
+    /**
+     * <p>
+     * This command provides a way to see the call stack by printing a stack trace. The output will go to stderr and will
+     * also be returned in the output value "stackTrace". An optional message may be provided to be included in the trace.
+     * </p>
+     */
+    public void printStackTrace(String msg) {
+        // See if we have a message to print w/ it
+        if (msg == null) {
+            msg = "";
+        }
+
+        // Get the StackTrace
+        StringWriter strWriter = new StringWriter();
+        new RuntimeException(msg).printStackTrace(new PrintWriter(strWriter));
+        String trace = strWriter.toString();
+
+        // Print it to stderr and return it
+        System.err.println(trace);
+    }
+
+    /**
+     * <p>
+     * Returns the nano seconds since some point in time. This is only useful for relative measurments.
+     * </p>
+     */
+    public long getNanoTime() {
+        return nanoStartTime - System.nanoTime();
+    }
+
+    /**
+     * <p>
+     * This is application scoped, so it is not safe to change. Use caution.
+     * </p>
+     */
+    private long nanoStartTime = System.nanoTime();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/commands/UtilCommands.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/commands/UtilCommands.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *  UtilCommands.java
+ *
+ *  Created March 29, 2011
+ *  @author Ken Paulsen kenapaulsen@gmail.com
+ */
+package com.sun.jsft.commands;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.faces.component.UIComponent;
+import jakarta.inject.Named;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class contains methods that perform common utility-type functionality.
+ * </p>
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+@ApplicationScoped
+@Named("util")
+public class UtilCommands {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public UtilCommands() {
+    }
+
+    /**
+     * <p>
+     * This command prints out the contents of the given <code>UIComponent</code>'s attribute map.
+     * </p>
+     */
+    public void dumpAttributeMap(UIComponent comp) {
+        if (comp != null) {
+            Map<String, Object> map = comp.getAttributes();
+            for (Iterator iter = map.entrySet().iterator(); iter.hasNext();) {
+                Map.Entry me = (Map.Entry) iter.next();
+                System.out.println("key=" + me.getKey() + "'" + "value=" + me.getValue());
+            }
+        } else {
+            System.out.println("UIComponent is null");
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns an <code>Iterator</code> for the given <code>List</code>. The <code>List</code> input value key
+     * is: "list". The output value key for the <code>Iterator</code> is: "iterator".
+     * </p>
+     *
+     * @param context The HandlerContext. @Handler(id="getIterator", input={ @HandlerInput(name="list", type=List.class,
+     * required=true)}, output={
+     * @HandlerOutput(name="iterator", type=Iterator.class)}) public static void getIterator(HandlerContext context) {
+     * List<Object> list = (List<Object>) context.getInputValue("list"); context.setOutputValue("iterator",
+     * list.iterator()); }
+     */
+
+    /**
+     * <p>
+     * This method returns a <code>Boolean</code> value representing whether another value exists for the given
+     * <code>Iterator</code>. The <code>Iterator</code> input value key is: "iterator". The output value key is "hasNext".
+     * </p>
+     *
+     * @param context The HandlerContext. @Handler(id="iteratorHasNext", input={ @HandlerInput(name="iterator",
+     * type=Iterator.class, required=true)}, output={
+     * @HandlerOutput(name="hasNext", type=Boolean.class)}) public static void iteratorHasNext(HandlerContext context) {
+     * Iterator<Object> it = (Iterator<Object>) context.getInputValue("iterator"); context.setOutputValue("hasNext",
+     * Boolean.valueOf(it.hasNext())); }
+     */
+
+    /**
+     * <p>
+     * This method returns the next object in the <code>List</code> that the given <code>Iterator</code> is iterating over.
+     * The <code>Iterator</code> input value key is: "iterator". The output value key is "next".
+     * </p>
+     *
+     * @param context The HandlerContext. @Handler(id="iteratorNext", input={ @HandlerInput(name="iterator",
+     * type=Iterator.class, required=true)}, output={
+     * @HandlerOutput(name="next")}) public static void iteratorNext(HandlerContext context) { Iterator<Object> it =
+     * (Iterator<Object>) context.getInputValue("iterator"); context.setOutputValue("next", it.next()); }
+     */
+
+    /**
+     * <p>
+     * This method creates a List. Optionally you may supply "size" to create a List of blank "" values of the specified
+     * size. The output value from this command is "result".
+     * </p>
+     *
+     * @param context The HandlerContext @Handler(id="createList", input={ @HandlerInput(name="size", type=Integer.class,
+     * required=true)}, output={
+     * @HandlerOutput(name="result", type=List.class)}) public static void createList(HandlerContext context) { int size =
+     * ((Integer) context.getInputValue("size")).intValue(); List<Object> list = new ArrayList<Object>(size); for (int count
+     * = 0; count < size; count++) { list.add(""); } context.setOutputValue("result", list); }
+     */
+
+    /**
+     * <p>
+     * This method creates a <code>Map</code> (<code>HashMap</code>). The output value from this command is "result".
+     * </p>
+     *
+     * @param context The <code>HandlerContext<code> @Handler(id="createMap", output={
+     * @HandlerOutput(name="result", type=Map.class)}) public static void createMap(HandlerContext context) { Map<Object,
+     * Object> map = new HashMap<Object, Object>(); context.setOutputValue("result", map); }
+     */
+
+    /**
+     * <p>
+     * This method adds a value to a </code>Map</code>. You must supply <code>map</code> to use as well as the
+     * <code>key</code> and <code>value</code> to add.
+     * </p>
+     *
+     * @param context The <code>HandlerContext<code> @Handler(id="mapPut", input={ @HandlerInput(name="map", type=Map.class,
+     * required=true), @HandlerInput(name="key", type=Object.class, required=true), @HandlerInput(name="value",
+     * type=Object.class, required=true)} ) public static void mapPut(HandlerContext context) { Map map = (Map)
+     * context.getInputValue("map"); Object key = context.getInputValue("key"); Object value =
+     * context.getInputValue("value"); map.put(key, value); }
+     */
+
+    /**
+     * <p>
+     * This command url-encodes the given String. It will return null if null is given and it will use a default encoding of
+     * "UTF-8" if no encoding is specified.
+     * </p>
+     *
+     * @param context The HandlerContext. @Handler(id="urlencode", input={ @HandlerInput(name="value", type=String.class,
+     * required=true), @HandlerInput(name="encoding", type=String.class) }, output={
+     * @HandlerOutput(name="result", type=String.class)}) public static void urlencode(HandlerContext context) { String
+     * value = (String) context.getInputValue("value"); String encoding = (String) context.getInputValue("encoding"); if
+     * (encoding == null) { encoding = "UTF-8"; } // The value could be null if an EL expression maps to null if (value !=
+     * null) { try { value = java.net.URLEncoder.encode(value, encoding); } catch (java.io.UnsupportedEncodingException ex)
+     * { throw new IllegalArgumentException(ex); } } context.setOutputValue("result", value); }
+     */
+
+    /**
+     * <p>
+     * This command gets the current system time in milliseconds. It may be used to time things.
+     * </p>
+     * @Handler(id="getDate", output={
+     *
+     * @HandlerOutput(name="time", type=Long.class) }) public static void getDate(HandlerContext context) {
+     * context.setOutputValue("time", new java.util.Date().getTime()); }
+     */
+
+    /**
+     * <p>
+     * This method converts '&lt;' and '&gt;' characters into "&amp;lt;" and "&amp;gt;" in an effort to avoid HTML from
+     * being processed. This can be used to avoid &lt;script&gt; tags, or to show code examples which might include HTML
+     * characters. '&amp;' characters will also be converted to "&amp;amp;".
+     * </p>
+     * @Handler(id="htmlEscape", input={ @HandlerInput(name="value", type=String.class, required=true) }, output={
+     *
+     * @HandlerOutput(name="result", type=String.class)}) public static void htmlEscape(HandlerContext context) { String
+     * value = (String) context.getInputValue("value"); value = com.sun.jsft.util.Util.htmlEscape(value);
+     * context.setOutputValue("result", value); }
+     */
+
+    /**
+     * <p>
+     * A utility command that resembles the for() method in Java. Commands inside the for loop will be executed in a loop.
+     * The starting index is specified by <code>start</code>. The index will increase sequentially untill it is equal to
+     * <code>end</code>. <code>var</code> will be a request attribute that is set to the current index value as the loop
+     * iterates.
+     * </p>
+     * <p>
+     * For example:
+     * </p>
+     *
+     * <code>forLoop(start="1"  end="3" var="foo") {...}</code>
+     *
+     * <p>
+     * The commands inside the {...} will be executed 2 times (with foo=1 and foo=2).
+     * </p>
+     *
+     * <ul>
+     * <li><code>start</code> -- type: <code>Integer</code> Starting index, defaults to zero if not specified.</li>
+     * <li><code>end</code> -- type: <code>Integer</code>; Ending index. Required.</li>
+     * <li><code>var</code> -- type: <code>String</code>; Request attribute to be set in the for loop to the value of the
+     * index.</li>
+     * </ul>
+     * public static boolean forLoop(int start, int end, String var) { List<> commands =
+     * handlerCtx.getHandler().getChildHandlers(); if (commands.size() > 0) { // We have child commands in the loop...
+     * execute while we iterate Map<String, Object> requestMap = FacesContext.getCurrentInstance().
+     * getExternalContext().getRequestMap(); for (int idx=start; idx < end; idx++) { requestMap.put(var, idx); // Ignore
+     * what is returned by the commands... we need to return // false anyway to prevent children from being executed again
+     * elt.dispatchHandlers(commands); } }
+     *
+     * // This will prevent the child commands from executing again return false; }
+     */
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/component/DeferredFragment.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/component/DeferredFragment.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.component;
+
+import com.sun.jsft.tasks.Task;
+import com.sun.jsft.tasks.TaskEvent;
+import com.sun.jsft.tasks.TaskManager;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.AbortProcessingException;
+import jakarta.faces.event.ComponentSystemEvent;
+import jakarta.faces.event.ComponentSystemEventListener;
+import jakarta.faces.event.PostAddToViewEvent;
+import jakarta.faces.event.SystemEvent;
+import jakarta.faces.event.SystemEventListener;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/**
+ *
+ */
+public class DeferredFragment extends UIComponentBase {
+
+    /**
+     * <p>
+     * Default constructor.
+     * </p>
+     */
+    public DeferredFragment() {
+        subscribeToEvent(PostAddToViewEvent.class, new DeferredFragment.AfterCreateListener());
+    }
+
+    /**
+     *
+     */
+    @Override
+    public String getFamily() {
+        return FAMILY;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public boolean getRendersChildren() {
+        return true;
+    }
+
+    @Override
+    public void encodeBegin(FacesContext context) throws IOException {
+        System.out.println("Encode Begin (" + getId() + ")...");
+    }
+
+    @Override
+    public void encodeEnd(FacesContext context) throws IOException {
+        System.out.println("Encode End (" + getId() + ")...");
+    }
+
+    /**
+     * <p>
+     * This method returns <code>true</code> when all tasks this deferred fragment depends on are complete. This method is
+     * not intended to be used to poll this task for completion, you should instead register for the ready event that it
+     * fires.
+     * </p>
+     */
+    private boolean isReady() {
+        return (taskCount == 0);
+    }
+
+    /**
+     * <p>
+     * This method gets the id of the "place-holder" component for this <code>DeferredFragment</code>.
+     * </p>
+     */
+    public String getPlaceHolderId() {
+        return placeHolderId;
+    }
+
+    /**
+     * <p>
+     * This method sets the id of the "place-holder" component for this <code>DeferredFragment</code>.
+     * </p>
+     */
+    public void setPlaceHolderId(String id) {
+        placeHolderId = id;
+    }
+
+    /**
+     * <p>
+     * This method returns the number of tasks this DeferredFragment is waiting for.
+     * </p>
+     */
+    public int getTaskCount() {
+        return taskCount;
+    }
+
+    /**
+     * <p>
+     * This method sets the number of tasks this <code>DeferredFragment</code> must wait for.
+     * </p>
+     */
+    public void setTaskCount(int count) {
+        taskCount = count;
+    }
+
+    /**
+     * <p>
+     * This method registers the given <code>ComponentSystemEventListener</code> that should be notified when this
+     * <code>DeferredFragment</code> is ready to be rendered.
+     * </p>
+     */
+    public void addReadyListener(ComponentSystemEventListener listener) {
+        listeners.add(listener);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for firing the {@link FragmentReadyEvent} to signal to listeners that the {@link Task}s
+     * needed by this <code>DeferredFragment</code> have completed and it is now ready to be processed.
+     * </p>
+     */
+    protected void fireFragmentReadyEvent() {
+        ComponentSystemEvent event = new FragmentReadyEvent(this);
+        System.out.println("listeners" + listeners);
+        for (ComponentSystemEventListener listener : listeners) {
+            listener.processEvent(event);
+        }
+    }
+
+    /**
+     * <p>
+     * Listener used to handle TaskEvents.
+     * </p>
+     */
+    public static class DeferredFragmentTaskListener implements SystemEventListener {
+
+        /**
+         * <p>
+         * Default Constructor.
+         * </p>
+         */
+        public DeferredFragmentTaskListener(DeferredFragment df) {
+            super();
+            this.df = df;
+        }
+
+        /**
+         * <p>
+         * The event passed in will be a {@link TaskEvent}.
+         * </p>
+         */
+        @Override
+        public void processEvent(SystemEvent event) throws AbortProcessingException {
+            System.out.println("DeferredFragmentTaskListener.processEvent()!");
+            Task task = (Task) event.getSource();
+            String eventType = ((TaskEvent) event).getType();
+            int count = 0;
+            synchronized (df) {
+                // Synch to ensure we don't change it during this time.
+                count = df.getTaskCount() - 1;
+                df.setTaskCount(count);
+            }
+            if (count == 0) {
+                // We're done!
+                df.fireFragmentReadyEvent();
+            }
+        }
+
+        @Override
+        public boolean isListenerForSource(Object source) {
+            // We only dispatch this correctly... this method is not needed.
+            return true;
+        }
+
+        // A reference to the DeferredFragment
+        private DeferredFragment df = null;
+    }
+
+    /**
+     * <p>
+     * Listener used to relocate the children to a facet on the UIViewRoot.
+     * </p>
+     */
+    public static class AfterCreateListener implements ComponentSystemEventListener {
+        AfterCreateListener() {
+        }
+
+        /**
+         * <p>
+         * This method is responsible for setting up this <code>DeferredFragment</code>. This includes the following steps:
+         * </p>
+         *
+         * <ul>
+         * <li>Put a "place-holder" component at the location of the fragment so it can be swapped out by the client at a later
+         * time.</li>
+         * <li>Move this component to a facet in the UIViewRoot.</li>
+         * <li>Register any tasks that need to be executed, add a listener for each task or the specified event within the
+         * task.</li>
+         * <li>Ensure a FragmentRenderer component exists at the end of the page.</li>
+         */
+        @Override
+        public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
+            // Ensure we only do this once... NOTE: I tried to unsubscribe from
+            // the event, but ran into a ConcurrentModificationException... the
+            // list of listeners is probably still being looped through while I
+            // am attempting to remove this Listener. So I'll do this instead:
+            if (done) {
+                return;
+            }
+            done = true;
+
+            // Get the component
+            DeferredFragment comp = (DeferredFragment) event.getComponent();
+
+            // Get the UIViewRoot Facet Map
+            FacesContext ctx = FacesContext.getCurrentInstance();
+            UIViewRoot viewRoot = ctx.getViewRoot();
+            Map<String, UIComponent> facetMap = viewRoot.getFacets();
+
+            // Create a place holder...
+            String key = "jsft_" + comp.getClientId(ctx);
+            UIComponent placeHolder = new UIOutput();
+            placeHolder.getAttributes().put("value", "<span id='" + key + "'></span>");
+
+            // Swap comp with the placeHolder...
+            List<UIComponent> peers = comp.getParent().getChildren();
+            int index = peers.indexOf(comp);
+            peers.set(index, placeHolder);
+            comp.setPlaceHolderId(placeHolder.getClientId(ctx));
+
+            // Move this component to the FacetMap
+            facetMap.put(key, comp);
+
+            // Register task(s)
+            String task = (String) comp.getAttributes().get("task");
+            StringTokenizer tok = new StringTokenizer(task, ";");
+            TaskManager tm = TaskManager.getInstance();
+            int taskCount = 0;
+            while (tok.hasMoreTokens()) {
+                task = tok.nextToken().trim();
+
+                // Check to see if we have task:listenerType
+                int idx = task.indexOf(":");
+                String type = null;
+                if (idx != -1) {
+                    type = task.substring(idx + 1);
+                    task = task.substring(0, idx);
+                }
+
+                // Register the Task...
+                tm.addTask(task, type, new DeferredFragmentTaskListener(comp));
+
+                // Count the tasks we depend on...
+                taskCount++;
+            }
+
+            // Store the task count...
+            comp.setTaskCount(taskCount);
+
+            // Ensure we have a FragmentRenderer component...
+            Map<String, Object> requestScope = ctx.getExternalContext().getRequestMap();
+            FragmentRenderer fragmentRenderer = (FragmentRenderer) requestScope.get(FRAGMENT_RENDERER);
+            if (fragmentRenderer == null) {
+                // Create one...
+                fragmentRenderer = new FragmentRenderer();
+                fragmentRenderer.setId(FRAGMENT_RENDERER);
+
+                // Store FragmentRenderer in request scope as well as the last
+                // component in the UIViewRoot. (request scope for fast access)
+                viewRoot.getChildren().add(fragmentRenderer);
+                requestScope.put(FRAGMENT_RENDERER, fragmentRenderer);
+            }
+
+            // Increment fragment count on FragmentRenderer component...
+            fragmentRenderer.addDeferredFragment(comp);
+            comp.addReadyListener(fragmentRenderer);
+        }
+
+        private boolean done = false;
+        private static final String FRAGMENT_RENDERER = "jsft-FR";
+    }
+
+    /**
+     * <p>
+     * The component family.
+     * </p>
+     */
+    public static final String FAMILY = DeferredFragment.class.getName();
+
+    /**
+     * <p>
+     * The number of tasks that need to be complete before this <code>DeferredFragment</code> can be rendered. It is
+     * initialized to a postiive value (1) so that {@link #isReady()} will return <code>false</code> -- important since the
+     * tasks have not yet been counted.
+     * </p>
+     */
+    private int taskCount = 1;
+
+    /**
+     * <p>
+     * The id of the placeholder for this component so we can find it later.
+     * </p>
+     */
+    private transient String placeHolderId = "";
+
+    /**
+     * <p>
+     * This <code>List</code> will hold the list of listeners interested in being notified with this
+     * <code>DeferredFragment</code> is ready to be rendered.
+     * </p>
+     */
+    private List<ComponentSystemEventListener> listeners = new ArrayList<>(2);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/component/FragmentReadyEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/component/FragmentReadyEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.component;
+
+import jakarta.faces.event.ComponentSystemEvent;
+
+/**
+ * <p>
+ * This event is used for dispatching {@link Task} related events.
+ * </p>
+ */
+public class FragmentReadyEvent extends ComponentSystemEvent {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public FragmentReadyEvent(DeferredFragment source) {
+        super(source);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/component/FragmentRenderer.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/component/FragmentRenderer.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.component;
+
+import com.sun.jsft.tasks.TaskManager;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.AbortProcessingException;
+import jakarta.faces.event.ComponentSystemEvent;
+import jakarta.faces.event.ComponentSystemEventListener;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ *
+ */
+public class FragmentRenderer extends UIComponentBase implements ComponentSystemEventListener {
+
+    /**
+     * <p>
+     * Default constructor.
+     * </p>
+     */
+    public FragmentRenderer() {
+    }
+
+    /**
+     *
+     */
+    @Override
+    public String getFamily() {
+        return FAMILY;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public boolean getRendersChildren() {
+        return true;
+    }
+
+    @Override
+    public void encodeBegin(FacesContext context) throws IOException {
+        System.out.println("Starting FragmentRenderer...");
+        // Start processing the Tasks...
+        TaskManager.getInstance().start();
+    }
+
+    @Override
+    public void encodeChildren(FacesContext context) throws IOException {
+        // It should have no children... do nothing...
+    }
+
+    @Override
+    public void encodeEnd(FacesContext context) throws IOException {
+        // Render fragments as they become ready.
+        fragsToRender = getFragmentCount();
+        DeferredFragment comp = null;
+        while (fragsToRender > 0) {
+            synchronized (renderQueue) {
+                if (renderQueue.isEmpty()) {
+                    try {
+                        // Wait at most 30 seconds...
+                        renderQueue.wait(30 * 1000);
+                        if (renderQueue.isEmpty()) {
+                            System.out.println("EMPTY QUEUE!");
+                            return;
+                        }
+                    } catch (InterruptedException ex) {
+                        System.out.println("Interrupted!");
+                        return;
+                    }
+                }
+                comp = renderQueue.poll();
+            }
+            if (comp != null) {
+                fragsToRender--;
+                try {
+                    System.out.println("Encoding: " + comp.getId());
+                    comp.encodeAll(FacesContext.getCurrentInstance());
+                } catch (Exception ex) {
+                    // FIXME: cleanup
+                    ex.printStackTrace();
+                }
+            }
+        }
+
+        System.out.println("Ending FragmentRenderer..." + fragsToRender);
+    }
+
+    /**
+     * <p>
+     * This method returns the number of tasks this DeferredFragment is waiting for.
+     * </p>
+     */
+    public int getFragmentCount() {
+        return fragments.size();
+    }
+
+    /**
+     * <p>
+     * This method adds the given {@link DeferredFragment} to the <code>List</code> of fragments that are to be processed by
+     * this <code>FragmentRenderer</code>.
+     * </p>
+     */
+    public void addDeferredFragment(DeferredFragment fragment) {
+        fragments.add(fragment);
+    }
+
+    /**
+     * <p>
+     * This method gets invoked whenever a DeferredFragment associated with this component becomes ready to be rendered.
+     * </p>
+     */
+    @Override
+    public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
+        // Get the component
+        processDeferredFragment((DeferredFragment) event.getComponent());
+    }
+
+    /**
+     *
+     */
+    private void processDeferredFragment(DeferredFragment comp) {
+        // Find the "place-holder" component...
+        String key = ":" + comp.getPlaceHolderId();
+        UIComponent placeHolder = comp.findComponent(key);
+        if (placeHolder != null) {
+            // This "should" always be the case... swap it back.
+            List<UIComponent> peers = placeHolder.getParent().getChildren();
+            int index = peers.indexOf(placeHolder);
+            peers.set(index, comp);
+        }
+
+        // Queue it up...
+        synchronized (renderQueue) {
+            renderQueue.add(comp);
+            renderQueue.notifyAll();
+        }
+    }
+
+    /**
+     * <p>
+     * A count of remaining fragments to render.
+     * </p>
+     */
+    private transient int fragsToRender = 1;
+
+    private transient List<DeferredFragment> fragments = new ArrayList<>();
+
+    private transient Queue<DeferredFragment> renderQueue = new ConcurrentLinkedQueue<>();
+
+    /**
+     * <p>
+     * The component family.
+     * </p>
+     */
+    public static final String FAMILY = FragmentRenderer.class.getName();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/event/Command.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/event/Command.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.event;
+
+import jakarta.faces.event.AbortProcessingException;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * <p>
+ * This class represents a Command.
+ * </p>
+ *
+ * Created March 31, 2011
+ *
+ * @author Ken Paulsen kenapaulsen@gmail.com
+ */
+public abstract class Command implements Serializable {
+
+    /**
+     * <p>
+     * Default constructor needed for serialization.
+     * </p>
+     */
+    public Command() {
+    }
+
+    /**
+     * <p>
+     * Constructor which sets the child commands.
+     * </p>
+     */
+    public Command(List<Command> children, Command elseCommand) {
+        setChildCommands(children);
+        setElseCommand(elseCommand);
+    }
+
+    /**
+     * <p>
+     * This is the method responsible for performing the action. It is also responsible for invoking any of its child
+     * commands.
+     * </p>
+     */
+    public abstract Object invoke() throws AbortProcessingException;
+
+    /**
+     * <p>
+     * This getter method retrieves the command to be invoked if this command has an "else" clause. In most cases this will
+     * return <code>null</code>.
+     * </p>
+     */
+    public Command getElseCommand() {
+        return this.elseCommand;
+    }
+
+    /**
+     * <p>
+     * Returns a reference to list of child commands. Note, there is nothing to stop you from modifying this list...
+     * however, it is strongly discouraged and may lead to problems.
+     * </p>
+     */
+    public List<Command> getChildCommands() {
+        return childCommands;
+    }
+
+    /**
+     * <p>
+     * This method is a useful helper utility for invoking the child {@link Command}s.
+     * </p>
+     */
+    public void invokeChildCommands() {
+        if (this.childCommands != null) {
+            for (Command childCommand : this.childCommands) {
+                childCommand.invoke();
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Print out the <code>ELCommand</code>.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder("");
+        if (childCommands != null) {
+            buf.append("{\n");
+            Iterator<Command> it = childCommands.iterator();
+            while (it.hasNext()) {
+                buf.append(it.next().toString());
+            }
+            buf.append("}\n");
+        } else {
+            buf.append(";\n");
+        }
+        return buf.toString();
+    }
+
+    /**
+     *
+     */
+    private void setChildCommands(List<Command> commands) {
+        this.childCommands = commands;
+    }
+
+    /**
+     * <p>
+     * This setter method stores the command to be invoked if this command has an "else" clause.
+     * </p>
+     */
+    private void setElseCommand(Command command) {
+        this.elseCommand = command;
+    }
+
+    /**
+     * <p>
+     * This is the request scoped key which will store the child {@link Command} for the currently executing
+     * {@link Command}.
+     * </p>
+     */
+    public static final String COMMAND_KEY = "jsftCommand";
+
+    private static final long serialVersionUID = 6945415932011238909L;
+
+    private List<Command> childCommands = null;
+    private Command elseCommand = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/event/CommandEventListener.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/event/CommandEventListener.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.event;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.AbortProcessingException;
+import jakarta.faces.event.ComponentSystemEvent;
+import jakarta.faces.event.ComponentSystemEventListener;
+
+import java.util.List;
+
+/**
+ * <p>
+ * This class handles the dispatching of events to commands. Currently Commands delegate execution to EL. In the future,
+ * other Command types may be supported.
+ * </p>
+ *
+ * Created March 29, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class CommandEventListener extends Command implements ComponentSystemEventListener {
+
+    /**
+     * <p>
+     * Default constructor needed for serialization.
+     * </p>
+     */
+    public CommandEventListener() {
+    }
+
+    /**
+     * <p>
+     * Primary constructor used. It is neeeded in order to supply a list of commands.
+     * </p>
+     */
+    public CommandEventListener(List<Command> commands) {
+        super(commands, null);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for dispatching the event to the various EL expressions that are listening to this event.
+     * It also stores the Event object in request scope under the key "theEvent" so that it can be accessed easiliy via EL.
+     * For example: <code>util.println(theEvent);</code>
+     * </p>
+     */
+    @Override
+    public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
+
+        // Store the event under the key "theEvent" in case we want to access
+        // it for some reason.
+        FacesContext.getCurrentInstance().getExternalContext().getRequestMap().put("theEvent", event);
+
+        // Execute the child commands
+        invoke();
+    }
+
+    /**
+     * <p>
+     * This is the method responsible for performing the action. It is also responsible for invoking any of its child
+     * commands.
+     * </p>
+     */
+    @Override
+    public Object invoke() throws AbortProcessingException {
+        // Invoke the child commands...
+        invokeChildCommands();
+
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        CommandEventListener that = (CommandEventListener) obj;
+
+        if (hashCode() != that.hashCode()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        if (hash == -1) {
+            StringBuilder builder = new StringBuilder("");
+            List<Command> commands = getChildCommands();
+            if (commands != null) {
+                for (Command command : commands) {
+                    builder.append(command.toString());
+                }
+            }
+            hash = builder.toString().hashCode();
+        }
+        return hash;
+    }
+
+    private transient int hash = -1;
+    private static final long serialVersionUID = 6945415935164238909L;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/event/ELCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/event/ELCommand.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.event;
+
+import jakarta.el.ELContext;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ValueExpression;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.AbortProcessingException;
+
+import java.util.List;
+
+/**
+ * <p>
+ * This class represents a Command that is processed via Unified EL.
+ * </p>
+ *
+ * Created March 31, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class ELCommand extends Command {
+
+    /**
+     * <p>
+     * Default constructor needed for serialization.
+     * </p>
+     */
+    public ELCommand() {
+    }
+
+    /**
+     * <p>
+     * This constructor should be used to create a new <code>ELCommand</code> instance. It expects to be passed an
+     * expression, and optionally a List&lt;Command&gt; that represent <i>child</i> commands.
+     * </p>
+     *
+     * FIXME: Add more documentation on how this works...
+     */
+    public ELCommand(String resultVar, String el, List<Command> childCommands, Command elseCommand) {
+        super(childCommands, elseCommand);
+        this.resultVar = resultVar;
+        this.el = el;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for dispatching the event to the various EL expressions that are listening to this event.
+     * It also stores the Event object in request scope under the key "theEvent" so that it can be accessed easiliy via EL.
+     * For example: <code>util.println(theEvent);</code>
+     * </p>
+     */
+    @Override
+    public Object invoke() throws AbortProcessingException {
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        ELContext elCtx = ctx.getELContext();
+
+        // Store the Command for access inside the expression.
+        // This is useful for loops or other commands which need access to
+        // their child Commands.
+        ctx.getExternalContext().getRequestMap().put(COMMAND_KEY, this);
+
+        // Create expression
+        ExpressionFactory fact = ctx.getApplication().getExpressionFactory();
+        ValueExpression ve = null;
+        Object result = null;
+        if (this.el.length() > 0) {
+            ve = fact.createValueExpression(elCtx, "#{" + this.el + "}", Object.class);
+            // Execute expression
+            result = ve.getValue(elCtx);
+
+            // If we should store the result... do it.
+            if (this.resultVar != null) {
+                ve = fact.createValueExpression(elCtx, "#{" + this.resultVar + "}", Object.class);
+                ve.setValue(elCtx, result);
+            }
+        } else {
+            // Do this since we have no command to execute (which is normally
+            // responsible for doing this)
+            invokeChildCommands();
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * Print out the <code>ELCommand</code>.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder(el);
+        buf.append(super.toString());
+        return buf.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        ELCommand that = (ELCommand) obj;
+
+        if (hashCode() == that.hashCode()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        if (hash == -1) {
+            StringBuilder builder = new StringBuilder(el);
+            List<Command> children = getChildCommands();
+            if (children != null) {
+                for (Command command : children) {
+                    builder.append(command.toString());
+                }
+            }
+            hash = builder.toString().hashCode();
+        }
+        return hash;
+    }
+
+    private String resultVar = null;
+    private String el = null;
+    private transient int hash = -1;
+    private static final long serialVersionUID = 6201115935174238909L;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/facelets/CommandParser.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/facelets/CommandParser.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.facelets;
+
+import com.sun.jsft.util.LogUtil;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This class is responsible for the actual parsing of a template.
+ * </p>
+ *
+ * <p>
+ * This class is intended to read the template one time. Often it may be useful to cache the result as it would be
+ * inefficient to reread a template multiple times. Templates that are generated from this class are intended to be
+ * static and safe to share. However, this class itself is not thread safe.
+ * </p>
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class CommandParser {
+
+    /**
+     * <p>
+     * Constructor which accepts a <code>InputStream</code>.
+     * </p>
+     *
+     * @param stream <code>InputStream</code> for the template.
+     */
+    public CommandParser(InputStream stream) {
+        _inputStream = stream;
+    }
+
+    /**
+     * <p>
+     * Accessor for the <code>InputStream</code>. This comes from the supplied <code>InputStream</code>.
+     * </p>
+     */
+    public InputStream getInputStream() throws IOException {
+        return _inputStream;
+    }
+
+    /**
+     * <p>
+     * Creates the Reader Object.
+     * </p>
+     *
+     * @throws IOException
+     */
+    public void open() throws IOException {
+        if (_reader != null) {
+            // Generally this should not happen, but just in case... start over
+            close();
+        }
+
+// FIXME: It is possible while evaluating the file an #include may need to log a message to the screen!  Provide a callback mechanism to do this in a Template-specific way
+        // Create the reader from the stream
+        _reader = new BufferedReader(new InputStreamReader(new BufferedInputStream(getInputStream())));
+
+        // Initialize the queue we will use to push values back
+        _stack = new Stack<>();
+    }
+
+    /**
+     * <p>
+     * This method closes the stream if it is open. It doesn't throw an exception, instead it logs any exceptions at the
+     * CONFIG level.
+     * </p>
+     */
+    public void close() {
+        try {
+            if (_reader != null) {
+                _reader.close();
+            }
+        } catch (Exception ex) {
+            if (LogUtil.configEnabled(this)) {
+                LogUtil.config("Exception while closing stream.", ex);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the next character.
+     * </p>
+     */
+    public int nextChar() throws IOException {
+        if (!_stack.empty()) {
+            // We have values in the queue
+            return _stack.pop().charValue();
+        }
+        return _reader.read();
+    }
+
+    /**
+     * <p>
+     * This method pushes a character on the read queue so that it will be read next.
+     * </p>
+     */
+    public void unread(int ch) {
+        _stack.push(new Character((char) ch));
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>String</code> of characters from the current position in the file until the given
+     * character (or end of file) is encountered. It will leave the given character in the buffer, so the next character to
+     * be read will be the <code>endingChar</code> or -1.
+     * </p>
+     *
+     * @param endingChar The character to read up to, but not including
+     * @param skipComments <code>true</code> to strip comments.
+     */
+    public String readUntil(int endingChar, boolean skipComments) throws IOException {
+        return readUntil(new int[] { endingChar }, skipComments);
+    }
+
+    /**
+     *
+     */
+    public String readUntil(int[] endingChars, boolean skipComments) throws IOException {
+        if (skipComments) {
+            // In case we start on a comment and should skip it...
+            skipCommentsAndWhiteSpace("");
+        }
+        int tmpch;
+        int next = nextChar();
+        StringBuffer buf = new StringBuffer();
+        while (!isInArray(endingChars, next) && (next != -1)) {
+            switch (next) {
+                case '\'':
+                case '\"':
+                    if (skipComments) {
+                        // In this case, we want to make sure no comments are
+                        // skipped when inside a quote
+                        //
+                        // NOTE: Also means endingChars will not be found in
+                        // a quote.
+                        buf.append((char) next);
+                        buf.append(readUntil(next, false));
+                        buf.append((char) next);
+                        nextChar(); // Throw away the last char read...
+                    } else {
+                        buf.append((char) next);
+                    }
+                    break;
+                case '#':
+                case '/':
+                case '<':
+                    // When reading we want to ignore comments, don't skip
+                    // whitespace, though...
+                    if (skipComments) {
+                        unread(next);
+                        skipCommentsAndWhiteSpace("");
+                        // If same char, read next to prevent infinite loop
+                        // We don't have to go through switch again b/c its
+                        // not the ending char and its not escaped -- so it is
+                        // safe to add.
+                        tmpch = nextChar();
+                        if (next == tmpch) {
+                            buf.append((char) next);
+                        } else {
+                            // We're somewhere different, unread
+                            unread(tmpch);
+                        }
+                    } else {
+                        buf.append((char) next);
+                    }
+                    break;
+                case '\\':
+                    // Escape Character...
+                    next = nextChar();
+                    if (next == 'n') {
+                        // Special case, insert a '\n' character.
+                        buf.append('\n');
+                    } else if (next == 't') {
+                        // Special case, insert a '\t' character.
+                        buf.append('\t');
+                    } else if (next != '\n') {
+                        // add the next char unless it's a return char
+                        buf.append((char) next);
+                    }
+                    break;
+                default:
+                    buf.append((char) next);
+                    break;
+            }
+            next = nextChar();
+        }
+        if (next != -1) {
+            unread(next);
+        }
+
+        // Return the result
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>String</code> of characters from the current position in the file until the given String
+     * (or end of file) is encountered. It will not leave the given String in the buffer, so the next character to be read
+     * will be the character following the given character.
+     * </p>
+     *
+     * @param endingStr The terminating <code>String</code>.
+     * @param skipComments <code>true</code> to ignore comments.
+     */
+    public String readUntil(String endingStr, boolean skipComments) throws IOException {
+        // Sanity Check
+        if ((endingStr == null) || (endingStr.length() == 0)) {
+            return "";
+        }
+
+        // Break String into characters
+        char arr[] = endingStr.toCharArray();
+        int arrlen = arr.length;
+
+        StringBuffer buf = new StringBuffer("");
+        int ch = nextChar(); // Read a char to unread
+        int idx = 1;
+        do {
+            // We didn't find the end, push read values back on queue
+            unread(ch);
+            for (int cnt = idx - 1; cnt > 0; cnt--) {
+                unread(arr[cnt]);
+            }
+
+            // Read until the beginning of the end (maybe)
+            buf.append(readUntil(arr[0], skipComments));
+            // buf.append(arr[0]); // readUntil reads but doesn't return this char
+
+            // Check to see if we are at the end
+            for (idx = 1; idx < arrlen; idx++) {
+                ch = nextChar();
+                if (ch != arr[idx]) {
+                    // This is not the end!
+                    break;
+                }
+            }
+        } while ((ch != -1) && (idx < arrlen));
+
+        // Append the remaining characters (use idx in case we hit eof)...
+        for (int cnt = 1; cnt < idx; cnt++) {
+            buf.append(arr[cnt]);
+        }
+
+        if (arrlen != idx) {
+            // Didn't find it!
+            throw new IllegalStateException("Unable to find: '" + endingStr + "'.  Read to EOF and gave up.  Read: \n" + buf.toString());
+        }
+
+        // Return the result
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method skips the given String of characters (usually used to skip white space. The contents of the String that
+     * is skipped is lost. Often you may wish to skip comments as well, use
+     * {@link CommandParser#skipCommentsAndWhiteSpace(String)} in this case.
+     * </p>
+     *
+     * @param skipChars The white space characters to skip.
+     *
+     * @see CommandParser#skipCommentsAndWhiteSpace(String)
+     */
+    public void skipWhiteSpace(String skipChars) throws IOException {
+        int next = nextChar();
+        while ((next != -1) && (skipChars.indexOf(next) != -1)) {
+            // Skip...
+            next = nextChar();
+        }
+
+        // This will skip one too many
+        unread(next);
+    }
+
+    /**
+     * <p>
+     * Normally you don't just want to skip white space, you also want to skip comments. This method allows you to do that.
+     * It skips comments of the following types:
+     * </p>
+     *
+     * <code>
+     *        <ul><li>//        -   Comment extends to the rest of the line.</li>
+     *        <li>#        -   Comment extends to the rest of the line.</li>
+     *        <li>/*        -   Comment extends until closing '*' and '/'.</li>
+     *        <li>&lt;!-- -   Comment extends until closing --&gt;.</li></ul>
+     *    </code>
+     *
+     * @param skipChars The white space characters to skip
+     *
+     * @see CommandParser#skipWhiteSpace(String)
+     */
+    public void skipCommentsAndWhiteSpace(String skipChars) throws IOException {
+        int ch = 0;
+        while (ch != -1) {
+            ch = nextChar();
+            switch (ch) {
+                case '#':
+                    // Skip rest of line
+                    readLine();
+                    break;
+                case '/':
+                    ch = nextChar();
+                    if (ch == '/') {
+                        // Skip rest of line
+                        readLine();
+                    } else if (ch == '*') {
+                        // Throw away everything until '*' & '/'.
+                        readUntil("*/", false);
+                        nextChar(); // Throw away the last char read...
+                    } else {
+                        // Not a comment, don't read
+                        unread(ch);
+                        unread('/');
+                        ch = -1; // Exit loop
+                    }
+                    break;
+                case '<':
+                    ch = nextChar(); // !
+                    if (ch == '!') {
+                        ch = nextChar(); // -
+                        if (ch == '-') {
+                            ch = nextChar(); // -
+                            if (ch == '-') {
+                                // Ignore HTML-style comment
+                                readUntil("-->", false);
+                                nextChar(); // Throw away the last char read...
+                            } else {
+                                // Not a comment, probably a mistake... lets
+                                // throw an exception
+                                unread(ch);
+                                unread('-');
+                                unread('!');
+                                unread('<');
+                                throw new IllegalArgumentException(
+                                        "Invalid " + "comment!  Expected comment to begin " + "with \"<!--\", but found: " + readLine());
+                            }
+                        } else {
+                            // Not a comment, probably an event.. back out
+                            unread(ch);
+                            unread('!');
+                            unread('<');
+                            ch = -1; // Cause loop to end
+                        }
+                    } else {
+                        // '!' not found, not a comment... we shouldn't be here
+                        // skipping this back out
+                        unread(ch);
+                        unread('<');
+                        ch = -1; // Cause loop to end
+                    }
+                    break;
+                case -1: // Ignore this case
+                    break;
+                default:
+                    // See if this is white space...
+                    if (skipChars.indexOf(ch) == -1) {
+                        // Nope... we're done skipping (undo last read)
+                        unread(ch);
+                        ch = -1; // Exit loop
+                    }
+                    break;
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method reads the rest of the line. This can be used to read entire lines (obviously), or as a means of skipping
+     * the remainder of a line (i.e. to ignore line comments).
+     * </p>
+     */
+    public String readLine() throws IOException {
+        StringBuffer buf = new StringBuffer();
+        int ch = -1;
+        while (!_stack.empty()) {
+            // We have values in the queue
+            ch = _stack.pop().charValue();
+            if ((ch == '\r') || (ch == '\n')) {
+                // We hit the EOL...
+                // Check to see if there are 2...
+                if (!_stack.empty()) {
+                    ch = _stack.peek().charValue();
+                    if ((ch == '\r') || (ch == '\n')) {
+                        // Remove this one too...
+                        _stack.pop().charValue();
+                    }
+                }
+                return buf.toString();
+            }
+            buf.append((char) ch);
+        }
+
+        // Read the rest of the line
+        buf.append(_reader.readLine());
+
+        int idx = buf.indexOf("\\n");
+        while (idx != -1) {
+            // Replace '\\n' with '\n'
+            buf.replace(idx, idx + 2, "\n");
+            idx = buf.indexOf("\\n", idx + 1);
+        }
+
+        // Check to see if '\' character is at eol, if so read next line too
+        int lastChar = buf.length() - 1;
+        if ((lastChar >= 0) && (buf.charAt(lastChar) == '\\')) {
+            buf.deleteCharAt(lastChar);
+            buf.append(readLine());
+        }
+
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * Simple check to see if the given <code>val</code> exists in <code>arr</code>.
+     * </p>
+     */
+    private boolean isInArray(int[] arr, int val) {
+        int len = arr.length;
+        for (int idx = 0; idx < len; idx++) {
+            if (arr[idx] == val) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Constants
+    //////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This String constant defines the characters that are interpretted to be basic white space characters. The value of
+     * this is:
+     * </p>
+     *
+     * <p>
+     * <ul>
+     * <li><code>" \t\r\n"</code></li>
+     * </ul>
+     * </p>
+     */
+    public static final String SIMPLE_WHITE_SPACE = " \t\r\n";
+
+    private InputStream _inputStream = null;
+    private transient BufferedReader _reader = null;
+    private transient Stack<Character> _stack = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/facelets/CommandReader.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/facelets/CommandReader.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.facelets;
+
+import com.sun.jsft.event.Command;
+import com.sun.jsft.event.ELCommand;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class is responsible for reading in all the commands for the given String. The String typically is passed in
+ * from the body content of event.
+ * </p>
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class CommandReader {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public CommandReader(String str) {
+        this(new ByteArrayInputStream(("{" + CommandReader.unwrap(str) + "}").getBytes()));
+    }
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param stream The <code>InputStream</code> for the {@link Command}.
+     */
+    protected CommandReader(InputStream stream) {
+        _parser = new CommandParser(stream);
+    }
+
+    /**
+     * <p>
+     * The read method uses the {@link CommandParser} to parses the template. It populates a {@link LayoutDefinition}
+     * structure, which is returned.
+     * </p>
+     *
+     * @return The {@link LayoutDefinition}
+     *
+     * @throws IOException
+     */
+    public List<Command> read() throws IOException {
+        // Start...
+        _parser.open();
+
+        try {
+            // Populate the LayoutDefinition from the Document
+            return readCommandList();
+        } finally {
+            _parser.close();
+        }
+    }
+
+    /**
+     *
+     */
+// FIXME: Parenthesis are not well supported.  When convertKeywords is called,
+// FIXME: it receivces "(foo...)".  First foo() is not recognized because of
+// FIXME: the leading '('.  Second, there is a good possibility that other
+// FIXME: keywords may exist in the middle of the string.  Need to rethink how
+// FIXME: this conversion is done.
+    private Command readCommand() throws IOException {
+        // Skip White Space...
+        _parser.skipCommentsAndWhiteSpace(CommandParser.SIMPLE_WHITE_SPACE);
+
+        // Read the next Command
+        String commandLine = _parser.readUntil(new int[] { ';', '{', '}' }, true);
+
+        // Read the children
+        int ch = _parser.nextChar();
+        List<Command> commandChildren = null;
+        if (ch == '{') {
+            // Read the Command Children
+            commandChildren = readCommandList();
+        } else if (ch == '}') {
+            _parser.unread(ch);
+        }
+
+        // Check to see if there is a variable to store the result...
+        String variable = null;
+        int idx = indexOf((byte) '=', commandLine);
+        if (idx != -1) {
+            // We have a result variable, store it separately...
+            variable = commandLine.substring(0, idx).trim();
+            commandLine = commandLine.substring(++idx).trim();
+        }
+
+        // If "if" handle "else" if present
+        Command elseCommand = null;
+        if (commandLine.startsWith("if")) {
+            // First convert "if" to the real if handler...
+            commandLine = "jsft._if" + commandLine.substring(2);
+
+            // Check the next few characters to see if they are "else"...
+            _parser.skipCommentsAndWhiteSpace(CommandParser.SIMPLE_WHITE_SPACE);
+            int next[] = new int[] { _parser.nextChar(), _parser.nextChar(), _parser.nextChar(), _parser.nextChar(), _parser.nextChar() };
+            if ((next[0] == 'e') && (next[1] == 'l') && (next[2] == 's') && (next[3] == 'e') && (Character.isWhitespace((char) next[4]))) {
+                // This is an else case, parse it...
+                elseCommand = readCommand();
+            } else {
+                // Not an else, restore the parser state
+                for (idx = 4; idx > -1; idx--) {
+                    if (next[idx] != -1) {
+                        _parser.unread(next[idx]);
+                    }
+                }
+            }
+        }
+
+        // Create the Command
+        Command command = null;
+        if ((commandLine.length() > 0) || (commandChildren != null)) {
+            command = new ELCommand(variable, convertKeywords(commandLine), commandChildren, elseCommand);
+        }
+
+        // Return the LayoutElement
+        return command;
+    }
+
+    /**
+     * <p>
+     * This method replaces keywords with the "real" syntax for developer convenience.
+     * </p>
+     */
+    private String convertKeywords(String exp) {
+        if (exp == null) {
+            return null;
+        }
+
+        // Get the key to lookup
+        String key = exp;
+        int paren = exp.indexOf(OPEN_PAREN);
+        if (paren != -1) {
+            key = exp.substring(0, paren);
+            if (key.indexOf(".") != -1) {
+                // '.' found, this is not a keyword...
+                return exp;
+            }
+        }
+        key = key.trim();
+
+        // Check for mapping...
+        String value = _reservedMappings.get(key);
+        if (value != null) {
+            exp = value + exp.substring(key.length());
+        }
+
+        return exp;
+    }
+
+    /**
+     * <p>
+     * This method looks for the given <code>char</code> in the given <code>String</code>. It will not match any values that
+     * are found within parenthesis or quotes.
+     * </p>
+     */
+    private int indexOf(byte ch, String str) {
+        byte[] bytes = str.getBytes();
+
+        int idx = 0;
+        int insideChar = -1;
+        for (byte curr : bytes) {
+            if (insideChar == -1) {
+                // Not inside anything...
+                if (ch == curr) {
+                    break;
+                } else if (('\'' == curr) || ('"' == curr)) {
+                    insideChar = curr;
+                } else if (OPEN_PAREN == curr) {
+                    insideChar = CLOSE_PAREN;
+                } else if (OPEN_BRACKET == curr) {
+                    insideChar = CLOSE_BRACKET;
+                }
+            } else if (insideChar == curr) {
+                // Was inside something, ending now...
+                insideChar = -1;
+            }
+            idx++;
+        }
+
+        // If we found it return it, otherwise return -1
+        if (idx >= bytes.length) {
+            idx = -1;
+        }
+        return idx;
+    }
+
+    /**
+     * <p>
+     * This method reads Commands until a closing '}' is encountered.
+     * </p>
+     */
+    private List<Command> readCommandList() throws IOException {
+        int ch = _parser.nextChar();
+        List<Command> commands = new ArrayList<>();
+        Command command = null;
+        while (ch != '}') {
+            // Make sure readCommand gets the full command line...
+            if (ch != '{') {
+                // We want to throw this char away...
+                _parser.unread(ch);
+            }
+
+            // Read a Command
+            command = readCommand();
+            if (command != null) {
+                commands.add(command);
+            }
+
+            // Skip White Space...
+            _parser.skipCommentsAndWhiteSpace(CommandParser.SIMPLE_WHITE_SPACE);
+
+            // Get the next char...
+            ch = _parser.nextChar();
+            if (ch == -1) {
+                throw new IOException("Unexpected end of stream! Expected to find '}'.");
+            }
+        }
+
+        // Return the Commands
+        return commands;
+    }
+
+    /**
+     * <p>
+     * This function removes the containing CDATA tags, if found.
+     * </p>
+     */
+    private static String unwrap(String str) {
+        str = str.trim();
+        if (str.startsWith(OPEN_CDATA)) {
+            int endingIdx = str.lastIndexOf(CLOSE_CDATA);
+            if (endingIdx != -1) {
+                // Remove the CDATA wrapper
+                str = str.substring(OPEN_CDATA.length(), endingIdx);
+            }
+        }
+        return str;
+    }
+
+    // Map to hold shortcut mappings (e.g. keywords)
+    private static Map<String, String> _reservedMappings = new HashMap<>(16);
+    static {
+        _reservedMappings.put("foreach", "jsft.foreach");
+        _reservedMappings.put("for", "jsft._for");
+        _reservedMappings.put("println", "jsft.println");
+        _reservedMappings.put("write", "jsft.write");
+        _reservedMappings.put("setAttribute", "jsft.setAttribute");
+        _reservedMappings.put("responseComplete", "jsft.responseComplete");
+        _reservedMappings.put("renderResponse", "jsft.renderResponse");
+        _reservedMappings.put("printStackTrace", "jsft.printStackTrace");
+        _reservedMappings.put("getNanoTime", "jsft.getNanoTime");
+    }
+
+    private static final char OPEN_BRACKET = '[';
+    private static final char CLOSE_BRACKET = ']';
+    private static final char OPEN_PAREN = '(';
+    private static final char CLOSE_PAREN = ')';
+    private static final String OPEN_CDATA = "<![CDATA[";
+    private static final String CLOSE_CDATA = "]]>";
+
+    private CommandParser _parser = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/facelets/EventHandler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/facelets/EventHandler.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.facelets;
+
+import com.sun.jsft.event.Command;
+import com.sun.jsft.event.CommandEventListener;
+import com.sun.jsft.util.Util;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.event.PostAddToViewEvent;
+import jakarta.faces.event.PostConstructViewMapEvent;
+import jakarta.faces.event.PostRestoreStateEvent;
+import jakarta.faces.event.PostValidateEvent;
+import jakarta.faces.event.PreDestroyViewMapEvent;
+import jakarta.faces.event.PreRemoveFromViewEvent;
+import jakarta.faces.event.PreRenderComponentEvent;
+import jakarta.faces.event.PreRenderViewEvent;
+import jakarta.faces.event.PreValidateEvent;
+import jakarta.faces.event.SystemEvent;
+import jakarta.faces.view.facelets.ComponentHandler;
+import jakarta.faces.view.facelets.FaceletContext;
+import jakarta.faces.view.facelets.TagAttribute;
+import jakarta.faces.view.facelets.TagConfig;
+import jakarta.faces.view.facelets.TagHandler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This is the TagHandler for the jsft:event tag.
+ * </p>
+ *
+ * Created March 29, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class EventHandler extends TagHandler {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public EventHandler(TagConfig config) {
+        super(config);
+
+        this.type = this.getRequiredAttribute("type");
+        if (!(config.getNextHandler().getClass().getName().equals("com.sun.faces.facelets.compiler.UIInstructionHandler"))) {
+            // This occurs when an empty jsft:event tag is used... ignore
+            return;
+        }
+
+        // Create a CommandReader
+        CommandReader reader = new CommandReader(config.getNextHandler().toString());
+
+        // Read the Commands
+        try {
+            commands = reader.read();
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to parse Commands for event type '" + type + "'.", ex);
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for queueing up the EL that should be invoked when the event is fired.
+     * </p>
+     */
+    @Override
+    public void apply(FaceletContext ctx, UIComponent parent) throws IOException {
+        if (ComponentHandler.isNew(parent)) {
+            Class<? extends SystemEvent> eventClass = getEventClass(ctx);
+            // ensure that f:event can be used anywhere on the page for
+            // these events, not just as a direct child of the viewRoot
+            if ((PreRenderViewEvent.class == eventClass) || (PostConstructViewMapEvent.class == eventClass)
+                    || (PreDestroyViewMapEvent.class == eventClass)) {
+                parent = ctx.getFacesContext().getViewRoot();
+            }
+            if ((eventClass != null) && (parent != null)) {
+                parent.subscribeToEvent(eventClass, new CommandEventListener(this.commands));
+            }
+        } else {
+            // already done...
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the event <code>Class</code>. Many event types have short aliases that are recognized by this
+     * method, others may need the fully qualified classname. The supported types are:
+     * </p>
+     *
+     * <ul>
+     * <li>afterCreate</li>
+     * <li>afterCreateView</li>
+     * <li>afterValidate</li>
+     * <li>beforeEncode</li>
+     * <li>beforeEncodeView
+     * <li>
+     * <li>beforeValidate</li>
+     * <li>preRenderComponent</li>
+     * <li>jakarta.faces.event.PreRenderComponent</li>
+     * <li>preRenderView</li>
+     * <li>jakarta.faces.event.PreRenderView</li>
+     * <li>postAddToView</li>
+     * <li>jakarta.faces.event.PostAddToView</li>
+     * <li>preValidate</li>
+     * <li>jakarta.faces.event.PreValidate</li>
+     * <li>postValidate</li>
+     * <li>jakarta.faces.event.PostValidate</li>
+     * <li>preRemoveFromView</li>
+     * <li>jakarta.faces.event.PreRemoveFromViewEvent</li>
+     * <li>postRestoreState</li>
+     * <li>jakarta.faces.event.PostRestoreStateEvent</li>
+     * <li>postConstructViewMap</li>
+     * <li>jakarta.faces.event.PostConstructViewMapEvent</li>
+     * <li>preDestroyViewMap</li>
+     * <li>jakarta.faces.event.PreDestroyViewMapEvent</li>
+     * </ul>
+     *
+     * @param ctx The <code>FaceletContext</code>.
+     *
+     * @return The <code>SystemEvent</code> class associated with the event type.
+     */
+    protected Class<? extends SystemEvent> getEventClass(FaceletContext ctx) {
+        String eventType = (String) this.type.getValueExpression(ctx, String.class).getValue(ctx);
+        if (eventType == null) {
+            throw new FacesException("Attribute 'type' can not be null!");
+        }
+
+        // Check the pre-defined types / aliases
+        Class cls = eventAliases.get(eventType);
+
+        if (cls == null) {
+            // Not found, try reflection...
+            try {
+                cls = Util.loadClass(eventType, eventType);
+            } catch (ClassNotFoundException ex) {
+                throw new FacesException("Invalid event type: " + eventType, ex);
+            }
+        }
+
+        // Return the result...
+        return cls;
+    }
+
+    /**
+     * <p>
+     * Print out the <code>Command</code>.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder("");
+        Iterator<Command> it = commands.iterator();
+        while (it.hasNext()) {
+            buf.append(it.next().toString());
+        }
+        return buf.toString();
+    }
+
+    private static Map<String, Class<? extends SystemEvent>> eventAliases = new HashMap<>(20);
+    static {
+        eventAliases.put("beforeEncode", PreRenderComponentEvent.class);
+        eventAliases.put("preRenderComponent", PreRenderComponentEvent.class);
+        eventAliases.put("jakarta.faces.event.PreRenderComponent", PreRenderComponentEvent.class);
+
+        eventAliases.put("beforeEncodeView", PreRenderViewEvent.class);
+        eventAliases.put("preRenderView", PreRenderViewEvent.class);
+        eventAliases.put("jakarta.faces.event.PreRenderView", PreRenderViewEvent.class);
+
+        eventAliases.put("afterCreate", PostAddToViewEvent.class);
+        eventAliases.put("postAddToView", PostAddToViewEvent.class);
+        eventAliases.put("jakarta.faces.event.PostAddToView", PostAddToViewEvent.class);
+
+        eventAliases.put("afterCreateView", PostRestoreStateEvent.class);
+        eventAliases.put("postRestoreState", PostRestoreStateEvent.class);
+        eventAliases.put("jakarta.faces.event.PostRestoreStateEvent", PostRestoreStateEvent.class);
+
+        eventAliases.put("beforeValidate", PreValidateEvent.class);
+        eventAliases.put("preValidate", PreValidateEvent.class);
+        eventAliases.put("jakarta.faces.event.PreValidate", PreValidateEvent.class);
+
+        eventAliases.put("afterValidate", PostValidateEvent.class);
+        eventAliases.put("postValidate", PostValidateEvent.class);
+        eventAliases.put("jakarta.faces.event.PostValidate", PostValidateEvent.class);
+
+        eventAliases.put("preRemoveFromView", PreRemoveFromViewEvent.class);
+        eventAliases.put("jakarta.faces.event.PreRemoveFromViewEvent", PreRemoveFromViewEvent.class);
+        eventAliases.put("postConstructViewMap", PostConstructViewMapEvent.class);
+        eventAliases.put("jakarta.faces.event.PostConstructViewMapEvent", PostConstructViewMapEvent.class);
+        eventAliases.put("preDestroyViewMap", PreDestroyViewMapEvent.class);
+        eventAliases.put("jakarta.faces.event.PreDestroyViewMapEvent", PreDestroyViewMapEvent.class);
+        /*
+         * FIXME: Look at supporting these too... Non component, system events: postConstructApplication ActionEvent... hmm...
+         * ValueChangedEvent exceptionQueued BehaviorEvent - AjaxBehaviorEvent
+         */
+    }
+
+    protected final TagAttribute type;
+    protected List<Command> commands = new ArrayList<>(5);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/DefaultTaskManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/DefaultTaskManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.tasks;
+
+import jakarta.faces.event.SystemEvent;
+import jakarta.faces.event.SystemEventListener;
+
+import java.util.List;
+
+/**
+ * <p>
+ * This is the default {@link TaskManager} implementation.
+ * </p>
+ */
+public class DefaultTaskManager extends TaskManager {
+
+    /**
+     * <p>
+     * Default constructor.
+     * </p>
+     */
+    protected DefaultTaskManager() {
+        super();
+    }
+
+    /**
+     * <p>
+     * This method is responsible for executing the queued Tasks. It is possible this method may be called more than once
+     * (not common), so care should be taken to ensure this is handled appropriately. This method is normally executed after
+     * the page (excluding DefferedFragments, of course) have been rendered.
+     * </p>
+     */
+    @Override
+    public void start() {
+        System.out.println("Starting to execute Tasks: " + getTasks());
+        // Loop through the tasks and execute them...
+        for (Task task : getTasks()) {
+// FIXME: This implementation is a no-op, it just loops through the tasks and fires the TASK_COMPLETE event.
+// FIXME: A real implementation would aggregate & dispatch the tasks and register listeners with the "backend dispatcher" which would fire the TASK_COMPLETE event.
+// FIXME: This method should not block.
+            SystemEvent event = new TaskEvent(task);
+            List<SystemEventListener> listeners = task.getListeners(TaskEvent.TASK_COMPLETE);
+            if (listeners != null) {
+                for (SystemEventListener listener : listeners) {
+                    listener.processEvent(event);
+                }
+            }
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/Task.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/Task.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.tasks;
+
+import jakarta.faces.event.SystemEventListener;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class holds the representation of a single task.
+ * </p>
+ */
+public class Task {
+
+    /**
+     * <p>
+     * Default constructor.
+     * </p>
+     */
+    public Task() {
+        super();
+    }
+
+    /**
+     * <p>
+     * Constructor w/ <code>name</code>.
+     * </p>
+     */
+    public Task(String name) {
+        this();
+        setName(name);
+    }
+
+    /**
+     * <p>
+     * The name used to identify the task. In some instances, the name may define the task (i.e. EL).
+     * </p>
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     */
+    public List<SystemEventListener> getListeners(String type) {
+        if (type == null) {
+            type = DEFAULT_EVENT_TYPE;
+        }
+        return listenersByType.get(type);
+    }
+
+    /**
+     *
+     */
+    public void setListeners(String type, List<SystemEventListener> listeners) {
+        if (type == null) {
+            type = DEFAULT_EVENT_TYPE;
+        }
+        listenersByType.put(type, listeners);
+    }
+
+    // The identifier for this Task
+    private String name = "";
+
+    // Map of List to store the events by type
+    private Map<String, List<SystemEventListener>> listenersByType = new HashMap<>(2);
+
+    /**
+     * <p>
+     * The default event type.
+     * </p>
+     */
+    public static final String DEFAULT_EVENT_TYPE = TaskEvent.TASK_COMPLETE;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/TaskEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/TaskEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.tasks;
+
+import jakarta.faces.event.SystemEvent;
+
+/**
+ * <p>
+ * This event is used for dispatching {@link Task} related events.
+ * </p>
+ */
+public class TaskEvent extends SystemEvent {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public TaskEvent(Task source) {
+        super(source);
+    }
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public TaskEvent(Task source, String type) {
+        super(source);
+        if (type != null) {
+            this.type = type;
+        }
+    }
+
+    /**
+     * <p>
+     * Returns the event sub-type.
+     * </p>
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * <p>
+     * This event's sub-type, which defaults to {@link TASK_COMPLETE}.
+     * </p>
+     */
+    private String type = TASK_COMPLETE;
+
+    /**
+     * <p>
+     * The sub-type used when a {@link Task} has completed.
+     * </p>
+     */
+    public static final String TASK_COMPLETE = "taskComplete";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/TaskManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/tasks/TaskManager.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.tasks;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.SystemEventListener;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * To get an instance of this class, use {@link #getInstance()}. This will check the
+ * "<code>com.sun.jsft.TASK_MANAGER</code>" <code>web.xml</code> <code>context-param</code> to find the correct
+ * implementation to use. If not specified, it will use the {@link DefaultTaskManager}. Alternatively, you can invoke
+ * "setTaskManager(TaskManager)" directly to specify the desired implementation.
+ * </p>
+ */
+public abstract class TaskManager {
+
+    /**
+     * <p>
+     * Default constructor.
+     * </p>
+     */
+    public TaskManager() {
+        super();
+    }
+
+    /**
+     * <p>
+     * This method is responsible for executing the queued Tasks. It is possible this method may be called more than once
+     * (not common), so care should be taken to ensure this is handled appropriately. This method is normally executed after
+     * the page (excluding DefferedFragments, of course) have been rendered.
+     * </p>
+     */
+    public abstract void start();
+
+    /**
+     * <p>
+     * This method locates or creates the TaskManager instance associated with this request.
+     * </p>
+     */
+    public static TaskManager getInstance() {
+        // See if we already calculated the TaskManager for this request
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        TaskManager taskManager = null;
+        Map<String, Object> requestMap = null;
+        if (ctx != null) {
+            requestMap = ctx.getExternalContext().getRequestMap();
+            taskManager = (TaskManager) requestMap.get(TASK_MANAGER);
+        }
+        if (taskManager == null) {
+            Map initParams = ctx.getExternalContext().getInitParameterMap();
+            String className = (String) initParams.get(IMPL_CLASS);
+            if (className != null) {
+                try {
+                    taskManager = (TaskManager) Class.forName(className).newInstance();
+                } catch (Exception ex) {
+                    throw new RuntimeException(ex);
+                }
+            } else {
+                taskManager = new DefaultTaskManager();
+            }
+            if (requestMap != null) {
+                requestMap.put(TASK_MANAGER, taskManager);
+            }
+        }
+        return taskManager;
+    }
+
+    /**
+     * <p>
+     * This method is provided in case the developer would like to provide their own way to calculate and create the
+     * <code>TaskManager</code> implementation to use.
+     * </p>
+     */
+    public static void setTaskManager(TaskManager taskManager) {
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (ctx != null) {
+            ctx.getExternalContext().getRequestMap().put(TASK_MANAGER, taskManager);
+        } else {
+            throw new RuntimeException("Currently only JSF is supported!  FacesContext not found.");
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for queuing up a <code>task</code> to be performed. The given <code>newListeners</code>
+     * will be fired according to the requested event <code>type</code>. If the <code>type</code> is not specified, it will
+     * default to {@link Task#DEFAULT_EVENT_TYPE} indicating that the given <code>newListeners</code> should be fired at the
+     * completion of the task.
+     * </p>
+     *
+     * <p>
+     * Note: If the <code>task</code> is already queued, it will NOT be performed twice. The <code>newListeners</code> will
+     * be added to the already-queued <code>task</code>.
+     * </p>
+     *
+     * @param task A unique string identifying a task to perform. This is implementation specific to the TaskManager
+     * implementation.
+     *
+     * @param type Optional String identifying the event name within the task in which the given Listeners are associated.
+     * If no type is given, the listeners will be fired at the end of the task ({@link Task#DEFAULT_EVENT_TYPE}).
+     *
+     * @param newListeners The SystemEventListener to be associated with this task and optional type if specified.
+     */
+    public void addTask(String taskName, String type, SystemEventListener... newListeners) {
+// FIXME: Do I want to accept priority too??  Or perhaps that is handled in
+// FIXME: the implementation-specific way tasks are registered?  Or is priority
+// FIXME: only associated with DeferredFragments?
+        Task task = tasks.get(taskName);
+        if (task == null) {
+            // New Task, create and add...
+            task = new Task(taskName);
+            task.setListeners(type, toArrayList(newListeners));
+            tasks.put(taskName, task);
+        } else {
+            // Task already created, add the listeners for this type...
+            List<SystemEventListener> taskListeners = task.getListeners(type);
+            if (taskListeners == null) {
+                task.setListeners(type, toArrayList(newListeners));
+            } else {
+                taskListeners.addAll(toArrayList(newListeners));
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>List&lt;Task&gt;</code>.
+     * </p>
+     */
+    public Collection<Task> getTasks() {
+        return tasks.values();
+    }
+
+    /**
+     * <p>
+     * Convert an array of <code>T</code> to an <code>ArrayList&lt;T&gt;</code>.
+     * </p>
+     */
+    private <T> ArrayList<T> toArrayList(T arr[]) {
+        ArrayList<T> list = new ArrayList<>(arr.length);
+        for (T item : arr) {
+            list.add(item);
+        }
+        return list;
+    }
+
+    /**
+     * <p>
+     * This <code>Map</code> will hold all the Tasks.
+     * </p>
+     */
+    private Map<String, Task> tasks = new HashMap<>(2);
+
+    /**
+     * <p>
+     * The request scope key for holding the TASK_MANAGER instance to make it easily obtained.
+     * </p>
+     */
+    private static final String TASK_MANAGER = "_jsftTM";
+
+    /**
+     * <p>
+     * The web.xml <code>context-param</code> for declaring the implementation of this class to use.
+     * </p>
+     */
+    public static final String IMPL_CLASS = "com.sun.jsft.TASK_MANAGER";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/LogUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/LogUtil.java
@@ -1,0 +1,1059 @@
+/*
+ * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>
+ * This class provides helper methods for logging messages. It uses standard J2SE logging. However, using these API's is
+ * abstracts this away from our code in case we want to go back to Apache commons logging or some other logging API in
+ * the future.
+ * </p>
+ *
+ * <p>
+ * The logging levels follow the J2SE log level names, they are as follows:
+ * </p>
+ *
+ * <ul>
+ * <li>FINEST -- Highly detailed tracing message</li>
+ * <li>FINER -- Fairly detailed tracing message</li>
+ * <li>FINE -- Coarse tracing message</li>
+ * <li>CONFIG -- Static configuration messages</li>
+ * <li>INFO -- Informational messages (logged by default)</li>
+ * <li>WARNING -- Potentially problematic messages</li>
+ * <li>SEVERE -- Serious failure messages</li>
+ * </ul>
+ *
+ * Created March 29, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class LogUtil {
+
+    ////////////////////////////////////////////////////////////
+    // FINEST LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finestEnabled() {
+        return getLogger().isLoggable(Level.FINEST);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finestEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.FINEST);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finest(String msgId, Object... params) {
+        getLogger().log(Level.FINEST, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finest(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.FINEST, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finest(String msg) {
+        finest(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finest(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.FINEST, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finest(String msg, Throwable ex) {
+        getLogger().log(Level.FINEST, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finest(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.FINEST, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // FINER LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finerEnabled() {
+        return getLogger().isLoggable(Level.FINER);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finerEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.FINER);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finer(String msgId, Object... params) {
+        getLogger().log(Level.FINER, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finer(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.FINER, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finer(String msg) {
+        finer(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finer(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.FINER, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finer(String msg, Throwable ex) {
+        getLogger().log(Level.FINER, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finer(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.FINER, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // FINE LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean fineEnabled() {
+        return getLogger().isLoggable(Level.FINE);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean fineEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.FINE);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void fine(String msgId, Object... params) {
+        getLogger().log(Level.FINE, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void fine(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.FINE, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void fine(String msg) {
+        fine(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void fine(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.FINE, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void fine(String msg, Throwable ex) {
+        getLogger().log(Level.FINE, getMessage(msg, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void fine(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.FINE, getMessage(msg, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // CONFIG LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean configEnabled() {
+        return getLogger().isLoggable(Level.CONFIG);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean configEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.CONFIG);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void config(String msgId, Object... params) {
+        getLogger().log(Level.CONFIG, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void config(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.CONFIG, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void config(String msg) {
+        config(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void config(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.CONFIG, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void config(String msg, Throwable ex) {
+        getLogger().log(Level.CONFIG, getMessage(msg, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void config(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.CONFIG, getMessage(msg, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // INFO LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean infoEnabled() {
+        return getLogger().isLoggable(Level.INFO);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean infoEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.INFO);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The default Logger will be used.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(String msgId) {
+        getLogger().log(Level.INFO, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(Object loggerId, String msgId) {
+        getLogger(loggerId).log(Level.INFO, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(String msgId, Object... params) {
+        getLogger().log(Level.INFO, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.INFO, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(String msgId, Throwable ex) {
+        getLogger().log(Level.INFO, getMessage(msgId, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(Object loggerId, String msgId, Throwable ex) {
+        getLogger(loggerId).log(Level.INFO, getMessage(msgId, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // WARNING LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean warningEnabled() {
+        return getLogger().isLoggable(Level.WARNING);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean warningEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.WARNING);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The default Logger will be used.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(String msgId) {
+        getLogger().log(Level.WARNING, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(Object loggerId, String msgId) {
+        getLogger(loggerId).log(Level.WARNING, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(String msgId, Object... params) {
+        getLogger().log(Level.WARNING, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.WARNING, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(String msgId, Throwable ex) {
+        getLogger().log(Level.WARNING, getMessage(msgId, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(Object loggerId, String msgId, Throwable ex) {
+        getLogger(loggerId).log(Level.WARNING, getMessage(msgId, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // SEVERE LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean severeEnabled() {
+        return getLogger().isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean severeEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The default Logger will be used.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(String msgId) {
+        getLogger().log(Level.SEVERE, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(Object loggerId, String msgId) {
+        getLogger(loggerId).log(Level.SEVERE, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(String msgId, Object... params) {
+        getLogger().log(Level.SEVERE, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.SEVERE, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(String msgId, Throwable ex) {
+        getLogger().log(Level.SEVERE, getMessage(msgId, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(Object loggerId, String msgId, Throwable ex) {
+        getLogger(loggerId).log(Level.SEVERE, getMessage(msgId, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Misc methods
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This method provides direct access to the default Logger. It is private because the internals of what type of logger
+     * is being used should not be exposed outside this class.
+     * </p>
+     */
+    private static Logger getLogger() {
+        return DEFAULT_LOGGER;
+    }
+
+    /**
+     * <p>
+     * This method provides direct access to the Logger. It is private because the internals of what type of logger is being
+     * used should not be exposed outside this class.
+     * </p>
+     *
+     * <p>
+     * This method will return the default logger (if INFO), or delegate to {@link #getLogger(String)} or
+     * {@link #getLogger(Class)}.
+     * </p>
+     *
+     * @param key The logger to use as specified by the Object.
+     */
+    private static Logger getLogger(Object key) {
+        // If null, use default
+        if (key == null) {
+            return getLogger();
+        }
+
+        // If string, use it as logger name
+        if (key instanceof String) {
+            return getLogger((String) key);
+        }
+
+        // If Log, return it
+        if (key instanceof Logger) {
+            return (Logger) key;
+        }
+
+        // If class, use it
+        if (key instanceof Class) {
+            return getLogger((Class) key);
+        }
+
+        // else, use the class name
+        return getLogger(key.getClass());
+    }
+
+    /**
+     * <p>
+     * This method provides direct access to the Logger. It is private because the internals of what type of logger is being
+     * used should not be exposed outside this class.
+     * </p>
+     *
+     * @param key The logger to use as specified by the String.
+     */
+    private static Logger getLogger(String key) {
+        if (key.trim().length() == 0) {
+            return DEFAULT_LOGGER;
+        }
+        return Logger.getLogger(key);
+    }
+
+    /**
+     * <p>
+     * This method provides direct access to the Logger. It is private because the internals of what type of logger is being
+     * used should not be exposed outside this class.
+     * </p>
+     *
+     * @param key The logger to use as specified by the Class.
+     */
+    private static Logger getLogger(Class key) {
+        if (key == null) {
+            return DEFAULT_LOGGER;
+        }
+        return Logger.getLogger(key.getName());
+    }
+
+    /**
+     * <p>
+     * This method gets the appropriate message to display. It will attempt to resolve it from the
+     * <code>ResourceBundle</code>. If not found and it will either use the message id as the key, or it will return an
+     * error message depending on whether <code>strict</code> is true or false.
+     * </p>
+     *
+     * @param msgId The message key
+     * @param strict True if key not found should be an error
+     *
+     * @return The message to write to the log file.
+     */
+    private static String getMessage(String msgId, boolean strict) {
+        return getMessage(msgId, new Object[0], strict);
+    }
+
+    /**
+     * <p>
+     * This method gets the appropriate message to display. It will attempt to resolve it from the
+     * <code>ResourceBundle</code>. If not found and it will either use the message id as the key, or it will return an
+     * error message depending on whether <code>strict</code> is true or false.
+     * </p>
+     *
+     * @param msgId The message key
+     * @param params The parameters
+     * @param strict True if key not found should be an error
+     *
+     * @return The message to write to the log file.
+     */
+    private static String getMessage(String msgId, Object[] params, boolean strict) {
+        String result = MessageUtil.getInstance().getMessage(BUNDLE_NAME, msgId, params);
+        if ((result == null) || result.equals(msgId)) {
+            // We didn't find the key...
+            if (strict) {
+                // A key is required, return an error message
+                if ((msgId != null) && msgId.equals(KEY_NOT_FOUND_KEY)) {
+                    // This is here to prevent and infinite loop
+                    result = KEY_NOT_FOUND_KEY + LOG_KEY_MESSAGE_SEPARATOR + "'" + params[0] + "' not found in ResourceBundle: '"
+                            + BUNDLE_NAME + "'";
+                } else {
+                    result = getMessage(KEY_NOT_FOUND_KEY, new Object[] { msgId }, strict);
+                }
+            } else {
+                // Use the msgId as the message, use the default key
+                result = DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msgId;
+            }
+        } else {
+            // We found the key, construct the log format...
+            result = msgId + LOG_KEY_MESSAGE_SEPARATOR + result;
+        }
+
+        // Return the formatted result
+        return result;
+    }
+
+    /**
+     * <p>
+     * This is the bundle name for the <code>ResourceBundle</code> that contains all the message strings.
+     * </p>
+     */
+    public static final String BUNDLE_NAME = "com.sun.jsft.LogMessages";
+
+    /**
+     * <p>
+     * This is the default log key.
+     * </p>
+     */
+    public static final String DEFAULT_LOG_KEY = "JSFT0001";
+
+    /**
+     * <p>
+     * This is the default logger name.
+     * </p>
+     */
+    public static final String DEFAULT_LOGGER_NAME = "com.sun.jsft";
+
+    /**
+     * <p>
+     * This key is used when the requested key is not found to inform the developer they forgot to add a key.
+     * </p>
+     */
+    public static final String KEY_NOT_FOUND_KEY = "JSFT0002";
+
+    /**
+     * <p>
+     * The default Logger.
+     * </p>
+     */
+    private static final Logger DEFAULT_LOGGER = getLogger(DEFAULT_LOGGER_NAME);
+
+    /**
+     * <p>
+     * This is the separator between the the log key and log message.
+     * </p>
+     */
+    private static final String LOG_KEY_MESSAGE_SEPARATOR = ": ";
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/MessageUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/MessageUtil.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * <p>
+ * This class gets ResourceBundle messages and formats them.
+ * </p>
+ *
+ * Created March 29, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class MessageUtil extends Object {
+
+    /**
+     * <p>
+     * This class should not be instantiated directly.
+     * </p>
+     */
+    private MessageUtil() {
+    }
+
+    /**
+     * <p>
+     * Use this to get an instance of this class.
+     * </p>
+     */
+    public static MessageUtil getInstance() {
+        return _instance;
+    }
+
+    /**
+     * <p>
+     * This method returns a formatted String from the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param baseName The <code>ResourceBundle</code> name.
+     * @param key The <code>ResourceBundle</code> key.
+     */
+    public String getMessage(String baseName, String key) {
+        return getMessage(baseName, key, null);
+    }
+
+    /**
+     * <p>
+     * This method returns a formatted String from the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param baseName The <code>ResourceBundle</code> name.
+     * @param key The <code>ResourceBundle</code> key.
+     * @param args The substitution values (may be null).
+     */
+    public String getMessage(String baseName, String key, Object args[]) {
+        return getMessage(null, baseName, key, args);
+    }
+
+    /**
+     * <p>
+     * This method returns a formatted String from the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param locale The desired <code>Locale</code> (may be null).
+     * @param baseName The <code>ResourceBundle</code> name.
+     * @param key The <code>ResourceBundle</code> key.
+     * @param args The substitution values (may be null).
+     */
+    public String getMessage(Locale locale, String baseName, String key, Object args[]) {
+        if (key == null) {
+            return null;
+        }
+        if (baseName == null) {
+            throw new RuntimeException("'baseName' is null for key '" + key + "'!");
+        }
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (locale == null) {
+            locale = Util.getLocale(ctx);
+        }
+
+        // Get the ResourceBundle
+        ResourceBundle bundle = ResourceBundleManager.getInstance(ctx).getBundle(baseName, locale);
+        if (bundle == null) {
+            // FIXME: Log a warning
+            return key;
+        }
+
+        String message = null;
+        try {
+            message = bundle.getString(key);
+        } catch (MissingResourceException ex) {
+            // Key not found!
+            // FIXME: Log a warning
+        }
+        if (message == null) {
+            // No message found?
+            return key;
+        }
+
+        return getFormattedMessage(message, args);
+    }
+
+    /**
+     * Format message using given arguments.
+     *
+     * @param message The string used as a pattern for inserting arguments.
+     * @param args The arguments to be inserted into the string.
+     */
+    public static String getFormattedMessage(String message, Object args[]) {
+        // Sanity Check
+        if ((message == null) || (args == null) || (args.length == 0)) {
+            return message;
+        }
+
+        String result = null;
+
+        MessageFormat mf = new MessageFormat(message);
+        result = mf.format(args);
+
+        return (result != null) ? result : message;
+    }
+
+    /**
+     * <p>
+     * Singleton. This one is OK to share across VMs (no state).
+     * </p>
+     */
+    private static final MessageUtil _instance = new MessageUtil();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/ResourceBundleManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/ResourceBundleManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * <p>
+ * This class caches <code>ResourceBundle</code> objects per locale.
+ * </p>
+ *
+ * Created March 29, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class ResourceBundleManager {
+
+    /**
+     * <p>
+     * Use {@link #getInstance()} to obtain an instance.
+     * </p>
+     */
+    protected ResourceBundleManager() {
+    }
+
+    /**
+     * <p>
+     * Use this method to get the instance of this class.
+     * </p>
+     *
+     * @deprecated Use ResourceBundleManager#getInstance(FacesContext).
+     */
+    @Deprecated
+    public static ResourceBundleManager getInstance() {
+        return getInstance(null);
+    }
+
+    /**
+     * <p>
+     * Use this method to get the instance of this class.
+     * </p>
+     */
+    public static ResourceBundleManager getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        ResourceBundleManager mgr = null;
+        if (ctx != null) {
+            // Look in application scope for it...
+            mgr = (ResourceBundleManager) ctx.getExternalContext().getApplicationMap().get(RB_MGR);
+        }
+        if (mgr == null) {
+            // 1st time... create / initialize it
+            mgr = new ResourceBundleManager();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(RB_MGR, mgr);
+            }
+        }
+
+        // Return the map...
+        return mgr;
+    }
+
+    /**
+     * <p>
+     * This method checks the cache for the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param baseName Name of the bundle.
+     * @param locale The <code>Locale</code>.
+     *
+     * @return The requested <code>ResourceBundle</code> in the most appropriate <code>Locale</code>.
+     */
+    protected ResourceBundle getCachedBundle(String baseName, Locale locale) {
+        return _cache.get(getCacheKey(baseName, locale));
+    }
+
+    /**
+     * <p>
+     * This method generates a unique key for setting / getting <code>ResourceBundle</code>s from the cache. It is important
+     * to have different keys per locale (obviously).
+     * </p>
+     */
+    protected String getCacheKey(String baseName, Locale locale) {
+        return baseName + "__" + locale.toString();
+    }
+
+    /**
+     * <p>
+     * This method adds a <code>ResourceBundle</code> to the cache.
+     * </p>
+     */
+    protected void addCachedBundle(String baseName, Locale locale, ResourceBundle bundle) {
+        // Copy the old Map to prevent changing a Map while someone is
+        // accessing it.
+        Map<String, ResourceBundle> map = new HashMap<>(_cache);
+
+        // Add the new bundle
+        map.put(getCacheKey(baseName, locale), bundle);
+
+        // Set this new Map as the shared cache Map
+        _cache = map;
+    }
+
+    /**
+     * <p>
+     * This method obtains the requested <code>ResourceBundle</code> as specified by the given <code>basename</code> and
+     * <code>locale</code>.
+     * </p>
+     *
+     * @param baseName The base name for the <code>ResourceBundle</code>.
+     * @param locale The desired <code>Locale</code>.
+     */
+    public ResourceBundle getBundle(String baseName, Locale locale) {
+        ResourceBundle bundle = getCachedBundle(baseName, locale);
+        if (bundle == null) {
+            try {
+                bundle = ResourceBundle.getBundle(baseName, locale, Util.getClassLoader(baseName));
+            } catch (MissingResourceException ex) {
+                // Use System.out.println b/c we don't want infinite loop and
+                // we're too lazy to do more...
+                System.out.println("Can't find bundle: " + baseName);
+                ex.printStackTrace();
+            }
+            if (bundle != null) {
+                addCachedBundle(baseName, locale, bundle);
+            }
+        }
+        return bundle;
+    }
+
+    /**
+     * <p>
+     * This method obtains the requested ResourceBundle as
+     * specified by the given basename, locale, and classloader.</p>
+     *
+     * @param    baseName    The base name for the <code>ResourceBundle</code>.
+     * @param locale The desired <code>Locale</code>.
+     * @param loader The <code>ClassLoader</code> that should be used.
+     */
+    public ResourceBundle getBundle(String baseName, Locale locale, ClassLoader loader) {
+        ResourceBundle bundle = getCachedBundle(baseName, locale);
+        if (bundle == null) {
+            bundle = ResourceBundle.getBundle(baseName, locale, loader);
+            if (bundle != null) {
+                addCachedBundle(baseName, locale, bundle);
+            }
+        }
+        return bundle;
+    }
+
+    /**
+     * <p>
+     * Application scope key which stores the <code>ResourceBundleManager</code> instance for this application.
+     * </p>
+     */
+    private static final String RB_MGR = "__jsft_ResourceBundleMgr";
+
+    /**
+     * <p>
+     * The cache of <code>ResourceBundle</code>s.
+     * </p>
+     */
+    private Map<String, ResourceBundle> _cache = new HashMap<>();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/Util.java
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/java/com/sun/jsft/util/Util.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Portions Copyright (c) 2011 Ken Paulsen
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsft.util;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * <p>
+ * This class is for general purpose utility methods.
+ * </p>
+ *
+ * Created March 29, 2011
+ *
+ * @author Ken Paulsen (kenapaulsen@gmail.com)
+ */
+public class Util {
+
+    /**
+     * <p>
+     * This method returns the ContextClassLoader unless it is null, in which case it returns the ClassLoader that loaded
+     * "obj". Unless it is null, in which it will return the system ClassLoader.
+     * </p>
+     *
+     * @param obj May be null, if non-null when the Context ClassLoader is null, then the Classloader used to load this
+     * Object will be returned.
+     */
+    public static ClassLoader getClassLoader(Object obj) {
+        // Get the ClassLoader
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            if (obj != null) {
+                loader = obj.getClass().getClassLoader();
+            }
+        }
+
+        // Wrap with custom ClassLoader if specified
+        loader = getCustomClassLoader(loader);
+
+        return loader;
+    }
+// NOTE: Maybe in addition to getClassLoader, we should have Iterator<ClassLoader> getClassLoaders() for cases where we want to attempt multiple ClassLoaders
+
+    /**
+     * <p>
+     * Method to get the custom <code>ClassLoader</code> if one exists. If one does not exist, it will return the
+     * <code>ClassLoader</code> that is passed in. If (null) is passed in for the parent <code>ClassLoader</code>, it will
+     * get the <b>System</b> <code>ClassLoader</code>, not the context <code>ClassLoader</code> or any other one.
+     * </p>
+     */
+    private static ClassLoader getCustomClassLoader(ClassLoader parent) {
+        // Figure out the parent ClassLoader
+        parent = (parent == null) ? ClassLoader.getSystemClassLoader() : parent;
+
+        // Check to see if we've calculated the ClassLoader for this parent
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        Map<ClassLoader, ClassLoader> classLoaderCache = getClassLoaderCache(ctx);
+        ClassLoader loader = classLoaderCache.get(parent);
+        if (loader != null) {
+            return loader;
+        }
+        loader = parent;
+
+        // Look to see if a custom ClassLoader was specified via an initParam
+        String clsName = null;
+        if (ctx != null) {
+            clsName = ctx.getExternalContext().getInitParameterMap().get(CUSTOM_CLASS_LOADER);
+        }
+        if (clsName != null) {
+            if (clsName.equals(loader.getClass().getName())) {
+                // It has already been wrapped
+                return loader;
+            }
+            try {
+                // Intantiate the custom classloader w/ "loader" as its parent
+                Class cls = Class.forName(clsName, true, parent);
+                loader = (ClassLoader) cls.getConstructor(new Class[] { ClassLoader.class }).newInstance(parent);
+
+                // Set custom classloader as the context-classloader... This
+                // didn't work, JSF blew up... revisit this if necessary
+//        Thread.currentThread().setContextClassLoader(loader);
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalArgumentException("Unable to load class (" + clsName + ").  Make sure your context-param is "
+                        + "specified correctly and that your custom ClassLoader " + "is included in your application.", ex);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalArgumentException("Unable to load class (" + clsName + ").  You must have a constructor that "
+                        + "allows the parent ClassLoader to be provided on your " + "custom ClassLoader.", ex);
+            } catch (InstantiationException ex) {
+                throw new RuntimeException("Unable to instantiate class (" + clsName + ")!", ex);
+            } catch (IllegalAccessException ex) {
+                throw new RuntimeException("Unable to access class (" + clsName + ")!", ex);
+            } catch (java.lang.reflect.InvocationTargetException ex) {
+                throw new RuntimeException("Unable to instantiate class (" + clsName + ")!", ex);
+            }
+        }
+
+        // Cache for next time
+        classLoaderCache.put(parent, loader);
+
+        // Return the ClassLoader (may be the same one passed in)
+        return loader;
+    }
+
+    /**
+     * <p>
+     * Provides access to the application-scoped Map which stores custom ClassLoaders which may wrap a parent ClassLoader in
+     * this application.
+     * </p>
+     */
+    private static Map<ClassLoader, ClassLoader> getClassLoaderCache(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<ClassLoader, ClassLoader> map = null;
+        if (ctx != null) {
+            map = (Map<ClassLoader, ClassLoader>) ctx.getExternalContext().getApplicationMap().get(CLASSLOADER_CACHE);
+        }
+        if (map == null) {
+            // 1st time... initialize it
+            map = new HashMap<>(4);
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(CLASSLOADER_CACHE, map);
+            }
+        }
+
+        // Return the map...
+        return map;
+    }
+
+    /**
+     * <p>
+     * This method will attempt to load a Class from the context ClassLoader. If it fails, it will try from the ClassLoader
+     * used to load the given object. If that's null, or fails, it will try using the System ClassLoader.
+     * </p>
+     *
+     * @param className The full name of the class to load.
+     * @param obj An optional Object used to help find the ClassLoader to use.
+     */
+    public static Class loadClass(String className, Object obj) throws ClassNotFoundException {
+        // Get the context ClassLoader
+        ClassLoader loader = getClassLoader(obj);
+        Class cls = null;
+        if (loader != null) {
+            try {
+                cls = Class.forName(className, false, loader);
+            } catch (ClassNotFoundException ex) {
+                // Ignore
+                if (LogUtil.finestEnabled()) {
+                    LogUtil.finest("Unable to find class (" + className + ") using the context ClassLoader: '" + loader
+                            + "'.  I will keep looking.", ex);
+                }
+            }
+        }
+        if (cls == null) {
+            // Still haven't found it... look for it somewhere else.
+            if (obj != null) {
+                loader = obj.getClass().getClassLoader();
+                if (loader != null) {
+                    try {
+                        cls = Class.forName(className, false, loader);
+                    } catch (ClassNotFoundException ex) {
+                        // Ignore
+                        if (LogUtil.finestEnabled()) {
+                            LogUtil.finest("Unable to find class (" + className + ") using ClassLoader: '" + loader
+                                    + "'.  I will try the System ClassLoader.", ex);
+                        }
+                    }
+                }
+            }
+            if (cls == null) {
+                // Still haven't found it, use System ClassLoader
+                loader = ClassLoader.getSystemClassLoader();
+
+                // Allow this one to throw the Exception if not found
+                cls = Class.forName(className, false, loader);
+            }
+        }
+
+        // Return the Class
+        return cls;
+    }
+
+    /**
+     * <p>
+     * Method which returns the Class for the given class name, or null if any exception occurs. No exceptions are thrown.
+     * </p>
+     */
+    public static Class noExceptionLoadClass(String name) {
+        Class cls = null;
+        try {
+            cls = Util.loadClass(name, null);
+        } catch (Exception ex) {
+            // Ignore...
+        }
+        return cls;
+    }
+
+    /**
+     * <p>
+     * This method attempts load the requested Class. If obj is a String, it will use this value as the fully qualified
+     * class name. If it is a Class, it will return it. If it is anything else, it will return the Class for the given
+     * Object.
+     * </p>
+     *
+     * @param obj The Object describing the requested Class
+     */
+    public static Class getClass(Object obj) throws ClassNotFoundException {
+        if ((obj == null) || (obj instanceof Class)) {
+            return (Class) obj;
+        }
+        Class cls = null;
+        if (obj instanceof String) {
+            cls = loadClass((String) obj, obj);
+        } else {
+            cls = obj.getClass();
+        }
+        return cls;
+    }
+
+    /**
+     * <p>
+     * This method locates the requested <code>Method</code> on the given <code>Class</code>, with the given
+     * <code>params</code>. This method does not throw any exceptions. Instead it will return <code>null</code> if unable to
+     * locate the method.
+     * </p>
+     */
+    public static Method getMethod(Class cls, String name, Class... prms) {
+        Method method = null;
+        try {
+            method = cls.getMethod(name, prms);
+        } catch (NoSuchMethodException ex) {
+            // Do nothing, we're eating the exception
+        } catch (SecurityException ex) {
+            // Do nothing, we're eating the exception
+        }
+        return method;
+    }
+
+    /**
+     * <p>
+     * This method converts the given Map into a Properties Map (if it is already one, then it simply returns the given
+     * Map).
+     * </p>
+     */
+    public static Properties mapToProperties(Map map) {
+        if ((map == null) || (map instanceof Properties)) {
+            return (Properties) map;
+        }
+
+        // Create Properties and add all the values
+        Properties props = new Properties();
+        props.putAll(map);
+
+        // Return the result
+        return props;
+    }
+
+    /**
+     * <p>
+     * Help obtain the current <code>Locale</code>.
+     * </p>
+     */
+    public static Locale getLocale(FacesContext context) {
+        Locale locale = null;
+        if (context != null) {
+            // Attempt to obtain the locale from the UIViewRoot
+            UIViewRoot root = context.getViewRoot();
+            if (root != null) {
+                locale = root.getLocale();
+            }
+        }
+
+        // Return the locale; if not found, return the system default Locale
+        return (locale == null) ? Locale.getDefault() : locale;
+    }
+
+    /**
+     * <p>
+     * This method escapes text so that HTML tags and escape characters can be shown in an HTML page without seeming to be
+     * parsed.
+     * </p>
+     */
+    public static String htmlEscape(String str) {
+        if (str == null) {
+            return null;
+        }
+        StringBuffer buf = new StringBuffer("");
+        for (char ch : str.toCharArray()) {
+            switch (ch) {
+                case '&':
+                    buf.append("&amp;");
+                    break;
+                case '<':
+                    buf.append("&lt;");
+                    break;
+                case '>':
+                    buf.append("&gt;");
+                    break;
+                default:
+                    buf.append(ch);
+                    break;
+            }
+        }
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method strips leading delimeter.
+     * </p>
+     *
+     */
+    protected static String stripLeadingDelimeter(String str, char ch) {
+        if (str == null || str.equals("")) {
+            return str;
+        }
+        int j = 0;
+        char[] strArr = str.toCharArray();
+        for (int i = 0; i < strArr.length; i++) {
+            j = i;
+            if (strArr[i] != ch) {
+                break;
+            }
+        }
+        return str.substring(j);
+
+    }
+
+    /**
+     * Closes an InputStream if it is non-null, throwing away any Exception that may occur
+     *
+     * @param is
+     */
+    public static void closeStream(InputStream is) {
+        if (is != null) {
+            try {
+                is.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Application scope attribute name for storing custom <code>ClassLoaders</code>.
+     * </p>
+     */
+    private static final String CLASSLOADER_CACHE = "__jsft_ClassLoaders";
+
+    /**
+     * <p>
+     * This is the context-param that specifies the JSFTemplating custom <code>ClassLoader</code> to use.
+     * </p>
+     */
+    public static final String CUSTOM_CLASS_LOADER = "com.sun.jsft.CLASSLOADER";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsft/src/main/resources/META-INF/jsft.taglib.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsft/src/main/resources/META-INF/jsft.taglib.xml
@@ -1,0 +1,75 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+    Portions Copyright (c) 2011 Ken Paulsen
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd"
+                version="4.0">
+
+    <namespace>http://jsftemplating.java.net/jsft</namespace>
+
+    <tag>
+    <tag-name>event</tag-name>
+    <handler-class>com.sun.jsft.facelets.EventHandler</handler-class>
+    <attribute>
+        <description><![CDATA[
+        <p> Name of the event for which to install a listener. The
+        following table lists the valid values for this attribute,
+        and the corresponding event type for which the listener
+        action is registered.</p>
+
+        <table border="1">
+            <tr><th>value for "<code>type</code>" tag attribute</th>
+            <th>Type of event sent to listener method</th></tr>
+            <tr><td>preRenderComponent</td>
+            <td>jakarta.faces.event.PreRenderComponentEvent</td></tr>
+            <tr><td>postAddToView</td>
+            <td>jakarta.faces.event.PostAddToViewEvent</td></tr>
+            <tr><td>preValidate</td>
+            <td>jakarta.faces.event.PreValidateEvent</td></tr>
+            <tr><td>postValidate</td>
+            <td>jakarta.faces.event.PostValidateEvent</td></tr>
+        </table>
+
+        <p> In addition to these values, the fully qualified class
+            name of any java class that extends
+            <code>jakarta.faces.event.ComponentSystemEvent</code> may be
+            used as the value of the "type" attribute.</p>
+
+        <p> The listener that is registered will dipatch to the
+            expressions specified in the body of this element.  Each
+            expression must be separated by a semicolon and need not
+            be enclosed in #{}.</p>
+        ]]></description>
+        <name>type</name>
+        <required>true</required>
+        <type>java.lang.String</type>
+    </attribute>
+    </tag>
+
+    <tag>
+    <tag-name>deferredFragment</tag-name>
+    <component>
+        <component-type>com.sun.jsft.component.fragment.DeferredFragment</component-type>
+    </component>
+    </tag>
+
+</facelet-taglib>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/pom.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
+    Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.admingui</groupId>
+        <artifactId>jsftemplating-parent</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jsftemplating-dt</artifactId>
+
+    <name>jsftemplating-dt</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinition.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinition.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * This is the <code>FormatDefinition Annotation</code>. It is expected to exist on each
+ * {@link com.sun.jsftemplating.component.factory.ComponentFactory}. It must specify an identifier for the
+ * <code>ComponentFactory</code> so that it may be referenced when defining <code>UIComponents</code> in your template
+ * or code.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface FormatDefinition {
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinitionAP.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/FormatDefinitionAP.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+/**
+ * A JSR 169 compliant annotation processor for FormatDefinition annotation This is required for JDK8+, since APT has
+ * been deprecated.
+ *
+ * @author Romain Grecourt
+ */
+@SupportedAnnotationTypes(value = { "com.sun.jsftemplating.annotation.FormatDefinition" })
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+public class FormatDefinitionAP extends AbstractProcessor {
+
+    public static final String FACTORY_FILE = "META-INF/jsftemplating/FormatDefinition.map";
+    private PrintWriter writer = null;
+    private boolean _setup = false;
+
+    private boolean setup() {
+        if (_setup) {
+            // Don't do setup more than once
+            return true;
+        }
+        try {
+            // Create factory mapping file
+            writer = getMapWriter();
+        } catch (IOException ex) {
+            StringWriter buf = new StringWriter();
+            ex.printStackTrace(new PrintWriter(buf));
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, String
+                    .format("Unable to write %s file while processing @FormatDefinition annotation %s", FACTORY_FILE, buf.toString()));
+            return false;
+        }
+        _setup = true;
+        return _setup;
+    }
+
+    private PrintWriter getMapWriter() throws IOException {
+        PrintWriter _writer = null;
+        ClassLoader cl = this.getClass().getClassLoader();
+        URL url;
+        for (Enumeration<URL> urls = cl.getResources(FACTORY_FILE); urls.hasMoreElements() && (_writer == null);) {
+            url = urls.nextElement();
+            if ((url != null) && new File(url.getFile()).canRead()) {
+                // Append to the existing file...
+                _writer = new PrintWriter(new FileOutputStream(url.getFile(), true));
+            }
+        }
+        if (_writer == null) {
+            // File not found, create a new one...
+            FileObject fo = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", FACTORY_FILE);
+            _writer = new PrintWriter(fo.openWriter());
+            return _writer;
+        }
+        return _writer;
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
+        setup();
+
+        for (Element decl : roundEnv.getElementsAnnotatedWith(FormatDefinition.class)) {
+            for (AnnotationMirror an : decl.getAnnotationMirrors()) {
+                writer.println(decl.toString());
+            }
+        }
+
+        if (_setup) {
+            writer.close();
+        }
+        return roundEnv.processingOver();
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/Handler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/Handler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * This is the <code>Handler Annotation</code>. It is expected to exist on each
+ * {@link com.sun.jsftemplating.component.factory.ComponentFactory}. It must specify an identifier for the
+ * <code>ComponentFactory</code> so that it may be referenced when defining <code>UIComponents</code> in your template
+ * or code.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface Handler {
+    public String id();
+
+    public HandlerInput[] input() default {};
+
+    public HandlerOutput[] output() default {};
+
+    public static final String ID = "id";
+    public static final String INPUT = "input";
+    public static final String OUTPUT = "output";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerAP.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerAP.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.SimpleElementVisitor6;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+import static javax.lang.model.SourceVersion.RELEASE_21;
+
+/**
+ * A JSR 169 compliant annotation processor for Handler annotation This is required for JDK8+, since APT has been
+ * deprecated.
+ *
+ * @author Romain Grecourt
+ */
+@SupportedAnnotationTypes(value = {
+    "com.sun.jsftemplating.annotation.Handler",
+    "com.sun.jsftemplating.annotation.HandlerInput",
+    "com.sun.jsftemplating.annotation.HandlerOutput" })
+@SupportedSourceVersion(RELEASE_21)
+@SupportedOptions(value = {
+    "AnnotationVerifier.Annotations",
+    "AnnotationVerifier.Baseclasses",
+    "AnnotationVerifier.ClassAnnotation.Mappings" })
+public class HandlerAP extends AbstractProcessor {
+
+    public static final String HANDLER_FILE = "META-INF/jsftemplating/Handler.map";
+    private PrintWriter writer = null;
+    private boolean _setup = false;
+    private Map handlers = new HashMap();
+
+    private boolean setup() {
+        if (_setup) {
+            // Don't do setup more than once
+            return true;
+        }
+        try {
+            // Create factory mapping file
+            writer = getMapWriter();
+        } catch (IOException ex) {
+            StringWriter buf = new StringWriter();
+            ex.printStackTrace(new PrintWriter(buf));
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, String
+                    .format("Unable to write %s file while processing @FormatDefinition annotation %s", HANDLER_FILE, buf.toString()));
+            return false;
+        }
+        _setup = true;
+        return _setup;
+    }
+
+    private PrintWriter getMapWriter() throws IOException {
+        PrintWriter _writer = null;
+        ClassLoader cl = this.getClass().getClassLoader();
+        URL url;
+        for (Enumeration<URL> urls = cl.getResources(HANDLER_FILE); urls.hasMoreElements() && (_writer == null);) {
+            url = urls.nextElement();
+            if ((url != null) && new File(url.getFile()).canRead()) {
+                // Append to the existing file...
+                _writer = new PrintWriter(new FileOutputStream(url.getFile(), true));
+            }
+        }
+        if (_writer == null) {
+            // File not found, create a new one...
+            FileObject fo = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", HANDLER_FILE);
+            _writer = new PrintWriter(fo.openWriter());
+            return _writer;
+        }
+        return _writer;
+    }
+
+    private static final class ElementVisitor extends SimpleElementVisitor6<TypeElement, Void> {
+
+        @Override
+        public TypeElement visitType(TypeElement e, Void p) {
+            return e;
+        }
+    }
+
+    private static final class ExecutableElementVisitor extends SimpleElementVisitor6<ExecutableElement, Void> {
+
+        @Override
+        public ExecutableElement visitExecutable(ExecutableElement e, Void p) {
+            return e;
+        }
+    }
+
+    private static TypeElement getTypeElement(Element elt) {
+        return elt.accept(new ElementVisitor(), null);
+    }
+
+    private static TypeElement getDeclaringTypeElement(Element elt) {
+        return getTypeElement(elt.getEnclosingElement());
+    }
+
+    private String getJavadocComments(Element elt) {
+        return processingEnv.getElementUtils().getDocComment(elt);
+    }
+
+    /**
+     * <p>
+     * This is a helper method that writes out property lines to represent either a HandlerInput or a HandlerOutput. The
+     * <code>type</code> that is passed in is expected to be either <code>input</code> or <code>output</code>.
+     * </p>
+     */
+    private void writeIOProperties(String id, String type, List<AnnotationValue> ioList) {
+        int cnt = 0;
+        for (AnnotationValue ioVal : ioList) {
+            // Process each @HandlerInput annotation...
+            for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> prop : ((AnnotationMirror) ioVal.getValue())
+                    .getElementValues().entrySet()) {
+                // Look at each "param": @Handler<I/O>put(param=)
+                writer.println(id + "." + type + "[" + cnt + "]." + prop.getKey().getSimpleName() + "="
+                        + convertClassName(prop.getValue().getValue().toString()));
+            }
+            cnt++;
+        }
+    }
+
+    /**
+     * <p>
+     * This method attempts to convert the given <code>clsName</code> to a valid class name. The issue is that arrays appear
+     * something like "java.lang.String[]" where they should appear "[Ljava.lang.String;".
+     * </p>
+     */
+    private String convertClassName(String str) {
+        int idx = str.indexOf("[]");
+        if (idx == -1) {
+            // For not only worry about Strings that contain array brackets
+            return str;
+        }
+
+        // Count []'s
+        int count = 0;
+        while (idx != -1) {
+            str = str.replaceFirst("\\[]", "");
+            idx = str.indexOf("[]");
+            count++;
+        }
+
+        // Generate new String
+        String brackets = "";
+        for (idx = 0; idx < count; idx++) {
+            brackets += "[";
+        }
+        // Return something of the format: [Ljava.lang.String;
+        return brackets + "L" + str + ";";
+    }
+
+    /**
+     * <p>
+     * This method strips off HTML tags, converts "&lt;" and "&gt;", inserts '#' characters in front of each line, and
+     * ensures there are no trailing returns.
+     * </p>
+     */
+    private String formatComment(String javadoc) {
+        if (javadoc == null) {
+            // No JavaDoc, return
+            return "";
+        }
+
+        // First trim off extra stuff
+        int idx = javadoc.indexOf("@param");
+        if (idx > -1) {
+            // Ignore @param stuff
+            javadoc = javadoc.substring(0, idx);
+        }
+        javadoc = javadoc.trim();
+
+        // Now process the String
+        StringBuilder buf = new StringBuilder("\n# ");
+        int len = javadoc.length();
+        char ch;
+        idx = 0;
+        while (idx < len) {
+            ch = javadoc.charAt(idx);
+            switch (ch) {
+                case '&':
+                    if ((idx + 3) < len) {
+                        if ((javadoc.charAt(idx + 2) == 't') && (javadoc.charAt(idx + 3) == ';')) {
+                            if (javadoc.charAt(idx + 1) == 'g') {
+                                buf.append('>');
+                                idx += 3;
+                            } else if (javadoc.charAt(idx + 1) == 'l') {
+                                buf.append('<');
+                                idx += 3;
+                            }
+                        }
+                    }
+                    break;
+                case '<':
+                    idx++;
+                    while ((idx < len) && (javadoc.charAt(idx) != '>')) {
+                        idx++;
+                    }
+                    break;
+                case '>':
+                    idx++;
+                    while ((idx < len) && (javadoc.charAt(idx) != '<')) {
+                        idx++;
+                    }
+                    break;
+                case '\n':
+                case '\r':
+                    if (((idx + 1) > len) && ((javadoc.charAt(idx + 1) == '\n') || (javadoc.charAt(idx + 1) == '\r'))) {
+                        idx++;
+                    }
+                    buf.append("\n# ");
+                    break;
+                default:
+                    buf.append(ch);
+            }
+            idx++;
+        }
+
+        // Return the stripped javadoc
+        return buf.toString();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        String key;
+        Object value;
+        String id;
+        List<AnnotationValue> input;
+        List<AnnotationValue> output;
+
+        setup();
+
+        for (Element decl : roundEnv.getElementsAnnotatedWith(Handler.class)) {
+            for (AnnotationMirror an : decl.getAnnotationMirrors()) {
+                // Loop through the NVPs contained in the annotation
+                id = null;
+                input = null;
+                output = null;
+                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : an.getElementValues().entrySet()) {
+                    // At this point I'm processing a "Handler" annotation
+                    // it may contain "id", "input", "output"
+                    key = entry.getKey().getSimpleName().toString();
+                    value = entry.getValue().getValue();
+                    if (key.equals(Handler.ID)) {
+                        // Found 'id', save it
+                        id = value.toString();
+                    } else if (key.equals(Handler.INPUT)) {
+                        // Found inputs
+                        input = (List<AnnotationValue>) value;
+                    } else if (key.equals(Handler.OUTPUT)) {
+                        // Found outputs
+                        output = (List<AnnotationValue>) value;
+                    }
+                }
+
+                TypeElement te = getTypeElement(decl);
+                TypeElement teDecl = getDeclaringTypeElement(decl);
+
+                // Sanity Check
+                if (id == null) {
+                    processingEnv.getMessager().printMessage(Kind.ERROR,
+                            String.format("'id' is not specified for annotation of method: %s.%s", te.getQualifiedName().toString(),
+                                    te.getSimpleName().toString()),
+                            decl);
+                }
+
+                // Check for duplicate handler definitions
+                if (handlers.get(id) != null) {
+                    processingEnv.getMessager().printMessage(Kind.WARNING,
+                            String.format("Handler with 'id' of '%s' is declared more than once!'", id), decl);
+                }
+                handlers.put(id, id);
+
+                // Record class / method names (and javadoc comment)
+                writer.println(formatComment(getJavadocComments(decl)));
+                writer.println(String.format("%s.class=%s", id, teDecl.getQualifiedName()));
+                writer.println(String.format("%s.method=%s", id, decl.getSimpleName()));
+
+                // Now record inputs for this handler...
+                if (input != null) {
+                    writeIOProperties(id, "input", input);
+                }
+
+                // Now record outputs for this handler...
+                if (output != null) {
+                    writeIOProperties(id, "output", output);
+                }
+
+                // Method signature checks...
+                // Make sure method is accessible (public)
+                if (!decl.getModifiers().contains(Modifier.PUBLIC)) {
+                    processingEnv.getMessager().printMessage(Kind.ERROR, String.format("Annotated method: %s.%s should be declared public",
+                            teDecl.getQualifiedName().toString(), decl.getSimpleName().toString()), decl);
+                }
+
+                // Make sure correct args are specified
+                ExecutableElement exe = decl.accept(new ExecutableElementVisitor(), null);
+                List<? extends VariableElement> params = exe.getParameters();
+                String pdec = params.iterator().next().asType().toString();
+                if ((params.size() != 1) || !pdec.equals("com.sun.jsftemplating.layout.descriptors.handler.HandlerContext")) {
+
+                    processingEnv.getMessager().printMessage(Kind.ERROR, String.format(
+                            "Annotated method: %s.%s  must contain a single parameter of type 'com.sun.jsftemplating.layout.descriptors.handler.HandlerContext', instead type: %s was found",
+                            teDecl.getQualifiedName(), decl.getSimpleName(), pdec), decl);
+                }
+            }
+        }
+
+        if (_setup) {
+            writer.close();
+        }
+        return roundEnv.processingOver();
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerInput.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerInput.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * <p>
+ * This is the <code>HandlerInput Annotation</code>. It is expected to exist on each
+ * {@link com.sun.jsftemplating.component.factory.ComponentFactory}. It must specify an identifier for the
+ * <code>ComponentFactory</code> so that it may be referenced when defining <code>UIComponents</code> in your template
+ * or code.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@Retention(SOURCE)
+@Target(METHOD)
+public @interface HandlerInput {
+
+    public String name();
+
+    public Class type() default Object.class;
+
+    public boolean required() default DEFAULT_REQUIRED;
+
+    // Annotations don't allow Object, use String
+    // Annotations don't allow null, use special String
+    public String defaultValue() default DEFAULT_DEFAULT_VALUE;
+
+    public static final String NAME = "name";
+    public static final String DEFAULT = "defaultValue";
+    public static final String TYPE = "type";
+    public static final String REQUIRED = "required";
+
+    public static final boolean DEFAULT_REQUIRED = false;
+    public static final String DEFAULT_DEFAULT_VALUE = "jsfTempNULLString";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerOutput.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/HandlerOutput.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * This is the <code>HandlerOutput Annotation</code>. It is expected to exist on each
+ * {@link com.sun.jsftemplating.component.factory.ComponentFactory}. It must specify an identifier for the
+ * <code>ComponentFactory</code> so that it may be referenced when defining <code>UIComponents</code> in your template
+ * or code.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface HandlerOutput {
+    public String name();
+
+    public Class type() default Object.class;
+
+    public static final String NAME = "name";
+    public static final String TYPE = "type";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * This is the <code>UIComponentFactory Annotation</code>. It is expected to exist on each
+ * {@link com.sun.jsftemplating.component.factory.ComponentFactory}. It must specify an identifier for the
+ * <code>ComponentFactory</code> so that it may be referenced when defining <code>UIComponents</code> in your template
+ * or code.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface UIComponentFactory {
+    public String value();
+
+    public static final String FACTORY_ID = "value";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactoryAP.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/java/com/sun/jsftemplating/annotation/UIComponentFactoryAP.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.annotation;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+
+/**
+ * A JSR 169 compliant annotation processor for UIComponentFactory annotation This is required for JDK8+, since APT has
+ * been deprecated.
+ *
+ * @author Romain Grecourt
+ */
+@SupportedAnnotationTypes(value = { "com.sun.jsftemplating.annotation.UIComponentFactory" })
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+public class UIComponentFactoryAP extends AbstractProcessor {
+
+    public static final String FACTORY_FILE = "META-INF/jsftemplating/UIComponentFactory.map";
+    private boolean _setup = false;
+    private PrintWriter writer = null;
+
+    private boolean setup() {
+        if (_setup) {
+            // Don't do setup more than once
+            return true;
+        }
+        try {
+            // Create factory mapping file
+            writer = getMapWriter();
+        } catch (IOException ex) {
+            StringWriter buf = new StringWriter();
+            ex.printStackTrace(new PrintWriter(buf));
+            processingEnv.getMessager().printMessage(Kind.ERROR, String
+                    .format("Unable to write %s file while processing @UIComponentFactory annotation %s", FACTORY_FILE, buf.toString()));
+            return false;
+        }
+        _setup = true;
+        return _setup;
+    }
+
+    private PrintWriter getMapWriter() throws IOException {
+        PrintWriter _writer = null;
+        ClassLoader cl = this.getClass().getClassLoader();
+        URL url;
+        for (Enumeration<URL> urls = cl.getResources(FACTORY_FILE); urls.hasMoreElements() && (_writer == null);) {
+            url = urls.nextElement();
+            if ((url != null) && new File(url.getFile()).canRead()) {
+                // Append to the existing file...
+                _writer = new PrintWriter(new FileOutputStream(url.getFile(), true));
+            }
+        }
+        if (_writer == null) {
+            // File not found, create a new one...
+            FileObject fo = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", FACTORY_FILE);
+            _writer = new PrintWriter(fo.openWriter());
+            return _writer;
+        }
+        return _writer;
+    }
+
+    private static String escape(String str) {
+        if (str == null) {
+            return "";
+        }
+        StringBuilder buf = new StringBuilder("");
+        for (char ch : str.trim().toCharArray()) {
+            switch (ch) {
+            case ':':
+            case '=':
+                buf.append('\\').append(ch);
+                break;
+            default:
+                buf.append(ch);
+            }
+        }
+        return buf.toString();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        setup();
+        for (Element decl : roundEnv.getElementsAnnotatedWith(UIComponentFactory.class)) {
+            for (AnnotationMirror an : decl.getAnnotationMirrors()) {
+                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : an.getElementValues().entrySet()) {
+                    if (entry.getKey().getSimpleName().contentEquals(UIComponentFactory.FACTORY_ID)) {
+                        // Write NVP using the PrintWriter
+                        writer.println(escape(entry.getValue().getValue().toString()) + "=" + decl.toString());
+                    }
+                }
+            }
+        }
+        if (_setup) {
+            writer.close();
+        }
+        return roundEnv.processingOver();
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating-dt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,3 @@
+com.sun.jsftemplating.annotation.HandlerAP
+com.sun.jsftemplating.annotation.FormatDefinitionAP
+com.sun.jsftemplating.annotation.UIComponentFactoryAP

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/pom.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
+    Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.admingui</groupId>
+        <artifactId>jsftemplating-parent</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jsftemplating</artifactId>
+
+    <name>jsftemplating</name>
+
+    <properties>
+        <argLine></argLine>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.faces</groupId>
+            <artifactId>jakarta.faces-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-el-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.woodstock.dependlibs</groupId>
+            <artifactId>dataprovider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.admingui</groupId>
+            <artifactId>jsftemplating-dt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+
+        <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>org.glassfish.mojarra</groupId>
+            <artifactId>mojarra</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.21.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-jsft</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                            <goal>properties</goal>
+                        </goals>
+                        <configuration>
+                            <excludeTransitive>true</excludeTransitive>
+                            <includeArtifactIds>jsft</includeArtifactIds>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <excludes>META-INF/MANIFEST.MF</excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        @{argLine} -javaagent:${org.mockito:mockito-core:jar}
+                    </argLine>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Bundle-Name>com.sun.jsftemplating</Bundle-Name>
+                                <excludeDependencies>jakarta.faces</excludeDependencies>
+                                <Import-Package>com.sun.data.provider.*;resolution:=optional;password=GlassFish,!com.sun.jsftemplating.annotation.*,jakarta.servlet.*,*</Import-Package>
+                                <Export-Package>!com.sun.jsftemplating.annotation.*,!com.sun.data.*,com.sun.jsftemplating.*</Export-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/TemplatingException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/TemplatingException.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ * <p>
+ * This is the base exception class for other exception types that may be used in this project. It provides a means for
+ * setting / obtaining the responsible {@link LayoutElement} and / or <code>UIComponent</code> associated with the
+ * <code>Exception</code>. This information is optional and may be null.
+ * </p>
+ */
+public class TemplatingException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * This is the preferred constructor.
+     * </p>
+     */
+    public TemplatingException(String msg, Throwable ex, LayoutElement elt, UIComponent comp) {
+        super(msg, ex);
+
+        // Setup the rest
+        setResponsibleLayoutElement(elt);
+        setResponsibleUIComponent(comp);
+    }
+
+    /**
+     *
+     */
+    public TemplatingException() {
+        super();
+    }
+
+    /**
+     *
+     */
+    public TemplatingException(LayoutElement elt, UIComponent comp) {
+        super();
+
+        // Setup the rest
+        setResponsibleLayoutElement(elt);
+        setResponsibleUIComponent(comp);
+    }
+
+    /**
+     *
+     */
+    public TemplatingException(Throwable ex) {
+        super(ex);
+    }
+
+    /**
+     *
+     */
+    public TemplatingException(Throwable ex, LayoutElement elt, UIComponent comp) {
+        super(ex);
+
+        // Setup the rest
+        setResponsibleLayoutElement(elt);
+        setResponsibleUIComponent(comp);
+    }
+
+    /**
+     *
+     */
+    public TemplatingException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * This is the preferred constructor if there is no root cause.
+     */
+    public TemplatingException(String msg, LayoutElement elt, UIComponent comp) {
+        super(msg);
+
+        // Setup the rest
+        setResponsibleLayoutElement(elt);
+        setResponsibleUIComponent(comp);
+    }
+
+    /**
+     *
+     */
+    public TemplatingException(String msg, Throwable ex) {
+        super(msg, ex);
+    }
+
+    /**
+     * Allow the Exception to hold the responsible UIComponent
+     */
+    public void setResponsibleUIComponent(UIComponent comp) {
+        _comp = comp;
+    }
+
+    /**
+     * Allow the Exception to hold the responsible UIComponent
+     */
+    public UIComponent getResponsibleUIComponent() {
+        return _comp;
+    }
+
+    /**
+     * Allow the Exception to hold the responsible LayoutElement
+     */
+    public void setResponsibleLayoutElement(LayoutElement elt) {
+        _elt = elt;
+    }
+
+    /**
+     * Allow the responsible LayoutElement to be obtained.
+     *
+     * @return The responsible LayoutElement (null if not specified)
+     */
+    public LayoutElement getResponsibleLayoutElement() {
+        return _elt;
+    }
+
+    private UIComponent _comp = null;
+    private LayoutElement _elt = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/AjaxRequest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/AjaxRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+/**
+ * <p>
+ * This <code>UIComponent</code> exists to facilitate Ajax requests. Since these requests send information via the
+ * XMLHttpRequest Object, a standard href or form submit will not work. Further it is cumbersome to override the
+ * JavaScript in the available set of components to expect the developer to do this for each request.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class AjaxRequest extends TemplateComponentBase {
+
+    /**
+     * <p>
+     * This is the location of the XML file that declares the layout for the AjaxRequest. (/jsftemplating/ajaxRequest.xml)
+     * </p>
+     */
+    public static final String LAYOUT_KEY = "/jsftemplating/ajaxRequest.xml";
+
+    /**
+     * <p>
+     * Constructor for <code>AjaxRequest</code>.
+     * </p>
+     */
+    public AjaxRequest() {
+        super();
+        setRendererType("com.sun.jsftemplating.AjaxRequest");
+        setLayoutDefinitionKey(LAYOUT_KEY);
+    }
+
+    /**
+     * <p>
+     * Return the family for this component.
+     * </p>
+     */
+    @Override
+    public String getFamily() {
+        return "com.sun.jsftemplating.AjaxRequest";
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/ChildManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/ChildManager.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This interface defines a method to find or create a child <code>UIComponent</code>. It is designed to be used in
+ * conjunction with <code>UIComponent</code> implementations.
+ * </p>
+ *
+ * @see TemplateComponent
+ * @see com.sun.jsftemplating.component.ComponentUtil
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface ChildManager {
+
+    /**
+     * <p>
+     * This method will find the request child UIComponent by id (the id is obtained from the given
+     * {@link LayoutComponent}). If it is not found, it will attempt to create it from the supplied {@link LayoutComponent}.
+     * </p>
+     *
+     * @param context FacesContext
+     * @param descriptor {@link LayoutComponent} describing the UIComponent
+     *
+     * @return Requested UIComponent
+     */
+    UIComponent getChild(FacesContext context, LayoutComponent descriptor);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/ComponentUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/ComponentUtil.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.el.VariableResolver;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.util.LogUtil;
+import com.sun.jsftemplating.util.TypeConverter;
+
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * <p>
+ * Utility class that contains helper methods for components.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ComponentUtil {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    private ComponentUtil() {
+    }
+
+    /**
+     * <p>
+     * Method to get access to the ComponentUtil instance for the current application.
+     * </p>
+     */
+    public static ComponentUtil getInstance(FacesContext ctx) {
+        ComponentUtil cu = null;
+        if (ctx != null) {
+            Map<String, Object> appMap = ctx.getExternalContext().getApplicationMap();
+            cu = (ComponentUtil) appMap.get(COMPONENT_UTIL_KEY);
+            if (cu == null) {
+                cu = new ComponentUtil();
+                // Perhaps a SoftReference would be a good idea here?
+                appMap.put(COMPONENT_UTIL_KEY, cu);
+            }
+        } else {
+            // Not JSF env, create every time...
+            cu = new ComponentUtil();
+        }
+        return cu;
+    }
+
+    /**
+     * <p>
+     * Return a child with the specified component id from the specified component. If not found, return <code>null</code>.
+     * </p>
+     *
+     * <p>
+     * This method will NOT create a new <code>UIComponent</code>.
+     * </p>
+     *
+     * @param parent <code>UIComponent</code> to be searched
+     * @param id Component id (or facet name) to search for
+     *
+     * @return The child <code>UIComponent</code> if it exists, null otherwise.
+     */
+    public UIComponent getChild(UIComponent parent, String id) {
+        return findChild(parent, id, id);
+    }
+
+    /**
+     * <p>
+     * Return a child with the specified component id (or facetName) from the specified component. If not found, return
+     * <code>null</code>. <code>facetName</code> or <code>id</code> may be null to avoid searching the facet Map or the
+     * <code>parent</code>'s children.
+     * </p>
+     *
+     * <p>
+     * This method will NOT create a new <code>UIComponent</code>.
+     * </p>
+     *
+     * @param parent <code>UIComponent</code> to be searched
+     * @param id id to search for
+     * @param facetName Facet name to search for
+     *
+     * @return The child <code>UIComponent</code> if it exists, null otherwise.
+     */
+    public UIComponent findChild(UIComponent parent, String id, String facetName) {
+        // Sanity Check
+        if (parent == null) {
+            return null;
+        }
+
+        // First search for facet
+        UIComponent child = null;
+        if (facetName != null) {
+            child = parent.getFacets().get(facetName);
+            if (child != null) {
+                return child;
+            }
+        }
+
+        // Search for component by id
+        if (id != null) {
+            Iterator<UIComponent> it = parent.getChildren().iterator();
+            while (it.hasNext()) {
+                child = it.next();
+                if (id.equals(child.getId())) {
+                    return child;
+                }
+            }
+        }
+
+        // Not found, return null
+        return null;
+    }
+
+    /**
+     * <p>
+     * This method finds or creates a child <code>UIComponent</code> identified by the given id. If the child is not found,
+     * it will attempt to create it using the provided {@link com.sun.jsftemplating.component.factory.ComponentFactory}
+     * (<code>factoryClass</code>).
+     * </p>
+     *
+     * <p>
+     * If there are <code>Properties</code> to be set on the UIComponent, this method should generally be avoided. It is
+     * preferable to use the {@link #getChild(UIComponent, String, String, Properties)} form of <code>getChild</code>.
+     * </p>
+     *
+     * <p>
+     * <code>
+     *        // Example (no properties):<br>
+     *        UIComponent child = Util.getChild(component, "jklLabel", "com.sun.jsftemplating.component.factory.basic.LabelFactory");<br>
+     *        ((Label)child).setText("JKL Label:");<br>
+     *        ((Label)child).setFor("jkl");<br>
+     *        <br>
+     *        {@link LayoutComponent#encodeChild(FacesContext, UIComponent) LayoutComponent.encodeChild}(context, child);
+     *        </code>
+     * </p>
+     *
+     * @param parent Parent <code>UIComponent</code>
+     * @param id Identifier for child <code>UIComponent</code>
+     * @param factoryClass Full {@link com.sun.jsftemplating.component.factory.ComponentFactory} class name
+     *
+     * @return The child UIComponent that was found or created.
+     *
+     * @see #getChild(UIComponent, String, String, Properties)
+     */
+    public UIComponent getChild(UIComponent parent, String id, String factoryClass) {
+        return getChild(parent, id, factoryClass, id);
+    }
+
+    /**
+     * <p>
+     * Same as {@link #getChild(UIComponent, String, String)} except that it allows you to specify a facetName different
+     * than the id. If null is supplied, it won't save the component as a facet.
+     * </p>
+     *
+     * @param parent Parent <code>UIComponent</code>
+     * @param id Identifier for the child <code>UIComponent</code>
+     * @param factoryClass Full {@link com.sun.jsftemplating.component.factory.ComponentFactory} class name
+     * @param facetName The facet name (null means don't store it)
+     *
+     * @return The child UIComponent that was found or created.
+     *
+     * @see #getChild(UIComponent, String, String)
+     */
+    public UIComponent getChild(UIComponent parent, String id, String factoryClass, String facetName) {
+        return getChild(parent, id, getComponentType(factoryClass), null, facetName);
+    }
+
+    /**
+     * <p>
+     * This method finds or creates a child <code>UIComponent</code> identified by the given id. If the child is not found,
+     * it will attempt to create it using the provided {@link com.sun.jsftemplating.component.factory.ComponentFactory}
+     * (<code>factoryClass</code>). It will also initialize the <code>UIComponent</code> using the provided set of
+     * <code>Properties</code>.
+     * </p>
+     *
+     * <p>
+     * <code>
+     *        // Example (with properties):<br>
+     *        Properties props = new Properties();<br>
+     *        props.setProperty("text", "ABC Label:");<br>
+     *        props.setProperty("for", "abc");<br>
+     *        UIComponent child = Util.getChild(component, "abcLabel", "com.sun.jsftemplating.component.factory.basic.LabelFactory", props);<br>
+     *        <br>
+     *        {@link LayoutComponent#encodeChild(FacesContext, UIComponent) LayoutComponent.encodeChild}(context, child);
+     *        </code>
+     * </p>
+     *
+     * @param parent Parent <code>UIComponent</code>
+     * @param id Identifier for the child <code>UIComponent</code>
+     * @param factoryClass Full {@link com.sun.jsftemplating.component.factory.ComponentFactory} class name
+     * @param properties <code>java.util.Properties</code> needed to create and/or initialize the <code>UIComponent</code>
+     *
+     * @return The child UIComponent that was found or created.
+     */
+    public UIComponent getChild(UIComponent parent, String id, String factoryClass, Properties properties) {
+        return getChild(parent, id, factoryClass, properties, id);
+    }
+
+    /**
+     * <p>
+     * Same as {@link #getChild(UIComponent, String, String, Properties)} except that it allows you to specify a facetName
+     * different than the id. If null is supplied, it won't save the component as a facet.
+     * </p>
+     *
+     * @param parent Parent <code>UIComponent</code>
+     * @param id Identifier for the child <code>UIComponent</code>
+     * @param factoryClass Full {@link com.sun.jsftemplating.component.factory.ComponentFactory} class name
+     * @param properties <code>java.util.Properties</code> needed to create and/or initialize the <code>UIComponent</code>
+     * @param facetName The facet name (null means don't store it)
+     *
+     * @return The child UIComponent that was found or created.
+     */
+    public UIComponent getChild(UIComponent parent, String id, String factoryClass, Properties properties, String facetName) {
+        return getChild(parent, id, getComponentType(factoryClass), properties, facetName);
+    }
+
+    /**
+     * <p>
+     * This method finds or creates a child <code>UIComponent</code> identified by the given id. If the child is not found,
+     * it will attempt to create it using the provided {@link ComponentType} (<code>type</code>). It will also initialize
+     * the <code>UIComponent</code> using the provided set of <code>properties</code>.
+     * </p>
+     *
+     * @param parent Parent <code>UIComponent</code>
+     * @param id Identifier for the child <code>UIComponent</code>
+     * @param type The <code>ComponentType</code> class name
+     * @param properties Properties needed to create and/or initialize the <code>UIComponent</code>
+     * @param facetName The facet name (null means don't store it)
+     *
+     * @return The child <code>UIComponent</code> that was found or created.
+     */
+    private UIComponent getChild(UIComponent parent, String id, ComponentType type, Properties properties, String facetName) {
+        LayoutComponent desc = new LayoutComponent(null, id, type);
+        if (properties != null) {
+            // Remove Generics for now. Check with Ken to change thisinto HashMap.
+            desc.setOptions((Map) properties);
+        }
+        if (facetName != null) {
+            // Add the facetName to use
+// FIXME: Decide if this should have its own method
+            desc.addOption(LayoutComponent.FACET_NAME, facetName);
+        }
+
+        return getChild(parent, desc);
+    }
+
+    /**
+     * <p>
+     * This method creates a {@link ComponentType} instance from the given <code>factoryClass</code>. It will first check
+     * its cache to see if one has already been created. If not, it will create one and add to the cache for future use.
+     * </p>
+     *
+     * <p>
+     * This method sets <code>factoryClass</code> for the {@link ComponentType} id.
+     * </p>
+     *
+     * @param facatoryClass The full classname of the {@link com.sun.jsftemplating.component.factory.ComponentFactory}.
+     *
+     * @return A ComponentType instance for <code>factoryClass</code>.
+     */
+    private ComponentType getComponentType(String factoryClass) {
+        // Check the cache
+        ComponentType type = _types.get(factoryClass);
+        if (type == null) {
+            // Not in the cache... add it...
+            type = new ComponentType(factoryClass, factoryClass);
+            Map<String, ComponentType> newMap = new HashMap<>(_types);
+            newMap.put(factoryClass, type);
+            _types = newMap;
+        }
+
+        // Return the ComponentType
+        return type;
+    }
+
+    /**
+     * <p>
+     * This method finds or creates a child <code>UIComponent</code> identified by the given id. If the child is not found,
+     * it will attempt to create it using the provided {@link LayoutComponent} (<code>descriptor</code>). It will also
+     * initialize the <code>UIComponent</code> using the options set on the {@link LayoutComponent}.
+     * </p>
+     *
+     * <p>
+     * If <code>parent</code> implements {@link ChildManager}, then the responsibility of finding and creating the child
+     * will be delegated to the {@link ChildManager} <code>UIComponent</code>.
+     * </p>
+     *
+     * <p>
+     * If you are constructing and populating a LayoutComponent before calling this method, there are a few features that
+     * should be noted. Besides <code>id</code> and <code>type</code> which can be set in the LayoutComponent constructor,
+     * you can also set <code>options</code>, and {@link com.sun.jsftemplating.layout.descriptors.handler.Handler}'s.
+     * </p>
+     *
+     * <p>
+     * <code>Options</code> may be set via {@link LayoutComponent#setOptions(Map)}. These options will be applied to the
+     * <code>UIComponent</code> and may also be used by the {@link com.sun.jsftemplating.component.factory.ComponentFactory}
+     * while instantiating the <code>UIComponent</code>.
+     * </p>
+     *
+     * <p>
+     * {@link com.sun.jsftemplating.layout.descriptors.handler.Handler}'s can be supplied by calling
+     * {@link LayoutComponent#setHandlers(String, List)}. The <code>type</code> must match the event name which invokes the
+     * <code>List</code> of handlers you provide. The <code>Renderer</code> for this <code>UIComponent</code> is responsible
+     * for declaring and dispatching events. {@link com.sun.jsftemplating.renderer.TemplateRenderer} will invoke
+     * <code>beforeCreate</code> and <code>afterCreate</code> events for each child it creates (such as the one being
+     * requested here).
+     * </p>
+     *
+     * <p>
+     * <code>
+     *        // Example (with LayoutComponent):<br>
+     *        {@link ComponentType} type = new {@link ComponentType#ComponentType(String, String) ComponentType}("LabelFactory", "com.sun.jsftemplating.component.factory.basic.LabelFactory");<br>
+     *        {@link LayoutComponent} descriptor = new {@link LayoutComponent#LayoutComponent(LayoutElement, String, ComponentType) LayoutComponent}(null, "abcLabel", type);<br>
+     *        {@link LayoutComponent#addOption(String, Object) descriptor.addOption}("text", "ABC Label:");<br>
+     *        {@link LayoutComponent#addOption(String, Object) descriptor.addOption}("for", "abc");<br>
+     *        UIComponent child = Util.getChild(component, descriptor);<br>
+     *        <br>
+     *        {@link LayoutComponent#encodeChild(FacesContext, UIComponent) LayoutComponent.encodeChild}(context, child);
+     *        </code>
+     * </p>
+     *
+     * @param parent Parent <code>UIComponent</code>
+     * @param descriptor The {@link LayoutComponent} describing the <code>UIComponent</code>
+     *
+     * @return The child <code>UIComponent</code> that was found or created.
+     */
+    public UIComponent getChild(UIComponent parent, LayoutComponent descriptor) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        // First check to see if the UIComponent can create its own children
+        if (parent instanceof ChildManager) {
+            return ((ChildManager) parent).getChild(context, descriptor);
+        }
+
+        // Make sure it doesn't already exist
+        String childId = descriptor.getId(context, parent);
+        UIComponent childComponent = findChild(parent, childId,
+                (String) descriptor.getEvaluatedOption(context, LayoutComponent.FACET_NAME, null));
+        if (childComponent != null) {
+            return childComponent;
+        }
+
+        // Not found, create a new UIComponent
+        return createChildComponent(context, descriptor, parent);
+    }
+
+    /**
+     * <p>
+     * This method creates a child <code>UIComponent</code> by using the provided {@link LayoutComponent}
+     * (<code>descriptor</code>). It will associate the parent and the newly created <code>UIComponent</code>.
+     * </p>
+     *
+     * <p>
+     * It is recommended that this method NOT be called from a Renderer. It should not be called if you have not yet checked
+     * to see if a child UIComponent with the requested ID already exists.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code> object.
+     * @param descriptor The {@link LayoutComponent} describing the <code>UIComponent</code> to be created.
+     * @param parent Parent <code>UIComponent</code>.
+     *
+     * @return A new <code>UIComponent</code> based on the provided {@link LayoutComponent}.
+     *
+     * @throws IllegalArgumentException Thrown if descriptor equals null.
+     *
+     * @see #getChild(UIComponent, LayoutComponent)
+     * @see #getChild(UIComponent, String, String, Properties)
+     * @see LayoutComponent#getType()
+     * @see ComponentType#getFactory()
+     * @see com.sun.jsftemplating.component.factory.ComponentFactory#create(FacesContext, LayoutComponent, UIComponent)
+     */
+    public UIComponent createChildComponent(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Make sure a LayoutComponent was provided.
+        if (descriptor == null) {
+            throw new IllegalArgumentException("'descriptor' cannot be null!");
+        }
+
+        // Create & return the child UIComponent
+        return descriptor.getType().getFactory().create(context, descriptor, parent);
+    }
+
+    /**
+     * <p>
+     * This util method will set the given key/value on the <code>UIComponent</code>. It will resolve all $...{...}
+     * expressions, and convert the String into a <code>ValueExpression</code> if a valid expression is detected. The return
+     * value will be a <code>ValueExpression</code> or the value.
+     * </p>
+     *
+     * @param context <code>FacesContext</code>
+     * @param key The Property name to set
+     * @param value The Property value to set
+     * @param desc The {@link LayoutElement} associated with the <code>UIComponent</code>
+     * @param comp The <code>UIComponent</code>
+     *
+     * @return A <code>ValueExpression</code>, or the "$...{...}" evaulated value (if no <code>ValueExpression</code> is
+     * present).
+     */
+    public Object setOption(FacesContext context, String key, Object value, LayoutElement desc, UIComponent comp) {
+        // Invoke our own EL. This is needed b/c JSF's EL is designed for
+        // context-insensitive EL. Resolve our variables now because we
+        // cannot depend on the individual components to do this later. We
+        // need to find a way to make this work as a regular ValueExpression...
+        // for now, we'll continue to use it...
+        value = VariableResolver.resolveVariables(context, desc, comp, value);
+
+        // Next check to see if the value is/contains a JSF ValueExpression
+        if (value instanceof ValueExpression) {
+            if (comp != null) {
+                comp.setValueExpression(key, (ValueExpression) value);
+            }
+        } else if (value instanceof String && isValueReference((String) value)) {
+            ValueExpression ve = context.getApplication().getExpressionFactory().createValueExpression(context.getELContext(),
+                    (String) value, Object.class);
+            if (comp != null) {
+                comp.setValueExpression(key, ve);
+            }
+            value = ve;
+        } else if (comp != null) {
+            // In JSF, you must directly modify the attribute Map
+            Map<String, Object> attributes = comp.getAttributes();
+            if (value == null) {
+                // Setting null, assume they want to remove the value
+                try {
+                    attributes.remove(key);
+                } catch (Exception ex) { // Switched from IAE to E b/c of MyFaces incompatibility
+                    // JSF is mesed up... it throws an exception if it has a
+                    // property descriptor and you call remove(...). It also
+                    // throws an exception if you attempt to call put w/ null
+                    // and there is no property descriptor. Either way you
+                    // MUST catch something and then handle the other case.
+                    try {
+                        attributes.put(key, (Object) null);
+                    } catch (Exception iae) { // Switched from IAE to E b/c of MyFaces incompatibility
+                        // We'll make this non-fatal, but log a message
+                        if (LogUtil.infoEnabled()) {
+                            LogUtil.info("JSFT0006", new Object[] { key, comp.getId(), comp.getClass().getName() });
+                            if (LogUtil.fineEnabled()) {
+                                LogUtil.fine("Unable to set (" + key + ").", iae);
+                            }
+                        }
+                    }
+                }
+            } else {
+                try {
+                    // Attempt to set the value as given...
+                    attributes.put(key, value);
+                } catch (Exception ex) { // Switched from IAE to E b/c of MyFaces incompatibility
+                    // Ok, try a little harder...
+                    Class type = findPropertyType(comp, key);
+                    if (type != null) {
+                        try {
+                            attributes.put(key, TypeConverter.asType(type, value));
+                        } catch (Exception ex2) { // Switched from IAE to E b/c of MyFaces incompatibility
+                            throw new IllegalArgumentException("Failed to set property (" + key + ") with " + "value (" + value
+                                    + "), which is of type (" + value.getClass().getName() + ").  Expected " + "type (" + type.getName()
+                                    + ").  This " + "occured on the component named (" + comp.getId() + ") of type ("
+                                    + comp.getClass().getName() + ").", ex2);
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Failed to set property (" + key + ") with value (" + value
+                                + "), which is of type (" + value.getClass().getName() + ").  This occured " + "on the component named ("
+                                + comp.getId() + ") of type (" + comp.getClass().getName() + ").", ex);
+                    }
+                }
+            }
+        }
+
+        // Return the value (which may be a ValueExpression)
+        return value;
+    }
+
+    /**
+     * <p>
+     * This method attempts to resolve the expected type for the given property <code>key</code> and
+     * <code>UIComponent</code>.
+     * </p>
+     */
+    private Class findPropertyType(UIComponent comp, String key) {
+        // First check to see if we've done this before...
+        Class compClass = comp.getClass();
+        String cacheKey = compClass.getName() + ';' + key;
+        if (_typeCache.containsKey(cacheKey)) {
+            // May return null if method previously executed unsuccessfully
+            return _typeCache.get(cacheKey);
+        }
+
+        // Search a little...
+        Class val = null;
+        Method meth = null;
+        String methodName = getGetterName(key);
+        try {
+            meth = compClass.getMethod(methodName);
+        } catch (NoSuchMethodException ex) {
+            // May fail if we have a boolean property that has an "is" getter.
+            try {
+                // Try again, replace "get" with "is"
+                meth = compClass.getMethod("is" + methodName.substring(3));
+            } catch (NoSuchMethodException ex2) {
+                // Still not found, must not have getter / setter
+                ex2.printStackTrace();
+            }
+        }
+        if (meth != null) {
+            val = meth.getReturnType();
+        } else {
+            Object obj = comp.getAttributes().get("key");
+            if (val != null) {
+                val = obj.getClass();
+            }
+        }
+
+        // Save the value for future calls for the same information
+        // NOTE: We do it this way to avoid modifying a shared Map
+        Map<String, Class> newTypeCache = new HashMap<>(_typeCache);
+        newTypeCache.put(cacheKey, val);
+        _typeCache = newTypeCache;
+
+        // Return the result
+        return val;
+    }
+
+    /**
+     * <p>
+     * This method converts the given <code>name</code> to a bean getter method name. In other words, it capitalizes the
+     * first letter and prepends "get".
+     * </p>
+     */
+    public String getGetterName(String name) {
+        return "get" + (char) (name.charAt(0) & 0xFFDF) + name.substring(1);
+    }
+
+    /**
+     * <p>
+     * This method will attempt to resolve the given EL string.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param elt The LayoutElement associated w/ the expression.
+     * @param parent The parent <code>UIComponent</code>. This is used because the current UIComponent is typically unknown
+     * (or not even created yet).
+     * @param value The String (or List / Array) to resolve.
+     *
+     * @return The evaluated value (may be null).
+     */
+    public Object resolveValue(FacesContext context, LayoutElement elt, UIComponent parent, Object value) {
+        // Invoke our own EL. This is needed b/c JSF's EL is designed for
+        // Bean getters only. It does not get CONSTANTS or pull data from
+        // other sources without adding a custom VariableResolver and/or
+        // PropertyResolver. Eventually we may want to find a good way to
+        // make this work as a regular ValueExpression expression... but for
+        // now, we'll just resolve it this way.
+        Object result = VariableResolver.resolveVariables(context, elt, parent, value);
+
+        // Next check to see if the result contains a JSF ValueExpression
+        if (result != null && result instanceof String && isValueReference((String) result)) {
+            ELContext elctx = context.getELContext();
+            ValueExpression ve = context.getApplication().getExpressionFactory().createValueExpression(elctx, (String) result,
+                    Object.class);
+            result = ve.getValue(elctx);
+            /*
+             * 1.1+ // JSF 1.1 VB: try { ValueBinding vb = context.getApplication().createValueBinding((String) result); result =
+             * vb.getValue(context); } catch (EvaluationException ex) { if (LogUtil.infoEnabled()) { LogUtil.info("JSFT0007", new
+             * Object[] {value}); } throw ex; }
+             */
+        }
+
+        // Return the result
+        return result;
+    }
+
+    /**
+     * <p>
+     * Returns true if this expression looks like an EL expression.
+     * </p>
+     */
+    public boolean isValueReference(String value) {
+        if (value == null) {
+            return false;
+        }
+// FIXME: Consider adding logic to look for "matching" {}'s
+        int start = value.indexOf("#{");
+        if (start != -1 && start < value.indexOf('}', start)) {
+            return true;
+        }
+        return false;
+    }
+
+    // While this is static, the information seems reasonable to share across
+    // applications as it is very unlikely to be different... leaving for now
+    private static Map<String, Class> _typeCache = new HashMap<>();
+
+    /**
+     * <p>
+     * This Map caches ComponentTypes by their factoryClass name.
+     * </p>
+     */
+    private Map<String, ComponentType> _types = new HashMap<>();
+
+    /**
+     * <p>
+     * Application scope key for an instance of <code>ComponentUtil</code>.
+     * </p>
+     */
+    public static final String COMPONENT_UTIL_KEY = "_jsft_COMP_UTIL";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/EventComponent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/EventComponent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+/**
+ * <p>
+ * This <code>UIComponent</code> exists so that custom events may be queued and triggered at appropriate times. This
+ * will allow "beforeEncode", "afterEncode", and even "command" events to be associated with components by wrapping 1 or
+ * more components with this component.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class EventComponent extends TemplateComponentBase {
+
+    /**
+     * <p>
+     * This is the location of the XML file that declares the layout for the EventComponent. (/jsftemplating/event.xml)
+     * </p>
+     */
+    public static final String LAYOUT_KEY = "/jsftemplating/event.xml";
+
+    /**
+     * <p>
+     * Constructor for <code>EventComponent</code>.
+     * </p>
+     */
+    public EventComponent() {
+        super();
+        setRendererType("com.sun.jsftemplating.EventComponent");
+        setLayoutDefinitionKey(LAYOUT_KEY);
+    }
+
+    /**
+     * <p>
+     * Return the family for this component.
+     * </p>
+     */
+    @Override
+    public String getFamily() {
+        return "com.sun.jsftemplating.EventComponent";
+    }
+
+    /**
+     * <p>
+     * Restore the state of this component.
+     * </p>
+     * public void restoreState(FacesContext _context,Object _state) { Object _values[] = (Object[]) _state;
+     * super.restoreState(_context, _values[0]); }
+     */
+
+    /**
+     * <p>
+     * Save the state of this component.
+     * </p>
+     * public Object saveState(FacesContext _context) { Object _values[] = new Object[1]; _values[0] =
+     * super.saveState(_context); return _values; }
+     */
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/ForEach.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/ForEach.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+/**
+ * <p>
+ * This <code>UIComponent</code> exists so "foreach" conditions can be processed during rendering.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ForEach extends TemplateComponentBase {
+
+    /**
+     * <p>
+     * This is the location of the XML file that declares the layout for the <code>ForEach</code>.
+     * (/jsftemplating/foreach.xml)
+     * </p>
+     */
+    public static final String LAYOUT_KEY = "/jsftemplating/foreach.xml";
+
+    /**
+     * <p>
+     * Constructor for <code>ForEach</code>.
+     * </p>
+     */
+    public ForEach() {
+        super();
+        setRendererType("com.sun.jsftemplating.ForEach");
+        setLayoutDefinitionKey(LAYOUT_KEY);
+    }
+
+    /**
+     * <p>
+     * Return the family for this component.
+     * </p>
+     */
+    @Override
+    public String getFamily() {
+        return "com.sun.jsftemplating.ForEach";
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/If.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/If.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+/**
+ * <p>
+ * This <code>UIComponent</code> exists so "if" conditions can be processed during rendering.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class If extends TemplateComponentBase {
+
+    /**
+     * <p>
+     * This is the location of the XML file that declares the layout for the If. (/jsftemplating/if.xml)
+     * </p>
+     */
+    public static final String LAYOUT_KEY = "/jsftemplating/if.xml";
+
+    /**
+     * <p>
+     * Constructor for <code>If</code>.
+     * </p>
+     */
+    public If() {
+        super();
+        setRendererType("com.sun.jsftemplating.If");
+        setLayoutDefinitionKey(LAYOUT_KEY);
+    }
+
+    /**
+     * <p>
+     * Return the family for this component.
+     * </p>
+     */
+    @Override
+    public String getFamily() {
+        return "com.sun.jsftemplating.If";
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/StaticText.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/StaticText.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+/**
+ * <p>
+ * This <code>UIComponent</code> produces static text output.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class StaticText extends TemplateComponentBase {
+
+    /**
+     * <p>
+     * This is the location of the XML file that declares the layout for the StaticText. (/jsftemplating/staticText.xml)
+     * </p>
+     */
+    public static final String LAYOUT_KEY = "/jsftemplating/staticText.xml";
+
+    /**
+     * <p>
+     * Constructor for <code>StaticText</code>.
+     * </p>
+     */
+    public StaticText() {
+        super();
+        setRendererType("com.sun.jsftemplating.StaticText");
+        setLayoutDefinitionKey(LAYOUT_KEY);
+    }
+
+    /**
+     * <p>
+     * Return the family for this component.
+     * </p>
+     */
+    @Override
+    public String getFamily() {
+        return "com.sun.jsftemplating.StaticText";
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateComponent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateComponent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This interface defines additional methods in addition to those defined by UIComponent that are needed to work with a
+ * TemplateRenderer.
+ * </p>
+ *
+ * <p>
+ * JSF did not define an interface for UIComponent, so I cannot extend an interface here. This means that casting is
+ * needed to use UIComponent features from a TemplateComponent.
+ * </p>
+ *
+ * <p>
+ * If you need to have a <code>NamingContainer</code>, do not forget to implement that interface in addition to this
+ * interface.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface TemplateComponent extends ChildManager {
+
+    /**
+     * This method will find the request child UIComponent by id. If it is not found, it will attempt to create it if it can
+     * find a LayoutElement describing it.
+     *
+     * @param context The FacesContext
+     * @param id The UIComponent id to search for
+     *
+     * @return The requested UIComponent
+     */
+    UIComponent getChild(FacesContext context, String id);
+
+    /**
+     * This method returns the LayoutDefinition associated with this component.
+     *
+     * @param context The FacesContext
+     *
+     * @return LayoutDefinition associated with this component.
+     */
+    LayoutDefinition getLayoutDefinition(FacesContext context);
+
+    /**
+     * This method returns the LayoutDefinitionKey for this component.
+     *
+     * @return key The key to use in the LayoutDefinitionManager
+     */
+    String getLayoutDefinitionKey();
+
+    /**
+     * This method sets the LayoutDefinition key for this component.
+     *
+     * @param key The key to use in the LayoutDefinitionManager
+     */
+    void setLayoutDefinitionKey(String key);
+
+    /**
+     * <p>
+     * This method returns the value of the requested field. It should first check the value of <code>field</code> passed
+     * in, it should return that value if set. Next, it should check to see if there is a <code>ValueExpression</code>
+     * matching <code>attributeName</code> and return that value, if it exists. If neither of the first 2 cases yielded a
+     * result, <code>defaultValue</code> is returned.
+     * </p>
+     *
+     * @param field The field which may contain the value.
+     * @param attributeName The <code>ValueExpression</code> name.
+     * @param defaultValue The default value.
+     *
+     * @return The value of the property.
+     */
+    <V> V getPropertyValue(V field, String attributeName, V defaultValue);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateComponentBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateComponentBase.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This abstract class provides base functionality for components that work in conjunction with the
+ * {@link com.sun.jsftemplating.renderer.TemplateRenderer} that do not need any "special" component features (such as
+ * provided by <code>UIInput</code>, or an <code>ActionSource</code> implementation). This class is a suitable class for
+ * "container" types of components, or components that simply agregate other components together. It provides a default
+ * implementation of the {@link com.sun.jsftemplating.component.TemplateComponent} interface.
+ * </p>
+ *
+ * @see com.sun.jsftemplating.renderer.TemplateRenderer
+ * @see com.sun.jsftemplating.component.TemplateComponent
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class TemplateComponentBase extends UIComponentBase implements TemplateComponent {
+
+    /**
+     * <p>
+     * Our <code>TemplateComponentHelper</code>. We initialize it on access b/c we want to ensure it exists, if it is
+     * serialized it won't exist if we init it here or in the constructor.
+     * </p>
+     */
+    private transient TemplateComponentHelper _helper;
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id. If it is not found, it will attempt to create
+     * it if it can find a {@link LayoutElement} describing it.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param id The <code>UIComponent</code> id to find.
+     *
+     * @return The requested <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getChild(FacesContext context, String id) {
+        return getHelper().getChild(this, context, id);
+    }
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id. If it is not found, it will use the given
+     * {@link LayoutComponent} to create it.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param descriptor The <code>UIComponent</code> id to find.
+     *
+     * @return The requested <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getChild(FacesContext context, LayoutComponent descriptor) {
+        return getHelper().getChild(this, context, descriptor);
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} associated with this component.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return {@link LayoutDefinition} associated with this component.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition(FacesContext context) {
+        return getHelper().getLayoutDefinition(context);
+    }
+
+    /**
+     * <p>
+     * This method saves the state for this component. It relies on the superclass to save its own sate, this method will
+     * invoke super.saveState().
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return The serialized state.
+     */
+    @Override
+    public Object saveState(FacesContext context) {
+        return getHelper().saveState(context, super.saveState(context));
+    }
+
+    /**
+     * <p>
+     * This method restores the state for this component. It will invoke the superclass to restore its state.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param state The serialized state.
+     */
+    @Override
+    public void restoreState(FacesContext context, Object state) {
+        super.restoreState(context, getHelper().restoreState(context, state));
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} key for this component.
+     * </p>
+     *
+     * @return The key to use in the {@link LayoutDefinitionManager}.
+     */
+    @Override
+    public String getLayoutDefinitionKey() {
+        return getHelper().getLayoutDefinitionKey();
+    }
+
+    /**
+     * <p>
+     * This method sets the {@link LayoutDefinition} key for this component.
+     * </p>
+     *
+     * @param key The key to use in the {@link LayoutDefinitionManager}.
+     */
+    @Override
+    public void setLayoutDefinitionKey(String key) {
+        getHelper().setLayoutDefinitionKey(key);
+    }
+
+    @Override
+    public <V> V getPropertyValue(V field, String attributeName, V defaultValue) {
+        return getHelper().getAttributeValue(this, field, attributeName, defaultValue);
+    }
+
+    /**
+     * <p>
+     * This method retrieves the {@link TemplateComponentHelper} used by this class to help implement the
+     * {@link TemplateComponent} interface.
+     * </p>
+     *
+     * @return The {@link TemplateComponentHelper} for this component.
+     */
+    protected TemplateComponentHelper getHelper() {
+        if (_helper == null) {
+            _helper = new TemplateComponentHelper();
+        }
+        return _helper;
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateComponentHelper.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateComponentHelper.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This class provides base functionality for components that work in conjunction with the
+ * {@link com.sun.jsftemplating.renderer.TemplateRenderer}. It provides the bulk of the default implementation of the
+ * {@link TemplateComponent} interface.
+ * </p>
+ *
+ * <p>
+ * This class is meant to be used inside a <code>UIComponent</code> class that implements <code>TemplateComponent</code>
+ * to help provide the behavior of a <code>TemplateComponent</code>. It is <em>NOT</em> an implementation by itself. A
+ * <code>TemplateComonent</code> implementation class may use this to help define its functionality and must also be an
+ * instance of <code>UIComponent</code>.
+ * </p>
+ *
+ * @see com.sun.jsftemplating.renderer.TemplateRenderer
+ * @see TemplateComponent
+ * @see TemplateComponentBase
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class TemplateComponentHelper {
+
+    /**
+     * <p>
+     * This is the LayoutDefinition key for the <code>UIComponent</code>. This is typically set by the Tag. The Component
+     * may also provide a default by setting it in its constructor.
+     * </p>
+     */
+    private String _ldmKey;
+
+    /**
+     * <p>
+     * This is a cached reference to the {@link LayoutDefinition} used by the <code>UIComponent</code>.
+     * </p>
+     */
+    private transient LayoutDefinition _layoutDefinition;
+
+    /**
+     * <p>
+     * This class should only be used by <code>TemplateComponent</code> implementations to help them provide their
+     * <code>TemplateComponent</code> funtionality.
+     * </p>
+     */
+    public TemplateComponentHelper() {
+    }
+
+    /**
+     * <p>
+     * This method will find the request child UIComponent by id. If it is not found, it will attempt to create it if it can
+     * find a {@link LayoutElement} describing it.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param id The <code>UIComponent</code> id to find.
+     *
+     * @return The requested UIComponent
+     */
+    public UIComponent getChild(UIComponent comp, FacesContext context, String id) {
+        if (id == null || id.trim().equals("")) {
+            // No id, no LayoutComponent, nothing we can do.
+            return null;
+        }
+
+        // We have an id, use it to search for an already-created child
+        // FIXME: I am doing this 2x if it falls through to create the child...
+        // FIXME: think about optimizing this
+        UIComponent childComponent = ComponentUtil.getInstance(context).findChild(comp, id, id);
+        if (childComponent != null) {
+            return childComponent;
+        }
+
+        // If we're still here, then we need to create it... hopefully we have
+        // a LayoutComponent to tell us how to do this!
+        LayoutDefinition ld = getLayoutDefinition(context);
+        if (ld == null) {
+            // No LayoutDefinition to tell us how to create it... return null
+            return null;
+        }
+
+        // Attempt to find a LayoutComponent matching the id
+        LayoutElement elt = LayoutDefinition.getChildLayoutElementById(context, id, ld, comp);
+
+        // Create the child from the LayoutComponent
+        return getChild(comp, context, (LayoutComponent) elt);
+    }
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id (the id is obtained from the given
+     * {@link LayoutComponent}). If it is not found, it will attempt to create it from the supplied {@link LayoutElement}.
+     * </p>
+     *
+     * @param descriptor The {@link LayoutElement} describing the <code>UIComponent</code>.
+     *
+     * @return The requested UIComponent
+     */
+    public UIComponent getChild(UIComponent comp, FacesContext context, LayoutComponent descriptor) {
+        UIComponent childComponent = null;
+
+        // Sanity check
+        if (descriptor == null) {
+            throw new IllegalArgumentException("The LayoutComponent is null!");
+        }
+
+        // First pull off the id from the descriptor
+        String id = descriptor.getId(context, comp);
+        ComponentUtil compUtil = ComponentUtil.getInstance(context);
+        if (id != null && !id.trim().equals("")) {
+            // We have an id, use it to search for an already-created child
+            childComponent = compUtil.findChild(comp, id, id);
+            if (childComponent != null) {
+                return childComponent;
+            }
+        }
+
+        // No id, or the component hasn't been created. In either case, we
+        // create a new component (moral: always have an id)
+
+        // Invoke "beforeCreate" handlers
+        descriptor.beforeCreate(context, comp);
+
+        // Create UIComponent
+        childComponent = compUtil.createChildComponent(context, descriptor, comp);
+
+        // Invoke "afterCreate" handlers
+        descriptor.afterCreate(context, childComponent);
+
+        // Return the newly created UIComponent
+        return childComponent;
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} associated with the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return {@link LayoutDefinition} associated with the <code>UIComponent</code>.
+     */
+    public LayoutDefinition getLayoutDefinition(FacesContext context) {
+        // Make sure we don't already have it...
+        if (_layoutDefinition != null) {
+            return _layoutDefinition;
+        }
+
+        // Get the LayoutDefinitionManager key
+        String key = getLayoutDefinitionKey();
+        if (key == null) {
+            throw new NullPointerException("LayoutDefinition key is null!");
+        }
+
+        // Save the LayoutDefinition for future calls to this method
+        try {
+            _layoutDefinition = LayoutDefinitionManager.getLayoutDefinition(context, key);
+        } catch (LayoutDefinitionException ex) {
+            throw new IllegalArgumentException("A LayoutDefinition was not provided for '" + key + "'!  This is required.", ex);
+        }
+
+        // Return the LayoutDefinition (if found)
+        return _layoutDefinition;
+    }
+
+    /**
+     * <p>
+     * This method saves the state for the <code>UIComponent</code>. It relies on the <code>UIComponent</code>'s superclass
+     * to save its own sate, and to pass in that <code>Object</code> to this method.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param superState The <code>UIComponent</code>'s superclass state.
+     *
+     * @return The serialized State.
+     */
+    public Object saveState(FacesContext context, Object superState) {
+        Object[] values = new Object[2];
+        values[0] = superState;
+        values[1] = _ldmKey;
+        return values;
+    }
+
+    /**
+     * <p>
+     * This method restores the state for the <code>UIComponent</code>. It will return an <code>Object</code> that must be
+     * passed to the superclass's <code>restoreState</code> method.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param state The serialized state.
+     *
+     * @return The State for the superclass to deserialize.
+     */
+    public Object restoreState(FacesContext context, Object state) {
+        Object[] values = (Object[]) state;
+        _ldmKey = (java.lang.String) values[1];
+        return values[0];
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} key for the <code>UIComponent</code>.
+     * </p>
+     *
+     * @return key The key to use in the {@link LayoutDefinitionManager}.
+     */
+    public String getLayoutDefinitionKey() {
+        return _ldmKey;
+    }
+
+    /**
+     * <p>
+     * This method sets the LayoutDefinition key for the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param key The key to use in the {@link LayoutDefinitionManager}.
+     */
+    public void setLayoutDefinitionKey(String key) {
+        _ldmKey = key;
+    }
+
+    public <V> V getAttributeValue(UIComponent comp, V field, String attributeName, V defaultValue) {
+        if (field != null) {
+            return field;
+        }
+        ValueExpression ve = comp.getValueExpression(attributeName);
+        return ve != null ? (V) ve.getValue(FacesContext.getCurrentInstance().getELContext()) : defaultValue;
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateInputComponentBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateInputComponentBase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIInput;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This abstract class provides base functionality for components that work in conjunction with the
+ * {@link com.sun.jsftemplating.renderer.TemplateRenderer} and would like to provide <code>UIInput</code> functionality.
+ * It provides a default implementation of the {@link TemplateComponent} interface.
+ * </p>
+ *
+ * @see com.sun.jsftemplating.renderer.TemplateRenderer
+ * @see com.sun.jsftemplating.component.TemplateComponent
+ * @see com.sun.jsftemplating.component.TemplateComponentHelper
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class TemplateInputComponentBase extends UIInput implements TemplateComponent {
+
+    /**
+     * <p>
+     * Our <code>TemplateComponentHelper</code>. We initialize it on access b/c we want to ensure it exists, if it is
+     * serialized it won't exist if we init it here or in the constructor.
+     * </p>
+     */
+    private transient TemplateComponentHelper _helper;
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id. If it is not found, it will attempt to create
+     * it if it can find a {@link LayoutElement} describing it.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param id The <code>UIComponent</code> id to find.
+     *
+     * @return The requested <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getChild(FacesContext context, String id) {
+        return getHelper().getChild(this, context, id);
+    }
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id (the id is obtained from the given
+     * {@link LayoutComponent}). If it is not found, it will attempt to create it from the supplied {@link LayoutElement}.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param descriptor The {@link LayoutElement} describing the <code>UIComponent</code>
+     *
+     * @return The requested <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getChild(FacesContext context, LayoutComponent descriptor) {
+        return getHelper().getChild(this, context, descriptor);
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} associated with this component.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return {@link LayoutDefinition} associated with this component.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition(FacesContext context) {
+        return getHelper().getLayoutDefinition(context);
+    }
+
+    /**
+     * <p>
+     * This method saves the state for this component. It relies on the superclass to save its own sate, this method will
+     * invoke super.saveState().
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return The serialized state.
+     */
+    @Override
+    public Object saveState(FacesContext context) {
+        return getHelper().saveState(context, super.saveState(context));
+    }
+
+    /**
+     * <p>
+     * This method restores the state for this component. It will invoke the superclass to restore its state.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param state The serialized state.
+     */
+    @Override
+    public void restoreState(FacesContext context, Object state) {
+        super.restoreState(context, getHelper().restoreState(context, state));
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} key for this component.
+     * </p>
+     *
+     * @return The key to use in the {@link LayoutDefinitionManager}.
+     */
+    @Override
+    public String getLayoutDefinitionKey() {
+        return getHelper().getLayoutDefinitionKey();
+    }
+
+    /**
+     * <p>
+     * This method sets the {@link LayoutDefinition} key for this component.
+     * </p>
+     *
+     * @param key The key to use in the {@link LayoutDefinitionManager}.
+     */
+    @Override
+    public void setLayoutDefinitionKey(String key) {
+        getHelper().setLayoutDefinitionKey(key);
+    }
+
+    @Override
+    public <V> V getPropertyValue(V field, String attributeName, V defaultValue) {
+        return getHelper().getAttributeValue(this, field, attributeName, defaultValue);
+    }
+
+    /**
+     * <p>
+     * This method retrieves the {@link TemplateComponentHelper} used by this class to help implement the
+     * {@link TemplateComponent} interface.
+     * </p>
+     *
+     * @return The {@link TemplateComponentHelper} for this component.
+     */
+    protected TemplateComponentHelper getHelper() {
+        if (_helper == null) {
+            _helper = new TemplateComponentHelper();
+        }
+        return _helper;
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateOutputComponentBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/TemplateOutputComponentBase.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This abstract class provides base functionality for components that work in conjunction with the
+ * {@link com.sun.jsftemplating.renderer.TemplateRenderer} and would like to provide <code>UIInput</code> functionality.
+ * It provides a default implementation of the {@link TemplateComponent} interface.
+ * </p>
+ *
+ * @see com.sun.jsftemplating.renderer.TemplateRenderer
+ * @see com.sun.jsftemplating.component.TemplateComponent
+ * @see com.sun.jsftemplating.component.TemplateComponentHelper
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class TemplateOutputComponentBase extends UIOutput implements TemplateComponent {
+
+    /**
+     * <p>
+     * Our <code>TemplateComponentHelper</code>. We initialize it on access b/c we want to ensure it exists, if it is
+     * serialized it won't exist if we init it here or in the constructor.
+     * </p>
+     */
+    private transient TemplateComponentHelper _helper;
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id. If it is not found, it will attempt to create
+     * it if it can find a {@link LayoutElement} describing it.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param id The <code>UIComponent</code> id to find.
+     *
+     * @return The requested <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getChild(FacesContext context, String id) {
+        return getHelper().getChild(this, context, id);
+    }
+
+    /**
+     * <p>
+     * This method will find the request child <code>UIComponent</code> by id (the id is obtained from the given
+     * {@link LayoutComponent}). If it is not found, it will attempt to create it from the supplied {@link LayoutElement}.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param descriptor The {@link LayoutElement} describing the <code>UIComponent</code>
+     *
+     * @return The requested <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getChild(FacesContext context, LayoutComponent descriptor) {
+        return getHelper().getChild(this, context, descriptor);
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} associated with this component.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return {@link LayoutDefinition} associated with this component.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition(FacesContext context) {
+        return getHelper().getLayoutDefinition(context);
+    }
+
+    /**
+     * <p>
+     * This method saves the state for this component. It relies on the superclass to save its own sate, this method will
+     * invoke super.saveState().
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     *
+     * @return The serialized state.
+     */
+    @Override
+    public Object saveState(FacesContext context) {
+        return getHelper().saveState(context, super.saveState(context));
+    }
+
+    /**
+     * <p>
+     * This method restores the state for this component. It will invoke the superclass to restore its state.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param state The serialized state.
+     */
+    @Override
+    public void restoreState(FacesContext context, Object state) {
+        super.restoreState(context, getHelper().restoreState(context, state));
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} key for this component.
+     * </p>
+     *
+     * @return The key to use in the {@link LayoutDefinitionManager}.
+     */
+    @Override
+    public String getLayoutDefinitionKey() {
+        return getHelper().getLayoutDefinitionKey();
+    }
+
+    /**
+     * <p>
+     * This method sets the {@link LayoutDefinition} key for this component.
+     * </p>
+     *
+     * @param key The key to use in the {@link LayoutDefinitionManager}.
+     */
+    @Override
+    public void setLayoutDefinitionKey(String key) {
+        getHelper().setLayoutDefinitionKey(key);
+    }
+
+    @Override
+    public <V> V getPropertyValue(V field, String attributeName, V defaultValue) {
+        return getHelper().getAttributeValue(this, field, attributeName, defaultValue);
+    }
+
+    /**
+     * <p>
+     * This method retrieves the {@link TemplateComponentHelper} used by this class to help implement the
+     * {@link TemplateComponent} interface.
+     * </p>
+     *
+     * @return The {@link TemplateComponentHelper} for this component.
+     */
+    protected TemplateComponentHelper getHelper() {
+        if (_helper == null) {
+            _helper = new TemplateComponentHelper();
+        }
+        return _helper;
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/While.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/While.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component;
+
+/**
+ * <p>
+ * This <code>UIComponent</code> exists so "while" conditions can be processed during rendering.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class While extends TemplateComponentBase {
+
+    /**
+     * <p>
+     * This is the location of the XML file that declares the layout for the <code>While</code>. (/jsftemplating/while.xml)
+     * </p>
+     */
+    public static final String LAYOUT_KEY = "/jsftemplating/while.xml";
+
+    /**
+     * <p>
+     * Constructor for <code>While</code>.
+     * </p>
+     */
+    public While() {
+        super();
+        setRendererType("com.sun.jsftemplating.While");
+        setLayoutDefinitionKey(LAYOUT_KEY);
+    }
+
+    /**
+     * <p>
+     * Return the family for this component.
+     * </p>
+     */
+    @Override
+    public String getFamily() {
+        return "com.sun.jsftemplating.While";
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/IndexFieldKey.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/IndexFieldKey.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.dataprovider;
+
+import com.sun.data.provider.FieldKey;
+
+/**
+ * <p>
+ * This implementation of <code>FieldKey</code> provides a way to associate an index along with the fieldId. One use
+ * case for this is when a DataProvider acts as a facade for multiple data sources, the index can be used to indicate to
+ * which underlying source the key pertains.
+ * </p>
+ *
+ * <p>
+ * Keey in mind that a single <code>FieldKey</code> is meant to represent all rows, so it would not be useful to store
+ * row information in a FieldKey. Therefor the index in this <code>IndexFieldKey</code> is <b>not</b> intended to
+ * specify a row!
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class IndexFieldKey extends FieldKey {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructs a new <code>IndexFieldKey</code> with the specified <code>fieldId</code> and <code>index</code>.
+     * </p>
+     *
+     * @param fieldId The desired cannonical ID String.
+     * @param index The index for this <code>IndexFieldKey</code>.
+     */
+    public IndexFieldKey(String fieldId, int index) {
+        super(fieldId);
+        setIndex(index);
+    }
+
+    /**
+     * <p>
+     * Constructs a new <code>IndexFieldKey</code> with the specified <code>fieldId</code>, <code>displayName</code>, and
+     * <code>index</code>.
+     * </p>
+     *
+     * @param fieldId The desired cannonical ID String for this field.
+     * @param displayName The desired display name String.
+     * @param index The index for this <code>IndexFieldKey</code>.
+     */
+    public IndexFieldKey(String fieldId, String displayName, int index) {
+        super(fieldId, displayName);
+        setIndex(index);
+    }
+
+    /**
+     * <p>
+     * Constructs a new <code>IndexFieldKey</code> with the specified <code>fieldId</code>, <code>displayName</code>, and
+     * <code>index</code>.
+     * </p>
+     *
+     * @param fk The <code>FieldKey</code>.
+     * @param index The index for this <code>IndexFieldKey</code>.
+     */
+    public IndexFieldKey(FieldKey fk, int index) {
+        super(fk.getFieldId(), fk.getDisplayName());
+        setIndex(index);
+    }
+
+    /**
+     * <p>
+     * This method retreives the index associated with this object.
+     * </p>
+     */
+    public int getIndex() {
+        return _index;
+    }
+
+    /**
+     * <p>
+     * This method retreives the index associated with this object.
+     * </p>
+     */
+    public void setIndex(int idx) {
+        _index = idx;
+    }
+
+    /**
+     * <p>
+     * Standard equals implementation. This method compares the <code>IndexFieldKey</code> <code>fieldId</code> and
+     * <code>index</code> values for equality.
+     * </p>
+     *
+     * @param obj The Object to check equality.
+     *
+     * @return <code>true</code> if equal, <code>false</code> if not.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        boolean val = super.equals(obj);
+        if (val && obj instanceof IndexFieldKey) {
+            val = ((IndexFieldKey) obj).getIndex() == getIndex();
+        }
+        return val;
+    }
+
+    /**
+     * <p>
+     * This provides a hash for instances of this class.
+     * </p>
+     */
+    @Override
+    public int hashCode() {
+        if (_hash == -1) {
+            // Use the hashCode() of the String (id + index)
+            _hash = (getFieldId() + getIndex()).hashCode();
+        }
+        return _hash;
+    }
+
+    /**
+     * <p>
+     * The toString() implementation. This implementation prints out the index and fieldId:
+     * </p>
+     *
+     * <p>
+     * IndexFieldKey[<code>&lt;index&gt;</code>][<code>&lt;id&gt;</code>]
+     * </p>
+     */
+    @Override
+    public String toString() {
+        return "IndexFieldKey[" + getIndex() + "][" + getFieldId() + "]"; // NOI18N
+    }
+
+    /**
+     * <p>
+     * Storate for the index.
+     * </p>
+     */
+    private int _index = -1;
+    private transient int _hash = -1;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/MapObjectFieldKeySupport.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/MapObjectFieldKeySupport.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.dataprovider;
+
+import com.sun.data.provider.DataProviderException;
+import com.sun.data.provider.FieldKey;
+import com.sun.data.provider.impl.ObjectFieldKeySupport;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * Support class for <code>DataProvider</code> implementations that need to instrospect Java classes to discover
+ * properties, or Map values and return <code>FieldKey</code> instances for them.
+ * </p>
+ */
+public class MapObjectFieldKeySupport extends ObjectFieldKeySupport {
+
+    /**
+     * <p>
+     * Construct a new support instance wrapping the specified Map class, with the specified flag for including public
+     * fields.
+     * </p>
+     *
+     * @param cls Class whose properties should be exposed.
+     * @param inst Optional instance of <code>cls</code> used for resolving Map values.
+     */
+    public MapObjectFieldKeySupport(Class cls, Map inst) {
+        super(cls, false);
+        if (!Map.class.isAssignableFrom(cls)) {
+            throw new IllegalArgumentException(this.getClass().getName() + " is only valid for java.util.Map classes!");
+        }
+        _inst = inst;
+    }
+
+    /**
+     * <p>
+     * Return the <code>FieldKey</code> associated with the specified canonical identifier, if any; otherwise, return
+     * <code>null</code>.
+     * </p>
+     *
+     * @param fieldId Canonical identifier of the required field.
+     */
+    @Override
+    public FieldKey getFieldKey(String fieldId) throws DataProviderException {
+        FieldKey key = super.getFieldKey(fieldId);
+        if (key == null && _inst != null) {
+            if (_inst.get(fieldId) != null) {
+                key = new FieldKey(fieldId);
+            }
+        }
+        return key;
+    }
+
+    /**
+     * <p>
+     * Return an array of all supported <code>FieldKey</code>s.
+     * </p>
+     */
+    @Override
+    public FieldKey[] getFieldKeys() throws DataProviderException {
+        FieldKey keys[] = super.getFieldKeys();
+        if (_inst != null) {
+            FieldKey tmp[] = new FieldKey[keys.length + _inst.size()];
+            int cnt = 0;
+            // Add all other keys
+            for (FieldKey key : keys) {
+                tmp[cnt++] = key;
+            }
+
+            // Add all Map keys
+            for (Object key : _inst.keySet()) {
+                tmp[cnt++] = new FieldKey(key.toString());
+            }
+            keys = tmp;
+        }
+        return keys;
+    }
+
+    /**
+     * <p>
+     * Return the type of the field associated with the specified <code>FieldKey</code>, if it can be determined; otherwise,
+     * return <code>null</code>.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> to return the type for.
+     */
+    @Override
+    public Class getType(FieldKey fieldKey) throws DataProviderException {
+        Class type = super.getType(fieldKey);
+        if (type == null) {
+            Object obj = _inst.get(fieldKey.getFieldId());
+            if (obj != null) {
+                type = obj.getClass();
+            }
+        }
+        return type;
+    }
+
+    /**
+     * <p>
+     * Return the value for the specified <code>FieldKey</code>, from the specified base object.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> for the requested field.
+     * @param base Base object to be used.
+     */
+    @Override
+    public Object getValue(FieldKey fieldKey, Object base) throws DataProviderException {
+        // Make sure we have an instance
+        if (base != null) {
+            _inst = (Map) base;
+        }
+        if (_inst == null) {
+            return null;
+        }
+
+        // Check the properties (super behavior)
+        Object val = super.getValue(fieldKey, _inst);
+
+        // If not found, check the Map
+        if (val == null) {
+            val = _inst.get(fieldKey.getFieldId());
+        }
+
+        // Return the result (if found, null otherwise)
+        return val;
+    }
+
+    /**
+     * <p>
+     * Return <code>true</code> if the specified value may be successfully assigned to the specified field. The only time
+     * this is false is if a property of the Map implementation is being set. Map values can be any Object and therefor will
+     * always be true.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> to check assignability for.
+     * @param value Proposed value.
+     */
+    @Override
+    public boolean isAssignable(FieldKey fieldKey, Object value) throws DataProviderException {
+        Class type = super.getType(fieldKey);
+        if (type != null) {
+            // We only do this if we have a property...
+            return super.isAssignable(fieldKey, value);
+        }
+
+        // Return true in all other cases
+        return true;
+    }
+
+    /**
+     * <p>
+     * Return the read only state of the field associated with the specified <code>FieldKey</code>, if it can be determined,
+     * otherwise, return <code>false</code>.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> to return read only state for
+     */
+    @Override
+    public boolean isReadOnly(FieldKey fieldKey) throws DataProviderException {
+        Class type = super.getType(fieldKey);
+        if (type != null) {
+            // We only do this if we have a property...
+            return super.isReadOnly(fieldKey);
+        }
+        return false;
+    }
+
+    /**
+     * <p>
+     * Set the <code>value</code> for the specified <code>fieldKey</code>, on the specified <code>base</code> object. If the
+     * instance (<code>base</code>) is already set on this support object, then <code>base</code> may be <code>null</code>.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> for the requested field.
+     * @param base Base object to be used (null ok if already set).
+     * @param value Value to set.
+     *
+     * @exception NullPointerException If base and _inst are null.
+     * @exception IllegalArgumentException If a type mismatch occurs.
+     * @exception IllegalStateException If setting a read only field.
+     */
+    @Override
+    public void setValue(FieldKey fieldKey, Object base, Object value) throws DataProviderException {
+        if (base != null) {
+            _inst = (Map) base;
+        }
+        Class type = super.getType(fieldKey);
+        if (type != null) {
+            // We only do this if we have a property...
+            super.setValue(fieldKey, _inst, value);
+        } else {
+            _inst.put(fieldKey.getFieldId(), value);
+        }
+    }
+
+    private Map _inst = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/MultipleListDataProvider.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/MultipleListDataProvider.java
@@ -1,0 +1,670 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.dataprovider;
+
+import com.sun.data.provider.DataProviderException;
+import com.sun.data.provider.FieldKey;
+import com.sun.data.provider.RowKey;
+import com.sun.data.provider.TransactionalDataListener;
+import com.sun.data.provider.impl.IndexRowKey;
+import com.sun.data.provider.impl.ObjectFieldKeySupport;
+import com.sun.data.provider.impl.ObjectListDataProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * <p>
+ * This implementation allows for multiple <code>List</code> objects to be used to represent table rows. If mulitiple
+ * <code>List</code>s are used, they must be parallel lists (i.e. have the same # and order of information).
+ * </p>
+ */
+public class MultipleListDataProvider extends ObjectListDataProvider {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public MultipleListDataProvider() {
+        setIncludeFields(false);
+    }
+
+    /**
+     * <p>
+     * Constructor that creates initializes the DataProvider with a single <code>List</code>. Fields are <b>not</b> included
+     * by default.
+     * </p>
+     *
+     * @param list Primary list containing row information.
+     */
+    public MultipleListDataProvider(List<List<Object>> list) {
+        this(list, false);
+    }
+
+    /**
+     * <p>
+     * Constructor that creates initializes the DataProvider with a single <code>List</code>. Fields are included if
+     * <code>includeFields</code> is true.
+     * </p>
+     *
+     * @param lists <code>List&lt;List&lt;Object&gt;&gt; to be
+     *                wrapped.</code>
+     * @param includeFields Desired include fields property setting
+     */
+    public MultipleListDataProvider(List<List<Object>> lists, boolean includeFields) {
+        // Set the lists
+        setLists(lists);
+
+        // Do not include fields
+        setIncludeFields(false);
+    }
+
+    /**
+     * <p>
+     * Constructor for an empty <code>DataProvider</code> with a known type. This constructor is only useful when there is a
+     * single <code>List</code>. Fields are <b>not</b> included.
+     * </p>
+     *
+     * @param objectTypes Desired object type Classes.
+     */
+    public MultipleListDataProvider(Class[] objectTypes) {
+        this(objectTypes, false);
+    }
+
+    /**
+     * <p>
+     * Constructor for an empty <code>DataProvider</code> with a known type. This constructor is only useful when there is a
+     * single <code>List</code>. Fields are included if <code>includeFields</code> is true.
+     * </p>
+     *
+     * @param objTypes Desired object type of Classes
+     * @param includeFields Desired include fields property setting
+     */
+    public MultipleListDataProvider(Class[] objTypes, boolean includeFields) {
+        setObjectTypes(objTypes);
+        setIncludeFields(includeFields);
+    }
+
+// FIXME: Provide apis to manage multiple lists:
+// FIXME:   addList(String, List)
+// FIXME:   removeList(String)??
+
+    /**
+     * <p>
+     * This method returns an <b>array</b> of <code>Object</code> <code>(Object [])</code> for the given <code>row</code>.
+     * Each array element cooresponds to an <code>Object</code> in one of the <code>List</code>s represented by this
+     * instance of <code>MultipleListDataProvider</code>.
+     * </p>
+     *
+     * @throws IndexOutOfBoundsException If <code>row</code> is invalid.
+     */
+    @Override
+    public Object getObject(RowKey row) {
+        if (!isRowAvailable(row)) {
+            throw new IndexOutOfBoundsException("" + row);
+        }
+        int rowIdx = getRowIndex(row);
+        List<List<Object>> lists = getLists();
+        Object[] result = new Object[lists.size()];
+        int idx = 0;
+        for (List list : lists) {
+            result[idx++] = list.get(rowIdx);
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method returns an array of array of<code>Object</code>s <code>(Object [][])</code>. The first element of the
+     * array is the row, the second cooresponds to the <code>List</code>: <code>Object[row #][list #]</code>. If there is
+     * only one <code>List</code> represented by this instance of <code>MultipleListDataProvider</code>, then the list #
+     * will be 0; if there are 2 <code>List</code>s, then the list # will be 0 or 1, etc.
+     * </p>
+     */
+    @Override
+    public Object[] getObjects() {
+        // Get the array demensions
+        List<List<Object>> lists = getLists();
+        int numLists = lists.size();
+        if (numLists == 0) {
+            // This isn't likely, but just in case...
+            return new Object[0][0];
+        }
+        int numRows = lists.get(0).size();
+        Object[][] result = new Object[numRows][numLists];
+
+        // Fill the array
+        int listNum = 0;
+        for (int rowNum = 0; rowNum < numRows; rowNum++) {
+            listNum = 0;
+            for (List list : lists) {
+                result[rowNum][listNum++] = list.get(rowNum);
+            }
+        }
+
+        // Return the result (Object[rows][lists])
+        return result;
+    }
+
+    /**
+     * <p>
+     * This sets the <code>Object<code> type contained in the
+     *        <code>List</code> that this <code>MulitpleObjectDataProvider</code> represents. This method should only be
+     * used when there is one <code>List</code> held by this <code>MultipleListDataProvider</code>. In cases where you have
+     * more than one list (and likely you do because you are using this <code>DataProvider</code>), you should use
+     * {@link #setObjectTypes(Class [])}.
+     * </p>
+     */
+    @Override
+    public void setObjectType(Class objectType) {
+        setObjectTypes(new Class[] { objectType });
+    }
+
+    /**
+     * <p>
+     * This method sets the Object types for each <code>List</code> that is represented by this instance of this class. By
+     * doing this, you allow the FieldKeys to be generated. You only need to specify this information if you have no rows.
+     * If there is some data, that data will be used to determine the type.
+     * </p>
+     *
+     * @param objectTypes The <code>Class</code> types of the row data.
+     */
+    public void setObjectTypes(Class[] objectTypes) {
+        _types = objectTypes;
+    }
+
+    /**
+     * <p>
+     * Not supported. This method does not appear to have great value.
+     * </p>
+     */
+    @Override
+    public void removeObject(Object object) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * <p>
+     * Not yet supported.
+     * </p>
+     *
+     * @param row The <code>RowKey</code> of the row to check.
+     */
+    @Override
+    public boolean isRemoved(RowKey row) {
+        return _deletes.contains(row);
+    }
+
+    /**
+     * <p>
+     * Replace the object at the specified row.
+     * </p>
+     *
+     * @param row The desired row to set the contained object
+     * @param object The new object to set at the specified row
+     */
+    @Override
+    public void setObject(RowKey row, Object object) {
+        throw new UnsupportedOperationException(this.getClass().getName() + " does not support the setObject(RowKey, Object) method. "
+                + "Instead use setObjects(RowKey, Object []).");
+    }
+
+    /**
+     * <p>
+     * This method allows the given <code>row</code> to be replaced with the given <code>objects</code>.
+     * </p>
+     *
+     * @param row The row to replace.
+     * @param objects The array of <code>Objects</code> to use.
+     */
+    public void setObjects(RowKey row, Object[] objects) {
+        Object[] previous = (Object[]) getObject(row);
+        int rowNum = getRowIndex(row);
+        int cnt = 0;
+        for (List list : getLists()) {
+            list.set(rowNum, objects[cnt++]);
+        }
+        fireValueChanged(null, row, previous, objects);
+        if (getCursorRow() == row) {
+            fireValueChanged(null, previous, objects);
+        }
+    }
+
+    /**
+     * <p>
+     * Not yet supported...
+     * </p>
+     */
+    @Override
+    public void addObject(Object object) {
+// FIXME: Add api to add the Object*s* (see addObject(object), must have 1 for each List
+        throw new UnsupportedOperationException();
+    }
+
+    // ---------------------------------------------------- DataProvider Methods
+
+    /**
+     *
+     */
+    @Override
+    public FieldKey getFieldKey(String fieldId) throws DataProviderException {
+        return getSupport().getFieldKey(fieldId);
+    }
+
+    /**
+     *
+     */
+    @Override
+    public FieldKey[] getFieldKeys() throws DataProviderException {
+        return getSupport().getFieldKeys();
+    }
+
+    /**
+     *
+     */
+    @Override
+    public Class getType(FieldKey fieldKey) throws DataProviderException {
+        return getSupport().getType(fieldKey);
+    }
+
+    /**
+     *
+     */
+    @Override
+    public boolean isReadOnly(FieldKey fieldKey) throws DataProviderException {
+        return getSupport().isReadOnly(fieldKey);
+    }
+
+// FIXME: The following method is very difficult to implement correctly b/c
+// FIXME: the super class uses its own private "getSupport()" method which will
+// FIXME: return the wrong "support" class.  However, the superclass is also
+// FIXME: managing the "updates" so we must call it... Ask Creator group to
+// FIXME: properly expose "support" via an interface and get/setSupport()
+// FIXME: methods.  Or ask them to provide access to the updates/deletes/etc.
+// FIXME: properties.
+//
+// FIXME: OK... it appears that they ObjectListDataProvider does not utilize the FieldKey methods in its superclass and instead maintains a private list via its support class.  This means I cannot do anything to make this method work with updates!!!
+    /**
+     *
+     */
+    @Override
+    public Object getValue(FieldKey fieldKey, RowKey rowKey) throws DataProviderException {
+        Object val = null;
+        try {
+            // This will try to get the value, but is unlikely to succeed...
+            val = super.getValue(fieldKey, rowKey);
+        } catch (Exception ex) {
+            // Now check the "right" support class...
+            if (getSupport().getFieldKey(fieldKey.getFieldId()) == null) {
+                throw new IllegalArgumentException("" + fieldKey);
+            }
+
+            // Make sure it's a valid row key...
+            if (!isRowAvailable(rowKey)) {
+                throw new IndexOutOfBoundsException("" + rowKey);
+            }
+            int index = getRowIndex(rowKey);
+            if (index < getRowCount()) {
+                val = getSupport().getValue(fieldKey, getListForFieldKey(fieldKey).get(index));
+            } else {
+// FIXME: Need to manually implement appends, updates, and deletes!! :(
+//        return getSupport().getValue(fieldKey, appends.get(index - getRowCount()));
+            }
+        }
+        return val;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void setValue(FieldKey fieldKey, RowKey rowKey, Object value) throws DataProviderException {
+        if (getSupport().getFieldKey(fieldKey.getFieldId()) == null) {
+            throw new IllegalArgumentException("" + fieldKey);
+        }
+        if (getSupport().isReadOnly(fieldKey)) {
+            throw new IllegalStateException("" + fieldKey);
+        }
+        if (!isRowAvailable(rowKey)) {
+            throw new IndexOutOfBoundsException("" + rowKey);
+        }
+
+        // Retrieve the previous value and determine if it has changed
+        Object previous = getValue(fieldKey, rowKey);
+        if (previous == null && value == null || previous != null && value != null && previous.equals(value)) {
+            return; // No change
+        }
+
+        // Verify type compatibility of the proposed new value
+        if (!getSupport().isAssignable(fieldKey, value)) {
+            throw new IllegalArgumentException(fieldKey + " = " + value); // NOI18N
+        }
+
+// FIXME: Need to explicitly support updates (can't get via polymorphism due to bad design)! :(
+        /*
+         * // Record a pending change for this row and field Map fieldUpdates = (Map) updates.get(rowKey); if (fieldUpdates ==
+         * null) { fieldUpdates = new HashMap(); updates.put(rowKey, fieldUpdates); } fieldUpdates.put(fieldKey, value);
+         */
+        // Remove the following set line and defer until commit() once updates/deletes/etc. is worked out
+        int index = getRowIndex(rowKey);
+        getSupport().setValue(fieldKey, getListForFieldKey(fieldKey).get(index), value);
+
+        fireValueChanged(fieldKey, rowKey, previous, value);
+        fireValueChanged(fieldKey, previous, value);
+    }
+
+    /**
+     * <p>
+     * Construct new instances for each <code>List</code> represented by this class and appended them to each
+     * <code>List</code>.
+     */
+    @Override
+    public RowKey appendRow() throws DataProviderException {
+// FIXME: Support this!
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * <p>
+     * This method returns <code>true</code> if rows may be appended.
+     * </p>
+     */
+    @Override
+    public boolean canAppendRow() throws DataProviderException {
+        return isUserResizable() && getObjectTypes() != null;
+    }
+
+    /**
+     * <p>
+     * This method is not supported.
+     * </p>
+     *
+     * @param object Object to be appended.
+     */
+    @Override
+    public RowKey appendRow(Object object) throws DataProviderException {
+// FIXME: Support this!
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * <p>
+     * Remove the object at the specified row from the list.
+     * </p>
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeRow(RowKey rowKey) throws DataProviderException {
+        // Verify we can actually remove this row
+        if (!canRemoveRow(rowKey)) {
+// FIXME: I18N
+            throw new IllegalStateException("This ObjectListDataProvider is not resizable.");
+        }
+        if (!isRowAvailable(rowKey)) {
+// FIXME: I18N
+            throw new IllegalArgumentException("Cannot delete row for row key " + rowKey);
+        }
+
+        // Record the fact that we are going to delete this row
+        _deletes.add(rowKey);
+
+        // Fire appropriate events regarding this deletion
+        fireRowRemoved(rowKey);
+        if (getCursorRow() == rowKey) {
+            fireValueChanged(null, getObject(rowKey), null);
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the # of rows represented by this <code>MultipleListDataProvider</code>.
+     * </p>
+     */
+    @Override
+    public int getRowCount() throws DataProviderException {
+        List<List<Object>> lists = getLists();
+        int count = 0;
+        if (lists != null && lists.size() != 0) {
+            count = lists.get(0).size();
+        }
+        return count;
+    }
+
+    /**
+     * <p>
+     * Return <code>true</code> if the specified <code>RowKey</code> represents a row in the original list, or a row that
+     * has been appended.
+     * </p>
+     *
+     * @param row <code>RowKey</code> to test for availability.
+     */
+    @Override
+    public boolean isRowAvailable(RowKey row) throws DataProviderException {
+        int idx = getRowIndex(row);
+        if (idx < 0) {
+            return false;
+        }
+        if (idx < getRowCount()) {
+            return true;
+        }
+        return false;
+    }
+
+    // --------------------------------------- TransactionalDataProvider Methods
+    /**
+     * <p>
+     * Cause any cached updates to existing field values, as well as inserted and deleted rows, to be flowed through to the
+     * underlying <code>List</code>s wrapped by this <code>DataProvider</code>.
+     * </p>
+     */
+    @Override
+    public void commitChanges() throws DataProviderException {
+        // FIXME: Do updates here... (see super())
+
+        // Commit pending deletes
+        // Iterate backwards so that we correctly modify List
+        RowKey deletes[] = _deletes.toArray(new RowKey[_deletes.size()]);
+        int rowIdx = -1;
+        for (int idx = deletes.length - 1; idx >= 0; idx--) {
+            rowIdx = getRowIndex(deletes[idx]);
+            for (List list : getLists()) {
+                list.remove(rowIdx);
+            }
+        }
+        _deletes.clear();
+
+        // FIXME: Deal w/ appends (see super())
+
+        // Notify interested listeners that we have committed
+        fireChangesCommitted();
+    }
+
+    /**
+     * <p>
+     * Fire a <code>changesCommitted</code> method to all registered listeners.
+     * </p>
+     */
+    protected void fireChangesCommitted() {
+// FIXME: This method overrides a method by the same name in the superclass that is private!  The super() should make this protected.
+        TransactionalDataListener listeners[] = getTransactionalDataListeners();
+        for (TransactionalDataListener listener : listeners) {
+            listener.changesCommitted(this);
+        }
+    }
+
+    /**
+     * <p>
+     * Fire a <code>changesReverted</code> method to all registered listeners.
+     * </p>
+     */
+    private void fireChangesReverted() {
+// FIXME: This method overrides a method by the same name in the superclass that is private!  The super() should make this protected.
+        TransactionalDataListener listeners[] = getTransactionalDataListeners();
+        for (TransactionalDataListener listener : listeners) {
+            listener.changesReverted(this);
+        }
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void revertChanges() throws DataProviderException {
+        // FIXME: Do updates here... (see super())
+        // updates.clear();
+
+        _deletes.clear();
+
+        // FIXME: Deal w/ appends
+        // appends.clear();
+
+        // Notify interested listeners that we are reverting
+        fireChangesReverted();
+    }
+
+    /**
+     * <p>
+     * Accessor for the <code>List</code> of <code>List</code>s.
+     * </p>
+     */
+    public List<List<Object>> getLists() {
+        return _lists;
+    }
+
+    /**
+     * <p>
+     * Setter for the <code>List</code> of <code>List</code>s.
+     * </p>
+     */
+    public void setLists(List<List<Object>> lists) {
+        _lists = lists;
+    }
+
+    /**
+     * <p>
+     * This method returns
+     */
+    public List getListForFieldKey(FieldKey key) {
+        if (key != null && !(key instanceof IndexFieldKey)) {
+            key = support.getFieldKey(key.getFieldId());
+        }
+        if (key == null) {
+            throw new IllegalArgumentException("Invalid FieldKey: " + key);
+        }
+        return getLists().get(((IndexFieldKey) key).getIndex());
+    }
+
+    /**
+     * <p>
+     * The cached support object for field key manipulation. Must be transient because its content is not Serializable.
+     * </p>
+     */
+    private transient MultipleObjectFieldKeySupport support = null;
+
+    /**
+     * <p>
+     * Return the {@link ObjectFieldKeySupport} instance for the object class we are wrapping.
+     * </p>
+     */
+    private MultipleObjectFieldKeySupport getSupport() {
+        if (support == null) {
+            // Try to get first element of the list to help find FieldKeys
+            Object[] objs = (Object[]) getObject(getRowKey(0));
+            if (objs != null && objs.length > 0) {
+                support = new MultipleObjectFieldKeySupport(objs, isIncludeFields());
+            }
+//        else {
+// FIXME: Add ability to use other meta information (i.e. _types and/or special class to describe info (i.e. for Maps)) to do this.
+//        }
+        }
+        return support;
+    }
+
+    /**
+     * <p>
+     * This method converts the given <code>rowKey</code> to an <code>int</code>.
+     * </p>
+     */
+    protected int getRowIndex(RowKey rowKey) {
+// FIXME: This method overrides a private method by the same name... that method shouldn't be private!
+        if (rowKey instanceof IndexRowKey) {
+            return ((IndexRowKey) rowKey).getIndex();
+        }
+        return -1;
+    }
+
+    /**
+     * <p>
+     * This method converts the given <code>int</code> to a <code>RowKey</code>.
+     * </p>
+     */
+    protected RowKey getRowKey(int index) {
+        return new IndexRowKey(index);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+    // Unsupported Methods
+    ////////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This method is not supported.
+     * </p>
+     */
+    @Override
+    public Class getObjectType() {
+        throw new UnsupportedOperationException(this.getClass().getName() + " does not support the getObjectType() method because it "
+                + "must return multiple types.  Please use \"Class [] " + "getObjectTypes()\" instead.");
+    }
+
+    /**
+     * <p>
+     * This method returns an array of <code>Class []</code> representing the <code>Object</code> types represented by this
+     * instance of this class.
+     * </p>
+     */
+    public Class[] getObjectTypes() {
+        return _types;
+    }
+
+    /**
+     * <p>
+     * Storage for our List of Lists.
+     * </p>
+     */
+    private List<List<Object>> _lists = new ArrayList<>();
+
+    /**
+     * <p>
+     * Type information for the LIsts.
+     * </p>
+     */
+    private Class[] _types = null;
+
+    /**
+     * <p>
+     * Set of {@link RowKey}s marked to be deleted. An <code>Iterator</code> over this set will return the corresponding
+     * {@link RowKey}s in ascending order.
+     * </p>
+     */
+    protected Set<RowKey> _deletes = new TreeSet<>();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/MultipleObjectFieldKeySupport.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/MultipleObjectFieldKeySupport.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.dataprovider;
+
+import com.sun.data.provider.DataProviderException;
+import com.sun.data.provider.FieldKey;
+import com.sun.data.provider.impl.ObjectFieldKeySupport;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * <p>
+ * Support class for <code>DataProvider</code> implementations that need to instrospect Java classes to discover
+ * properties, Map values, or public fields (optional) and return <code>FieldKey</code> instances for them. This
+ * implementation provides support for multiple Objects.
+ * </p>
+ */
+public class MultipleObjectFieldKeySupport {
+
+    /**
+     * <p>
+     * Construct a new support instance wrapping the specified classes, with the specified flag for including public fields.
+     * </p>
+     *
+     * @param classes Class whose properties should be exposed.
+     * @param includeFields Flag indicating whether public fields should also be included. public
+     * MultipleObjectFieldKeySupport(Class classes[], boolean includeFields) { for (Class cls : classes) { } }
+     */
+
+    /**
+     * <p>
+     * Construct a new support instance wrapping the specified objects, with the specified flag for including public fields.
+     * </p>
+     *
+     * @param objs Class whose properties should be exposed.
+     * @param includeFields Flag indicating whether public fields should also be included.
+     */
+    public MultipleObjectFieldKeySupport(Object objs[], boolean includeFields) {
+        _children = new ArrayList();
+        for (Object obj : objs) {
+            if (obj instanceof Map) {
+                _children.add(new MapObjectFieldKeySupport(obj.getClass(), (Map) obj));
+            } else {
+                _children.add(new ObjectFieldKeySupport(obj.getClass(), includeFields));
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Return the <code>FieldKey</code> associated with the specified canonical identifier, if any; otherwise, return
+     * <code>null</code>.
+     * </p>
+     *
+     * @param fieldId Canonical identifier of the required field.
+     */
+    public FieldKey getFieldKey(String fieldId) throws DataProviderException {
+        FieldKey key = null;
+        int idx = 0;
+        for (ObjectFieldKeySupport support : _children) {
+            key = support.getFieldKey(fieldId);
+            if (key != null) {
+                key = new IndexFieldKey(key, idx);
+                break;
+            }
+            idx++;
+        }
+        return key;
+    }
+
+    /**
+     * <p>
+     * Return an array of all supported <code>FieldKey</code>s.
+     * </p>
+     */
+    public FieldKey[] getFieldKeys() throws DataProviderException {
+        Set<FieldKey> keys = new TreeSet<>();
+        FieldKey keyArr[] = null;
+        int idx = 0;
+        for (ObjectFieldKeySupport support : _children) {
+            keyArr = support.getFieldKeys();
+            for (int cnt = 0; cnt < keyArr.length; cnt++) {
+                keyArr[cnt] = new IndexFieldKey(keyArr[cnt], idx++);
+            }
+            keys.addAll(Arrays.asList(keyArr));
+        }
+        return keys.toArray(new FieldKey[keys.size()]);
+    }
+
+    /**
+     * <p>
+     * Return the type of the field associated with the specified <code>FieldKey</code>, if it can be determined; otherwise,
+     * return <code>null</code>.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> for which to return the type.
+     */
+    public Class getType(FieldKey fieldKey) throws DataProviderException {
+        Class type = null;
+        if (fieldKey instanceof IndexFieldKey) {
+            type = _children.get(((IndexFieldKey) fieldKey).getIndex()).getType(fieldKey);
+        } else {
+            for (ObjectFieldKeySupport support : _children) {
+                type = support.getType(fieldKey);
+                if (type != null) {
+                    break;
+                }
+            }
+        }
+        return type;
+    }
+
+    /**
+     * <p>
+     * Return the value for the specified <code>FieldKey</code>, from the specified base object.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> for the requested field.
+     * @param base Base object to be used.
+     */
+    public Object getValue(FieldKey fieldKey, Object base) throws DataProviderException {
+        Object value = null;
+        if (fieldKey instanceof IndexFieldKey) {
+            value = _children.get(((IndexFieldKey) fieldKey).getIndex()).getValue(fieldKey, base);
+        } else {
+            for (ObjectFieldKeySupport support : _children) {
+                value = support.getValue(fieldKey, base);
+                if (value != null) {
+                    break;
+                }
+            }
+        }
+        return value;
+    }
+
+    /**
+     * <p>
+     * Return <code>true</code> if the specified value may be successfully assigned to the specified field.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> to check assignability.
+     * @param value Proposed value.
+     */
+    public boolean isAssignable(FieldKey fieldKey, Object value) throws DataProviderException {
+        boolean assignable = false;
+        if (fieldKey instanceof IndexFieldKey) {
+            assignable = _children.get(((IndexFieldKey) fieldKey).getIndex()).isAssignable(fieldKey, value);
+        } else {
+            for (ObjectFieldKeySupport support : _children) {
+                assignable = support.isAssignable(fieldKey, value);
+                if (assignable) {
+                    break;
+                }
+            }
+        }
+        return assignable;
+    }
+
+    /**
+     * <p>
+     * Return the read only state of the field associated with the specified <code>FieldKey</code>, if it can be determined,
+     * otherwise, return <code>true</code>.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> to check.
+     */
+    public boolean isReadOnly(FieldKey fieldKey) throws DataProviderException {
+        boolean readOnly = true;
+        if (fieldKey instanceof IndexFieldKey) {
+            readOnly = _children.get(((IndexFieldKey) fieldKey).getIndex()).isReadOnly(fieldKey);
+        } else {
+            FieldKey fk = null;
+            for (ObjectFieldKeySupport support : _children) {
+                fk = support.getFieldKey(fieldKey.getFieldId());
+                if (fk != null) {
+                    // Only call support for the one that claims it has a FieldKey!
+                    readOnly = support.isReadOnly(fieldKey);
+                    break;
+                }
+            }
+        }
+        return readOnly;
+    }
+
+    /**
+     * <p>
+     * Set the value for the specified <code>FieldKey</code>, on the specified base object.
+     * </p>
+     *
+     * @param fieldKey <code>FieldKey</code> for the requested field.
+     * @param base Base object to be used.
+     * @param value Value to be set.
+     *
+     * @exception IllegalArgumentException If a type mismatch occurs
+     * @exception IllegalStateException If setting a read only field is attempted.
+     */
+    public void setValue(FieldKey fieldKey, Object base, Object value) throws DataProviderException {
+        if (fieldKey instanceof IndexFieldKey) {
+            _children.get(((IndexFieldKey) fieldKey).getIndex()).setValue(fieldKey, base, value);
+        } else {
+            FieldKey fk = null;
+            for (ObjectFieldKeySupport support : _children) {
+                fk = support.getFieldKey(fieldKey.getFieldId());
+                if (fk != null) {
+                    // Only call support for the one that claims it has a FieldKey!
+                    support.setValue(fieldKey, base, value);
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This list hold the child ObjectFieldKeySupport implementations.
+     * </p>
+     */
+    private List<ObjectFieldKeySupport> _children = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/README.txt
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/dataprovider/README.txt
@@ -1,0 +1,17 @@
+The files in this directory extend the capabilities of the DataProvider API.
+The Woodstock (sun) and Creator (rave) components make use of the
+dataprovider APIs.
+
+Data Provider APIs are part of Visual web Pack (also part of Java Studio
+Creator). You can get the sources for the dataproviders from VisualWeb module
+that is open sourced as a sub project on netbeans.org. You can either download
+a source bundle or checkout the sources. Instructions are here:
+
+    http://visualweb.netbeans.org/
+
+Once you have the sources, you will find the data provider sources under:
+
+    visualweb\dataprovider\runtime\library\src\com\sun\data\provider
+
+
+  (above instructions from Jayashri)

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ComponentFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ComponentFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.Serializable;
+
+/**
+ * <p>
+ * This interface must be implemented by all UIComponent factories. This enabled UIComponents to be created via a
+ * consistent interface. This is critical to classes such as
+ * {@link com.sun.jsftemplating.component.TemplateComponentBase} and {@link LayoutComponent}.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface ComponentFactory {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UIComponent</code>.
+     */
+    UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent);
+
+    /**
+     * <p>
+     * This method returns the extraInfo that was set for this <code>ComponentFactory</code> from the
+     * {@link com.sun.jsftemplating.layout.descriptors.ComponentType}.
+     * </p>
+     */
+    Serializable getExtraInfo();
+
+    /**
+     * <p>
+     * This method is invoked from the {@link com.sun.jsftemplating.layout.descriptors.ComponentType} to provide more
+     * information to the factory. For example, if the JSF component type was passed in, a single factory class could
+     * instatiate multiple components the extra info that is passed in.
+     * </p>
+     *
+     * <p>
+     * Some factory implementations may want to use this method to execute intialization code for the factory based in the
+     * value passed in.
+     * </p>
+     */
+    void setExtraInfo(Serializable extraInfo);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ComponentFactoryBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ComponentFactoryBase.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.event.CommandActionListener;
+import com.sun.jsftemplating.layout.event.ValueChangeListener;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.ActionSource;
+import jakarta.faces.component.EditableValueHolder;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This abstract class provides common functionality for UIComponent factories.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class ComponentFactoryBase implements ComponentFactory {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UIComponent</code>.
+     */
+    @Override
+    public abstract UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent);
+
+    /**
+     * <p>
+     * This method iterates through the Map of options. It looks at each one, if it contians an EL expression, it sets a
+     * value binding. Otherwise, it calls setAttribute() on the component (which in turn will invoke the bean setter if
+     * there is one).
+     * </p>
+     *
+     * <p>
+     * This method also interates through the child <code>LayoutElement</code>s of the given {@link LayoutComponent}
+     * descriptor and adds Facets or children as appropriate.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param desc The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param comp The <code>UIComponent</code>
+     */
+    protected void setOptions(FacesContext context, LayoutComponent desc, UIComponent comp) {
+        if (desc == null) {
+            // Nothing to do
+            return;
+        }
+
+        // First set the id if supplied, treated special b/c the component
+        // used for ${} expressions is the parent and this must be set first
+        // so other ${} expressions can use $this{id} and $this{clientId}.
+        String compId = desc.getId(context, comp.getParent());
+        if (compId != null && !compId.equals("")) {
+            comp.setId(compId);
+        }
+
+        // Loop through all the options and set the values
+// FIXME: Figure a way to skip options that should not be set on the Component
+        Iterator<String> it = desc.getOptions().keySet().iterator();
+        String key = null;
+        while (it.hasNext()) {
+            // Get next property
+            key = it.next();
+
+            setOption(context, comp, desc, key, desc.getOption(key));
+        }
+
+        // Check for "command" handlers...
+        List<Handler> handlers = desc.getHandlers(LayoutComponent.COMMAND);
+        if (handlers != null && comp instanceof ActionSource) {
+            ((ActionSource) comp).addActionListener(CommandActionListener.getInstance());
+        }
+
+        // Check for "valueChange" handlers...
+        handlers = desc.getHandlers(ValueChangeListener.VALUE_CHANGE);
+        if (handlers != null && comp instanceof EditableValueHolder) {
+            ((EditableValueHolder) comp).addValueChangeListener(ValueChangeListener.getInstance());
+        }
+
+        // Set the events on the new component
+        storeInstanceHandlers(desc, comp);
+    }
+
+    /**
+     * <p>
+     * This method sets an individual option on the <code>UIComponent</code>. It will check to see if it is a
+     * <code>ValueExpression</code>, if it is it will store it as such.
+     * </p>
+     */
+    protected void setOption(FacesContext context, UIComponent comp, LayoutComponent desc, String key, Object value) {
+        ComponentUtil.getInstance(context).setOption(context, key, value, desc, comp);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for interating over the "instance" handlers and applying them to the UIComponent. An
+     * "instance" handler is one that is defined <b>outside a renderer</b>, or <b>a nested component within a renderer</b>.
+     * In other words, a handler that would not get fired by the TemplateRenderer. By passing this in via the UIComponent,
+     * code that is aware of events (see {@link com.sun.jsftemplating.layout.descriptors.LayoutElementBase}) may find these
+     * events and fire them. These may vary per "instance" of a particular component (i.e. <code>TreeNode</code>) unlike the
+     * handlers defined in a TemplateRender's XML (which are shared and therefor should not change dynamically).
+     * </p>
+     *
+     * <p>
+     * This method is invoked from setOptions(), however, if setOptions is not used in by a factory, this method may be
+     * invoked directly. Calling this method multiple times will not cause any harm, besides making an extra unnecessary
+     * call.
+     * </p>
+     *
+     * @param desc The descriptor potentially containing handlers to copy.
+     * @param comp The UIComponent instance to store the handlers.
+     */
+    protected void storeInstanceHandlers(LayoutComponent desc, UIComponent comp) {
+        if (!desc.isNested()) {
+            UIComponent parent = comp.getParent();
+            if (parent == null || parent instanceof UIViewRoot) {
+                // This is not a nested LayoutComponent, it should not store
+                // instance handlers
+                // NOTE: could skip TemplateComponent children also. Although
+                // this is harder to detect as dynamic children aren't
+                // defined in the template and therefor must be stored in
+                // the UIComponent tree.
+                return;
+            }
+        }
+
+        // Iterate over the instance handlers
+        Iterator<String> it = desc.getHandlersByTypeMap().keySet().iterator();
+        if (it.hasNext()) {
+            String eventType = null;
+            Map<String, Object> compAttrs = comp.getAttributes();
+            while (it.hasNext()) {
+                // Assign instance handlers to attribute for retrieval later
+                // (NOTE: retrieval must be explicit, see LayoutElementBase)
+                eventType = it.next();
+                if (eventType.equals(LayoutComponent.BEFORE_CREATE) || eventType.equals(LayoutComponent.AFTER_CREATE)) {
+                    // This is handled directly, no need for instance handler
+                    continue;
+                }
+                compAttrs.put(eventType, desc.getHandlers(eventType));
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method associates the given child with the given parent. By using this method we centralize the code so that if
+     * we decide later to add it as a real child it can be done in one place.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     * @param child The child <code>UIComponent</code>
+     */
+    protected void addChild(FacesContext context, LayoutComponent descriptor, UIComponent parent, UIComponent child) {
+        // Check to see if we should add this as a facet. NOTE: We add
+        // UIViewRoot children as facets b/c we render them via the
+        // LayoutElement tree.
+        String facetName = descriptor.getFacetName(parent);
+        if (facetName != null) {
+            // Add child as a facet...
+            if (LogUtil.configEnabled() && facetName.equals("_noname")) {
+                // Warn the developer that they may have a problem
+                LogUtil.config("Warning: no id was supplied for " + "component '" + child + "'!");
+            }
+            // Resolve the id if its dynamic
+            facetName = (String) ComponentUtil.getInstance(context).resolveValue(context, descriptor, child, facetName);
+            parent.getFacets().put(facetName, child);
+        } else {
+            // Add this as an actual child
+            parent.getChildren().add(child);
+        }
+    }
+
+    /**
+     * <p>
+     * This method instantiates the <code>UIComponent</code> given its <code>ComponentType</code>. It will respect the
+     * <code>binding</code> property so that a <code>UIComponent</code> can be created via the <code>binding</code>
+     * property. While a custom {@link ComponentFactory} can do a better job, at times it may be desirable to use
+     * <code>binding</code> instead.
+     * </p>
+     */
+    protected UIComponent createComponent(FacesContext ctx, String componentType, LayoutComponent desc, UIComponent parent) {
+        UIComponent comp = null;
+
+        // Check for the "binding" property
+        String binding = null;
+        if (desc != null) {
+            binding = (String) desc.getEvaluatedOption(ctx, "binding", parent);
+        }
+        if (binding != null && ComponentUtil.getInstance(ctx).isValueReference(binding)) {
+            // Create a ValueExpression
+            ValueExpression ve = ctx.getApplication().getExpressionFactory().createValueExpression(ctx.getELContext(), binding,
+                    UIComponent.class);
+            // Create / get the UIComponent
+            comp = ctx.getApplication().createComponent(ve, ctx, componentType);
+        } else {
+            // No binding, do the normal way...
+            comp = ctx.getApplication().createComponent(componentType);
+        }
+
+        // Parent the new component
+        if (parent != null) {
+            addChild(ctx, desc, parent, comp);
+        }
+
+        // Return it...
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This method returns the extraInfo that was set for this <code>ComponentFactory</code> from the
+     * {@link com.sun.jsftemplating.layout.descriptors.ComponentType}.
+     * </p>
+     */
+    @Override
+    public Serializable getExtraInfo() {
+        return _extraInfo;
+    }
+
+    /**
+     * <p>
+     * This method is invoked from the {@link com.sun.jsftemplating.layout.descriptors.ComponentType} to provide more
+     * information to the factory. For example, if the JSF component type was passed in, a single factory class could
+     * instatiate multiple components the extra info that is passed in.
+     * </p>
+     *
+     * <p>
+     * Some factory implementations may want to override this method to execute intialization code for the factory based in
+     * the value passed in.
+     * </p>
+     */
+    @Override
+    public void setExtraInfo(Serializable extraInfo) {
+        _extraInfo = extraInfo;
+    }
+
+    /**
+     * <p>
+     * Extra information associated with this ComponentFactory.
+     * </p>
+     */
+    private Serializable _extraInfo = null;
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/EventComponentFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/EventComponentFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>EventComponent
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "event".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("event")
+public class EventComponentFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>EventComponent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    public static final String COMPONENT_TYPE = "com.sun.jsftemplating.EventComponent";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/ForEachFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/ForEachFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>ForEach
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "foreach".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("foreach")
+public class ForEachFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>ForEach</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.jsftemplating.ForEach";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/GenericFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/GenericFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.Serializable;
+
+/**
+ * <p>
+ * This factory is capable of creating any UIComponent that can be created via the
+ * <code>Application.createComponent(componentType)</code> method. It requires that the <code>componentType</code>
+ * property be set indicating what type of component should be instantiated.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "component".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("component")
+public class GenericFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>. It requires that the
+     * "componentType" attribute be supplied with a valid JSF ComponentType. This may be supplied in the page on a per-use
+     * basis, or on an instance of this Factory via the {@link ComponentFactoryBase#setExtraInfo(Serializable)} method.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Determine the componentType
+        String componentType = (String) descriptor.getEvaluatedOption(context, COMPONENT_TYPE, parent);
+        if (componentType == null) {
+            Serializable extraInfo = getExtraInfo();
+            if (extraInfo != null) {
+                // This component allows the (default) CompnentType to be set
+                // on the factory.
+                componentType = extraInfo.toString();
+            } else {
+                throw new IllegalArgumentException("\"&gt;component&lt;\" requires a \"" + COMPONENT_TYPE + "\" property to be set to the componentType of the "
+                        + "component you wish to create.");
+            }
+        }
+
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, componentType, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This the is the property name ("componentType") that will be used to define the componentType to be used to create
+     * the <code>UIComponent</code>. This much match the defined component type in the faces-config.xml file (this is
+     * usually stored along with the component .class files in the component's jar file).
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "componentType";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/IfFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/IfFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>If
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "if".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("if")
+public class IfFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>If</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // (re)set the "condition" property to avoid using an evaluated version
+        Object val = descriptor.getOption("condition");
+        if (val != null) {
+            comp.getAttributes().put("condition", val);
+        }
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.jsftemplating.If";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/MessageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/MessageFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIMessage;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>UIMessage
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "message".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("message")
+public class MessageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UIMessage</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIMessage comp = new UIMessage();
+
+        // This needs to be done here (before setOptions) so that $...{...}
+        // expressions can be resolved... may want to defer these?
+        if (parent != null) {
+            addChild(context, descriptor, parent, comp);
+        }
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/StaticTextFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/StaticTextFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>StaticText
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "staticText".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("staticText")
+public class StaticTextFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>StaticText</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.jsftemplating.StaticText";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/WhileFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/basic/WhileFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.basic;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>While
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "while".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("while")
+public class WhileFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>While</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.jsftemplating.While";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/AjaxWrapperFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/AjaxWrapperFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jmaki;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a jMaki <code>
+ *    AjaxWrapper UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "<b>jmaki:ajax</b>".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jmaki:ajax")
+public class AjaxWrapperFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>AjaxWrapper</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "AjaxWrapper";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/ExtensionFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/ExtensionFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jmaki;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a jMaki <code>
+ *    Extension UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "<b>jmaki:extension</b>".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jmaki:extension")
+public class ExtensionFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Extension</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // jMaki doesn't do this -- 3/4/2008
+        comp.setRendererType("jmaki.ExtensionRenderer");
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jmaki.Extension";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/PageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/PageFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jmaki;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a jMaki <code>
+ *    Page UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "<b>jmaki:page</b>".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jmaki:page")
+public class PageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Page</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // jMaki doesn't do this -- 3/4/2008
+        comp.setRendererType("jmaki.PageRenderer");
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jmaki.Page";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/ResourcesFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/ResourcesFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jmaki;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a jMaki <code>
+ *    Resources UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "<b>jmaki:resources</b>".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jmaki:resources")
+public class ResourcesFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Resources</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // jMaki doesn't do this -- 3/4/2008
+        comp.setRendererType("jmaki.ResourcesRenderer");
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jmaki.Resources";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/WidgetFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jmaki/WidgetFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jmaki;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a jMaki <code>
+ *    Widget UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "<b>jmaki:widget</b>".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jmaki:widget")
+public class WidgetFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Widget</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // jMaki doesn't do this -- 3/4/2008
+        comp.setRendererType("jmaki.WidgetRenderer");
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jmaki.Widget";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jsfext/AjaxZoneFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jsfext/AjaxZoneFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jsfext;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>AjaxZone
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "jsfExt:ajaxZone".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jsfExt:ajaxZone")
+public class AjaxZoneFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating an <code>AjaxZone UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>AjaxZone UIComponent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.faces.AjaxZone";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jsfext/ScriptsFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/jsfext/ScriptsFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.jsfext;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Scripts
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "jsfExt:scripts".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("jsfExt:scripts")
+public class ScriptsFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Scripts UIComponent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.faces.extensions.avatar.Scripts";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/BodyFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/BodyFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Body
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:body".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:body")
+public class BodyFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Body</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+        comp.setRendererType(RENDERER_TYPE);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Output";
+
+    /**
+     * <p>
+     * The default RendererType to set on the newly created component.
+     * </p>
+     */
+    public static final String RENDERER_TYPE = "jakarta.faces.Body";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/ColumnFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/ColumnFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Column
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:column".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:column")
+public class ColumnFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Column</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Column";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/CommandButtonFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/CommandButtonFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>CommandButton
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:commandButton".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:commandButton")
+public class CommandButtonFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>CommandButton</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlCommandButton";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/CommandLinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/CommandLinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>CommandLink
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:commandLink".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:commandLink")
+public class CommandLinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>CommandLink</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlCommandLink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/DataTableFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/DataTableFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>DataTable
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:dataTable".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:dataTable")
+public class DataTableFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>DataTable</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlDataTable";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/FormFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/FormFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Form
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:form".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:form")
+public class FormFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Form</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Form";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/GraphicImageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/GraphicImageFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>GraphicImage
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:graphicImage".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:graphicImage")
+public class GraphicImageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>GraphicImage</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlGraphicImage";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/HeadFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/HeadFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Head
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:head".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:head")
+public class HeadFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Head</code> component.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+        comp.setRendererType(RENDERER_TYPE);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Output";
+
+    /**
+     * <p>
+     * The default RendererType to set on the newly created component.
+     * </p>
+     */
+    public static final String RENDERER_TYPE = "jakarta.faces.Head";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputHiddenFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputHiddenFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>InputHidden
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:inputHidden".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:inputHidden")
+public class InputHiddenFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>InputHidden</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlInputHidden";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputSecretFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputSecretFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>InputSecret
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:inputSecret".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:inputSecret")
+public class InputSecretFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>InputSecret</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlInputSecret";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputTextFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputTextFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>InputText
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:inputText".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:inputText")
+public class InputTextFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>InputText</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlInputText";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputTextareaFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/InputTextareaFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>InputTextarea
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:inputTextarea".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:inputTextarea")
+public class InputTextareaFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>InputTextarea</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlInputTextarea";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/LoadBundleFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/LoadBundleFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.EventComponent;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * <p>
+ * When using JSP as the view technology for JSF, you not only have components but also JSP tags that interact with JSF.
+ * In JSFTemplating the recommended approach to doing this is to use handlers. This offers a clean way to execute
+ * arbitrary Java code. While that is still the recommendation, this class is provided for added flexibility. The
+ * purpose of this class is to read a ResourceBundle and make it available to the page. The better approach would be to
+ * use the {@link com.sun.jsftemplating.handlers.ScopeHandlers#setResourceBundle} handler.
+ * </p>
+ *
+ * <p>
+ * The &gt;f:loadBundle&lt; tag does not represent a component, so this handler does not create a component, it returns
+ * the <code>parent</code> (which is passed in) after configuring the <code>ResourceBundle</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "f:loadBundle". It
+ * requires a <code>basename</code> and a <code>var</code> property to be passed in. Optionally the <code>locale</code>
+ * can be passed in (this is not a feature of the JSF version, but an extra feature supported by the handler in
+ * JSFTemplating.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("f:loadBundle")
+public class LoadBundleFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method loads a <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor.
+     * @param parent The parent <code>UIComponent</code> (not used)
+     *
+     * @return <code>parent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create an Event component for this
+        EventComponent event = new EventComponent();
+        if (parent != null) {
+            addChild(context, descriptor, parent, event);
+        }
+
+        // Get the inputs
+        String baseName = (String) descriptor.getEvaluatedOption(context, "basename", parent);
+        String var = (String) descriptor.getEvaluatedOption(context, "var", parent);
+        Locale locale = (Locale) descriptor.getEvaluatedOption(context, "locale", parent);
+
+        // Create a handler (needed to execute code each time displayed)...
+        HandlerDefinition def = LayoutDefinitionManager.getGlobalHandlerDefinition("setResourceBundle");
+        Handler handler = new Handler(def);
+        handler.setInputValue("bundle", baseName);
+        handler.setInputValue("key", var);
+        handler.setInputValue("locale", locale);
+        List<Handler> handlers = new ArrayList<>();
+        handlers.add(handler);
+        event.getAttributes().put("beforeEncode", handlers);
+
+        // Return (parent)
+        return event;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/MessageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/MessageFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Message
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:message".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:message")
+public class MessageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Message</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Message";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/MessagesFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/MessagesFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Messages
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:messages".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:messages")
+public class MessagesFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Messages</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Messages";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/NamingContainerFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/NamingContainerFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>NamingContainer
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "namingContainer".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("namingContainer")
+public class NamingContainerFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>NamingContainer</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.NamingContainer";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputFormatFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputFormatFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>OutputFormat
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:outputFormat".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:outputFormat")
+public class OutputFormatFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OutputFormat</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlOutputFormat";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputLabelFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputLabelFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>OutputLabel
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:outputLabel".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:outputLabel")
+public class OutputLabelFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OutputLabel</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlOutputLabel";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputLinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputLinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>OutputLink
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:outputLink".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:outputLink")
+public class OutputLinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OutputLink</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlOutputLink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputScriptFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputScriptFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>OutputScript
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:outputScript".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:outputScript")
+public class OutputScriptFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OutputScript</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+        comp.setRendererType(RENDERER_TYPE);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Output";
+
+    /**
+     * <p>
+     * The default RendererType to set on the newly created component.
+     * </p>
+     */
+    public static final String RENDERER_TYPE = "jakarta.faces.resource.Script";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputStylesheetFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputStylesheetFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>OutputStylesheet
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:outputStylesheet".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:outputStylesheet")
+public class OutputStylesheetFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OutputStylesheet</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+        comp.setRendererType(RENDERER_TYPE);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.Output";
+
+    /**
+     * <p>
+     * The default RendererType to set on the newly created component.
+     * </p>
+     */
+    public static final String RENDERER_TYPE = "jakarta.faces.resource.Stylesheet";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputTextFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/OutputTextFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>OutputText
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:outputText".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:outputText")
+public class OutputTextFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OutputText</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlOutputText";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/PanelGridFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/PanelGridFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PanelGrid
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:panelGrid".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:panelGrid")
+public class PanelGridFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PanelGrid</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlPanelGrid";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/PanelGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/PanelGroupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PanelGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:panelGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:panelGroup")
+public class PanelGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PanelGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlPanelGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/ParamFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/ParamFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>UIParameter
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "f:param".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("f:param")
+public class ParamFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UIParameter</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = jakarta.faces.component.UIParameter.COMPONENT_TYPE;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectBooleanCheckboxFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectBooleanCheckboxFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectBooleanCheckbox
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectBooleanCheckbox".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectBooleanCheckbox")
+public class SelectBooleanCheckboxFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectBooleanCheckbox</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlSelectBooleanCheckbox";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectItemFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectItemFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>UISelectItem
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "f:selectItem".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("f:selectItem")
+public class SelectItemFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UISelectItem</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.SelectItem";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectItemsFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectItemsFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>UISelectItems
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "f:selectItems".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("f:selectItems")
+public class SelectItemsFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>UISelectItems</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.SelectItems";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectManyCheckboxFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectManyCheckboxFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectManyCheckbox
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectManyCheckbox".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectManyCheckbox")
+public class SelectManyCheckboxFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectManyCheckbox</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlSelectManyCheckbox";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectManyListboxFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectManyListboxFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectManyListbox
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectManyListbox".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectManyListbox")
+public class SelectManyListboxFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectManyListbox</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.SelectManyListbox";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectManyMenuFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectManyMenuFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectManyMenu
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectManyMenu".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectManyMenu")
+public class SelectManyMenuFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectManyMenu</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlSelectManyMenu";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectOneListboxFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectOneListboxFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectOneListbox
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectOneListbox".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectOneListbox")
+public class SelectOneListboxFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectOneListbox</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlSelectOneListbox";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectOneMenuFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectOneMenuFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectOneMenu
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectOneMenu".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectOneMenu")
+public class SelectOneMenuFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectOneMenu</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlSelectOneMenu";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectOneRadioFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/SelectOneRadioFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SelectOneRadio
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "h:selectOneRadio".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("h:selectOneRadio")
+public class SelectOneRadioFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SelectOneRadio</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "jakarta.faces.HtmlSelectOneRadio";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/ValidatorFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/ri/ValidatorFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.ri;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
+import jakarta.faces.application.Application;
+import jakarta.faces.component.EditableValueHolder;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.validator.Validator;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Validator</code> and adding it to the parent. This factory does
+ * <b>not</b> create a <code>UIComponent</code>.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("f:validator")
+public class ValidatorFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The <b>parent</b> <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        Object value = null;
+        Validator validator = null;
+
+        // Check for the "binding" property
+        String binding = (String) descriptor.getOption("binding");
+        if (binding != null) {
+            value = ComponentUtil.getInstance(context).resolveValue(context, descriptor, parent, binding);
+            if (value != null && !(value instanceof Validator)) {
+                // Warn developer that attempted to set a Validator that was
+                // not a Validator
+                if (LogUtil.warningEnabled()) {
+                    LogUtil.warning("JSFT0009", (Object) parent.getId());
+                }
+            } else {
+                validator = (Validator) value;
+            }
+        }
+
+        // Check to see if we still need to create one...
+        if (validator == null) {
+            // Check for the "validatorId" property
+            String id = (String) descriptor.getOption("validatorId");
+            if (id != null) {
+                id = (String) ComponentUtil.getInstance(context).resolveValue(context, descriptor, parent, id);
+                if (id != null) {
+                    // Create a new Validator
+                    Application app = context.getApplication();
+                    validator = app.createValidator(id);
+                    if (validator != null && binding != null) {
+                        // Set the validator on the binding, if bound
+                        ELContext elctx = context.getELContext();
+                        ValueExpression ve = app.getExpressionFactory().createValueExpression(elctx, binding, Object.class);
+                        ve.setValue(elctx, validator);
+                    }
+                }
+            }
+        }
+
+        // Set the validator on the parent...
+        if (validator != null) {
+            if (!(parent instanceof EditableValueHolder)) {
+                throw new IllegalArgumentException("You may only add " + "f:validator tags to components which are " + "EditableValueHolders.  Component ("
+                        + parent.getId() + ") is not an EditableValueHolder.");
+            }
+            ((EditableValueHolder) parent).addValidator(validator);
+        }
+
+        // Return the validator
+        return parent;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AddRemoveFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AddRemoveFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>AddRemove
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:addRemove".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:addRemove")
+public class AddRemoveFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>AddRemove</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.AddRemove";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AjaxRequestFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AjaxRequestFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Hyperlink
+ *    UIComponent</code> that is configured to submit an Ajax request.
+ * </p>
+ *
+ * <p>
+ * All properties are passed through to the underlying <code>Hyperlink</code> UIComponent.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "ajaxRequest".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("ajaxRequest")
+public class AjaxRequestFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>. You should specify the
+     * <code>ajaxTarget</code> for this component. See {@link #AJAX_TARGET}.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>AjaxRequest</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Setup the AjaxRequest Request
+// FIXME: support javascript function to handle return value
+// FIXME: support extra NVPs??  Maybe not needed?  UIParameter instead?  May be easier as a &n=v&... string.
+        String clientId = comp.getClientId(context);
+// FIXME: XXX DEAL WITH THIS!!!
+// FIXME: BUG: JSF automatically converts the '&' characters in attributes to &amp; this causes a problem... talk to LH and JSF about this.
+//    String extraNVPs = "'&" + clientId + "_submittedField=" + clientId + "'";
+        String extraNVPs = "'" + clientId + "_submittedField=" + clientId + "'";
+        String jsHandlerFunction = "null";
+// FIXME: Support multiple targets?  If I render multiple sections of the UIComponent tree and return a document describing the results...
+        String target = (String) descriptor.getEvaluatedOption(context, AJAX_TARGET, comp);
+        if (target == null || target.equals("")) {
+            target = clientId;
+        }
+        comp.getAttributes().put("onClick", "submitAjaxRequest('" + target + "', " + extraNVPs + ", " + jsHandlerFunction + "); return false;");
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This is the property name that specifies the target for the Ajax request. If not specified, the link itself will be
+     * the target (which is likely not the desired target of the XMLHttpRequest). The target should be the clientId (i.e.
+     * the "id" you see in the HTML source) of the <code>UIComponent</code>.
+     * </p>
+     *
+     * <p>
+     * The property name is: <code>ajaxTarget</code>.
+     * </p>
+     */
+    public static final String AJAX_TARGET = "ajaxTarget";
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Hyperlink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AlarmFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AlarmFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Alarm
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:alarm".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:alarm")
+public class AlarmFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Alarm</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Alarm";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AlarmStatusFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AlarmStatusFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>AlarmStatus
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:alarmStatus".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:alarmStatus")
+public class AlarmStatusFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>AlarmStatus</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.AlarmStatus";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AlertFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AlertFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Alert
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:alert".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:alert")
+public class AlertFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Alert</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Alert";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AnchorFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/AnchorFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Anchor
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:anchor".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:anchor")
+public class AnchorFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Anchor</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Anchor";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/BodyFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/BodyFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Body
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:body".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:body")
+public class BodyFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Body</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Body";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/BreadcrumbsFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/BreadcrumbsFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Breadcrumbs
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:breadcrumbs".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:breadcrumbs")
+public class BreadcrumbsFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Breadcrumbs</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Breadcrumbs";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ButtonFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ButtonFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Button
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:button".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:button")
+public class ButtonFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Button</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Default to primary button
+        if (descriptor.getOption("primary") == null) {
+            // Use ValueExpression vs. property so we don't set the local value
+            // flag which will hide any future VE that is set on the component
+            ExpressionFactory factory = context.getApplication().getExpressionFactory();
+            ValueExpression valueExpression = factory.createValueExpression(context.getELContext(), "#{true}", Object.class);
+            comp.setValueExpression("primary", valueExpression);
+        }
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the value
+        return comp;
+
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Button";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CalendarFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CalendarFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Calendar
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:calendar".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:calendar")
+public class CalendarFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Calendar</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Calendar";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CheckboxFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CheckboxFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Checkbox
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:checkbox".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:checkbox")
+public class CheckboxFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Checkbox</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Checkbox";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CheckboxGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CheckboxGroupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>CheckboxGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:checkboxGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:checkboxGroup")
+public class CheckboxGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>CheckboxGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.CheckboxGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ColoredTextFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ColoredTextFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>StaticText
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:coloredText".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:coloredText")
+public class ColoredTextFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>StaticText</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set escape as false by default, don't call setEscape() b/c then
+        // ValueExpressions won't get evaluated
+        if (!descriptor.getOptions().containsKey("escape")) {
+            setOption(context, comp, descriptor, "escape", "#{false}");
+        }
+
+        // Set the color
+        String color = (String) descriptor.getEvaluatedOption(context, "color", comp);
+        if (color != null) {
+            comp.getAttributes().put("style", "color: " + color + ";");
+        }
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.StaticText";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CommonTaskFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CommonTaskFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>CommonTask
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:commonTask".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:commonTask")
+public class CommonTaskFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>CommonTask</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.CommonTask";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CommonTasksGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CommonTasksGroupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>CommonTasksGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:commonTasksGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:commonTasksGroup")
+public class CommonTasksGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>CommonTasksGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.CommonTasksGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CommonTasksSectionFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/CommonTasksSectionFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>CommonTasksSection
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:commonTasksSection".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:commonTasksSection")
+public class CommonTasksSectionFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>CommonTasksSection</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.CommonTasksSection";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/DropDownFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/DropDownFactory.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+// FIXME: Document
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>DropDrown
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:dropDown".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:dropDown")
+public class DropDownFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>DropDown</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, getComponentType(), descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Check to see if the user is passing in Lists to be converted to a
+        // List of Option objects for the "items" property.
+        ComponentUtil compUtil = ComponentUtil.getInstance(context);
+        Object labels = compUtil.resolveValue(context, descriptor, comp, descriptor.getOption("labels"));
+        if (labels != null) {
+            List optionList = new ArrayList();
+            Object values = compUtil.resolveValue(context, descriptor, comp, descriptor.getOption("values"));
+            if (values == null) {
+                values = labels;
+            }
+
+            try {
+                // Use reflection (for now) to avoid a build dependency
+                // Find the Option constuctor...
+                Constructor optConst = Util.loadClass("com.sun.webui.jsf.model.Option", this).getConstructor(Object.class, String.class);
+
+                if (values instanceof List) {
+                    // We have a List, we need to convert to Option objects.
+                    Iterator<Object> it = ((List<Object>) labels).iterator();
+                    for (Object obj : (List<Object>) values) {
+                        optionList.add(optConst.newInstance(obj, it.next().toString()));
+                    }
+                } else if (values instanceof Object[]) {
+                    Object[] valArr = (Object[]) values;
+                    Object[] labArr = (Object[]) labels;
+                    int len = valArr.length;
+                    // Convert the array to Option objects
+                    for (int count = 0; count < len; count++) {
+                        optionList.add(optConst.newInstance(valArr[count], labArr[count].toString()));
+                    }
+                }
+            } catch (ClassNotFoundException ex) {
+                ex.printStackTrace();
+            } catch (NoSuchMethodException ex) {
+                ex.printStackTrace();
+            } catch (InstantiationException ex) {
+                ex.printStackTrace();
+            } catch (IllegalAccessException ex) {
+                ex.printStackTrace();
+            } catch (InvocationTargetException ex) {
+                ex.printStackTrace();
+            }
+
+            // Set the options
+            comp.getAttributes().put("items", optionList);
+        }
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This method returns the ComponentType of this component. It is implemented this way to allow subclasses to easily
+     * provide a different ComponentType.
+     * </p>
+     */
+    protected String getComponentType() {
+        return COMPONENT_TYPE;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.DropDown";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/DynamicColumnTableRowGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/DynamicColumnTableRowGroupFactory.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutStaticText;
+import com.sun.jsftemplating.layout.event.CreateChildEvent;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TableRowGroup
+ *    UIComponent</code> which supports a dynamic # of columns.
+ * </p>
+ *
+ * <p>
+ * The {@link ComponentType} id for this factory is: "sun:dynamicColumnRowGroup".
+ * </p>
+ *
+ * <p>
+ * This factory fires a "createChild" event for each column that it creates. This allows the children of the column to
+ * be created in the event allowing for the page developer to customize this (otherwise only "StaticText" children will
+ * be created in the columns). In the "createChild" event handler, you may return a <code>UIComponent</code> which will
+ * be used as the <code>UIComponent</code> for that column. You also have access to the column <code>UICompoent</code>
+ * and may add children directly to it if you wish. The "data" value set in the <code>CreateChildEvent</code> object is
+ * the value passed in for the column.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:dynamicColumnRowGroup")
+public class DynamicColumnTableRowGroupFactory extends TableRowGroupFactory {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>
+     * @param desc The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TableRowGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext ctx, LayoutComponent desc, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = super.create(ctx, desc, parent);
+        String id = comp.getId();
+
+        // Dynamically create the child columns...
+        // First find all the column-specific properties
+        ArrayList<String> colAttKeys = new ArrayList<>();
+        for (String key : desc.getOptions().keySet()) {
+            if (key.startsWith("column")) {
+                colAttKeys.add(key);
+            }
+        }
+
+        // Make sure we have some...
+        if (colAttKeys.size() == 0) {
+            // Nothing to do... hopefully there are table column children,
+            // otherwise nothing will happen
+            return comp;
+        }
+
+        // Now determine the # of columns
+        List<Object> values = getColumnPropertyValues(ctx, desc, colAttKeys.get(0), parent);
+        int size = values.size();
+
+        // Create the LC's for the columns
+        List<LayoutComponent> columns = new ArrayList<>(size);
+        ComponentType colType = LayoutDefinitionManager.getGlobalComponentType(ctx, COLUMN_TYPE);
+        for (int idx = 0; idx < size; idx++) {
+            LayoutComponent column = new LayoutComponent(desc, id + COLUMN_SEPERATOR + idx, colType);
+            columns.add(column);
+        }
+
+        // Loop through the properties to set on the columns
+        for (String key : colAttKeys) {
+            if (key.equals(COLUMN_VALUE_KEY)) {
+                // Skip the value as it is added as a child.
+                continue;
+            }
+            values = getColumnPropertyValues(ctx, desc, key, parent);
+
+            // Loop through the columns
+            int idx = 0;
+            for (Object entry : values) {
+                // Set the value of each property on each column
+                columns.get(idx++).addOption(getColumnKey(key), entry);
+            }
+        }
+
+        // Create the columns...
+        UIComponent columnComp = null;
+        String value = null;
+        Object eventVal = null;
+        values = getColumnPropertyValues(ctx, desc, COLUMN_VALUE_KEY, parent);
+        int idx = 0;
+        ComponentUtil compUtil = ComponentUtil.getInstance(ctx);
+        for (LayoutComponent columnDesc : columns) {
+            columnComp = compUtil.createChildComponent(ctx, columnDesc, comp);
+
+            value = "" + values.get(idx++);
+            eventVal = desc.dispatchHandlers(ctx, CreateChildEvent.EVENT_TYPE, new CreateChildEvent(columnComp, value));
+
+            if (eventVal != null && eventVal instanceof UIComponent) {
+                // Add the child created during the event.
+                columnComp.getChildren().add((UIComponent) eventVal);
+            } else {
+                // Create the column (value) child
+                // The child of each TableColumn will be a LayoutStaticText for now...
+                compUtil.createChildComponent(ctx, new LayoutStaticText(columnDesc, columnDesc.getUnevaluatedId() + CHILD_SUFFIX, value), columnComp);
+            }
+        }
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This method obtains a <code>List</code> from the given property name. If the value is not a <code>List</code>, it
+     * will throw an exception.
+     * </p>
+     */
+    private List<Object> getColumnPropertyValues(FacesContext ctx, LayoutComponent parentDesc, String propertyName, UIComponent parent) {
+        Object val = parentDesc.getEvaluatedOption(ctx, propertyName, parent);
+        if (val == null) {
+            throw new IllegalArgumentException(
+                    "DynamicColumnTableRowGroupFactory requires a valid '" + propertyName + "' attribute, however one was not supplied!");
+        }
+        if (val instanceof String) {
+            // Only try to do this if we have a String (not for Lists)
+            if (ComponentUtil.getInstance(ctx).isValueReference((String) val)) {
+// FIXME: resolve $x{y} values: Object newBinding = VariableResolver.resolveVariables(ctx, elt, parent, binding);??
+// FIXME: I believe I have a util method for this (resolveValue?)
+                ValueExpression ve = ctx.getApplication().getExpressionFactory().createValueExpression(ctx.getELContext(), (String) val, Object.class);
+                val = ve.getValue(ctx.getELContext());
+            }
+        }
+        if (!(val instanceof List)) {
+            throw new IllegalArgumentException("DynamicColumnTableRowGroupFactory requires all 'column*' " + "properties to resolve to an instance of a List. '"
+                    + propertyName + "' is a '" + val.getClass().getName() + "'!");
+        }
+
+        // Return the result
+        return (List<Object>) val;
+    }
+
+    /**
+     * <p>
+     * This method removes the "column" prefix and lower-cases the first letter of the property name.
+     * </p>
+     */
+    private String getColumnKey(String key) {
+        return key.substring(COLUMN_LEN, COLUMN_LEN + 1).toLowerCase() + key.substring(COLUMN_LEN + 1);
+    }
+
+    /**
+     * <p>
+     * This method is overriden to prevent setting properties that don't apply to this component (but may apply to their
+     * children or to the behavior of this factory).
+     * </p>
+     */
+    @Override
+    protected void setOption(FacesContext ctx, UIComponent comp, LayoutComponent desc, String key, Object value) {
+        if (key.startsWith("column")) {
+            return;
+        }
+        super.setOption(ctx, comp, desc, key, value);
+    }
+
+    /**
+     * <p>
+     * The component type of the column component to create.
+     * </p>
+     */
+    public static final String COLUMN_TYPE = "sun:tableColumn";
+    public static final String COLUMN_VALUE_KEY = "columnValue";
+    public static final String COLUMN_SEPERATOR = "col";
+    public static final String CHILD_SUFFIX = "child";
+    public static final int COLUMN_LEN = "column".length();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/EditableListFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/EditableListFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>EditableList
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:editableList".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:editableList")
+public class EditableListFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>EditableList</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.EditableList";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FieldFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FieldFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a radio button UIComponent.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:field"
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:field")
+public class FieldFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>.
+     *
+     * @return The newly created <code>TextField</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the value
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Field";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FileChooserFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FileChooserFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>FileChooser
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:fileChooser".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:fileChooser")
+public class FileChooserFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>FileChooser</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.FileChooser";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FooterFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FooterFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Footer
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:footer".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:footer")
+public class FooterFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Footer</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Footer";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FormFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FormFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Form
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:form".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:form")
+public class FormFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Form</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Form";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FrameFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FrameFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Frame
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:frame".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:frame")
+public class FrameFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Frame</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Frame";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FrameSetFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/FrameSetFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>FrameSet
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:frameSet".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:frameSet")
+public class FrameSetFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>FrameSet</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.FrameSet";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HeadFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HeadFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Head
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:head".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:head")
+public class HeadFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>HelpInline</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Head";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HelpInlineFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HelpInlineFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>HelpInline
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:helpInline".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:helpInline")
+public class HelpInlineFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>HelpInline</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.HelpInline";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HelpWindowFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HelpWindowFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>HelpWindow
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:helpWindow".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:helpWindow")
+public class HelpWindowFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>HelpWindow</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.HelpWindow";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HiddenFieldFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HiddenFieldFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>HiddenField
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:hidden".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:hidden")
+public class HiddenFieldFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>HiddenField</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.HiddenField";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HtmlFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HtmlFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Html
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:html".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:html")
+public class HtmlFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Html</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Html";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HyperlinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/HyperlinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Hyperlink
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:hyperlink".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:hyperlink")
+public class HyperlinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Hyperlink</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Hyperlink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/IFrameFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/IFrameFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>IFrame
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:iframe".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:iframe")
+public class IFrameFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>IFrame</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.IFrame";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/IconFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/IconFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Icon
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:icon"
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:icon")
+public class IconFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Icon</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Icon";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/IconHyperlinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/IconHyperlinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>IconHyperlink
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:iconHyperlink".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:iconHyperlink")
+public class IconHyperlinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>IconHyperlink</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.IconHyperlink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ImageComponentFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ImageComponentFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for creating a <code>ImageComponent</code> UIComponent.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:image".
+ * </p>
+ *
+ * @author Rick Ratta
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:image")
+public class ImageComponentFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>ImageComponent</code> UIComponent.
+     * </p>
+     *
+     * @param context The FacesContext
+     *
+     * @param descriptor The {@link LayoutComponent} descriptor that is associated with the requested
+     * <code>ImageComponent</code>.
+     *
+     * @param parent The parent UIComponent
+     *
+     * @return The newly created <code>ImageComponent</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties (allow these to override theme)
+        setOptions(context, descriptor, comp);
+
+        // Return the value
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Image";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ImageHyperlinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ImageHyperlinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>ImageHyperlink
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:imageHyperlink".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:imageHyperlink")
+public class ImageHyperlinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>ImageHyperlink</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.ImageHyperlink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/JobStatusFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/JobStatusFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>JobStatus
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:jobStatus".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:jobStatus")
+public class JobStatusFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>JobStatus</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.JobStatus";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/LabelFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/LabelFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for creating a <code>Label
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:label".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:label")
+public class LabelFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Label</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the value
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Label";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/LegendFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/LegendFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Legend
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:legend".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:legend")
+public class LegendFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Legend</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Legend";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/LinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/LinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Link
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:link".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:link")
+public class LinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Link</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Link";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ListboxFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ListboxFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+
+// FIXME: Document
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Listbox
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:listbox".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:listbox")
+public class ListboxFactory extends DropDownFactory {
+
+    /**
+     * <p>
+     * This method overrides the parent class to return a different ComponentType.
+     * </p>
+     */
+    @Override
+    protected String getComponentType() {
+        return COMPONENT_TYPE;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Listbox";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MarkupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MarkupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Markup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:markup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:markup")
+public class MarkupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Markup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Markup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MastheadFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MastheadFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Masthead
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:masthead".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:masthead")
+public class MastheadFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Masthead</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Masthead";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MessageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MessageFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Message
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:message".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:message")
+public class MessageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Message</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Message";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MessageGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MessageGroupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>MessageGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:messageGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:messageGroup")
+public class MessageGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>MessageGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.MessageGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MetaFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/MetaFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Meta
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:meta".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:meta")
+public class MetaFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Meta</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Meta";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/NotificationPhraseFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/NotificationPhraseFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>NotificationPhrase
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:notificationPhrase".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:notificationPhrase")
+public class NotificationPhraseFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>NotificationPhrase</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.NotificationPhrase";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/OrderableListFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/OrderableListFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>OrderableList
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:orderableList".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:orderableList")
+public class OrderableListFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>OrderableList</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.OrderableList";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PageAlertFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PageAlertFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PageAlert
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:pageAlert".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:pageAlert")
+public class PageAlertFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PageAlert</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.PageAlert";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PageFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Page
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:page".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:page")
+public class PageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Page</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Page";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PageSeparatorFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PageSeparatorFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PageSeparator
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:pageSeparator".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:pageSeparator")
+public class PageSeparatorFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PageSeparator</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.PageSeparator";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PanelGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PanelGroupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PanelGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:panelGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:panelGroup")
+public class PanelGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PanelGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.PanelGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PasswordFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PasswordFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a radio button UIComponent.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:password".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:passwordField")
+public class PasswordFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>.
+     *
+     * @return The newly created <code>PasswordField</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the value
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.PasswordField";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PropertyFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PropertyFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Property
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:property".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:property")
+public class PropertyFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Property</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Property";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PropertySheetFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PropertySheetFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PropertySheet
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:propertySheet".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:propertySheet")
+public class PropertySheetFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PropertySheet</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.PropertySheet";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PropertySheetSectionFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/PropertySheetSectionFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>PropertySheetSection UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is:
+ * "sun:propertySheetSection".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:propertySheetSection")
+public class PropertySheetSectionFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>PropertySheetSection</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.PropertySheetSection";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/RadioButtonFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/RadioButtonFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>RadioButton
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:radioButton".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:radioButton")
+public class RadioButtonFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>RadioButton</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.RadioButton";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/RadioButtonGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/RadioButtonGroupFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>RadioButtonGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:radioButtonGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:radioButtonGroup")
+public class RadioButtonGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>RadioButtonGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.RadioButtonGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/SchedulerFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/SchedulerFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating an <code>Scheduler
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:scheduler".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:scheduler")
+public class SchedulerFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Scheduler</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Scheduler";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ScriptFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ScriptFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Script
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:script".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:script")
+public class ScriptFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Script</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Script";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/SkipHyperlinkFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/SkipHyperlinkFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>SkipHyperlink
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:skipHyperlink".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:skipHyperlink")
+public class SkipHyperlinkFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>SkipHyperlink</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.SkipHyperlink";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/StaticTextFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/StaticTextFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>StaticText
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:staticText".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:staticText")
+public class StaticTextFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>StaticText</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set escape as false by default, don't call setEscape() b/c then
+        // ValueExpressions won't get evaluated
+        if (!descriptor.getOptions().containsKey("escape")) {
+            setOption(context, comp, descriptor, "escape", "#{false}");
+        }
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.StaticText";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TabFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TabFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Tab
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tab".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tab")
+public class TabFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Tab</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        /*
+         * String actionString = (String) descriptor.getOption("actionString"); if (null != actionString) { // FIXME: Add back
+         * when we have a ConstantMethodBinding class to use // comp.setAction(new ConstantMethodBinding(actionString)); }
+         */
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Tab";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TabSetFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TabSetFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TabSet
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tabSet".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tabSet")
+public class TabSetFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TabSet</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TabSet";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableActionsFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableActionsFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TableActions
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tableActions".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tableActions")
+public class TableActionsFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TableActions</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TableActions";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableColumnFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableColumnFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TableColumn
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tableColumn".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tableColumn")
+public class TableColumnFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TableColumn</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TableColumn";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Table
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:table".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:table")
+public class TableFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Table</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Table";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableFooterFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableFooterFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TableFooter
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tableFooter".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tableFooter")
+public class TableFooterFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TableFooter</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TableFooter";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableHeaderFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableHeaderFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TableHeader
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tableHeader".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tableHeader")
+public class TableHeaderFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TableHeader</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TableHeader";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TablePanelsFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TablePanelsFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TablePanels
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tablePanels".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tablePanels")
+public class TablePanelsFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TablePanels</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TablePanels";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableRowGroupFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TableRowGroupFactory.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.component.dataprovider.MultipleListDataProvider;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TableRowGroup
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tableRowGroup".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tableRowGroup")
+public class TableRowGroupFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TableRowGroup</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Handle "data" option specially...
+        ComponentUtil compUtil = ComponentUtil.getInstance(context);
+        Object data = compUtil.resolveValue(context, descriptor, comp, descriptor.getOption("data"));
+        if (data != null) {
+            // Create a DataProvider
+            if (!(data instanceof List)) {
+                throw new IllegalArgumentException("TableRowGroupFactory " + "only supports values of type \"java.util.List\" " + "for the 'data' attribute.");
+            }
+            if (((List) data).size() > 0 && !(((List) data).get(0) instanceof List)) {
+                Object obj = ((List) data).get(0);
+                if (obj == null) {
+                    // In this case, treat this as an empty List and log a
+                    // warning... this prevents some cases from blowing up
+                    // just b/c there is no data.
+                    if (LogUtil.configEnabled()) {
+                        LogUtil.config("JSFT0008");
+                    }
+                    ((List) data).set(0, new ArrayList());
+                } else {
+                    obj = obj.getClass().getName();
+                    // We don't have a List of List of Object!
+                    throw new IllegalArgumentException(
+                            "TableRowGroupFactory " + "expects a List<List<Object>>.  Where the outer " + "List should be a List of sources, and the inner"
+                                    + " List should be a List of rows.  However, the " + "following was passed in: List<" + obj + ">.");
+                }
+            }
+            List<List<Object>> lists = (List<List<Object>>) data;
+            Object dataProvider = new MultipleListDataProvider(lists);
+
+            // Remove the data object from the UIComponent, not needed
+            Map<String, Object> atts = comp.getAttributes();
+            atts.remove("data");
+// FIXME: This stores the *data* in the UIComponent... change to use a #{} value binding to push the data somewhere else. Session?? Configurable?
+            atts.put("sourceData", dataProvider);
+        }
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TableRowGroup";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TextAreaFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TextAreaFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TextArea
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:textArea".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:textArea")
+public class TextAreaFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TextArea</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TextArea";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TextFieldFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TextFieldFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TextField
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:textField".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:textField")
+public class TextFieldFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TextField</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TextField";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ThemeLinksFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/ThemeLinksFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>ThemeLinks
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:themeLinks".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:themeLinks")
+public class ThemeLinksFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>ThemeLinks</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.ThemeLinks";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TimeStampFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TimeStampFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TimeStamp
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:timeStamp".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:timeStamp")
+public class TimeStampFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TimeStamp</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TimeStamp";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TitleFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TitleFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>ContentPageTitle
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:title".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:title")
+public class TitleFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>ContentPageTitle</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.ContentPageTitle";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TreeFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TreeFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Tree
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:tree".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:tree")
+public class TreeFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Tree</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Tree";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TreeNodeFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/TreeNodeFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>TreeNode
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:treeNode".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:treeNode")
+public class TreeNodeFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>TreeNode</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.TreeNode";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/UploadFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/UploadFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Upload
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:upload".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:upload")
+public class UploadFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Upload</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Upload";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/VersionPageFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/VersionPageFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>VersionPage
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:versionPage".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:versionPage")
+public class VersionPageFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>VersionPage</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.VersionPage";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardBranchFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardBranchFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>WizardBranch
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:wizardBranch".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:wizardBranch")
+public class WizardBranchFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>WizardBranch</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.WizardBranch";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardBranchStepsFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardBranchStepsFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>WizardBranchSteps
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:wizardBranchSteps".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:wizardBranchSteps")
+public class WizardBranchStepsFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>WizardBranchSteps</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.WizardBranchSteps";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>Wizard
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:wizard".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:wizard")
+public class WizardFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>Wizard</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.Wizard";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardStepFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardStepFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>WizardStep
+ *    UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:wizardStep".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:wizardStep")
+public class WizardStepFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>WizardStep</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.WizardStep";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardSubstepBranchFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/sun/WizardSubstepBranchFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.sun;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This factory is responsible for instantiating a <code>WizardSubstepBranch UIComponent</code>.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "sun:wizardSubstepBranch".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("sun:wizardSubstepBranch")
+public class WizardSubstepBranchFactory extends ComponentFactoryBase {
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created <code>WizardSubstepBranch</code>.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Create the UIComponent
+        UIComponent comp = createComponent(context, COMPONENT_TYPE, descriptor, parent);
+
+        // Set all the attributes / properties
+        setOptions(context, descriptor, comp);
+
+        // Return the component
+        return comp;
+    }
+
+    /**
+     * <p>
+     * The <code>UIComponent</code> type that must be registered in the <code>faces-config.xml</code> file mapping to the
+     * UIComponent class to use for this <code>UIComponent</code>.
+     * </p>
+     */
+    public static final String COMPONENT_TYPE = "com.sun.webui.jsf.WizardSubstepBranch";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/tree/DynamicTreeNodeFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/tree/DynamicTreeNodeFactory.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.tree;
+
+import com.sun.jsftemplating.annotation.UIComponentFactory;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.component.factory.ComponentFactoryBase;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * <p>
+ * Portions of many trees are non-static, or Dynamic. By this it is meant that some of the nodes can only be determined
+ * at Runtime. The goal of this factory is to provide a means for dynamic tree nodes to be defined. This implementation
+ * allows a portion or an entire tree to be defined.
+ * </p>
+ *
+ * <p>
+ * It relies on the supplied {@link TreeAdaptor} to drive the creation of the "root" tree node. The "root" node is a
+ * single Tree or TreeNode that is returned from the {@link #create(FacesContext, LayoutComponent, UIComponent)} method.
+ * Since this is a factory class for creating a single UIComponent, it is expected that a single UIComponent is returned
+ * from this method. However, the returned UIComponent may contain 0 or more children (other TreeNodes). The
+ * {@link TreeAdaptor} facilitates this.
+ * </p>
+ *
+ * <p>
+ * The {@link TreeAdaptor} implemenation is respsonsible for traversing the tree data and providing the necessary
+ * information about that data to this factory. The tree data can be stored in any format, a specific TreeAdaptor must
+ * be written to interpret each unique type of data format. When this factory interacts with the {@link TreeAdaptor}, it
+ * passes an <code>Object</code> that represents a tree node in the arbitrary data format. This <code>Object</code> is
+ * obtained originally from the {@link TreeAdaptor}, so the developer has control over what object is used to identify
+ * tree nodes in their own data format.
+ * </p>
+ *
+ * <p>
+ * See {@link TreeAdaptor} to see the necessary methods to implement in order for this factory to be capable of
+ * populating <code>TreeNode</code>s based on your data.
+ * </p>
+ *
+ * <p>
+ * The {@link com.sun.jsftemplating.layout.descriptors.ComponentType} id for this factory is: "dynamicTreeNode".
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@UIComponentFactory("dynamicTreeNode")
+public class DynamicTreeNodeFactory extends ComponentFactoryBase {
+
+    /**
+     * Constructor
+     */
+    public DynamicTreeNodeFactory() {
+    }
+
+    /**
+     * <p>
+     * This is the factory method responsible for creating the <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param descriptor The {@link LayoutComponent} descriptor associated with the requested <code>UIComponent</code>.
+     * @param parent The parent <code>UIComponent</code>
+     *
+     * @return The newly created component.
+     */
+    @Override
+    public UIComponent create(FacesContext context, LayoutComponent descriptor, UIComponent parent) {
+        // Get the TreeAdaptor which should be used
+        TreeAdaptor treeAdaptor = getTreeAdaptor(context, descriptor, parent);
+
+        // Initialize the TreeAdaptor instance
+        treeAdaptor.init();
+
+        // First pull off the root...
+        Object currentObj = treeAdaptor.getTreeNodeObject();
+
+        // Return the root TreeNode
+        return processNode(context, treeAdaptor, currentObj, parent);
+    }
+
+    /**
+     * <p>
+     * This method gets the <code>TreeAdaptor</code> by looking at the {@link #TREE_ADAPTOR_CLASS} option and invoking
+     * <code>getInstance</code> on the specified <code>TreeAdaptor</code> implementation.
+     * </p>
+     */
+    protected TreeAdaptor getTreeAdaptor(FacesContext ctx, LayoutComponent desc, UIComponent parent) {
+        TreeAdaptor adaptor = null;
+        Object cls = desc.getEvaluatedOption(ctx, TREE_ADAPTOR_CLASS, parent);
+        if (cls == null) {
+            throw new IllegalArgumentException("'" + TREE_ADAPTOR_CLASS + "' must be specified!");
+        }
+        try {
+            Class adaptorClass = Util.getClass(cls);
+            adaptor = (TreeAdaptor) adaptorClass.getMethod("getInstance", new Class[] { FacesContext.class, LayoutComponent.class, UIComponent.class })
+                    .invoke((Object) null, new Object[] { ctx, desc, parent });
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
+        } catch (NoSuchMethodException ex) {
+            throw new RuntimeException(ex);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        } catch (InvocationTargetException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        // Return the TreeAdaptor
+        return adaptor;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for creating and configuring a <code>TreeNode</code> given its <code>TreeNode</code>
+     * object. It then recurses for each child <code>TreeNode</code> object.
+     * </p>
+     */
+    protected UIComponent processNode(FacesContext ctx, TreeAdaptor adaptor, Object currentObj, UIComponent parent) {
+        // Pull off the important information...
+        String id = adaptor.getId(currentObj);
+        String factoryClass = adaptor.getFactoryClass(currentObj);
+        // NOTE: Properties specify things such as:
+        // URL, Text, Image, Action, Expanded, ActionListener, etc.
+        Map<String, Object> props = adaptor.getFactoryOptions(currentObj);
+        Properties properties = Util.mapToProperties(props);
+
+        // Create TreeNode
+        UIComponent node = ComponentUtil.getInstance(ctx).getChild(parent, id, factoryClass, properties);
+
+        // The above util method defaults to using a facet... change to child
+        // NOTE: The above needs "parent" to correctly evaluate ${}
+        // NOTE: expressions, in the future find a way to make it store as a
+        // NOTE: child vs. facet (possible if I create the LayoutComponent).
+        if (parent != null) {
+            parent.getFacets().remove(id);
+            parent.getChildren().add(node);
+        }
+
+        // Configure TreeNode
+        configureTreeNode(ctx, adaptor, node, currentObj);
+
+        // Walk TreeAdaptor and Create child TreeNodes
+        List<Object> children = adaptor.getChildTreeNodeObjects(currentObj);
+        if (children != null) {
+            Iterator<Object> it = children.iterator();
+            while (it.hasNext()) {
+                currentObj = it.next();
+                // We can ignore the return value b/c the factory should
+                // automatically set the parent
+                processNode(ctx, adaptor, currentObj, node);
+            }
+        }
+
+        // Return the recently created TreeNode (or whatever it is)
+        return node;
+    }
+
+    /**
+     * <p>
+     * Adds on facets and handlers.
+     * </p>
+     */
+    protected void configureTreeNode(FacesContext ctx, TreeAdaptor adaptor, UIComponent treeNode, Object currentObj) {
+        // Add facets (such as "content" and "image")
+        Map<String, UIComponent> facets = adaptor.getFacets(treeNode, currentObj);
+        if (facets != null) {
+            Map<String, UIComponent> treeNodeFacets = treeNode.getFacets();
+            Iterator<String> it = facets.keySet().iterator();
+            String facetName;
+            UIComponent facetValue;
+            while (it.hasNext()) {
+                facetName = it.next();
+                facetValue = facets.get(facetName);
+                if (facetValue != null) {
+                    treeNodeFacets.put(facetName, facetValue);
+                }
+            }
+        }
+
+        // Add instance handlers
+        Map<String, List<Handler>> handlersByType = adaptor.getHandlersByType(treeNode, currentObj);
+        if (handlersByType != null) {
+            Iterator<String> it = handlersByType.keySet().iterator();
+            if (it.hasNext()) {
+                String eventType = null;
+                Map<String, Object> compAttrs = treeNode.getAttributes();
+                while (it.hasNext()) {
+                    // Assign instance handlers to attribute for retrieval later
+                    // (Retrieval must be explicit, see LayoutElementBase)
+                    eventType = it.next();
+                    compAttrs.put(eventType, handlersByType.get(eventType));
+                }
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This is the option that must be supplied when using this factory in order to specify which TreeAdaptor instance
+     * should be used. The value should be a fully qualified class name of a valid TreeAdaptor instance. The TreeAdaptor
+     * instance must have a <code>public static TreeAdaptor getInstance(FacesContext,
+     *        LayoutComponent, UIComponent)</code> method in order to get access to an instance of the TreeAdaptor instance.
+     * </p>
+     */
+    public static final String TREE_ADAPTOR_CLASS = "treeAdaptorClass";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/tree/TreeAdaptor.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/tree/TreeAdaptor.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.tree;
+
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+
+import jakarta.faces.component.UIComponent;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This interface defines the methods required by {@link DynamicTreeNodeFactory}. By providing these methods, you are
+ * able to interface some tree structure with the {@link DynamicTreeNodeFactory} so that whole or partial trees can be
+ * created without having to do any tree conversion work (the work is done by the <code>TreeAdaptor</code>
+ * implementation in conjunction with the {@link DynamicTreeNodeFactory}).
+ * </p>
+ *
+ * <p>
+ * The <code>TreeAdaptor</code> implementation must have a <code>public
+ *    static TreeAdaptor getInstance(FacesContext, LayoutComponent,
+ *    UIComponent)</code> method in order to get access to an instance of the <code>TreeAdaptor</code> instance.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface TreeAdaptor {
+
+    /**
+     * <p>
+     * This method is called shortly after getInstance(FacesContext, LayoutComponent, UIComponent). It provides a place for
+     * post-creation initialization to take occur.
+     * </p>
+     */
+    void init();
+
+    /**
+     * <p>
+     * Returns the model object for the top <code>TreeNode</code>, this may contain sub <code>TreeNode</code>s.
+     * </p>
+     */
+    Object getTreeNodeObject();
+
+    /**
+     * <p>
+     * Returns child <code>TreeNode</code>s for the given <code>TreeNode</code> model Object.
+     * </p>
+     */
+    List<Object> getChildTreeNodeObjects(Object nodeObject);
+
+    /**
+     * <p>
+     * This method returns the <code>UIComponent</code> factory class implementation that should be used to create a
+     * <code>TreeNode</code> for the given tree node model object.
+     * </p>
+     */
+    String getFactoryClass(Object nodeObject);
+
+    /**
+     * <p>
+     * This method returns the "options" that should be supplied to the factory that creates the <code>TreeNode</code> for
+     * the given tree node model object.
+     * </p>
+     *
+     * <p>
+     * Some useful options for the standard <code>TreeNode</code> component include:
+     * <p>
+     *
+     * <ul>
+     * <li>text</li>
+     * <li>url</li>
+     * <li>imageURL</li>
+     * <li>target</li>
+     * <li>action
+     * <li>
+     * <li>actionListener</li>
+     * <li>expanded</li>
+     * </ul>
+     *
+     * <p>
+     * See Tree / TreeNode component documentation for more details.
+     * </p>
+     */
+    Map<String, Object> getFactoryOptions(Object nodeObject);
+
+    /**
+     * <p>
+     * This method returns the <code>id</code> for the given tree node model object.
+     * </p>
+     */
+    String getId(Object nodeObject);
+
+    /**
+     * <p>
+     * This method returns any facets that should be applied to the <code>TreeNode (comp)</code>. Useful facets for the sun
+     * <code>TreeNode</code> component are: "content" and "image".
+     * </p>
+     *
+     * <p>
+     * Facets that already exist on <code>comp</code>, or facets that are directly added to <code>comp</code> do not need to
+     * be returned from this method.
+     * </p>
+     *
+     * @param comp The tree node <code>UIComponent</code>.
+     * @param nodeObject The (model) object representing the tree node.
+     */
+    Map<String, UIComponent> getFacets(UIComponent comp, Object nodeObject);
+
+    /**
+     * <p>
+     * Advanced framework feature which provides better handling for things such as expanding TreeNodes, beforeEncode, and
+     * other events.
+     * </p>
+     *
+     * <p>
+     * This method should return a <code>Map</code> of <code>List</code> of <code>Handler</code> objects. Each
+     * <code>List</code> in the <code>Map</code> should be registered under a key that cooresponds to to the "event" in
+     * which the <code>Handler</code>s should be invoked.
+     * </p>
+     */
+    Map<String, List<Handler>> getHandlersByType(UIComponent comp, Object nodeObject);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/tree/TreeAdaptorBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/component/factory/tree/TreeAdaptorBase.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.component.factory.tree;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+
+import jakarta.faces.component.UIComponent;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class provides some of the implemenation for the methods required by the TreeAdaptor interface. This class may
+ * be extended to assist in implementing a TreeAdaptor implementation.
+ * </p>
+ *
+ * <p>
+ * The <code>TreeAdaptor</code> implementation must have a <code>public
+ *    static TreeAdaptor getInstance(FacesContext, LayoutComponent,
+ *    UIComponent)</code> method in order to get access to an instance of the <code>TreeAdaptor</code> instance.
+ * </p>
+ *
+ * @see TreeAdaptor
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class TreeAdaptorBase implements TreeAdaptor {
+
+    /**
+     * <p>
+     * This Constructor does nothing. If you need to store a reference to the <code>LayoutComponent</code> or
+     * <code>UIComponent</code> associated with this <code>TreeAdaptor</code>, it may be more convenient to use a different
+     * constructor.
+     * </p>
+     */
+    protected TreeAdaptorBase() {
+    }
+
+    /**
+     * <p>
+     * This Constructor save the <code>LayoutComponent</code> and the <code>UIComponent</code> for easy use later.
+     * </p>
+     */
+    protected TreeAdaptorBase(LayoutComponent desc, UIComponent parent) {
+        setLayoutComponent(desc);
+        setParentUIComponent(parent);
+    }
+
+    /**
+     * <p>
+     * This method retrieves the <code>LayoutComponent</code> associated with this <code>TreeAdaptor</code>.
+     * </p>
+     */
+    public LayoutComponent getLayoutComponent() {
+        return _layoutComponent;
+    }
+
+    /**
+     * <p>
+     * This method sets the <code>LayoutComponent</code> associated with this <code>TreeAdaptor</code>.
+     * </p>
+     */
+    public void setLayoutComponent(LayoutComponent comp) {
+        _layoutComponent = comp;
+    }
+
+    /**
+     * <p>
+     * This method retrieves the <code>UIComponent</code> associated with this <code>TreeAdaptor</code>.
+     * </p>
+     */
+    public UIComponent getParentUIComponent() {
+        return _parent;
+    }
+
+    /**
+     * <p>
+     * This method sets the <code>UIComponent</code> associated with this <code>TreeAdaptor</code>.
+     * </p>
+     */
+    public void setParentUIComponent(UIComponent comp) {
+        _parent = comp;
+    }
+
+    /**
+     * <p>
+     * This method is called shortly after getInstance(FacesContext, LayoutComponent, UIComponent). It provides a place for
+     * post-creation initialization to take occur.
+     * </p>
+     *
+     * <p>
+     * This implemenation does nothing.
+     * </p>
+     */
+    @Override
+    public void init() {
+    }
+
+    /**
+     * <p>
+     * Returns the model object for the top <code>TreeNode</code>, this may contain sub <code>TreeNode</code>s.
+     * </p>
+     *
+     * <p>
+     * This implementation returns the value that was supplied by {@link #setTreeNodeObject(Object)}. If that method is not
+     * explicitly called, then this implementation will return null.
+     * </p>
+     */
+    @Override
+    public Object getTreeNodeObject() {
+        return _topNodeObject;
+    }
+
+    /**
+     * <p>
+     * This method stores the top tree node model object.
+     * </p>
+     */
+    public void setTreeNodeObject(Object nodeObject) {
+        _topNodeObject = nodeObject;
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>UIComponent</code> factory class implementation that should be used to create a
+     * <code>TreeNode</code> for the given tree node model object.
+     * </p>
+     */
+    @Override
+    public String getFactoryClass(Object nodeObject) {
+        return "com.sun.jsftemplating.component.factory.sun.TreeNodeFactory";
+    }
+
+    /**
+     * <p>
+     * This method returns any facets that should be applied to the <code>TreeNode (comp)</code>. Useful facets for the sun
+     * <code>TreeNode</code> component are: "content" and "image".
+     * </p>
+     *
+     * <p>
+     * Facets that already exist on <code>comp</code>, or facets that are directly added to <code>comp</code> do not need to
+     * be returned from this method.
+     * </p>
+     *
+     * @param nodeObject The (model) object representing the tree node.
+     */
+    public Map<String, UIComponent> getFacets(Object nodeObject) {
+        return null;
+    }
+
+    /**
+     * <p>
+     * Advanced framework feature which provides better handling for things such as expanding TreeNodes, beforeEncode, and
+     * other events.
+     * </p>
+     *
+     * <p>
+     * This method should return a <code>Map</code> of <code>List</code> of <code>Handler</code> objects. Each
+     * <code>List</code> in the <code>Map</code> should be registered under a key that cooresponds to to the "event" in
+     * which the <code>Handler</code>s should be invoked.
+     * </p>
+     *
+     * <p>
+     * This implementation returns null. This method must be overriden to take advantage of this feature.
+     * </p>
+     */
+    @Override
+    public Map<String, List<Handler>> getHandlersByType(UIComponent comp, Object nodeObject) {
+        return null;
+    }
+
+    private Object _topNodeObject = null;
+    private LayoutComponent _layoutComponent = null;
+    private UIComponent _parent = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/MethodNotAllowedException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/MethodNotAllowedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELException;
+
+/**
+ * Thrown when a method could not be accessed while evaluating a {@link jakarta.el.MethodExpression MethodExpression}.
+ *
+ * @author avpinchuk
+ */
+final class MethodNotAllowedException extends ELException {
+
+    private static final long serialVersionUID = 1L;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/PageSessionResolver.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.PropertyNotFoundException;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This {@link ELResolver} exists to resolve "page session" attributes. This concept, borrowed from NetDynamics / JATO,
+ * stores data w/ the page so that it is available throughout the life of the page. This is longer than request scope,
+ * but usually shorter than session.
+ *
+ * <p>
+ * This implementation stores the attributes on the {@link UIViewRoot}.
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class PageSessionResolver extends ELResolver {
+
+    /**
+     * The name an expression must use when it explicitly specifies page session ("pageSession").
+     */
+    public static final String PAGE_SESSION = "pageSession";
+
+    /**
+     * The attribute key in which to store the "page" session Map.
+     */
+    private static final String PAGE_SESSION_KEY = "_ps";
+
+    /**
+     * Checks standard scopes and "page session" to see if the value exists.
+     */
+    @Override
+    public Object getValue(ELContext elContext, Object base, Object property) {
+        if (base != null) {
+            return null;
+        }
+
+        if (property == null) {
+            throw new PropertyNotFoundException();
+        }
+
+        elContext.setPropertyResolved(true);
+
+        FacesContext facesContext = (FacesContext) elContext.getContext(FacesContext.class);
+        ExternalContext externalContext = facesContext.getExternalContext();
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+        Map<String, Serializable> pageSession = getPageSession(facesContext, viewRoot);
+        String attribute = (String) property;
+
+        // Check to see if expression explicitly asks for PAGE_SESSION
+        if (property.equals(PAGE_SESSION)) {
+            // It does, return the Map
+            if (pageSession == null) {
+                // No Map! That's ok, create one...
+                pageSession = createPageSession(facesContext, viewRoot);
+            }
+            return pageSession;
+        }
+
+        // Check page session exists and contains a property
+        if (pageSession == null || !pageSession.containsKey(attribute)) {
+            elContext.setPropertyResolved(false);
+            return null;
+        }
+
+        // Check request map
+        Object value = externalContext.getRequestMap().get(attribute);
+        if (value != null) {
+            return value;
+        }
+
+        // Check view map
+        Map<String, Object> viewMap = viewRoot.getViewMap(false);
+        if (viewMap != null) {
+            value = viewMap.get(attribute);
+            if (value != null) {
+                return value;
+            }
+        }
+
+        // Check session map
+        value = externalContext.getSessionMap().get(attribute);
+        if (value != null) {
+            return value;
+        }
+
+        // Check application map
+        value = externalContext.getApplicationMap().get(attribute);
+        if (value != null) {
+            return value;
+        }
+
+        // Not found updated property in the standard scopes.
+        // Return value from page session.
+        return pageSession.get(attribute);
+    }
+
+    @Override
+    public Class<?> getType(ELContext elContext, Object base, Object property) {
+        checkPropertyFound(base, property);
+        return null;
+    }
+
+    @Override
+    public void setValue(ELContext elContext, Object base, Object property, Object value) {
+        checkPropertyFound(base, property);
+    }
+
+    @Override
+    public boolean isReadOnly(ELContext elContext, Object base, Object property) {
+        checkPropertyFound(base, property);
+        return false;
+    }
+
+    @Override
+    public Class<?> getCommonPropertyType(ELContext elContext, Object base) {
+        return base == null ? String.class : null;
+    }
+
+    /**
+     * This method provides access to the "page session" {@link Map}. If it doesn't exist, it returns {@code null}. If the
+     * given {@link UIViewRoot} is {@code null}, then the current {@link UIViewRoot} will be used.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Serializable> getPageSession(FacesContext facesContext, UIViewRoot viewRoot) {
+        if (viewRoot == null) {
+            viewRoot = facesContext.getViewRoot();
+        }
+        return (Map<String, Serializable>) viewRoot.getAttributes().get(PAGE_SESSION_KEY);
+    }
+
+    /**
+     * This method will create a new "page session" {@code Map} if it doesn't exist yet. It will overwrite any existing
+     * "page session" {@code Map}, so be careful.
+     */
+    public static Map<String, Serializable> createPageSession(FacesContext facesContext, UIViewRoot viewRoot) {
+        if (viewRoot == null) {
+            viewRoot = facesContext.getViewRoot();
+        }
+
+        // Create it...
+        Map<String, Serializable> pageSession = new HashMap<>(4);
+
+        // Store it...
+        viewRoot.getAttributes().put(PAGE_SESSION_KEY, pageSession);
+
+        // Return it...
+        return pageSession;
+    }
+
+    private static void checkPropertyFound(Object base, Object property) {
+        if (base == null && property == null) {
+            throw new PropertyNotFoundException();
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/PermissionChecker.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/PermissionChecker.java
@@ -1,0 +1,1257 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.util.ArrayList;
+import java.util.EmptyStackException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This class evaluates a Boolean equation. The supported functions / operators are:
+ * </p>
+ *
+ * <ul>
+ * <li>$&lt;type&gt;{&lt;key&gt;} -- To read a value according to &lt;type&gt; using &lt;key&gt; (See:
+ * {@link VariableResolver}). (null is interpretted as false, non boolean values (besides the string "false") are
+ * interpretted to mean true)</li>
+ * <li>'(' and ')' can be used to override order of operation</li>
+ * <li>'!' negate a boolean value</li>
+ * <li>'|' logical OR</li>
+ * <li>'&amp;' logical AND</li>
+ * <li>'=' String equals</li>
+ * <li>'&lt;' less than between 2 Integers</li>
+ * <li>'&gt;' greater than between 2 Integers</li>
+ * <li>'%' modulus of 2 Integers</li>
+ * </ul>
+ *
+ *
+ * <p>
+ * Operator Precedence (for infix notation) is:
+ * </p>
+ *
+ * <ul>
+ * <li>() -- Highest</li>
+ * <li>!</li>
+ * <li>%</li>
+ * <li>&amp;</li>
+ * <li>|</li>
+ * <li>&lt; and &gt;</li>
+ * <li>=</li>
+ * </ul>
+ *
+ * @see VariableResolver
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class PermissionChecker {
+
+    /**
+     * <p>
+     * This variable represents a "false" BooleanFunction.
+     * </p>
+     */
+    public static final BooleanFunction FALSE_BOOLEAN_FUNCTION = new BooleanFunction(false);
+
+    /**
+     * <p>
+     * This variable represents a "true" BooleanFunction.
+     * </p>
+     */
+    public static final BooleanFunction TRUE_BOOLEAN_FUNCTION = new BooleanFunction(true);
+
+    protected static final char POST_TRUE = 't';
+    protected static final char POST_FALSE = 'f';
+    protected static final char POST_TRUE_CAP = 'T';
+    protected static final char POST_FALSE_CAP = 'F';
+
+    public static final String TRUE = "true";
+    public static final String FALSE = "false";
+
+    // Function representation in postfix String
+    public static final char FUNCTION_MARKER = 'F';
+
+    // Operator constants
+    public static final char LEFT_PAREN = '(';
+    public static final char RIGHT_PAREN = ')';
+    public static final char EQUALS_OPERATOR = '=';
+    public static final char OR_OPERATOR = '|';
+    public static final char AND_OPERATOR = '&';
+    public static final char NOT_OPERATOR = '!';
+    public static final char LESS_THAN_OPERATOR = '<';
+    public static final char MORE_THAN_OPERATOR = '>';
+    public static final char MODULUS_OPERATOR = '%';
+    public static final char DIVIDE_OPERATOR = '/';
+
+    // The COMMA separates function arguments... not really an operator
+    public static final char ARGUMENT_SEPARATOR = ',';
+
+    // Reserved operators, although not currently used...
+    /*
+     * These may be added eventually
+     *
+     * public static final char AT_OPERATOR = '@'; public static final char POUND_OPERATOR = '#'; public static final char
+     * DOLLAR_OPERATOR = '$'; public static final char UP_OPERATOR = '^'; public static final char STAR_OPERATOR = '*';
+     * public static final char TILDA_OPERATOR = '~';
+     */
+
+    private static final String PERMISSION_FUNCTIONS = "__jsft_permFuncs";
+
+    /**
+     * <p>
+     * This holds the infix equation.
+     * </p>
+     */
+    private String _infixStr;
+
+    /**
+     * <p>
+     * This holds the postfix equation.
+     * </p>
+     */
+    private char[] _postfixArr;
+
+    /**
+     * <p>
+     * This List holds the actual Function objects that correspond to the 'F' markers in the postfix string.
+     * </p>
+     */
+    private List<Function> _functionList;
+
+    /**
+     * <p>
+     * This List of functions maintains variableSubstitution Functions which happen out-of-order. They will be pulled from
+     * this list as placed into the actual _functionList when the are encountered during the preProcessing.
+     * </p>
+     */
+    private LayoutElement _desc;
+    private UIComponent _component;
+
+    /**
+     * This is the constructor method that is required to create this object.
+     */
+    public PermissionChecker(LayoutElement desc, UIComponent component, String infixStr) {
+        if (infixStr == null) {
+            infixStr = "false";
+        }
+        setLayoutElement(desc);
+        setUIComponent(component);
+        setInfix(stripWhiteSpace(infixStr));
+    }
+
+    /**
+     * <p>
+     * This method sets the LayoutElement that is associated with the 'if' check being evaluated. This is not normally
+     * needed, it is only needed if the 'if' check contains an expression which requires a LayoutElement to be properly
+     * evaluated.
+     * </p>
+     */
+    protected void setUIComponent(UIComponent component) {
+        _component = component;
+    }
+
+    /**
+     * <p>
+     * Retreives the LayoutElement associated with this PermissionChecker (only needed in cases where a expression requires
+     * a LayoutElement for evaluation).
+     * </p>
+     */
+    public UIComponent getUIComponent() {
+        return _component;
+    }
+
+    /**
+     * <p>
+     * This method sets the LayoutElement that is associated with the 'if' check being evaluated. This is not normally
+     * needed, it is only needed if the 'if' check contains an expression which requires a LayoutElement to be properly
+     * evaluated.
+     * </p>
+     */
+    protected void setLayoutElement(LayoutElement desc) {
+        _desc = desc;
+    }
+
+    /**
+     * <p>
+     * Retreives the LayoutElement associated with this PermissionChecker (only needed in cases where a expression requires
+     * a LayoutElement for evaluation).
+     * </p>
+     */
+    public LayoutElement getLayoutElement() {
+        return _desc;
+    }
+
+    /**
+     * <p>
+     * This method returns the precedence of the given operator. This only applies to infix notation (of course) and is
+     * needed to correctly order the operators when converting to postfix.
+     * </p>
+     *
+     * <ul>
+     * <li>! (not) has the highest precedence</li>
+     * <li>% (modulus)</li>
+     * <li>&amp; (and)</li>
+     * <li>| (or)</li>
+     * <li>&lt; (less than) and &gt; (greater than)</li>
+     * <li>= (equals)</li>
+     * </ul>
+     *
+     * <p>
+     * Of course '(' and ')' can be used to override the order of operations in infix notation.
+     * </p>
+     *
+     * @param op The operator to evaluate.
+     *
+     * @return A number that can be used to compare its precedence.
+     */
+    private static int getPrecedence(char op) {
+        switch (op) {
+        case LEFT_PAREN:
+            return 1;
+        case RIGHT_PAREN:
+            return 999;
+        case EQUALS_OPERATOR:
+            return 2;
+        case LESS_THAN_OPERATOR:
+        case MORE_THAN_OPERATOR:
+            return 4;
+        case OR_OPERATOR:
+            return 8;
+        case AND_OPERATOR:
+            return 16;
+        case MODULUS_OPERATOR:
+        case DIVIDE_OPERATOR:
+            return 32;
+        case NOT_OPERATOR:
+            return 64;
+        }
+        return 1;
+    }
+
+    /**
+     * <p>
+     * This method replaces all "true" / "false" strings w/ 't'/'f'. It converts the String into a char[]. It replaces all
+     * user defined functions w/ 'F' and places a Function in a list per the registered user-defined function. All other
+     * strings are converted to an 'F' and a StringFunction is added to the function list.
+     * </p>
+     */
+    protected char[] preProcessString(String source) {
+        char[] arr = source.toCharArray();
+        int sourceLen = arr.length;
+        int destLen = 0;
+
+        // Loop through the String, char by char
+        for (int idx = 0; idx < sourceLen; idx++) {
+            switch (arr[idx]) {
+            case POST_TRUE:
+            case POST_TRUE_CAP:
+                if (idx + TRUE.length() <= sourceLen && TRUE.equalsIgnoreCase(new String(arr, idx, TRUE.length()))) {
+                    arr[destLen++] = POST_TRUE;
+                    idx += TRUE.length() - 1;
+                } else {
+                    idx = storeFunction(arr, idx);
+                    arr[destLen++] = FUNCTION_MARKER;
+                }
+                break;
+            case POST_FALSE:
+            case POST_FALSE_CAP:
+                if (idx + FALSE.length() <= sourceLen && FALSE.equalsIgnoreCase(new String(arr, idx, FALSE.length()))) {
+                    arr[destLen++] = POST_FALSE;
+                    idx += FALSE.length() - 1;
+                } else {
+                    idx = storeFunction(arr, idx);
+                    arr[destLen++] = FUNCTION_MARKER;
+                }
+                break;
+            case OR_OPERATOR:
+            case EQUALS_OPERATOR:
+            case LESS_THAN_OPERATOR:
+            case MORE_THAN_OPERATOR:
+            case MODULUS_OPERATOR:
+            case DIVIDE_OPERATOR:
+            case AND_OPERATOR:
+            case NOT_OPERATOR:
+            case LEFT_PAREN:
+            case RIGHT_PAREN:
+                arr[destLen++] = arr[idx];
+                break;
+            default:
+                idx = storeFunction(arr, idx);
+                arr[destLen++] = FUNCTION_MARKER;
+            }
+        }
+        char[] dest = new char[destLen];
+        for (int idx = 0; idx < destLen; idx++) {
+            dest[idx] = arr[idx];
+        }
+        return dest;
+    }
+
+    /**
+     * <p>
+     * This method looks at the given char array starting at index and continues until an operator (or end of String) is
+     * encountered. It then uses this string to lookup a registered function (if any), it stores that function (with
+     * parameters)... or if the function is not found, it registers a "String function" (which always returns true).
+     * </p>
+     */
+    protected int storeFunction(char[] arr, int idx) {
+        // Find string...
+        int start = idx;
+        int len = arr.length;
+        while (idx < len && !isOperator(arr[idx])) {
+            idx++;
+        }
+
+        // Create String...
+        String str = new String(arr, start, idx - start);
+
+        // Check to see if it is a registered function...
+        Function function = getFunction(str);
+        if (function != null) {
+            // Find the left paren...
+            int left = idx;
+            if (left >= len || arr[left] != LEFT_PAREN) {
+                throw new RuntimeException("Function '" + str + "' is expected to have a '" + LEFT_PAREN
+                        + "' immediately following it.  Equation: '" + new String(arr) + "'.");
+            }
+
+            List<String> arguments = new ArrayList<>();
+
+            // Find the right Paren...
+            while (++idx < len && arr[idx] != RIGHT_PAREN) {
+                if (arr[idx] == ARGUMENT_SEPARATOR) {
+                    left++;
+                    arguments.add(new String(arr, left, idx - left));
+                    left = idx;
+                }
+            }
+
+            // Make sure we don't have ()
+            left++;
+            if (idx > left) {
+                arguments.add(new String(arr, left, idx - left));
+            }
+
+            // Set the arguments...
+            function.setArguments(arguments);
+        } else {
+            // Not a registered function...
+            idx--; // In this case, there are no ()'s to consume, backup 1
+            /*
+             * if ((str.charAt(0) == FUNCTION_MARKER) && (str.length() == 1) && !_tmpFunctionStack.empty()) { // We have a function
+             * added during the subtitute() phase function = (Function) _tmpFunctionStack.pop(); } else {
+             */
+            // Create a StringFunction
+            function = new StringFunction(str);
+            /*
+             * }
+             */
+        }
+
+        // Add the function to the function list
+        _functionList.add(function);
+
+        // Return the number of characters that we consumed...
+        return idx;
+    }
+
+    /**
+     * <p>
+     * This returns a <code>Map&lt;String, Class&gt;</code> which represent user-registered functions.
+     * </p>
+     */
+    private static Map<String, Class> getFunctions(FacesContext ctx) {
+        Map<String, Class> funcs = null;
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        if (ctx != null) {
+            Map<String, Object> appMap = ctx.getExternalContext().getApplicationMap();
+            funcs = (Map<String, Class>) appMap.get(PERMISSION_FUNCTIONS);
+            if (funcs == null) {
+                // Perhaps a SoftReference would be a good idea here?
+                funcs = new HashMap<>();
+            }
+        } else {
+            // Not JSF env, create every time...
+            funcs = new HashMap<>();
+        }
+        return funcs;
+    }
+
+    /**
+     * <p>
+     * This sets a <code>Map&lt;String, Class&gt;</code> which represent user-registered functions.
+     * </p>
+     */
+    private static void setFunctions(FacesContext ctx, Map<String, Class> map) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        if (ctx != null) {
+            // Only set if we're in a JSF env
+            ctx.getExternalContext().getApplicationMap().put(PERMISSION_FUNCTIONS, map);
+        }
+    }
+
+    /**
+     * <p>
+     * This method is a factory method for constructing a new function based on the function name passed in. The function
+     * must be registered prior to invoking this method.
+     * </p>
+     */
+    protected static Function getFunction(String functionName) {
+        // Get the Function class
+        Class functionClass = getFunctions(null).get(functionName);
+        if (functionClass == null) {
+            return null;
+        }
+
+        // Create a new instance
+        Function function = null;
+        try {
+            function = (Function) functionClass.newInstance();
+        } catch (Exception ex) {
+            throw new RuntimeException("Unable to instantiate '" + functionClass.getName() + "' for '" + functionName + "'", ex);
+        }
+
+        // Return the instance
+        return function;
+    }
+
+    /**
+     * <p>
+     * This method allows arbitrary functions to be registered. Function names should only contain letters or numbers, other
+     * characters or whitespace may cause problems. No checking is done to ensure this, however.
+     * </p>
+     *
+     * <p>
+     * Functions will be expressed in an equation as follows:
+     * </p>
+     *
+     * <ul>
+     * <li>function_name(param1,param2)</li>
+     * </ul>
+     *
+     * <p>
+     * Function parameters also should only contain alpha-numeric characters.
+     * </p>
+     *
+     * <p>
+     * Functions must implement PermissionChecker.Function interface
+     * </p>
+     */
+    public static void registerFunction(String functionName, Class function) {
+        // Get a copy of the existing f()'s
+        Map<String, Class> newFuncs = new HashMap<>(getFunctions(null));
+        if (function == null) {
+            // Remove it...
+            newFuncs.remove(functionName);
+        } else {
+            if (!Function.class.isAssignableFrom(function)) {
+                throw new RuntimeException("'" + function.getName() + "' must implement '" + Function.class.getName() + "'");
+            }
+            // Add it...
+            newFuncs.put(functionName, function);
+        }
+
+        // Save new copy of function Map
+        setFunctions(null, newFuncs);
+    }
+
+    /**
+     * <p>
+     * This method returns true if the given character is a valid operator.
+     * </p>
+     */
+    public static boolean isOperator(char ch) {
+        switch (ch) {
+        case LEFT_PAREN:
+        case RIGHT_PAREN:
+        case EQUALS_OPERATOR:
+        case LESS_THAN_OPERATOR:
+        case MORE_THAN_OPERATOR:
+        case MODULUS_OPERATOR:
+        case DIVIDE_OPERATOR:
+        case OR_OPERATOR:
+        case AND_OPERATOR:
+        case NOT_OPERATOR:
+//        case AT_OPERATOR:
+//        case POUND_OPERATOR:
+//        case DOLLAR_OPERATOR:
+//        case UP_OPERATOR:
+//        case STAR_OPERATOR:
+//        case TILDA_OPERATOR:
+//        case ARGUMENT_SEPARATOR:
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * <p>
+     * This method calculates the postfix representation of the infix equation passed in. It returns the postfix equation as
+     * a char[].
+     * </p>
+     *
+     * @param infixStr The infix representation of the equation.
+     *
+     * @return postfix representation of the equation as a char[] (the f()'s are removed and stored in _functionList).
+     */
+    protected char[] generatePostfix(String infixStr) {
+        // Reset the _functionList
+        _functionList = new ArrayList<>();
+
+        // Convert string to our parsable format
+        char[] result = preProcessString(infixStr);
+//System.out.println("DEBUG: Initial String: '"+infixStr+"'");
+//System.out.println("DEBUG: After Pre-process: '"+new String(result)+"'");
+        int resultLen = result.length;
+        int postIdx = 0;
+        int precedence = 0;
+        Stack opStack = new Stack();
+
+        // Put f()'s directly into result, push operators into right order
+        for (int idx = 0; idx < resultLen; idx++) {
+            switch (result[idx]) {
+            case FUNCTION_MARKER:
+            case POST_TRUE:
+            case POST_FALSE:
+                result[postIdx++] = result[idx];
+                break;
+            case LEFT_PAREN:
+                opStack.push(new Character(LEFT_PAREN));
+                break;
+            case RIGHT_PAREN:
+                while (!opStack.empty() && ((Character) opStack.peek()).charValue() != LEFT_PAREN) {
+                    result[postIdx++] = ((Character) opStack.pop()).charValue();
+                }
+                if (!opStack.empty()) {
+                    // Throw away the LEFT_PAREN that should still be there
+                    opStack.pop();
+                }
+                break;
+            default:
+                // clear stuff
+                precedence = getPrecedence(result[idx]);
+                while (!opStack.empty() && getPrecedence(((Character) opStack.peek()).charValue()) >= precedence) {
+                    result[postIdx++] = ((Character) opStack.pop()).charValue();
+                }
+
+                /* Put it on the stack */
+                opStack.push(new Character(result[idx]));
+                break;
+            }
+        }
+
+        // empty the rest of the stack to the result
+        while (!opStack.empty()) {
+            result[postIdx++] = ((Character) opStack.pop()).charValue();
+        }
+        // Copy the result to the postfixStr
+        char[] postfixStr = new char[postIdx];
+        for (int idx = 0; idx < postIdx; idx++) {
+            postfixStr[idx] = result[idx];
+        }
+//System.out.println("DEBUG: Postfix String: '"+new String(postfixStr)+"'");
+        return postfixStr;
+    }
+
+    /**
+     * <p>
+     * This method is invoked to determine if the equation evaluates to true or false.
+     * </p>
+     */
+    public boolean hasPermission() {
+        char[] postfixArr = getPostfixArr();
+        int len = postfixArr.length;
+        Stack result = new Stack();
+        result.push(FALSE_BOOLEAN_FUNCTION); // Default to false
+        boolean val1, val2;
+        Iterator<Function> it = _functionList.iterator();
+
+        // Iterate through the postfix array
+        for (int idx = 0; idx < len; idx++) {
+            switch (postfixArr[idx]) {
+            case POST_TRUE:
+                result.push(TRUE_BOOLEAN_FUNCTION);
+                break;
+            case POST_FALSE:
+                result.push(FALSE_BOOLEAN_FUNCTION);
+                break;
+            case FUNCTION_MARKER:
+                if (!it.hasNext()) {
+                    throw new RuntimeException(
+                            "Unable to evaluate: '" + toString() + "' -- found function marker " + "w/o cooresponding function!");
+                }
+                result.push(it.next());
+                break;
+            case EQUALS_OPERATOR:
+                try {
+                    // Allow reg expression matching
+                    String matchStr = result.pop().toString();
+                    val1 = result.pop().toString().matches(matchStr);
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                result.push(val1 ? TRUE_BOOLEAN_FUNCTION : FALSE_BOOLEAN_FUNCTION);
+                break;
+            case LESS_THAN_OPERATOR:
+                try {
+                    // The stack reverses the order, so check greater than
+                    val1 = Integer.parseInt(result.pop().toString()) > Integer.parseInt(result.pop().toString());
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                result.push(val1 ? TRUE_BOOLEAN_FUNCTION : FALSE_BOOLEAN_FUNCTION);
+                break;
+            case MORE_THAN_OPERATOR:
+                try {
+                    // The stack reverses the order, so check less than
+                    val1 = Integer.parseInt(result.pop().toString()) < Integer.parseInt(result.pop().toString());
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                result.push(val1 ? TRUE_BOOLEAN_FUNCTION : FALSE_BOOLEAN_FUNCTION);
+                break;
+            case MODULUS_OPERATOR:
+                try {
+                    // The stack reverses the order...
+                    int modNumber = Integer.parseInt(result.pop().toString());
+                    int num = Integer.parseInt(result.pop().toString());
+                    result.push(new StringFunction("" + num % modNumber));
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                break;
+            case DIVIDE_OPERATOR:
+                try {
+                    // The stack reverses the order...
+                    int divNumber = Integer.parseInt(result.pop().toString());
+                    int num = Integer.parseInt(result.pop().toString());
+                    result.push(new StringFunction("" + num / divNumber));
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                break;
+            case OR_OPERATOR:
+                try {
+                    val1 = ((Function) result.pop()).evaluate();
+                    val2 = ((Function) result.pop()).evaluate();
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                result.push(val1 || val2 ? TRUE_BOOLEAN_FUNCTION : FALSE_BOOLEAN_FUNCTION);
+                break;
+            case AND_OPERATOR:
+                try {
+                    val1 = ((Function) result.pop()).evaluate();
+                    val2 = ((Function) result.pop()).evaluate();
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                result.push(val1 && val2 ? TRUE_BOOLEAN_FUNCTION : FALSE_BOOLEAN_FUNCTION);
+                break;
+            case NOT_OPERATOR:
+                try {
+                    val1 = ((Function) result.pop()).evaluate();
+                } catch (EmptyStackException ex) {
+                    throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+                }
+                result.push(!val1 ? TRUE_BOOLEAN_FUNCTION : FALSE_BOOLEAN_FUNCTION);
+                break;
+            }
+        }
+
+        // Return the only element on the stack (hopefully)
+        try {
+            val1 = ((Function) result.pop()).evaluate();
+        } catch (EmptyStackException ex) {
+            throw new RuntimeException("Unable to evaluate: '" + toString() + "'.", ex);
+        }
+        if (!result.empty()) {
+            result.pop(); // We added a false that wasn't needed
+            if (!result.empty()) {
+                throw new RuntimeException("Unable to evaluate: '" + toString() + "' -- values left on the stack.");
+            }
+        }
+        return val1;
+    }
+
+    /**
+     * <p>
+     * This method returns the infix representation of the equation, in other words: the original String passed in.
+     * </p>
+     */
+    public String getInfix() {
+        return _infixStr;
+    }
+
+    /**
+     * <p>
+     * This method sets the equation and forces a re-evaluation of the equation. It returns the postfix representation of
+     * the equation.
+     * </p>
+     *
+     * @param equation The infix equation to use.
+     *
+     */
+    public void setInfix(String equation) {
+        _infixStr = equation;
+        setPostfixArr(generatePostfix(equation));
+    }
+
+    /**
+     * <p>
+     * Getter for the post fix array. If it is currently null, an empty <code>char[]</code> array will be returned.
+     * </p>
+     */
+    protected char[] getPostfixArr() {
+        if (_postfixArr == null) {
+            _postfixArr = new char[] { ' ' };
+        }
+        return _postfixArr;
+    }
+
+    /**
+     * <p>
+     * Setter for the postfix array of chars.
+     * </p>
+     */
+    protected void setPostfixArr(char[] postfix) {
+        _postfixArr = postfix;
+    }
+
+    /**
+     * <p>
+     * This method provides access to a <code>String</code> representation of the postfix equation held by this
+     * <code>Object</code>.
+     * </p>
+     */
+    public String getPostfix() {
+        if (getPostfixArr() == null) {
+            return "";
+        }
+        return new String(getPostfixArr());
+    }
+
+    /**
+     * <p>
+     * Displays the infix and postfix version of the equation.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        return _infixStr + " = " + toString(getPostfixArr());
+    }
+
+    /**
+     * <p>
+     * This toString(...) method generates just the postfix representation of the equation. The postfix notation is stored
+     * as a char[] and it has the functions removed from the char[]. This method iterates through the char[] and generates a
+     * String with the functions put back into the equation.
+     * </p>
+     *
+     * @param post The char[] representation of the postfix equation.
+     */
+    private String toString(char[] post) {
+        int len = post.length;
+        StringBuffer result = new StringBuffer("");
+        Iterator<Function> it = _functionList.iterator();
+
+        for (int idx = 0; idx < len; idx++) {
+            switch (post[idx]) {
+            case POST_TRUE:
+                result.append(TRUE);
+                break;
+            case POST_FALSE:
+                result.append(FALSE);
+                break;
+            case FUNCTION_MARKER:
+                result.append(it.next().toString());
+                break;
+            default:
+                result.append(post[idx]);
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * <p>
+     * This method removes all whitespace from the given String.
+     * </p>
+     */
+    public static String stripWhiteSpace(String input) {
+        char[] arr = input.toCharArray();
+        int len = arr.length;
+        int destLen = 0;
+
+        // Loop through the array skipping whitespace
+        for (int idx = 0; idx < len; idx++) {
+            if (Character.isWhitespace(arr[idx])) {
+                continue;
+            }
+            arr[destLen++] = arr[idx];
+        }
+
+        // Return the result
+        return new String(arr, 0, destLen);
+    }
+
+    /**
+     * <p>
+     * This class must be implemented by all user defined Functions.
+     * </p>
+     *
+     * <p>
+     * In addition to these methods, a toString() should be implemented that reconstructs the original format of the
+     * function (i.e. function_name(arg1,arg2...)).
+     * </p>
+     */
+    public interface Function {
+
+        /**
+         * <p>
+         * This method returns the List of arguments.
+         * </p>
+         */
+        List<String> getArguments();
+
+        /**
+         * <p>
+         * This method is invoked be the PermissionChecker to set the arguments.
+         * </p>
+         */
+        void setArguments(List<String> args);
+
+        /**
+         * <p>
+         * This method is invoked by the PermissionCheck to evaluate the function to true or false.
+         * </p>
+         */
+        boolean evaluate();
+    }
+
+    /**
+     * <p>
+     * <code>StringFunction</code> implements <code>Function</code> and serves as the default function. This function is
+     * special in that it is NEVER registered and is the only function that SHOULD NOT be followed by ()'s. This function
+     * will process embedded expressions and evaulate to false if the entire string evaulates to null. Otherwise it will
+     * return true. This <code>Function</code> ignores all arguments (arguments only apply if it is registered, which
+     * shouldn't be the case anyway).
+     * </p>
+     */
+    protected class StringFunction implements PermissionChecker.Function {
+
+        /**
+         * Constructor.
+         *
+         * @param value The expression to evaluate.
+         */
+        public StringFunction(String value) {
+            _value = value;
+        }
+
+        /**
+         * Not used.
+         */
+        @Override
+        public List<String> getArguments() {
+            return null;
+        }
+
+        /**
+         * Not used.
+         */
+        @Override
+        public void setArguments(List<String> args) {
+        }
+
+        /**
+         * <p>
+         * Determine if the value of the <code>Function</code> is <code>true</code> or <code>false</code>.
+         * </p>
+         */
+        @Override
+        public boolean evaluate() {
+            Object obj = getEvaluatedValue();
+            if (obj == null) {
+                return false;
+            }
+            obj = obj.toString();
+            if (obj.equals("") || ((String) obj).equalsIgnoreCase("false")) {
+                return false;
+            }
+            return true;
+        }
+
+        /**
+         * <p>
+         * This methis uses the {@link VariableResolver} to evaluate the String and returns the result.
+         * </p>
+         */
+        public Object getEvaluatedValue() {
+            FacesContext ctx = FacesContext.getCurrentInstance();
+            return ComponentUtil.getInstance(ctx).resolveValue(ctx, getLayoutElement(), getUIComponent(), _value);
+        }
+
+        /**
+         * <p>
+         * This implementation of <code>toString()</code> returns the evaluated value, except when the value is
+         * <code>(null)</code> in which case it returns the empty string ("").
+         * </p>
+         */
+        @Override
+        public String toString() {
+            Object obj = getEvaluatedValue();
+            if (obj == null) {
+                return "";
+            }
+            return obj.toString();
+        }
+
+        private String _value;
+    }
+
+    /**
+     * <p>
+     * <code>BooleanFunction</code> is either <code>true</code> or <code>false</code>. It is used internally by
+     * <code>PermissionChecker</code> and is not needed outside <code>PermissionChecker</code> since the Strings "true" or
+     * "false" used in an equation are sufficient.
+     * </p>
+     */
+    protected static class BooleanFunction implements PermissionChecker.Function {
+
+        /**
+         * <p>
+         * Constructor (defaults to false).
+         * </p>
+         */
+        public BooleanFunction() {
+        }
+
+        /**
+         * <p>
+         * Constructor.
+         * </p>
+         */
+        public BooleanFunction(boolean value) {
+            _value = value;
+        }
+
+        /**
+         * <p>
+         * Not used.
+         * </p>
+         */
+        @Override
+        public List<String> getArguments() {
+            return null;
+        }
+
+        /**
+         * <p>
+         * Not used.
+         * </p>
+         */
+        @Override
+        public void setArguments(List<String> args) {
+        }
+
+        /**
+         * <p>
+         * Return the value of the <code>Function</code>; <code>true</code> or <code>false</code>.
+         * </p>
+         */
+        @Override
+        public boolean evaluate() {
+            return _value;
+        }
+
+        /**
+         * <p>
+         * This implementation prints the <code>String</code> "true" or "false" based on the stored value.
+         * </p>
+         */
+        @Override
+        public String toString() {
+            return _value ? "true" : "false";
+        }
+
+        private boolean _value = false;
+    }
+
+    /**
+     * <p>
+     * This is here to provide some test cases. It only tests the conversion to postfix notation.
+     * </p>
+     */
+    public static void main(String[] args) {
+        PermissionChecker checker;
+        if (args.length > 0) {
+            for (String arg : args) {
+                checker = new PermissionChecker(null, null, arg);
+                System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            }
+        } else {
+            boolean success = true;
+            checker = new PermissionChecker(null, null, "false|false");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("false|false = falsefalse|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "true|false = truefalse|");
+                success = false;
+            }
+            if (checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "true |false");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("true|false = truefalse|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "true|false = truefalse|");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "true&(false|true)");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("true&(false|true) = truefalsetrue|&")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "true&(false|true) = truefalsetrue|&");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "true&false|true");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("true&false|true = truefalse&true|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "true&false|true = truefalse&true|");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "true&true|false&true");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("true&true|false&true = truetrue&falsetrue&|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "true&true|false&true = truetrue&falsetrue&|");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "!true|false&!(false|true)");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("!true|false&!(false|true) = true!falsefalsetrue|!&|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "!true|false&!(false|true) = true!falsefalsetrue|!&|");
+                success = false;
+            }
+            if (checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "!(!(true&!true)|!(false|false))|(true|false)&true");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString()
+                    .equals("!(!(true&!true)|!(false|false))|(true|false)&true = truetrue!&!falsefalse|!|!truefalse|true&|")) {
+
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n"
+                        + "!(!(true&!true)|!(false|false))|(true|false)&true = truetrue!&!falsefalse|!|!truefalse|true&|");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            // Test '='
+            checker = new PermissionChecker(null, null, "false =false");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("false=false = falsefalse=")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "false=false = falsefalse=");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, " test= me ");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("test=me = testme=")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "test=me = testme=");
+                success = false;
+            }
+            if (checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, " this should work=thisshouldwork");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("thisshouldwork=thisshouldwork = thisshouldworkthisshouldwork=")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "thisshouldwork=thisshouldwork = thisshouldworkthisshouldwork=");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "false|ab=true");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("false|ab=true = falseab|true=")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "false|ab=true = falseab|true=");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "false|(ab=true)");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("false|(ab=true) = falseabtrue=|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "false|ab=true = falseab|true=");
+                success = false;
+            }
+            if (checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "false|(ab=ab)");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("false|(ab=ab) = falseabab=|")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "false|ab=true = falseab|true=");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "!");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("! = !")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "! = !");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals(" = ")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + " = ");
+                success = false;
+            }
+            if (checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "!$escape{}");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("!$escape{} = !")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + "! = !");
+                success = false;
+            }
+            if (!checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            checker = new PermissionChecker(null, null, "$escape{}");
+            System.out.println("Output:\n" + checker.toString() + " (" + checker.hasPermission() + ")");
+            if (!checker.toString().equals("$escape{} = ")) {
+                System.out.println("\tFAILED!");
+                System.out.println("Should have been:\n" + " = ");
+                success = false;
+            }
+            if (checker.hasPermission()) {
+                System.out.println("\tFAILED!");
+                System.out.println("hasPermission(" + checker.toString(checker.getPostfixArr()) + ") returned the wrong result!");
+                success = false;
+            }
+
+            if (success) {
+                System.out.println("\n\tALL TESTS PASSED!");
+            } else {
+                System.out.println("\n\tNOT ALL TESTS PASSED!");
+            }
+        }
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/PropertyNotAllowedException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/PropertyNotAllowedException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELException;
+
+/**
+ * Thrown when a property could not be accessed while evaluating a {@link jakarta.el.ValueExpression ValueExpression}.
+ *
+ * @author avpinchuk
+ */
+final class PropertyNotAllowedException extends ELException {
+
+    private static final long serialVersionUID = 1L;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/RestrictedELResolver.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/RestrictedELResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import jakarta.el.ELClass;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+
+import java.util.Objects;
+
+/**
+ * This {@link ELResolver} exists to restrict access to the next EL expressions:
+ *
+ * <ul>
+ * <li>Static method calls</li>
+ * <li>Constructor calls</li>
+ * <li>The {@code getClass() instance method calls}</li>
+ * <li>The {@code class} instance property</li>
+ * <li>Static fields</li>
+ * </ul>
+ *
+ * @author avpinchuk
+ */
+public class RestrictedELResolver extends ELResolver {
+
+    @Override
+    public Object getValue(ELContext elContext, Object base, Object property) {
+        // Go to the next resolver in chain
+        if (base == null) {
+            return null;
+        }
+        // Disable static fields and 'class' instance property
+        if (base instanceof ELClass || Objects.equals(property, "class")) {
+            elContext.setPropertyResolved(true);
+            throw new PropertyNotAllowedException();
+        }
+        return null;
+    }
+
+    @Override
+    public Object invoke(ELContext elContext, Object base, Object method, Class<?>[] paramTypes, Object[] params) {
+        // Go to the next resolver in chain
+        if (base == null) {
+            return null;
+        }
+        // Disable static methods, constructors and 'getClass()' method
+        if (base instanceof ELClass || Objects.equals(method, "getClass")) {
+            elContext.setPropertyResolved(true);
+            throw new MethodNotAllowedException();
+        }
+        return null;
+    }
+
+    @Override
+    public Class<?> getType(ELContext elContext, Object base, Object property) {
+        return null;
+    }
+
+    @Override
+    public void setValue(ELContext elContext, Object base, Object property, Object value) {
+        // Do nothing
+    }
+
+    @Override
+    public boolean isReadOnly(ELContext elContext, Object base, Object property) {
+        return false;
+    }
+
+    @Override
+    public Class<?> getCommonPropertyType(ELContext elContext, Object base) {
+        return null;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/VariableResolver.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/el/VariableResolver.java
@@ -1,0 +1,1793 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.el;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutComposition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.util.LogUtil;
+import com.sun.jsftemplating.util.MessageUtil;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.el.ExpressionFactory;
+import jakarta.faces.component.NamingContainer;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.ActionEvent;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+/**
+ * <p>
+ * VariableResolver is used to parse expressions of the format.
+ * </p>
+ *
+ * <p>
+ * <dd>$&lt;type&gt;{&lt;key&gt;}</dd>
+ * </p>
+ *
+ * <p>
+ * &lt;type&gt; refers to a registerd {@link VariableResolver.DataSource}, custom {@link VariableResolver.DataSource}s
+ * can be registered via: {@link #setDataSource(FacesContext ctx, String key, VariableResolver.DataSource dataSource)}.
+ * However, there are many built-in {@link VariableResolver.DataSource} types that are pre-registered.
+ * </p>
+ *
+ * <p>
+ * Below are the pre-registered types:
+ * </p>
+ *
+ * <ul>
+ * <li>{@link #ATTRIBUTE} -- {@link AttributeDataSource}</li>
+ * <li>{@link #APPLICATION} -- {@link ApplicationDataSource}</li>
+ * <li>{@link #BOOLEAN} -- {@link BooleanDataSource}</li>
+ * <li>{@link #CONSTANT} -- {@link ConstantDataSource}</li>
+ * <li>{@link #COPY_PROPERTY} -- {@link CopyPropertyDataSource}</li>
+ * <li>{@link #ESCAPE} -- {@link EscapeDataSource}</li>
+ * <li>{@link #EVAL} -- {@link EvalDataSource}</li>
+ * <li>{@link #HAS_FACET} -- {@link HasFacetDataSource}</li>
+ * <li>{@link #HAS_PROPERTY} -- {@link HasPropertyDataSource}</li>
+ * <li>{@link #INT} -- {@link IntDataSource}</li>
+ * <li>{@link #METHOD_BINDING} -- {@link MethodBindingDataSource}</li>
+ * <li>{@link #METHOD_EXPRESSION} -- {@link MethodExpressionDataSource}</li>
+ * <li>{@link #OPTION} -- {@link OptionDataSource}</li>
+ * <li>{@link #PAGE_SESSION} -- {@link PageSessionDataSource}</li>
+ * <li>{@link #PROPERTY} -- {@link PropertyDataSource}</li>
+ * <li>{@link #REQUEST_PARAMETER} -- {@link RequestParameterDataSource}</li>
+ * <li>{@link #RESOURCE} -- {@link ResourceBundleDataSource}</li>
+ * <li>{@link #SESSION} -- {@link SessionDataSource}</li>
+ * <li>{@link #STACK_TRACE} -- {@link StackTraceDataSource}</li>
+ * <li>{@link #THIS} -- {@link ThisDataSource}</li>
+ * </ul>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class VariableResolver {
+
+    /**
+     * <p>
+     * Defines "attribute" in $attribute{...}. This allows you to retrieve an HttpRequest attribute.
+     * </p>
+     */
+    public static final String ATTRIBUTE = "attribute";
+
+    /**
+     * <p>
+     * Defines "application" in $application{...}. This allows you to retrieve an application-scoped attribute.
+     * </p>
+     */
+    public static final String APPLICATION = "application";
+
+    /**
+     * <p>
+     * Defines "copyProperty" in $copyProperty{...}. This allows you to copy a property from the current UIComponent (or
+     * search for the property to copy by passing in "propName,true".
+     * </p>
+     */
+    public static final String COPY_PROPERTY = "copyProperty";
+
+    /**
+     * <p>
+     * Defines "option" in $option{...}. This allows you to obtain an "option" that is defined in a {@link LayoutComponent}.
+     * </p>
+     */
+    public static final String OPTION = "option";
+
+    /**
+     * <p>
+     * Defines "pageSession" in $pageSession{...}. This allows you to retrieve a PageSession attribute.
+     * </p>
+     */
+    public static final String PAGE_SESSION = "pageSession";
+
+    /**
+     * <p>
+     * Defines "property" in $property{...}. This allows you to retrieve a property from the UIComponent.
+     * </p>
+     */
+    public static final String PROPERTY = "property";
+
+    /**
+     * <p>
+     * Defines "hasProperty" in $hasProperty{...}. This allows you to see if a property from the UIComponent exists.
+     * </p>
+     */
+    public static final String HAS_PROPERTY = "hasProperty";
+
+    /**
+     * <p>
+     * Defines "hasFacet" in $hasFacet{...}. This allows you to see if a facet from the UIComponent exists.
+     * </p>
+     */
+    public static final String HAS_FACET = "hasFacet";
+
+    /**
+     * <p>
+     * Defines "session" in $session{...}. This allows you to retrieve an HttpSession attribute.
+     */
+    public static final String SESSION = "session";
+
+    /**
+     * <p>
+     * Defines "stackTrace" in $stackTrace{...}. This allows you to get a stack trace from the current <code>Thread</code>.
+     */
+    public static final String STACK_TRACE = "stackTrace";
+
+    /**
+     * <p>
+     * Defines "requestParameter" in $requestParameter{...}. This allows you to retrieve a HttpRequest parameter
+     * (QUERY_STRING parameter).
+     * </p>
+     */
+    public static final String REQUEST_PARAMETER = "requestParameter";
+
+    /**
+     * <p>
+     * Defines "display" in $display{...}. This allows you to retrive a DisplayField value.
+     * </p>
+     * public static final String DISPLAY = "display";
+     */
+
+    /**
+     * <p>
+     * Defines "this" in $this{...}. This allows you to retrieve a number of different objects related to the relative
+     * placement of this expression.
+     * </p>
+     *
+     * @see ThisDataSource
+     */
+    public static final String THIS = "this";
+
+    /**
+     * <p>
+     * Defines "escape" in $escape{...}. This allows some reserved characters to be escaped in "if" attributes. Such as '='
+     * or '|'.
+     * </p>
+     */
+    public static final String ESCAPE = "escape";
+
+    /**
+     * <p>
+     * Defines "eval" in $eval{...}. This allows a boolean expression to be evaulated.
+     * </p>
+     */
+    public static final String EVAL = "eval";
+
+    /**
+     * <p>
+     * Defines "boolean" in $boolean{...}. This converts the given String to a Boolean.
+     * </p>
+     */
+    public static final String BOOLEAN = "boolean";
+
+    /**
+     * <p>
+     * Defines "browser" in $browser{...}. This checks properties of the browser that sent the request.
+     * </p>
+     */
+    public static final String BROWSER = "browser";
+
+    /**
+     * <p>
+     * Defines "int" in $int{...}. This converts the given String to an Integer.
+     * </p>
+     */
+    public static final String INT = "int";
+
+    /**
+     * <p>
+     * Defines "methodBinding" in $methodBinding{...}. This allows MethodBindings to be created.
+     * </p>
+     */
+    public static final String METHOD_BINDING = "methodBinding";
+
+    /**
+     * <p>
+     * Defines "methodExpression" in $methodExpression{...}. This allows MethodExpressions to be created.
+     * </p>
+     */
+    public static final String METHOD_EXPRESSION = "methodExpression";
+
+    /**
+     * <p>
+     * Defines "constant" in $constant{...}. This allows constants in java classes to be accessed.
+     * </p>
+     */
+    public static final String CONSTANT = "constant";
+
+    /**
+     * <p>
+     * Defines "resource" in $resource{...}. This allows resource to be accessed.
+     * </p>
+     */
+    public static final String RESOURCE = "resource";
+
+    /**
+     * Constant defining the arguments required for a Action MethodBinding.
+     */
+    private static final Class[] ACTION_ARGS = { ActionEvent.class };
+
+    /**
+     * Empty <code>Class[]</code> for methods that take no arguments.
+     */
+    private static final Class[] EMPTY_CLASS_ARRAY = {};
+
+    /**
+     * <p>
+     * Application scope key to hold the VariableResolver DataSources.
+     * </p>
+     */
+    public static final String VR_APP_KEY = "__jsft_vrds_map";
+
+    /**
+     * Escape character.
+     */
+    public static final char ESCAPE_CHAR = '\\';
+
+    /**
+     * The '$' character marks the beginning of a substituion in a String.
+     */
+    public static final String SUB_START = "$";
+
+    /**
+     * The '(' character marks the beginning of the data content of a String substitution.
+     */
+    public static final String SUB_TYPE_DELIM = "{";
+
+    /**
+     * The ')' character marks the end of the data content for a String substitution.
+     */
+    public static final String SUB_END = "}";
+
+    /**
+     * <p>
+     * This method will substitute variables into the given String, or return the variable if the substitution is the whole
+     * String. This method looks for the LAST occurance of startToken in the given String. It then searches from that
+     * location (if found) to the first occurance of typeDelim. The value inbetween is used as the type of substitution to
+     * perform (i.e. request attribute, session, etc.). It next looks for the next occurance of endToken. The value
+     * inbetween is used as the key passed to the {@link VariableResolver.DataSource} specified by the type. The String
+     * value from the {@link VariableResolver.DataSource} replaces the portion of the String from the startToken to the
+     * endToken. If this is the entire String, the Object is returned instead of the String value. This process is repeated
+     * until no more substitutions are * needed.
+     * </p>
+     *
+     * <p>
+     * This algorithm will accomodate nested variables (e.g. "${A{$x}}"). It also allows the replacement value itself to
+     * contain variables. Care should be taken to ensure that the replacement String included does not directly or
+     * indirectly refer to itself -- this will cause an infinite loop.
+     * </p>
+     *
+     * <p>
+     * There is one special case where the string to be evaluated begins with the startToken and ends with the endToken. In
+     * this case, string substitution is NOT performed. Instead the value of the request attribute is returned.
+     * </p>
+     *
+     * <p>
+     * This method has a "hack" attached at the end of its processing which looks at the resulting value and does magic. If
+     * the value is a String that starts with "#{" then it will attempt to locate a composition parameter matching the next
+     * token value and replace or merge its content with the value. It will replace the value if the value is in the format
+     * #{key}. If there is additonal information after "key", it will attempt to merge value from the template parameter
+     * with the content after "key". A default value may be provided for the template parameter by providing a ",default"
+     * (e.g. #{key,default}.
+     * </p>
+     *
+     * @param ctx The FacesContext
+     * @param desc The closest LayoutElement to this string
+     * @param component The assoicated UIComponent
+     * @param string The string to be evaluated.
+     * @param startToken Marks the beginning "$"
+     * @param typeDelim Marks separation of type/variable "{"
+     * @param endToken Marks the end of the variable "}"
+     *
+     * @return The new string with substitutions, or the specified request attribute value.
+     */
+    public static Object resolveVariables(FacesContext ctx, LayoutElement desc, UIComponent component, String string, String startToken,
+            String typeDelim, String endToken) {
+
+        int stringLen = string.length();
+        int delimIndex;
+        int endIndex;
+        int parenSemi;
+        int startTokenLen = startToken.length();
+        int delimLen = typeDelim.length();
+        int endTokenLen = endToken.length();
+        boolean expressionIsWholeString = false;
+        char firstEndChar = SUB_END.charAt(0);
+        char firstDelimChar = SUB_TYPE_DELIM.charAt(0);
+        char currChar;
+        String type;
+        Object variable;
+
+        for (int startIndex = string.lastIndexOf(startToken); startIndex != -1; startIndex = string.lastIndexOf(startToken,
+                startIndex - 1)) {
+
+            // Make sure the startToken isn't escaped
+            if (startIndex > 0 && string.charAt(startIndex - 1) == ESCAPE_CHAR) {
+                string = string.substring(0, startIndex - 1) // Before '\\'
+                        + string.substring(startIndex); // After
+                stringLen--;
+                startIndex--;
+                continue;
+            }
+
+            // Find first typeDelim
+            delimIndex = string.indexOf(typeDelim, startIndex + startTokenLen);
+            if (delimIndex == -1) {
+                continue;
+            }
+
+            // Next find the end token
+            parenSemi = 0;
+            endIndex = -1;
+            // Iterate through the string looking for the matching end
+            for (int curr = delimIndex + delimLen; curr < stringLen;) {
+                // Get the next char...
+                currChar = string.charAt(curr);
+                if (currChar == firstDelimChar && typeDelim.equals(string.substring(curr, curr + delimLen))) {
+                    // Found the start of another... inc the semi
+                    parenSemi++;
+                    curr += delimLen;
+                    continue;
+                }
+                if (currChar == firstEndChar && endToken.equals(string.substring(curr, curr + endTokenLen))) {
+                    parenSemi--;
+                    if (parenSemi < 0) {
+                        // Found the right one!
+                        endIndex = curr;
+                        break;
+                    }
+                    // Found one, but this isn't the right one
+                    curr += endTokenLen;
+                    continue;
+                }
+                curr++;
+            }
+            if (endIndex == -1) {
+                // We didn't find a matching end...
+                continue;
+            }
+
+            /*
+             * // Next find end token endIndex = string.indexOf(endToken, delimIndex+delimLen); matchingIndex =
+             * string.lastIndexOf(typeDelim, endIndex); while ((endIndex != -1) && (matchingIndex != delimIndex)) { // We found a
+             * endToken, but not the matching one...keep looking endIndex = string.indexOf(endToken, endIndex+endTokenLen);
+             * matchingIndex = string.lastIndexOf(typeDelim, matchingIndex-delimLen); } if ((endIndex == -1) || (matchingIndex ==
+             * -1)) { continue; }
+             */
+
+            // Handle special case where string starts with startToken and ends
+            // with endToken (and no replacements inbetween). This is special
+            // because we don't want to convert the attribute to a string, we
+            // want to return it (this allows Object types).
+            if (startIndex == 0 && endIndex == string.lastIndexOf(endToken) && string.endsWith(endToken)) {
+                // This is the special case...
+                expressionIsWholeString = true;
+            }
+
+            // Pull off the type...
+            type = string.substring(startIndex + startTokenLen, delimIndex);
+            DataSource ds = getDataSource(ctx, type);
+            if (ds == null) {
+                if (type.indexOf('<') > -1 || type.indexOf('&') > -1 || type.indexOf('[') > -1 || type.indexOf('#') > -1
+                        || type.indexOf('$') > -1 || type.indexOf('%') > -1 || type.indexOf('(') > -1 || type.indexOf(')') > -1) {
+                    // Do not consider this a valid EL expression, continue...
+                    continue;
+                }
+                throw new IllegalArgumentException("Invalid type '" + type + "' in attribute value: '" + string + "'.");
+            }
+
+            // Pull off the variable...
+            variable = string.substring(delimIndex + delimLen, endIndex);
+
+            // Get the value...
+            variable = ds.getValue(ctx, desc, component, (String) variable);
+            if (expressionIsWholeString) {
+                if (variable instanceof String) {
+                    // See if we need to do EL magic manipulation...
+                    variable = replaceCompParams(ctx, desc, component, (String) variable);
+                }
+                return variable;
+            }
+
+            // Make new string
+            string = string.substring(0, startIndex) + // Before replacement
+                    (variable == null ? "" : variable.toString()) + string.substring(endIndex + endTokenLen); // After
+            stringLen = string.length();
+        }
+
+        // Return the string
+        return replaceCompParams(ctx, desc, component, string);
+    }
+
+    /**
+     * <p>
+     * This method implements a "hack" which manipulates the given String when it starts with "#{". In this case, it will
+     * attempt to locate a composition parameter matching the next token and replace or merge its content with this String.
+     * It will replace the String if the value is in the format #{key}. If there is additonal content after "key" (besides a
+     * (,) comma), it will attempt to merge the value of the composition parameter matching key with the content after
+     * "key". A default value may be provided for the template parameter by providing a ",default" at the end of the
+     * expression (e.g. #{key,default}.
+     * </p>
+     *
+     * <p>
+     * This method does not support replacing template paramters in other locations within EL.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param string The String to evaluate and manipulate if necessary.
+     *
+     * @return The same String passed in, or a new one based on method description.
+     */
+    private static Object replaceCompParams(FacesContext ctx, LayoutElement desc, UIComponent comp, String string) {
+        // Sanity check
+        if (string == null) {
+            return null;
+        }
+
+        // First see if we have any params
+        Map<String, Object> globalParams = LayoutComposition.getGlobalParamMap(ctx);
+        if (globalParams.size() == 0) {
+            // No mappings, nothing to do
+            return string;
+        }
+
+        String token = null;
+        Object value = null;
+        int len, startEL, endEL = 0;
+        int loopStart = 0;
+        char chars[] = string.toCharArray();
+        boolean foundAtLeastOne = false, isWholeString = false;
+        StringBuilder buff = null;
+        Stack<LayoutElement> stack = null;
+
+        while (true) {
+            startEL = findOpenEL(chars, loopStart);
+            // Detect
+            while (startEL != -1) {
+                // Get the next token
+// FIXME: This is not nearly adequate!!
+// Need to find all real tokens in #{!(some == expression) || foo}
+                endEL = findChar(chars, startEL + 2, '}', '[', '.', '=', '>', '<', '!', '&', '|', '*', '+', '-', '?', '/', '%', '(');
+                if (endEL == -1) {
+                    // Not a match, non-fatal
+                    startEL = -1;
+                    break;
+                }
+                token = string.substring(startEL + 2, endEL);
+                token = token.trim();
+
+                // Check to see if this is template param
+                value = globalParams.get(token);
+                if (value != null) {
+                    // We're not done yet! This value is only a flag, we have to
+                    // look at the composition stack to be accurate!
+                    if (stack == null) {
+                        stack = LayoutComposition.getCompositionStack(ctx);
+                    }
+                    value = LayoutComposition.findTemplateParam(stack, token);
+                    break;
+                }
+                startEL = string.indexOf("#{", endEL + 1);
+            }
+
+            if (startEL == -1) {
+                if (!foundAtLeastOne) {
+                    // We didn't find anything to substitute
+                    return string;
+                }
+
+                // Append the rest of the String
+                buff.append(chars, loopStart, chars.length - loopStart);
+
+                // We're done
+                break;
+            }
+
+            // Only get here when we find one...
+            foundAtLeastOne = true;
+            if (buff == null) {
+                // Initialize the buffer
+                buff = new StringBuilder(100);
+            }
+
+            // Check to see if this expression starts at the beginning
+            isWholeString = startEL == 0;
+
+            // Add everything before the "#{"
+            buff.append(chars, loopStart, startEL - loopStart);
+
+            // We got "...#{replaceMe?*", look at the next char to see what to do
+            if (chars[endEL] == '}') {
+                // Swap everything, no merge
+                endEL++; // Move past '}'
+                if (isWholeString && endEL >= chars.length) {
+                    // Special case, #{} is entire string, return it
+                    return resolveVariables(ctx, desc, comp, value);
+                }
+                isWholeString = false;
+
+                // Ok, we just take the String value of "value" and add it
+                if (value != null) {
+                    buff.append(value);
+                }
+            } else {
+                // Merge... we're just going to strip off "#{}" from value and
+                // insert it for now, later we might support more.
+                int start = 0;
+                String strVal = value.toString();
+                if (strVal.startsWith("#{")) {
+                    start = 2;
+                }
+                int end = strVal.length();
+                if (strVal.charAt(end - 1) == '}') {
+                    end--;
+                }
+
+                // Add merged content...
+                buff.append("#{").append(strVal, start, end);
+
+                // Find the end of the rest of the #{}...
+                end = findChar(chars, endEL + 1, '}');
+                if (end == -1) {
+                    throw new IllegalArgumentException("EL has unterminated #{} expression: (" + string + ")");
+                }
+                buff.append(chars, endEL, ++end - endEL);
+                endEL = end;
+            }
+            loopStart = endEL;
+        }
+
+        // Replace ${}, return the result...
+        return resolveVariables(ctx, desc, comp, buff.toString());
+    }
+
+    /**
+     * <p>
+     * This looks for the first occurance of "<code>#{</code>" in <code>chars</code>. It returns the index of the starting
+     * character, or -1 if not found.
+     * </p>
+     */
+    private static int findOpenEL(char chars[], int idx) {
+        // Allow for a minimum of 3 characters after the # (i.e. {x})
+        int len = chars.length - 3;
+        for (; idx < len; idx++) {
+            if (chars[idx] == '#' && chars[idx + 1] == '{') {
+                return idx;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * <p>
+     * This method searches the given <code>chars</code> from the <code>startingIndex</code> for any of the characters in
+     * <code>matchChars</code>.
+     * </p>
+     */
+    private static int findChar(char chars[], int idx, char... matchChars) {
+        int len = chars.length;
+        for (; idx < len; idx++) {
+            for (char ch : matchChars) {
+                if (chars[idx] == ch) {
+                    return idx;
+                }
+            }
+        }
+
+        // Not found
+        return -1;
+    }
+
+    /**
+     * This method replaces the ${..} variables with their values. It will only do this for Strings and List's that contain
+     * Strings.
+     *
+     * @param desc The <code>LayoutElement</code> descriptor
+     * @param component The <code>UIComponent</code>
+     * @param value The value to resolve
+     *
+     * @return The result
+     */
+    public static Object resolveVariables(LayoutElement desc, UIComponent component, Object value) {
+        if (value == null) {
+            return null;
+        }
+        return VariableResolver.resolveVariables(FacesContext.getCurrentInstance(), desc, component, value);
+    }
+
+    /**
+     * This method replaces the ${..} variables with their attribute values. It will only do this for Strings and List's
+     * that contain Strings.
+     *
+     * @param ctx The <code>FacesContext</code>
+     * @param desc The <code>LayoutElement</code> descriptor
+     * @param component The <code>UIComponent</code>
+     * @param value The value to resolve
+     *
+     * @return The result
+     */
+    public static Object resolveVariables(FacesContext ctx, LayoutElement desc, UIComponent component, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            value = VariableResolver.resolveVariables(ctx, desc, component, (String) value, VariableResolver.SUB_START,
+                    VariableResolver.SUB_TYPE_DELIM, VariableResolver.SUB_END);
+        } else if (value instanceof List) {
+            // Create a new List b/c invalid to change shared List
+            List<Object> list = (List<Object>) value;
+            List<Object> newList = new ArrayList<>(list.size());
+            Iterator it = list.iterator();
+            while (it.hasNext()) {
+                newList.add(VariableResolver.resolveVariables(ctx, desc, component, it.next()));
+            }
+            return newList;
+        } else if (value instanceof Object[]) {
+            // Create a new array b/c invalid to change shared array
+            Object[] arr = (Object[]) value;
+            Object[] newArr = new Object[arr.length];
+            int idx = 0;
+            for (Object obj : arr) {
+                newArr[idx++] = VariableResolver.resolveVariables(ctx, desc, component, obj);
+            }
+            return newArr;
+        }
+        return value;
+    }
+
+    /**
+     * <p>
+     * This method looks up the requested {@link VariableResolver.DataSource} by the given key.
+     *
+     * @param key The key identifying the desired {@link VariableResolver.DataSource}
+     *
+     * @return The requested {@link VariableResolver.DataSource}
+     */
+    public static VariableResolver.DataSource getDataSource(FacesContext ctx, String key) {
+        // Get the Map... and pull off the value (may be null)
+        return VariableResolver.getDataSourceMap(ctx).get(key);
+    }
+
+    /**
+     * <p>
+     * Provides access to the application-scoped Map which stores the {@link VariableResolver#DataSource}'s for this
+     * application.
+     * </p>
+     */
+    private static Map<String, VariableResolver.DataSource> getDataSourceMap(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, VariableResolver.DataSource> dataSourceMap = null;
+        if (ctx != null) {
+            dataSourceMap = (Map<String, VariableResolver.DataSource>) ctx.getExternalContext().getApplicationMap().get(VR_APP_KEY);
+        }
+        if (dataSourceMap == null) {
+            // 1st time... initialize it
+            dataSourceMap = new HashMap<>();
+            AttributeDataSource attrDS = new AttributeDataSource();
+            dataSourceMap.put("", attrDS);
+            dataSourceMap.put(ATTRIBUTE, attrDS);
+            dataSourceMap.put(APPLICATION, new ApplicationDataSource());
+            dataSourceMap.put(COPY_PROPERTY, new CopyPropertyDataSource());
+            dataSourceMap.put(OPTION, new OptionDataSource());
+            dataSourceMap.put(PAGE_SESSION, new PageSessionDataSource());
+            dataSourceMap.put(PROPERTY, new PropertyDataSource());
+            dataSourceMap.put(HAS_PROPERTY, new HasPropertyDataSource());
+            dataSourceMap.put(HAS_FACET, new HasFacetDataSource());
+            dataSourceMap.put(SESSION, new SessionDataSource());
+            dataSourceMap.put(STACK_TRACE, new StackTraceDataSource());
+            dataSourceMap.put(REQUEST_PARAMETER, new RequestParameterDataSource());
+//    dataSourceMap.put(DISPLAY, new DisplayFieldDataSource());
+            dataSourceMap.put(THIS, new ThisDataSource());
+            dataSourceMap.put(ESCAPE, new EscapeDataSource());
+            dataSourceMap.put(EVAL, new EvalDataSource());
+            dataSourceMap.put(INT, new IntDataSource());
+            dataSourceMap.put(BOOLEAN, new BooleanDataSource());
+            dataSourceMap.put(CONSTANT, new ConstantDataSource());
+            dataSourceMap.put(RESOURCE, new ResourceBundleDataSource());
+            dataSourceMap.put(METHOD_BINDING, new MethodBindingDataSource());
+            dataSourceMap.put(METHOD_EXPRESSION, new MethodExpressionDataSource());
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(VR_APP_KEY, dataSourceMap);
+            }
+        }
+
+        // Return the map...
+        return dataSourceMap;
+    }
+
+    /**
+     * <p>
+     * This method sets the given {@link VariableResolver.DataSource} to be used for $[type]{...} when key matches type.
+     * </p>
+     *
+     * @param key The key identifying the {@link VariableResolver.DataSource}
+     * @param dataSource The {@link VariableResolver.DataSource}
+     */
+    public static synchronized void setDataSource(FacesContext ctx, String key, VariableResolver.DataSource dataSource) {
+        // Get the Map... and pull off the value (may be null)
+        // NOTE: This is not thread safe.... although this is very rare
+        VariableResolver.getDataSourceMap(ctx).put(key, dataSource);
+    }
+
+    /**
+     * <p>
+     * This interface defines a String substitution data source. This is used to retrieve values when a
+     * $&lt;type&gt;{&lt;data&gt;} is encountered within a parameter value.
+     * </p>
+     *
+     * <p>
+     * Implementations of this interface may register themselves statically to extend the capabilities of the ${}
+     * substitution mechanism.
+     * </p>
+     */
+    public interface DataSource {
+        /**
+         * <p>
+         * This method should return the resolved value based on the given key and contextual information.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key);
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to Application-scoped attributes. It uses the data portion
+     * of the substitution String as a key to the Map.
+     * </p>
+     */
+    public static class ApplicationDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return ctx.getExternalContext().getApplicationMap().get(key);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to HttpRequest attributes. It uses the data portion of the
+     * substitution String as a key to the HttpRequest attribute Map.
+     * </p>
+     */
+    public static class AttributeDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return ctx.getExternalContext().getRequestMap().get(key);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to "option" values that are set on a
+     * {@link LayoutComponent}. It uses the data portion of the substitution String as a key to the
+     * {@link LayoutComponent}'s options. If a value is not found, it will walk up the LayoutComponent's parents looking for
+     * a defined value.
+     * </p>
+     */
+    public static class OptionDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key. (null) if not found.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            Object value = null;
+            while (value == null && desc != null) {
+                if (desc instanceof LayoutComponent) {
+                    value = ((LayoutComponent) desc).getEvaluatedOption(ctx, key, component);
+                }
+                desc = desc.getParent();
+            }
+            return value;
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to PageSession attributes. It uses the data portion of the
+     * substitution String as a key to the PageSession attribute Map.
+     * </p>
+     */
+    public static class PageSessionDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            Map<String, Serializable> map = PageSessionResolver.getPageSession(ctx, ctx.getViewRoot());
+            Serializable value = null;
+            if (map != null) {
+                value = map.get(key);
+            }
+            return value;
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to HttpRequest Parameters. It uses the data portion of the
+     * substitution String as a key to the HttpRequest Parameter Map.
+     * </p>
+     */
+    public static class RequestParameterDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return ctx.getExternalContext().getRequestParameterMap().get(key);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} copies <code>UIComponent</code> properties. It uses the data portion of the
+     * substitution String as a key to the UIComponent's properties via the attribute map. If the property is null, it will
+     * attempt to look at the parent's properties.
+     * </p>
+     */
+    public static class CopyPropertyDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return findPropertyValue(ctx, desc, component, key, true);
+        }
+
+        public Object findPropertyValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key, boolean checkVE) {
+            if (component == null) {
+                return "";
+            }
+
+            // Check to see if we should walk up the tree or not
+            int idx = key.indexOf(',');
+            boolean walk = false;
+            if (idx > 0) {
+                walk = Boolean.valueOf(key.substring(idx + 1).trim()).booleanValue();
+                key = key.substring(0, idx);
+            }
+
+            Object value = null;
+            if (checkVE) {
+                value = component.getValueExpression(key);
+                if (value == null) {
+                    value = component.getAttributes().get(key);
+                }
+            } else {
+                value = component.getAttributes().get(key);
+            }
+            if (walk) {
+                while (value == null && component.getParent() != null) {
+                    component = component.getParent();
+                    if (checkVE) {
+                        value = component.getValueExpression(key);
+                        if (value == null) {
+                            value = component.getAttributes().get(key);
+                        }
+                    } else {
+                        value = component.getAttributes().get(key);
+                    }
+                }
+            }
+            /*
+             * if (LogUtil.finestEnabled()) { // Trace information LogUtil.finest(this, "RESOLVING ('" + key + "') for ('" +
+             * component.getId() + "'): '" + value + "'"); }
+             */
+            return value;
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to UIComponent Properties. It uses the data portion of the
+     * substitution String as a key to the UIComponent's properties via the attribute Map. If the property is null, it will
+     * attempt to look at the parent's properties.
+     * </p>
+     */
+    public static class PropertyDataSource extends CopyPropertyDataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return findPropertyValue(ctx, desc, component, key, false);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} tests if the given property exists on the UIComponent. It uses the data
+     * portion of the substitution String as a key to the UIComponent's properties via the attribute Map.
+     * </p>
+     */
+    public static class HasPropertyDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            boolean hasKey = component.getAttributes().containsKey(key);
+            if (!hasKey) {
+                // Check the getter... JSF sucks when wrt attrs vs. props
+                if (component.getValueExpression(key) != null || component.getAttributes().get(key) != null) {
+                    hasKey = true;
+                }
+            }
+            if (!hasKey && desc instanceof LayoutComponent) {
+                // In some cases, the component is a TemplateComponent child
+                return getValue(ctx, desc.getParent(), component.getParent(), key);
+            }
+            return Boolean.valueOf(hasKey);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} tests if the given facet exists on the UIComponent. It uses the data portion
+     * of the substitution String as a key to the UIComponent's facets.
+     * </p>
+     */
+    public static class HasFacetDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            boolean hasFacet = component.getFacets().containsKey(key);
+            if (!hasFacet && desc instanceof LayoutComponent) {
+                // In some cases, the component is a TemplateComponent child
+                return getValue(ctx, desc.getParent(), component.getParent(), key);
+            }
+            return Boolean.valueOf(hasFacet);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} simply returns the key that it is given. This is useful for supplying ${}'s
+     * around the string you wish to mark as a string. If not used, characters such as '=' will be interpretted as a
+     * separator causing your string to be split -- which can be very undesirable. Mostly useful in "if" statements.
+     * </p>
+     */
+    public static class EscapeDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return key;
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} evaluates the given boolean expression.
+     * </p>
+     */
+    public static class EvalDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            PermissionChecker checker = new PermissionChecker(desc, component, key);
+            return Boolean.valueOf(checker.hasPermission());
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} converts the given <code>key</code> to a <code>Boolean</code>. This is
+     * needed because JSF does not do this for you. When you call <code>UIComponent.getAttributes().put(key, value)</code>,
+     * <code>value</code> is expected to be the correct type. Often <code>Boolean</code> types are needed. This
+     * {@link VariableResolver.DataSource} provides a means to supply a <code>Boolean</code> value.
+     * </p>
+     */
+    public static class BooleanDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return Boolean.valueOf(key);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} converts the given <code>key</code> to an <code>Integer</code>. This is
+     * needed because JSF does not do this for you. When you call <code>UIComponent.getAttributes().put(key, value)</code>,
+     * <code>value</code> is expected to be the correct type. Often <code>Integer</code> types are needed. This
+     * {@link VariableResolver.DataSource} provides a means to supply an <code>Integer</code> value.
+     * </p>
+     */
+    public static class IntDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return Integer.valueOf(key);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} allows access to constants in java classes. It expects the key to be a fully
+     * qualified Java classname plus the variable name. Example:
+     * </p>
+     *
+     * <p>
+     * $constant{java.lang.Integer.MAX_VALUE}
+     * </p>
+     */
+    public static class ConstantDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            // First check to see if we've already found the value before.
+            Object value = constantMap.get(key);
+            if (value == null) {
+                // Not found, lets resolve it, duplicate the old Map to avoid
+                // sync problems
+                Map<String, Object> map = new HashMap<>(constantMap);
+                value = resolveValue(map, key);
+
+                // Replace the shared Map w/ this new one.
+                constantMap = map;
+            }
+            return value;
+        }
+
+        /**
+         * <p>
+         * This method resolves key. Key is expected to be in the format:
+         * </p>
+         *
+         * <p>
+         * some.package.Class.STATIC_VARIBLE
+         * </p>
+         *
+         * <p>
+         * This method will first resolve Class. It will then walk through all its variables adding each static final variable
+         * to the Map.
+         * </p>
+         *
+         * @param map The map to add variables to
+         * @param key The fully qualified CONSTANT name
+         *
+         * @return The value of the CONSTANT, or null if not found
+         */
+        private Object resolveValue(Map<String, Object> map, String key) {
+            int lastDot = key.lastIndexOf('.');
+            if (lastDot == -1) {
+                throw new IllegalArgumentException("Unable to resolve '" + key + "' in $constant{" + key + "}.  '" + key + "' must be a "
+                        + "fully qualified classname plus the constant name.");
+            }
+
+            // Get the classname / constant name
+            String className = key.substring(0, lastDot);
+
+            // Add all constants to the Map
+            try {
+                addConstants(map, Util.loadClass(className, key));
+            } catch (ClassNotFoundException ex) {
+                RuntimeException iae = new IllegalArgumentException("'" + className + "' was not found!  This must be a valid "
+                        + "classname.  This was found in expression $constant{" + key + "}.");
+                iae.initCause(ex);
+                throw iae;
+            }
+
+            // The constant hopefully is in the Map now, null if not
+            return map.get(key);
+        }
+
+        /**
+         * This method adds all constants in the given class to the Map. The Map key will be the fully qualified class name,
+         * plus a '.', plus the constant name.
+         *
+         * @param map <code>Map</code> to store <code>cls</code>
+         * @param cls The <code>Class</code> to store in <code>map</code>
+         */
+        private void addConstants(Map<String, Object> map, Class cls) {
+            // Get the class name
+            String className = cls.getName();
+
+            // Get the fields
+            Field[] fields = cls.getFields();
+
+            // Add the static final fields to the Map
+            Field field = null;
+            for (Field field2 : fields) {
+                field = field2;
+                if (Modifier.isStatic(field.getModifiers()) && Modifier.isFinal(field.getModifiers())) {
+                    try {
+                        map.put(className + '.' + field.getName(), field.get(null));
+                    } catch (IllegalAccessException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+            }
+        }
+
+        /**
+         * This embedded Map caches constant value lookups. It is static and is shared by all users.
+         */
+        private static Map<String, Object> constantMap = new HashMap<>();
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} creates a MethodExpression from the supplied key. Example:
+     * </p>
+     *
+     * <p>
+     * $methodExpression{#{bean.key}}
+     * </p>
+     */
+    public static class MethodExpressionDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            Class[] args = EMPTY_CLASS_ARRAY;
+            key = key.trim();
+            int commaIdx = key.lastIndexOf(',');
+            if (commaIdx != -1) {
+                if (key.endsWith("true")) {
+                    args = ACTION_ARGS;
+                    key = key.substring(0, commaIdx);
+                } else if (key.endsWith("false")) {
+                    key = key.substring(0, commaIdx);
+                }
+            }
+            return ctx.getApplication().getExpressionFactory().createMethodExpression(ctx.getELContext(), key, Object.class, args);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} creates a MethodBinding from the supplied key. Example:
+     * </p>
+     *
+     * <p>
+     * $methodBinding{#{bean.key}}
+     * </p>
+     */
+    public static class MethodBindingDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            ExpressionFactory factory = ctx.getApplication().getExpressionFactory();
+            return factory.createMethodExpression(ctx.getELContext(), key, null, ACTION_ARGS);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} allows access to resource bundle keys. It expects the key to be a resource
+     * bundle key plus a '.' then the actual resouce bundle key Example:
+     * </p>
+     *
+     * <p>
+     * $resource{bundleID.bundleKey}
+     * </p>
+     *
+     * <p>
+     * The bundleID should not contain '.' characters. The bundleKey may.
+     * </p>
+     */
+    public static class ResourceBundleDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            // Get the Request attribute key
+            int separator = key.indexOf(".");
+            if (separator == -1) {
+                throw new IllegalArgumentException("'" + key + "' is not in format: \"[bundleID].[bundleKey]\"!");
+            }
+            String value = key.substring(0, separator);
+
+            // Get the Resource Bundle
+            Object obj = ctx.getExternalContext().getRequestMap().get(value);
+
+            // Make sure we have something...
+            if (obj == null) {
+                // Only check the request scope b/c the RB is request specific
+                // Should we throw an exception? For now return the key
+                return key;
+            }
+
+            // Make sure its a RB
+            if (!(obj instanceof ResourceBundle)) {
+                throw new IllegalArgumentException("\"" + value + "\" in: \"" + SUB_START + RESOURCE + SUB_TYPE_DELIM + key + SUB_END
+                        + "\" did not resolve to a ResourceBundle!  Found: \"" + obj.getClass().getName() + "\" instead.  (toString(): "
+                        + obj.toString() + ")");
+            }
+            ResourceBundle bundle = (ResourceBundle) obj;
+
+            // Return the result of the ResouceBundle lookup
+            String str = null;
+            int argSep = key.indexOf(",", separator);
+            try {
+                if (argSep > -1) {
+                    str = bundle.getString(key.substring(separator + 1, argSep));
+                } else {
+                    str = bundle.getString(key.substring(separator + 1));
+                }
+                if (str == null) {
+                    str = key;
+                } else {
+                    // Parse arguments
+                    if (argSep > -1) {
+                        StringTokenizer st = new StringTokenizer(key.substring(argSep), ",");
+                        String[] tokens = new String[st.countTokens()];
+                        int i = 0;
+                        while (st.hasMoreTokens()) {
+                            tokens[i++] = st.nextToken().trim();
+                        }
+                        str = MessageUtil.getFormattedMessage(str, tokens);
+                    }
+                }
+            } catch (MissingResourceException ex) {
+                if (LogUtil.configEnabled()) {
+                    LogUtil.config("Unable to find key: '" + key.substring(separator + 1) + "' in ResourceBundle '" + value
+                            + "'.  Perhaps this needs to be added?", ex);
+                } else if (LogUtil.infoEnabled()) {
+                    // Info log level, don't be verbose, just display a benign
+                    // warning.
+                    LogUtil.info("JSFT0003", new Object[] { key.substring(separator + 1), value });
+                }
+                str = key;
+            }
+
+            return str;
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to HttpSession attributes. It uses the data portion of the
+     * substitution String as a key to the HttpSession Map.
+     * </p>
+     */
+    public static class SessionDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            return ctx.getExternalContext().getSessionMap().get(key);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} returns a strack trace (as a String) from the current <code>Thread</code>.
+     * The data portion of the "substitution String" is used as a message prefixing the trace.
+     * </p>
+     */
+    public static class StackTraceDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param component The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent component, String key) {
+            // Get the trace information
+            StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+            int len = trace.length;
+
+            // Create a String w/ this info...
+            StringBuffer buf = new StringBuffer(key + "\n");
+            for (int idx = 0; idx < len; idx++) {
+                buf.append(trace[idx] + "\n");
+            }
+
+            // Return it.
+            return buf.toString();
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link VariableResolver.DataSource} provides access to DisplayField values. It uses the data portion of the
+     * substitution String as the DisplayField name to find. This is a non-qualified DisplayField name. It will walk up the
+     * View tree starting at the View object cooresponding to the LayoutElement which contained this expression. At each
+     * ContainerView, it will look for a child with a matching name.
+     * </p>
+     * public static class DisplayFieldDataSource implements DataSource { public Object getValue(FacesContext ctx,
+     * LayoutElement desc, UIComponent component, String key) { while (desc != null) { View view = desc.getView(ctx); if
+     * (view instanceof ContainerView) { View child = null; //FIXME: use a better way to find if 'key' is a child of 'view'
+     * try { child = (((ContainerView)(view)).getChild(key)); } catch (Exception ex) { } if (child != null) { return
+     * ((ContainerView) view).getDisplayFieldValue(key); } } desc = desc.getParent(); } return null; } }
+     */
+
+    /**
+     * <p>
+     * This class provides an implementation for the syntax $this{xyz} where xyz can be any of the following.
+     * </p>
+     *
+     * <ul>
+     * <li>component -- Current <code>UIComponent</code></li>
+     * <li>clientId -- Current <code>UIComponent</code>'s client id</li>
+     * <li>id -- Current <code>UIComponent</code>'s id</li>
+     * <li>layoutElement -- Current {@link LayoutElement}</li>
+     * <li>parent -- Parent <code>UIComponent</code></li>
+     * <li>parentId -- Parent <code>UIComponent</code>'s client id</li>
+     * <li>parentLayoutElement -- Parent {@link LayoutElement}</li>
+     * <li>namingContainer -- Nearest <code>NamingContainer</code></li>
+     * <li>valueBinding -- <code>ValueBinding</code> representing the <code>UIComponent</code></li>
+     * <li>children -- Current <code>UIComponent</code>'s children</li>
+     * </ul>
+     */
+    public static class ThisDataSource implements DataSource {
+        /**
+         * <p>
+         * See class JavaDoc.
+         * </p>
+         *
+         * @param ctx The <code>FacesContext</code>
+         * @param desc The <code>LayoutElement</code>
+         * @param comp The <code>UIComponent</code>
+         * @param key The key used to obtain information from this <code>DataSource</code>.
+         *
+         * @return The value resolved from key.
+         */
+        @Override
+        public Object getValue(FacesContext ctx, LayoutElement desc, UIComponent comp, String key) {
+            Object value = null;
+
+            if (key.equalsIgnoreCase(CLIENT_ID) || key.length() == 0) {
+                value = comp.getClientId(ctx);
+            } else if (key.equalsIgnoreCase(ID)) {
+                value = comp.getId();
+            } else if (key.equalsIgnoreCase(CHILDREN)) {
+                value = comp.getChildren();
+            } else if (key.equalsIgnoreCase(COMPONENT)) {
+                value = comp;
+            } else if (key.equalsIgnoreCase(LAYOUT_ELEMENT)) {
+                value = desc;
+            } else if (key.equalsIgnoreCase(PARENT_ID)) {
+                value = comp.getParent().getId();
+            } else if (key.equalsIgnoreCase(PARENT_CLIENT_ID)) {
+                value = comp.getParent().getClientId(ctx);
+            } else if (key.equalsIgnoreCase(PARENT)) {
+                value = comp.getParent();
+            } else if (key.equalsIgnoreCase(PARENT_LAYOUT_ELEMENT)) {
+                value = desc.getParent();
+            } else if (key.equalsIgnoreCase(NAMING_CONTAINER)) {
+                for (value = comp.getParent(); value != null; value = ((UIComponent) value).getParent()) {
+                    if (value instanceof NamingContainer) {
+                        break;
+                    }
+                }
+            } else if (key.equalsIgnoreCase(VALUE_BINDING)) {
+                // Walk backward up the tree generate the path
+                Stack stack = new Stack();
+                String id = null;
+                // FIXME: b/c of a bug, the old behavior actually returned the
+                // FIXME: parent component... the next line is here to persist
+                // FIXME: this behavior b/c some code depends on this, fix this
+                // FIXME: when you have a chance.
+                comp = comp.getParent();
+                while (comp != null && !(comp instanceof UIViewRoot)) {
+                    id = comp.getId();
+                    if (id == null) {
+                        // Generate an id based on the clientId
+                        id = comp.getClientId(ctx);
+                        id = id.substring(id.lastIndexOf(NamingContainer.SEPARATOR_CHAR) + 1);
+                    }
+                    stack.push(id);
+                    comp = comp.getParent();
+                }
+                StringBuffer buf = new StringBuffer();
+                buf.append("view");
+                while (!stack.empty()) {
+                    buf.append("['" + stack.pop() + "']");
+                }
+                value = buf.toString();
+            } else {
+                throw new IllegalArgumentException("'" + key + "' is not valid in $this{" + key + "}.");
+            }
+
+            return value;
+        }
+
+        /**
+         * <p>
+         * Defines "children" in $this{children}. Returns the <code>UIComponent</code>'s children.
+         * </p>
+         */
+        public static final String CHILDREN = "children";
+
+        /**
+         * <p>
+         * Defines "component" in $this{component}. Returns the UIComponent object.
+         * </p>
+         */
+        public static final String COMPONENT = "component";
+
+        /**
+         * <p>
+         * Defines "clientId" in $this{clientId}. Returns the String representing the client id for the UIComponent.
+         * </p>
+         */
+        public static final String CLIENT_ID = "clientId";
+
+        /**
+         * <p>
+         * Defines "id" in $this{id}. Returns the String representing the id for the UIComponent.
+         * </p>
+         */
+        public static final String ID = "id";
+
+        /**
+         * <p>
+         * Defines "layoutElement" in $this{layoutElement}. Returns the LayoutElement.
+         * </p>
+         */
+        public static final String LAYOUT_ELEMENT = "layoutElement";
+
+        /**
+         * <p>
+         * Defines "parent" in $this{parent}. Returns the parent UIComponent object.
+         * </p>
+         */
+        public static final String PARENT = "parent";
+
+        /**
+         * <p>
+         * Defines "parentId" in $this{parentId}. Returns the parent UIComponent object's Id.
+         * </p>
+         */
+        public static final String PARENT_ID = "parentId";
+
+        /**
+         * <p>
+         * Defines "parentClientId" in $this{parentClientId}. Returns the parent UIComponent object's client Id.
+         * </p>
+         */
+        public static final String PARENT_CLIENT_ID = "parentClientId";
+
+        /**
+         * <p>
+         * Defines "parentLayoutElement" in $this{parentLayoutElement}. Returns the parent LayoutElement.
+         * </p>
+         */
+        public static final String PARENT_LAYOUT_ELEMENT = "parentLayoutElement";
+
+        /**
+         * <p>
+         * Defines "namingContainer" in $this{namingContainer}. Returns the nearest naming container object (i.e. the form).
+         * </p>
+         */
+        public static final String NAMING_CONTAINER = "namingContainer";
+
+        /**
+         * <p>
+         * Defines "valueBinding" in $this{valueBinding}. Returns a <code>ValueBinding</code> to this UIComponent.
+         * </p>
+         */
+        public static final String VALUE_BINDING = "valueBinding";
+    }
+
+    /**
+     * The main function for this class provides some simple test cases.
+     *
+     * @param args The commandline arguments.
+     */
+    public static void main(String[] args) {
+        String test = null;
+        String good = null;
+
+        test = "" + VariableResolver.resolveVariables(null, null, null, "$escape($escape(LayoutElement))", "$", "(", ")");
+        good = "LayoutElement";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null, "$escape($escape(EEPersistenceManager))", "$", "(", ")");
+        good = "EEPersistenceManager";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null, "$es$cape$escape(EEPersistenceManager))", "$", "(", ")");
+        good = "$es$capeEEPersistenceManager)";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null, "$escape($escapeEEP$ersistenceManager))", "$", "(", ")");
+        good = "$escapeEEP$ersistenceManager)";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null, "$escape($escape(EEPersistenceManager)))", "$", "(", ")");
+        good = "EEPersistenceManager)";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null, "$escape($escape(EEPersistenceManager())", "$", "(", ")");
+        good = "$escape(EEPersistenceManager()";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null,
+                "$escape($escape($escape(EEPersistenceManager()))==$escape(" + "EEPersistenceManager()))", "$", "(", ")");
+        good = "EEPersistenceManager()==EEPersistenceManager()";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        test = "" + VariableResolver.resolveVariables(null, null, null,
+                "$escape($escape($escape(EEPersistenceManager()))==$escape(" + "EEPersistenceManager()))", "$", "(", ")");
+        good = "EEPersistenceManager()==EEPersistenceManager()";
+        System.out.println("Expected Result: '" + good + "'");
+        System.out.println("         Result: '" + test + "'");
+        if (!test.equals(good)) {
+            System.out.println("FAILED!!!!");
+        }
+
+        /*
+         * for (int x = 0; x < 100000; x++) { System.out.println("" + VariableResolver.resolveVariables( null, null, null,
+         * "$escape($escape(EEPers" + x + "istenceManager()))==$escape(" + "EEPersistenceManager())", "$", "(", ")")); }
+         */
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/ComponentHandlers.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/ComponentHandlers.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * ComponentHandlers.java
+ *
+ * Created on December 6, 2004, 11:06 PM
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.LayoutViewHandler;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutElementBase;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class contains {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} methods that perform component
+ * functions.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ComponentHandlers {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public ComponentHandlers() {
+    }
+
+    /**
+     * <p>
+     * This handler returns the children of the given <code>UIComponent</code>.
+     * </p>
+     *
+     * <p>
+     * Input value: "parent" -- Type: <code>UIComponent</code>
+     * </p>
+     *
+     * <p>
+     * Output value: "children" -- Type: <code>java.util.List</code>
+     * </p>
+     * <p>
+     * Output value: "size" -- Type: <code>java.lang.Integer</code>
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "getUIComponentChildren", input = {
+            @HandlerInput(name = "parent", type = UIComponent.class, required = true) }, output = {
+                    @HandlerOutput(name = "children", type = List.class), @HandlerOutput(name = "size", type = Integer.class) })
+    public static void getChildren(HandlerContext context) {
+        UIComponent parent = (UIComponent) context.getInputValue("parent");
+        List<UIComponent> list = parent.getChildren();
+        context.setOutputValue("children", list);
+        context.setOutputValue("size", new Integer(list.size()));
+    }
+
+    /**
+     * <p>
+     * This handler replaces the given <code>old UIComponent</code> in the <code>UIComponent</code> tree with the given
+     * <code>new
+     *        UIComponent</code>. If the new <code>UIComponent</code> is not specified or is <code>null</code>, the old
+     * UIComponent will simply be removed.
+     * </p>
+     *
+     * <p>
+     * Input value: "old" -- Type: <code>UIComponent</code>
+     * </p>
+     * <p>
+     * Input value: "new" -- Type: <code>UIComponent</code>
+     * </p>
+     *
+     * @param context The <code>HandlerContext</code>.
+     */
+    @Handler(id = "replaceUIComponent", input = { @HandlerInput(name = "old", type = UIComponent.class, required = true),
+            @HandlerInput(name = "new", type = UIComponent.class, required = false) })
+    public static void replaceUIComponent(HandlerContext context) {
+        // Get the old component which is to be replaced
+        UIComponent oldComp = (UIComponent) context.getInputValue("old");
+        if (oldComp == null) {
+            throw new IllegalArgumentException("You must provide a non-null value for 'component'.");
+        }
+
+        // Check for a replacement UIComponent
+        UIComponent newComp = (UIComponent) context.getInputValue("new");
+
+        // Get the child UIComponent list...
+        List<UIComponent> list = oldComp.getParent().getChildren();
+        if (newComp == null) {
+            // Nothing to replace it with, just do a remove...
+            list.remove(oldComp);
+        } else {
+            // Find the index to put the new UIComponent in the right place
+            int index = list.indexOf(oldComp);
+            list.set(index, newComp);
+        }
+    }
+
+    /**
+     * <p>
+     * This will build a <code>UIComponent</code> tree from a {@link LayoutElement}. You must pass in the
+     * {@link LayoutElement} that will be used to create the <code>UIComponent</code> tree. You may optionally pass in the
+     * <code>parent UIComponent</code> which will serve as the parent for the newly created <code>UIComponent</code> tree.
+     * The resulting <code>UIComponent</code> tree will be returned via the <code>result</code> output value. If more than 1
+     * root node exists for the given <code>LayoutElement</code>, the last added to the <code>parent</code> will be
+     * returned. Typically, you will pass in a {@link LayoutComponent} as the <code>layoutElement</code> so there will only
+     * be 1.
+     * </p>
+     *
+     * <p>
+     * It is recommended that you *do* supply the parent since EL expressions may depend on this when creating the
+     * <code>UIComponent</code> tree.
+     * </p>
+     *
+     * <p>
+     * One possible use case for calling this method would be to have a dynamic "id" property of a {@link LayoutComponent},
+     * call this method multiple times with different values set in the "id" property. Remember, that you should not change
+     * a {@link LayoutComponent} (or any {@link LayoutElement}) directly. It is only safe to have dynamic values through EL
+     * bindings #{}.
+     * </p>
+     *
+     * <p>
+     * Another reason to use this handler is to cause a portion of a <code>UIComponent</code> tree to be recreated. This of
+     * often desirable during Ajax requests so that factory options can be reevaluated.
+     * </p>
+     *
+     * <p>
+     * Input value: "layoutElement" -- Type: <code>LayoutElement</code>
+     * </p>
+     * <p>
+     * Input value: "parent" -- Type: <code>UIComponent</code>
+     * </p>
+     *
+     * <p>
+     * Output value: "result" -- Type: <code>UIComponent</code>
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "buildUIComponentTree", input = { @HandlerInput(name = "layoutElement", type = LayoutElement.class, required = true),
+            @HandlerInput(name = "parent", type = UIComponent.class, required = false) }, output = {
+                    @HandlerOutput(name = "result", type = UIComponent.class) })
+    public static void buildUIComponentTree(HandlerContext context) {
+        LayoutElement desc = (LayoutElement) context.getInputValue("layoutElement");
+        UIComponent parent = (UIComponent) context.getInputValue("parent");
+
+        // If they didn't give us a parent, make one one up...
+        if (parent == null) {
+            parent = new UIViewRoot();
+            ((UIViewRoot) parent).setViewId("fake");
+        }
+
+        // Build it...
+        FacesContext facesCtx = context.getFacesContext();
+        if (desc instanceof LayoutComponent) {
+            // Special case if LayoutComponent is the root node element
+            // The LayoutViewHandler assumes that the root node is not used
+            // because it was written assuming that the LayoutDefinition was
+            // always going to be passed in. The result is that it ignores
+            // the LayoutElement that is passed in and goes striaight to the
+            // children. This isn't what we want. Process the child here,
+            // then continue as normal.
+            UIComponent tmpParent = ((LayoutComponent) desc).getChild(facesCtx, parent);
+            LayoutViewHandler.buildUIComponentTree(facesCtx, tmpParent, desc);
+        } else {
+            // Process normally (which in this path is probably not normal)
+            LayoutViewHandler.buildUIComponentTree(facesCtx, parent, desc);
+        }
+
+        // Get the result to return...
+        String id = desc.getId(facesCtx, parent);
+        UIComponent result = parent.findComponent(id);
+        if (result == null) {
+            // First see if we can find it in the facet Map
+            if (desc instanceof LayoutComponent) {
+                result = parent.getFacets().get(id);
+            } else {
+// FIXME: find a way to find a "facet child" if the root LayoutElement is not a LayoutComponent
+            }
+
+            if (result == null) {
+                // Still not found, check children...
+                List<UIComponent> children = parent.getChildren();
+                if (children.size() > 0) {
+                    // Return the last child added b/c we want to make sure
+                    // we're returning something that we added, not something
+                    // that already existed. While not perfect, this is
+                    // reasonable.
+                    result = children.get(children.size() - 1);
+                }
+            }
+        }
+
+        // Set the output...
+        context.setOutputValue("result", result);
+    }
+
+    /**
+     * <p>
+     * This handler creates a <code>UIComponent</code>. It requires you to pass in the componentType (<code>type</code>) and
+     * returns the new component via the output parameter <code>component</code>.
+     * </p>
+     *
+     * <p>
+     * Input value: "type" -- Type: <code>String</code>
+     * </p>
+     * <p>
+     * Input value: "parent" -- Type: <code>UIComponent</code>
+     * </p>
+     *
+     * <p>
+     * Output value: "component" -- Type: <code>UIComponent</code>
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "createComponent", input = { @HandlerInput(name = "type", type = String.class, required = true),
+            @HandlerInput(name = "id", type = String.class, required = false),
+            @HandlerInput(name = "parent", type = UIComponent.class, required = false) }, output = {
+                    @HandlerOutput(name = "component", type = UIComponent.class) })
+    public static void createComponent(HandlerContext context) {
+        // Get the input...
+        String type = (String) context.getInputValue("type");
+        UIComponent parent = (UIComponent) context.getInputValue("parent");
+        String id = (String) context.getInputValue("id");
+        if (id == null) {
+            id = LayoutElementUtil.getGeneratedId(type);
+        }
+
+        // Create a LayoutComponent...
+        FacesContext ctx = context.getFacesContext();
+        LayoutComponent desc = new LayoutComponent((LayoutComponent) null, id, LayoutDefinitionManager.getGlobalComponentType(ctx, type));
+
+        // Create the component...
+        UIComponent component = ComponentUtil.getInstance(ctx).createChildComponent(ctx, desc, parent);
+
+        // Return the result...
+        context.setOutputValue("component", component);
+    }
+
+    /**
+     * <p>
+     * This handler sets a <code>UIComponent</code> attribute / property.
+     * </p>
+     *
+     * <p>
+     * Input value: "component" -- Type: <code>UIComponent</code>
+     * </p>
+     * <p>
+     * Input value: "property" -- Type: <code>String</code>
+     * </p>
+     * <p>
+     * Input value: "value" -- Type: <code>Object</code>
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "setUIComponentProperty", input = { @HandlerInput(name = "component", type = UIComponent.class, required = true),
+            @HandlerInput(name = "property", type = String.class, required = true), @HandlerInput(name = "value") })
+    public static void setComponentProperty(HandlerContext context) {
+        UIComponent component = (UIComponent) context.getInputValue("component");
+        String propName = (String) context.getInputValue("property");
+        Object value = context.getInputValue("value");
+
+        // Set the attribute or property value
+        component.getAttributes().put(propName, value);
+    }
+
+    /**
+     * <p>
+     * This handler finds the requested <code>UIComponent</code> by <code>clientId</code>. It takes <code>clientId</code> as
+     * an input parameter, and returns <code>component</code> as an output parameter.
+     * </p>
+     */
+    @Handler(id = "getUIComponent", input = { @HandlerInput(name = "clientId", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "component", type = UIComponent.class) })
+    public static void getUIComponent(HandlerContext context) {
+        UIComponent viewRoot = context.getFacesContext().getViewRoot();
+        String clientId = (String) context.getInputValue("clientId");
+        context.setOutputValue("component", viewRoot.findComponent(clientId));
+    }
+
+    /**
+     * <p>
+     * This handler retrieves a property from the given <code>UIComponent</code>. It expects <code>component</code> and
+     * <code>name</code> as an input parameters, and returns <code>value</code> as an output parameter containing the value
+     * of the property.
+     * </p>
+     */
+    @Handler(id = "getUIComponentProperty", input = { @HandlerInput(name = "component", type = UIComponent.class, required = true),
+            @HandlerInput(name = "name", type = String.class, required = true) }, output = {
+                    @HandlerOutput(name = "value", type = Object.class) })
+    public static void getUIComponentProperty(HandlerContext context) {
+        UIComponent comp = (UIComponent) context.getInputValue("component");
+        String name = (String) context.getInputValue("name");
+        if (comp == null || name == null) {
+            throw new IllegalArgumentException("This Handler requires non-null" + " values for 'component' and 'name'.  'component' was"
+                    + " specified as '" + context.getHandler().getInputValue("component") + "' and evaluated to '" + comp + "'. 'name' was"
+                    + " specified as '" + context.getHandler().getInputValue("name") + "' and evaluated to '" + name + "'.");
+        }
+        Object value = comp.getAttributes().get(name);
+        context.setOutputValue("value", value);
+    }
+
+    /**
+     * <p>
+     * This handler retrieves the requested the "facet" from the given <code>UIComponent</code>. <code>component</code> or
+     * <code>clientId</code> for the component must be passed in. The facet <code>name</code> must also be specified. It
+     * will return the <code>UIComponent</code> found (or <code>null</code>) in the <code>value</code> output parameter.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "getFacet", input = { @HandlerInput(name = "clientId", type = String.class, required = false),
+            @HandlerInput(name = "component", type = UIComponent.class, required = false),
+            @HandlerInput(name = "name", type = String.class, required = true) }, output = {
+                    @HandlerOutput(name = "value", type = UIComponent.class) })
+    public static void getFacet(HandlerContext context) {
+        // Get the UIComponent to use
+        UIComponent comp = getUIComponentFromInput(context);
+
+        // Get the facet name
+        String clientId = "" + (String) context.getInputValue("name");
+
+        // Look for the facet
+        UIComponent value = null;
+        if (comp != null) {
+            value = comp.getFacets().get(clientId);
+        }
+
+        // Return the UIComponent (or null)
+        context.setOutputValue("value", value);
+    }
+
+    /**
+     * <p>
+     * This handler encodes the given <code>UIComponent</code>. You can specify the <code>UIComponent</code> by
+     * <code>clientId</code>, or pass it in directly via the <code>component</code> input parameter.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "encodeUIComponent", input = { @HandlerInput(name = "clientId", type = String.class, required = false),
+            @HandlerInput(name = "component", type = UIComponent.class, required = false) })
+    public static void encode(HandlerContext context) throws IOException {
+        // Get the UIComponent to use
+        UIComponent comp = getUIComponentFromInput(context);
+
+        // Encode the component
+        LayoutElementBase.encodeChild(context.getFacesContext(), comp);
+    }
+
+    /**
+     * <p>
+     * This method simply helps resolve a <code>UIComponent</code> for handlers that allow them to be specified via
+     * "component" or "clientId". "component" takes precedence. If neither are supplied, an
+     * <code>IllegalArgumentException</code> is thrown.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     *
+     * @return The <code>UIComponent</code> or <code>null</code> (if clientId did not resolve it).
+     *
+     * @throws IllegalArgumentException If neither "clientId" or "component" are provided.
+     */
+    private static UIComponent getUIComponentFromInput(HandlerContext context) {
+        UIComponent comp = (UIComponent) context.getInputValue("component");
+        if (comp == null) {
+            String clientId = (String) context.getInputValue("clientId");
+            if (clientId != null) {
+                UIComponent viewRoot = context.getFacesContext().getViewRoot();
+                comp = viewRoot.findComponent(clientId);
+            } else {
+                throw new IllegalArgumentException(
+                        "You must specify the component to use, or a clientId to " + "locate the UIComponent to use.");
+            }
+        }
+
+        // Return the UIComponent (may be null if clientId didn't resolve it)
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This handler will print out the structure of a <code>UIComponent</code> tree from the given UIComponent.
+     * </p>
+     */
+    @Handler(id = "dumpUIComponentTree", input = {
+            @HandlerInput(name = "component", type = UIComponent.class, required = false) }, output = {
+                    @HandlerOutput(name = "value", type = String.class) })
+    public static void dumpUIComponentTree(HandlerContext context) {
+        // FIXME: Add flag to dump attributes also, perhaps facets should be optional as well?
+        // Find the root UIComponent to use...
+        UIComponent comp = (UIComponent) context.getInputValue("component");
+        if (comp == null) {
+            Object eventObject = context.getEventObject();
+            if (eventObject instanceof UIComponent) {
+                comp = (UIComponent) eventObject;
+            } else {
+                comp = context.getFacesContext().getViewRoot();
+                if (comp == null) {
+                    throw new IllegalArgumentException("Unable to determine UIComponent to dump!");
+                }
+            }
+        }
+
+        // Create the buffer and populate it...
+        StringBuffer buf = new StringBuffer("UIComponent Tree:\n");
+        dumpTree(comp, buf, "    ");
+
+        context.setOutputValue("value", buf.toString());
+    }
+
+    /**
+     * <p>
+     * This method recurses through the <code>UIComponent</code> tree to generate a String representation of its structure.
+     * </p>
+     */
+    private static void dumpTree(UIComponent comp, StringBuffer buf, String indent) {
+        // First add the current UIComponent
+        buf.append(indent + comp.getId() + " (" + comp.getClass().getName() + ") = (" + comp.getAttributes().get("value") + ")\n");
+
+        // Children...
+        Iterator<UIComponent> it = comp.getChildren().iterator();
+        if (it.hasNext()) {
+            buf.append(indent + "  Children:\n");
+            while (it.hasNext()) {
+                dumpTree(it.next(), buf, indent + "    ");
+            }
+        }
+
+        // Facets...
+        Map<String, UIComponent> facetMap = comp.getFacets();
+        Iterator<String> facetNames = facetMap.keySet().iterator();
+        if (facetNames.hasNext()) {
+            while (facetNames.hasNext()) {
+                String name = facetNames.next();
+                buf.append(indent + "  Facet (" + name + "):\n");
+                dumpTree(facetMap.get(name), buf, indent + "    ");
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This handler will print out the structure of a {@link LayoutElement} tree from the given LayoutElement.
+     * </p>
+     */
+    @Handler(id = "dumpLayoutElementTree", input = {
+            @HandlerInput(name = "layoutElement", type = LayoutElement.class, required = false) }, output = {
+                    @HandlerOutput(name = "value", type = String.class) })
+    public static void dumpLayoutElementTree(HandlerContext context) {
+        // FIXME: Add flag to dump attributes also, perhaps facets should be optional as well?
+        // Find the root UIComponent to use...
+        LayoutElement elt = (LayoutElement) context.getInputValue("layoutElement");
+        if (elt == null) {
+            elt = context.getLayoutElement();
+            if (elt == null) {
+                throw new IllegalArgumentException("Unable to determine LayoutElement to dump!");
+            }
+        }
+
+        // Create the buffer and populate it...
+        StringBuffer buf = new StringBuffer("LayoutElement Tree:\n");
+        LayoutElementUtil.dumpTree(elt, buf, "    ");
+
+        context.setOutputValue("value", buf.toString());
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/HandlerException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/HandlerException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Payara Services Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.jsftemplating.handlers;
+
+/**
+ * This exception is thrown if there is an error when processing a
+ * {@link com.sun.jsftemplating.layout.descriptors.handler.Handler}
+ *
+ * @author jonathan coustick
+ */
+public class HandlerException extends RuntimeException {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    public HandlerException(String message) {
+        super(message);
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/MetaDataHandlers.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/MetaDataHandlers.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ *  MetaDataHandlers.java
+ *
+ *  Created on December 2, 2004, 3:06 AM
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.ViewRootUtil;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * <p>
+ * This class contains {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} methods that perform common
+ * utility-type functions.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class MetaDataHandlers {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public MetaDataHandlers() {
+    }
+
+    /**
+     * <p>
+     * This handler provides information about all known (global)
+     * {@link com.sun.jsftemplating.layout.descriptors.handler.Handler}s. It allows an input value ("id") to be passed in,
+     * this is optional. If the value is supplied, it will return information about that handler only. If not supplied, it
+     * will return information about all handlers. Output is passed via output values "info", "ids", and "handler". "info"
+     * is always returned and contains a <code>String</code> of information. "ids" is always returned and contains a
+     * <code>Set</code> of global {@link HandlerDefinition} ids that may be passed into this method. "handler" is returned
+     * only if an id was specified and will contain the requested {@link HandlerDefinition}.
+     * </p>
+     */
+    @Handler(id = "getGlobalHandlerInformation", input = { @HandlerInput(name = "id", type = String.class, required = false) }, output = {
+            @HandlerOutput(name = "info", type = String.class), @HandlerOutput(name = "ids", type = Set.class),
+            @HandlerOutput(name = "value", type = HandlerDefinition.class) })
+    public static void getGlobalHandlerInformation(HandlerContext context) {
+        // Get the known global HandlerDefinitions
+        Map<String, HandlerDefinition> defs = new TreeMap(LayoutDefinitionManager.getGlobalHandlerDefinitions());
+
+        // Provide a Set of ids
+        context.setOutputValue("ids", defs.keySet());
+
+        // If a single HandlerDefinition was requested, provide it
+        // Produce a String of information also
+        String key = (String) context.getInputValue("id");
+        if (key != null) {
+            context.setOutputValue("value", defs.get(key));
+            context.setOutputValue("info", defs.get(key).toString());
+        } else {
+            Iterator<HandlerDefinition> it = defs.values().iterator();
+            StringBuffer buf = new StringBuffer("");
+            while (it.hasNext()) {
+                buf.append(it.next().toString());
+            }
+            context.setOutputValue("info", buf.toString());
+        }
+    }
+
+    /**
+     * <p>
+     * This handler provides information about all known (global) {@link ComponentType}s. It allows an input value ("id") to
+     * be passed in, this is optional. If the value is supplied, it will return information about that {@link ComponentType}
+     * only. If not supplied, it will return information about all {@link ComponentType}s. Output is passed via output
+     * values "info", "ids", and "value". "info" is always returned and contains a <code>String</code> of information. "ids"
+     * is always returned and contains a <code>Set</code> of global {@link ComponentType} ids that may be passed into this
+     * method. "value" is returned only if an id was specified and will contain the requested {@link ComponentType}.
+     * </p>
+     */
+    @Handler(id = "getGlobalComponentTypeInformation", input = {
+            @HandlerInput(name = "id", type = String.class, required = false) }, output = {
+                    @HandlerOutput(name = "info", type = String.class), @HandlerOutput(name = "ids", type = Set.class),
+                    @HandlerOutput(name = "value", type = ComponentType.class) })
+    public static void getGlobalComponentTypeInformation(HandlerContext context) {
+        // Get the known global HandlerDefinitions
+        Map<String, ComponentType> defs = new TreeMap(LayoutDefinitionManager.getGlobalComponentTypes(context.getFacesContext()));
+
+        // Provide a Set of ids
+        context.setOutputValue("ids", defs.keySet());
+
+        // If a single HandlerDefinition was requested, provide it
+        // Produce a String of information also
+        String key = (String) context.getInputValue("id");
+        if (key != null) {
+            // Return info for 1 ComponentType, return the type itself too
+            context.setOutputValue("value", defs.get(key));
+            context.setOutputValue("info", defs.get(key).toString());
+        } else {
+            // Return info for ALL ComponentTypes
+            Iterator<ComponentType> it = defs.values().iterator();
+            StringBuffer buf = new StringBuffer("");
+            while (it.hasNext()) {
+                buf.append(it.next().toString());
+            }
+            context.setOutputValue("info", buf.toString());
+        }
+    }
+
+    /**
+     * <p>
+     * This handler finds the (closest) requested {@link LayoutComponent} for the given <code>viewId</code> /
+     * <code>clientId</code>. If the <code>viewId</code> is not supplied, the current <code>UIViewRoot</code> will be used.
+     * The {@link LayoutComponent} is returned via the <code>component</code> output parameter. If an exact match is not
+     * found, it will return the last {@link LayoutComponent} found while searching the tree -- this should be the last
+     * {@link LayoutComponent} in the hierarchy of the specified component.
+     * </p>
+     *
+     * <p>
+     * This is not an easy process since JSF components may not all be <code>NamingContainer</code>s, so the clientId is not
+     * sufficient to find it. This is unfortunate, but we we have to deal with it.
+     * </p>
+     */
+    @Handler(id = "getLayoutComponent", input = { @HandlerInput(name = "viewId", type = String.class, required = false),
+            @HandlerInput(name = "clientId", type = String.class, required = true) }, output = {
+                    @HandlerOutput(name = "component", type = LayoutComponent.class) })
+    public static void getLayoutComponent(HandlerContext ctx) {
+        // First get the clientId that we are going to attempt to walk.
+        String viewId = (String) ctx.getInputValue("viewId");
+        String clientId = (String) ctx.getInputValue("clientId");
+
+        // Next, find it
+        LayoutComponent result = LayoutDefinitionManager.getLayoutComponent(ctx.getFacesContext(), viewId, clientId);
+
+        // Set the result
+        ctx.setOutputValue("component", result);
+    }
+
+    /**
+     * <p>
+     * This handler provides a way to get a {@link LayoutDefinition}.
+     * </p>
+     */
+    @Handler(id = "getLayoutDefinition", input = { @HandlerInput(name = "viewId", type = String.class, required = false) }, output = {
+            @HandlerOutput(name = "layoutDefinition", type = LayoutDefinition.class) })
+    public static void getLayoutDefinition(HandlerContext ctx) {
+        // First get the viewId...
+        String viewId = (String) ctx.getInputValue("viewId");
+
+        // Find the LayoutDefinition
+        LayoutDefinition def = ViewRootUtil.getLayoutDefinition(viewId);
+
+        // Set the result
+        ctx.setOutputValue("layoutDefinition", def);
+    }
+
+    /**
+     * <p>
+     * This handler returns true if jsft is running in debug mode.
+     * </p>
+     */
+    @Handler(id = "isDebug", output = { @HandlerOutput(name = "value", type = Boolean.class) })
+    public static void isDebug(HandlerContext ctx) {
+        // Set the result
+        ctx.setOutputValue("value", LayoutDefinitionManager.isDebug(ctx.getFacesContext()));
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/NavigationHandlers.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/NavigationHandlers.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * NavigationHandlers.java
+ *
+ * Created on December 6, 2004, 11:06 PM
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This class contains {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} methods that perform navigation
+ * oriented actions.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class NavigationHandlers {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public NavigationHandlers() {
+    }
+
+    /**
+     * <p>
+     * This handler returns a <code>UIViewRoot</code>. If the <code>id</code> parameter is supplied it will return the
+     * requested <code>UIViewRoot</code> (this may fail and cause an exception). If the <code>id</code> is <em>not</em>
+     * supplied, it will return the current <code>UIViewRoot</code>. The result will be returned in an output parameter
+     * named <code>viewRoot</code>.
+     * </p>
+     */
+    @Handler(id = "getUIViewRoot", input = { @HandlerInput(name = "id", type = String.class) }, output = {
+            @HandlerOutput(name = "viewRoot", type = UIViewRoot.class) })
+    public void getUIViewRoot(HandlerContext context) {
+        String pageName = (String) context.getInputValue("id");
+        FacesContext ctx = context.getFacesContext();
+        UIViewRoot root = null;
+        if (pageName == null) {
+            root = ctx.getViewRoot();
+        } else {
+            if (pageName.charAt(0) != '/') {
+                // Ensure we start w/ a '/'
+                pageName = "/" + pageName;
+            }
+            root = ctx.getApplication().getViewHandler().createView(ctx, pageName);
+        }
+        context.setOutputValue("viewRoot", root);
+    }
+
+    /**
+     * <p>
+     * This method gives you a "resource URL" as defined by the <code>ViewHandler</code>'s <code>getActionURL(String
+     *        url)</code> method.
+     * </p>
+     *
+     * @param handlerCtx The {@link HandlerContext}.
+     */
+    @Handler(id = "getActionURL", input = { @HandlerInput(name = "url", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "result", type = String.class) })
+    public static void getActionURL(HandlerContext handlerCtx) {
+        String url = (String) handlerCtx.getInputValue("url");
+        FacesContext ctx = handlerCtx.getFacesContext();
+        handlerCtx.setOutputValue("result", ctx.getApplication().getViewHandler().getActionURL(ctx, url));
+    }
+
+    /**
+     * <p>
+     * This method gives you a "resource URL" as defined by the <code>ViewHandler</code>'s <code>getResourceURL(String
+     *        url)</code> method.
+     * </p>
+     *
+     * @param handlerCtx The {@link HandlerContext}.
+     */
+    @Handler(id = "getResourceURL", input = { @HandlerInput(name = "url", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "result", type = String.class) })
+    public static void getResourceURL(HandlerContext handlerCtx) {
+        String url = (String) handlerCtx.getInputValue("url");
+        FacesContext ctx = handlerCtx.getFacesContext();
+        handlerCtx.setOutputValue("result", ctx.getApplication().getViewHandler().getResourceURL(ctx, url));
+    }
+
+    /**
+     * <p>
+     * This handler navigates to the given page. <code>page</code> may either be a <code>UIViewRoot</code> or a
+     * <code>String</code> representing a <code>UIViewRoot</code>. Passing in a <code>String</code> name of a
+     * <code>UIViewRoot</code> will always create a new <code>UIViewRoot</code>. Passing in the <code>UIViewRoot</code>
+     * provides an opportunity to customize the <code>UIComponent</code> tree that will be displayed.
+     * </p>
+     *
+     * <p>
+     * The {@link #getUIViewRoot(HandlerContext)} handler provides a way to obtain a <code>UIViewRoot</code>.
+     * </p>
+     *
+     * <p>
+     * Input value: "page" -- Type: <code>Object</code> (should be a <code>String</code> or a <code>UIViewRoot</code>).
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "navigate", input = { @HandlerInput(name = "page", type = Object.class, required = true) })
+    public static void navigate(HandlerContext context) {
+        Object page = context.getInputValue("page");
+        UIViewRoot root = null;
+        FacesContext ctx = context.getFacesContext();
+        if (page instanceof String) {
+            // Create a new UIViewRoot with the given id
+            String strPage = (String) page;
+            if (strPage.charAt(0) != '/') {
+                // Ensure we start w/ a '/'
+                strPage = "/" + strPage;
+            }
+            root = ctx.getApplication().getViewHandler().createView(ctx, strPage);
+        } else if (page instanceof UIViewRoot) {
+            // We recieved a UIViewRoot, use it...
+            root = (UIViewRoot) page;
+        } else {
+            throw new IllegalArgumentException(
+                    "Type '" + page.getClass().getName() + "' is not valid.  It must be a String or UIViewRoot.");
+        }
+
+        // Set the UIViewRoot so that it will be displayed
+        ctx.setViewRoot(root);
+    }
+
+    /**
+     * <p>
+     * This handler redirects to the given page.
+     * </p>
+     *
+     * <p>
+     * Input value: "page" -- Type: <code>String</code>
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "redirect", input = { @HandlerInput(name = "page", type = String.class, required = true) })
+    public static void redirect(HandlerContext context) {
+        String page = (String) context.getInputValue("page");
+        FacesContext ctx = context.getFacesContext();
+        try {
+            ctx.getExternalContext().redirect(page);
+            ctx.responseComplete();
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to navigate to page '" + page + "'!", ex);
+        }
+    }
+
+    /**
+     * <p>
+     * This handler forwards to the given page. Normally you will want to do {@link #navigate} as that follows JSF patterns.
+     * This uses the raw dispatcher forward mechanism (via the ExternalContext).
+     * </p>
+     *
+     * <p>
+     * Input value: "url" -- Type: <code>String</code>
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "dispatch", input = { @HandlerInput(name = "path", type = String.class, required = true) })
+    public static void dispatch(HandlerContext context) {
+        String path = (String) context.getInputValue("path");
+        FacesContext ctx = context.getFacesContext();
+        try {
+            ctx.getExternalContext().dispatch(path);
+            ctx.responseComplete();
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to navigate to path '" + path + "'!", ex);
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/OptionsHandlers.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/OptionsHandlers.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * OptionsHandlers.java
+ *
+ * Created on June 8, 2006, 5:01 PM
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.model.SelectItem;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+
+/**
+ *
+ * @author Jennifer Chou
+ */
+public class OptionsHandlers {
+
+    /**
+     * Creates a new instance of OptionsHandlers
+     */
+    public OptionsHandlers() {
+    }
+
+    /**
+     * <p>
+     * This handler returns the Lockhart version of Options of the drop-down of the given <code>labels</code> and
+     * <code>values</code>. <code>labels</code> and <code>values</code> arrays must be equal in size and in matching
+     * sequence.
+     * </p>
+     *
+     * <p>
+     * Input value: <code>labels</code> -- Type: <code>java.util.Collection</code>
+     * </p>
+     *
+     * <p>
+     * Input value: <code>values</code> -- Type: <code>java.util.Collection</code>
+     * </p>
+     *
+     * <p>
+     * Output value: <code>options</code> -- Type: <code>SelectItem[] (castable to Option[])</code>
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "getSunOptions", input = { @HandlerInput(name = "labels", type = Collection.class, required = true),
+            @HandlerInput(name = "values", type = Collection.class, required = true) }, output = {
+                    @HandlerOutput(name = "options", type = SelectItem[].class) })
+    public static void getSunOptions(HandlerContext context) throws Exception {
+        Collection<String> labels = (Collection) context.getInputValue("labels");
+        Collection<String> values = (Collection) context.getInputValue("values");
+        if (labels.size() != values.size()) {
+            throw new Exception("getSunOptions Handler input " + "incorrect: Input 'labels' and 'values' size must be equal. "
+                    + "'labels' size: " + labels.size() + " 'values' size: " + values.size());
+        }
+
+        SelectItem[] options = (SelectItem[]) Array.newInstance(SUN_OPTION_CLASS, labels.size());
+        String[] labelsArray = labels.toArray(new String[labels.size()]);
+        String[] valuesArray = values.toArray(new String[values.size()]);
+        for (int i = 0; i < labels.size(); i++) {
+            SelectItem option = getSunOption(valuesArray[i], labelsArray[i]);
+            options[i] = option;
+        }
+        context.setOutputValue("options", options);
+    }
+
+    /**
+     * Creates a Woodstock Option instance.
+     */
+    private static SelectItem getSunOption(String value, String label) {
+        try {
+            return (SelectItem) SUN_OPTION_CONSTRUCTOR.newInstance(value, label);
+        } catch (InstantiationException ex) {
+            throw new RuntimeException("Unable to instantiate '" + SUN_OPTION_CLASS + "'!", ex);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException("Unable to instantiate '" + SUN_OPTION_CLASS + "'!", ex);
+        } catch (InvocationTargetException ex) {
+            throw new RuntimeException("Unable to instantiate '" + SUN_OPTION_CLASS + "'!", ex);
+        }
+    }
+
+    /**
+     * <p>
+     * Method wich returns the constructor on the class with the given arguments. It will return null if any exceptions
+     * occur, no exceptions will be thrown from this method.
+     * </p>
+     */
+    private static Constructor noExceptionFindConstructor(Class cls, Class args[]) {
+        Constructor constructor = null;
+        try {
+            constructor = cls.getConstructor(args);
+        } catch (Exception ex) {
+            // Ignore...
+        }
+        return constructor;
+    }
+
+    private static final Class SUN_OPTION_CLASS = Util.noExceptionLoadClass("com.sun.webui.jsf.model.Option");
+    private static final Constructor SUN_OPTION_CONSTRUCTOR = noExceptionFindConstructor(SUN_OPTION_CLASS,
+            new Class[] { Object.class, String.class });
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/ScopeHandlers.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/ScopeHandlers.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ *  ScopeHandlers.java
+ *
+ *  Created on December 2, 2004, 3:06 AM
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.el.PageSessionResolver;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.resource.ResourceBundleManager;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.Serializable;
+import java.util.Formatter;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.prefs.Preferences;
+
+/**
+ * <p>
+ * This class contains {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} methods that perform common
+ * utility-type functions.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ScopeHandlers {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public ScopeHandlers() {
+    }
+
+    /**
+     * <p>
+     * This handler gets a request attribute. It requires "key" as an input value. It returns "value" as an output value.
+     * Note this can also be done via #{requestScope["attributeName"]}.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "getAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "value", type = Object.class) })
+    public static void getAttribute(HandlerContext context) {
+        String key = (String) context.getInputValue("key");
+        Object value = context.getFacesContext().getExternalContext().getRequestMap().get(key);
+        context.setOutputValue("value", value);
+    }
+
+    /**
+     * <p>
+     * This handler sets a request attribute. It requires "key" and "value" input values to be passed in.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "setAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "value", required = true) })
+    public static void setAttribute(HandlerContext context) {
+        String key = (String) context.getInputValue("key");
+        Object value = context.getInputValue("value");
+        context.getFacesContext().getExternalContext().getRequestMap().put(key, value);
+    }
+
+    /**
+     * <p>
+     * This handler produces a String consisting of all the request attributes. It outputs this via the "value" output
+     * value.
+     * </p>
+     */
+    @Handler(id = "dumpAttributes", output = { @HandlerOutput(name = "value", type = String.class) })
+    public static void dumpAttributes(HandlerContext context) {
+        Map<String, Object> map = context.getFacesContext().getExternalContext().getRequestMap();
+        context.setOutputValue("value", formatAttributes(map));
+    }
+
+    /**
+     * <p>
+     * This handler gets a "page" session attribute. It requires <code>key</code> as an input value. It returns
+     * <code>value</code> as an output value. You may pass in the page (<code>UIViewRoot</code>) as an input value via the
+     * <code>page</code> input value, if you don't the current <code>UIViewRoot</code> will be used.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "getPageSessionAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "page", type = UIViewRoot.class, required = false) }, output = {
+                    @HandlerOutput(name = "value", type = Serializable.class) })
+    public static void getPageSessionAttribute(HandlerContext context) {
+        // Get the Page Session Map
+        Map<String, Serializable> map = PageSessionResolver.getPageSession(context.getFacesContext(),
+                (UIViewRoot) context.getInputValue("page"));
+
+        // Get the value to return
+        Serializable value = null;
+        if (map != null) {
+            value = map.get(context.getInputValue("key"));
+        }
+
+        // Return the value
+        context.setOutputValue("value", value);
+    }
+
+    /**
+     * <p>
+     * This handler sets a page session attribute. It requires <code>key</code> and <code>value</code> input values to be
+     * passed in. <code>page</code> may optionally be passed in to specify the page (<code>UIViewRoot</code>) that should be
+     * used -- otherwise the current <code>UIViewRoot</code> is used.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "setPageSessionAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "value", type = Serializable.class, required = true),
+            @HandlerInput(name = "page", type = UIViewRoot.class, required = false) })
+    public static void setPageSessionAttribute(HandlerContext context) {
+        UIViewRoot root = (UIViewRoot) context.getInputValue("page");
+        FacesContext ctx = context.getFacesContext();
+
+        // Get the Page Session Map
+        Map<String, Serializable> map = PageSessionResolver.getPageSession(ctx, root);
+        if (map == null) {
+            map = PageSessionResolver.createPageSession(ctx, root);
+        }
+
+        // Set the page session value
+        map.put((String) context.getInputValue("key"), (Serializable) context.getInputValue("value"));
+    }
+
+    /**
+     * <p>
+     * This handler produces a String consisting of all the page session attributes. It outputs this via the
+     * <code>value</code> output value. This handler optionally accepts the <code>page</code> input value
+     * (<code>UIViewRoot</code>) -- if not supplied the current <code>UIViewRoot</code> is used.
+     * </p>
+     */
+    @Handler(id = "dumpPageSessionAttributes", input = {
+            @HandlerInput(name = "page", type = UIViewRoot.class, required = false) }, output = {
+                    @HandlerOutput(name = "value", type = String.class) })
+    public static void dumpPageSessionAttributes(HandlerContext context) {
+        // Get the Page Session Map
+        Map<String, Serializable> map = PageSessionResolver.getPageSession(context.getFacesContext(),
+                (UIViewRoot) context.getInputValue("page"));
+
+        // Return the formatted result
+        context.setOutputValue("value", formatAttributes(map));
+    }
+
+    /**
+     * <p>
+     * This handler gets a session attribute. It requires "key" as an input value. It returns "value" as an output value.
+     * Note this can also be done via #{sessionScope["attributeName"]}.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "getSessionAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "value", type = Object.class) })
+    public static void getSessionAttribute(HandlerContext context) {
+        String key = (String) context.getInputValue("key");
+        Object value = context.getFacesContext().getExternalContext().getSessionMap().get(key);
+        context.setOutputValue("value", value);
+    }
+
+    /**
+     * <p>
+     * This handler sets a session attribute. It requires "key" and "value" input values to be passed in.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "setSessionAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "value", required = true) })
+    public static void setSessionAttribute(HandlerContext context) {
+        String key = (String) context.getInputValue("key");
+        Object value = context.getInputValue("value");
+        context.getFacesContext().getExternalContext().getSessionMap().put(key, value);
+    }
+
+    /**
+     * <p>
+     * This handler produces a String consisting of all the request attributes. It outputs this via the "value" output
+     * value.
+     * </p>
+     */
+    @Handler(id = "dumpSessionAttributes", output = { @HandlerOutput(name = "value", type = String.class) })
+    public static void dumpSessionAttributes(HandlerContext context) {
+        Map<String, Object> map = context.getFacesContext().getExternalContext().getSessionMap();
+        context.setOutputValue("value", formatAttributes(map));
+    }
+
+    /**
+     * <p>
+     * This handler gets a application attribute. It requires "key" as an input value. It returns "value" as an output
+     * value. Note this can also be done via #{applicationScope["attributeName"]}.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "getApplicationAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "value", type = Object.class) })
+    public static void getApplicationAttribute(HandlerContext context) {
+        String key = (String) context.getInputValue("key");
+        Object value = context.getFacesContext().getExternalContext().getApplicationMap().get(key);
+        context.setOutputValue("value", value);
+    }
+
+    /**
+     * <p>
+     * This handler sets a application attribute. It requires "key" and "value" input values to be passed in.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "setApplicationAttribute", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "value", required = true) })
+    public static void setApplicationAttribute(HandlerContext context) {
+        String key = (String) context.getInputValue("key");
+        Object value = context.getInputValue("value");
+        context.getFacesContext().getExternalContext().getApplicationMap().put(key, value);
+    }
+
+    /**
+     * <p>
+     * This handler produces a String consisting of all the request attributes. It outputs this via the "value" output
+     * value.
+     * </p>
+     */
+    @Handler(id = "dumpApplicationAttributes", output = { @HandlerOutput(name = "value", type = String.class) })
+    public static void dumpApplicationAttributes(HandlerContext context) {
+        Map<String, Object> map = context.getFacesContext().getExternalContext().getApplicationMap();
+        context.setOutputValue("value", formatAttributes(map));
+    }
+
+    /**
+     * <p>
+     * This method formats attributes from a <code>Map</code>. This is used with the dump handlers.
+     * </p>
+     */
+    private static <T> String formatAttributes(Map<String, T> map) {
+        Formatter printf = new Formatter();
+        if (map == null) {
+            printf.format("Map null.");
+        } else {
+            Iterator<Map.Entry<String, T>> it = map.entrySet().iterator();
+            Map.Entry<String, T> entry = null;
+            while (it.hasNext()) {
+                entry = it.next();
+                printf.format("%-20s = %s\n", entry.getKey(), entry.getValue());
+            }
+        }
+        return printf.toString();
+    }
+
+    /**
+     * <p>
+     * This handler sets a <code>ResourceBundle</code> in desired request attribute. It requires "key" as an input value,
+     * which is the request attribute key used to store the bundle. "bundle" is also required as an input value, this is the
+     * fully qualified name of the bundle. Optionally the "locale" can be specified, if not the web user's locale will be
+     * used. It returns "bundle" as an output value.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "setResourceBundle", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "bundle", type = String.class, required = true),
+            @HandlerInput(name = "locale", type = Locale.class, required = false) }, output = {
+                    @HandlerOutput(name = "result", type = ResourceBundle.class) })
+    public static void setResourceBundle(HandlerContext context) {
+        // Get the input
+        String key = (String) context.getInputValue("key");
+        String name = (String) context.getInputValue("bundle");
+        Locale locale = (Locale) context.getInputValue("locale");
+        FacesContext ctx = context.getFacesContext();
+        if (locale == null) {
+            locale = Util.getLocale(ctx);
+        }
+
+        // Get the ResourceBundle
+        ResourceBundle bundle = ResourceBundleManager.getInstance(ctx).getBundle(name, locale);
+
+        // Store it in the Request Map
+        ctx.getExternalContext().getRequestMap().put(key, bundle);
+
+        // Return it
+        context.setOutputValue("result", bundle);
+    }
+
+    /**
+     * <p>
+     * This method provides access to the named cookie. If the cookie doesn't exist, the value will be set to ""
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "getCookie", input = { @HandlerInput(name = "key", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "value", type = String.class) })
+    public static void getCookie(HandlerContext context) {
+        Map<String, Object> cookies = context.getFacesContext().getExternalContext().getRequestCookieMap();
+        Cookie cookie = (Cookie) cookies.get(context.getInputValue("key"));
+        context.setOutputValue("value", cookie == null ? "" : cookie.getValue());
+    }
+
+    /**
+     * <p>
+     * This method set the named cookie with the given value. Because cookies are set via a response header, this method
+     * must be called before the content rendering has begun (before the rendering phase). This method is not valid for
+     * Portlets and will do nothing if called in a Portlet environment.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}.
+     */
+    @Handler(id = "setCookie", input = { @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "value", type = String.class, required = true),
+            @HandlerInput(name = "maxAge", type = Integer.class, defaultValue = "-1", required = false),
+            @HandlerInput(name = "domain", type = String.class, required = false),
+            @HandlerInput(name = "path", type = String.class, required = false),
+            @HandlerInput(name = "secure", type = Boolean.class, defaultValue = "false", required = false),
+            @HandlerInput(name = "version", type = Integer.class, required = false) })
+    public static void setCookie(HandlerContext context) {
+        Object resp = context.getFacesContext().getExternalContext().getResponse();
+        if (resp instanceof HttpServletResponse) {
+            // Create a Cookie
+            Cookie cookie = new Cookie((String) context.getInputValue("key"), (String) context.getInputValue("value"));
+
+            // Set Max Age
+            cookie.setMaxAge((Integer) context.getInputValue("maxAge"));
+
+            // Set Domain
+            String domain = (String) context.getInputValue("domain");
+            if (domain != null) {
+                cookie.setDomain(domain);
+            }
+
+            // Set Path
+            String path = (String) context.getInputValue("path");
+            if (path != null) {
+                cookie.setPath(path);
+            }
+
+            // Set Secure Flag
+            cookie.setSecure((Boolean) context.getInputValue("secure"));
+
+            // Set version (0 = orig Netscape; 1= RFC 2109)
+            Integer version = (Integer) context.getInputValue("version");
+            if (version != null) {
+                cookie.setVersion(version);
+            }
+
+            // Add the cookie
+            ((HttpServletResponse) resp).addCookie(cookie);
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link Handler} allows you to set a preference via the Java Preferences API. The <code>root</code> specifies the
+     * path in which the preference should be stored (e.g. '/org/company/foo'). The <code>key</code> is the name of the
+     * preference, and the <code>value</code> is the value of the preference.
+     * </p>
+     */
+    @Handler(id = "setPreference", input = { @HandlerInput(name = "root", type = String.class, required = true),
+            @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "value", type = String.class, required = true) })
+    public static void setPreference(HandlerContext context) {
+        String nodeKey = (String) context.getInputValue("root");
+        String key = (String) context.getInputValue("key");
+        String value = (String) context.getInputValue("value");
+        Preferences prefs = Preferences.userRoot().node(nodeKey);
+        prefs.put(key, value);
+    }
+
+    /**
+     * <p>
+     * This {@link Handler} allows you to get a preference via the Java Preferences API. The <code>root</code> specifies the
+     * path in which the preference should be stored (e.g. '/org/company/foo'). The <code>key</code> is the name of the
+     * preference, and the <code>default</code> is the value of the preference if it does not yet exist. The preference
+     * value will be returned via the <code>value</code> output value.
+     * </p>
+     */
+    @Handler(id = "getPreference", input = { @HandlerInput(name = "root", type = String.class, required = true),
+            @HandlerInput(name = "key", type = String.class, required = true),
+            @HandlerInput(name = "default", type = String.class) }, output = { @HandlerOutput(name = "value", type = String.class) })
+    public static void getPreference(HandlerContext context) {
+        String nodeKey = (String) context.getInputValue("root");
+        String key = (String) context.getInputValue("key");
+        String def = (String) context.getInputValue("default");
+        Preferences prefs = Preferences.userRoot().node(nodeKey);
+        String value = prefs.get(key, def);
+        context.setOutputValue("value", value);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/UtilHandlers.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/handlers/UtilHandlers.java
@@ -1,0 +1,517 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019 Payara Services Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ *  UtilHandlers.java
+ *
+ *  Created on December 2, 2004, 3:06 AM
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.el.PageSessionResolver;
+import com.sun.jsftemplating.layout.LayoutViewHandler;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class contains {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} methods that perform common
+ * utility-type functions.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class UtilHandlers {
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public UtilHandlers() {
+    }
+
+    /**
+     * <p>
+     * This handler uses the special "condition" attribute to determine if it should execute (and therefor any of its child
+     * handlers. So the implementation itself does nothing.
+     * </p>
+     */
+    @Handler(id = "if", input = { @HandlerInput(name = "condition", type = String.class) })
+    public static void ifHandler(HandlerContext context) {
+        // Do nothing, the purpose of this handler is to provide condition
+        // support which is handled by the parser / runtime.
+    }
+
+    /**
+     * <p>
+     * A utility handler that resembles the for() method in Java. Handlers inside the for loop will be executed in a loop.
+     * The starting index is specified by <code>start</code>. The index will increase sequentially untill it is equal to
+     * <code>end</code>. <code>var</code> will be a request attribute that is set to the current index value as the loop
+     * iterates.
+     * </p>
+     * <p>
+     * For example:
+     * </p>
+     *
+     * <code>forLoop(start="1"  end="3" var="foo") {...}</code>
+     *
+     * <p>
+     * The handlers inside the {...} will be executed 2 times (with foo=1 and foo=2).
+     * </p>
+     *
+     * <ul>
+     * <li><code>start</code> -- type: <code>Integer</code> Starting index, defaults to zero if not specified.</li>
+     * <li><code>end</code> -- type: <code>Integer</code>; Ending index. Required.</li>
+     * <li><code>var</code> -- type: <code>String</code>; Request attribute to be set in the for loop to the value of the
+     * index.</li>
+     * </ul>
+     *
+     * @param handlerCtx The {@link HandlerContext}.
+     */
+    @Handler(id = "for", input = { @HandlerInput(name = "start", type = Integer.class),
+            @HandlerInput(name = "end", type = Integer.class, required = true),
+            @HandlerInput(name = "var", type = String.class, required = true) })
+    public static boolean forLoop(HandlerContext handlerCtx) {
+        Integer startInt = (Integer) handlerCtx.getInputValue("start");
+        int start = startInt == null ? 0 : startInt;
+        int end = (Integer) handlerCtx.getInputValue("end");
+        String var = (String) handlerCtx.getInputValue("var");
+
+        List<com.sun.jsftemplating.layout.descriptors.handler.Handler> handlers = handlerCtx.getHandler().getChildHandlers();
+        if (handlers.size() > 0) {
+            // We have child handlers in the loop... execute while we iterate
+            LayoutElement elt = handlerCtx.getLayoutElement();
+            Map<String, Object> requestMap = handlerCtx.getFacesContext().getExternalContext().getRequestMap();
+            for (int idx = start; idx < end; idx++) {
+                requestMap.put(var, idx);
+                // Ignore whats returned by the handler... we need to return
+                // false anyway to prevent children from being executed again
+                elt.dispatchHandlers(handlerCtx, handlers);
+            }
+        }
+
+        // This will prevent the child handlers from executing again
+        return false;
+    }
+
+    /**
+     * <p>
+     * This handler writes using <code>System.out.println</code>. It requires that <code>value</code> be supplied as a
+     * String input parameter.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "println", input = { @HandlerInput(name = "value", type = String.class, required = true) })
+    public static void println(HandlerContext context) {
+        String value = (String) context.getInputValue("value");
+        System.out.println(value);
+    }
+
+    /**
+     * <p>
+     * This handler writes using <code>FacesContext.getResponseWriter()</code>.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "write", input = { @HandlerInput(name = "value", type = String.class, required = true) })
+    public static void write(HandlerContext context) {
+        String text = (String) context.getInputValue("value");
+        if (text == null) {
+            // Even though this is required, an expression can evaluate to null
+            text = "";
+        }
+        try {
+            context.getFacesContext().getResponseWriter().write(text);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * <p>
+     * This handler decrements a number by 1. This handler requires "number" to be supplied as an Integer input value. It
+     * sets an output value "value" to number-1.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "dec", input = { @HandlerInput(name = "number", type = Integer.class, required = true) }, output = {
+            @HandlerOutput(name = "value", type = Integer.class) })
+    public static void dec(HandlerContext context) {
+        Integer value = (Integer) context.getInputValue("number");
+        context.setOutputValue("value", new Integer(value.intValue() - 1));
+    }
+
+    /**
+     * <p>
+     * This handler increments a number by 1. This handler requires "number" to be supplied as an Integer input value. It
+     * sets an output value "value" to number+1.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "inc", input = { @HandlerInput(name = "number", type = Integer.class, required = true) }, output = {
+            @HandlerOutput(name = "value", type = Integer.class) })
+    public static void inc(HandlerContext context) {
+        Integer value = (Integer) context.getInputValue("number");
+        context.setOutputValue("value", new Integer(value.intValue() + 1));
+    }
+
+    /**
+     * <p>
+     * This method returns an <code>Iterator</code> for the given <code>List</code>. The <code>List</code> input value key
+     * is: "list". The output value key for the <code>Iterator</code> is: "iterator".
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "getIterator", input = { @HandlerInput(name = "list", type = List.class, required = true) }, output = {
+            @HandlerOutput(name = "iterator", type = Iterator.class) })
+    public static void getIterator(HandlerContext context) {
+        List<Object> list = (List<Object>) context.getInputValue("list");
+        context.setOutputValue("iterator", list.iterator());
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>Boolean</code> value representing whether another value exists for the given
+     * <code>Iterator</code>. The <code>Iterator</code> input value key is: "iterator". The output value key is "hasNext".
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "iteratorHasNext", input = { @HandlerInput(name = "iterator", type = Iterator.class, required = true) }, output = {
+            @HandlerOutput(name = "hasNext", type = Boolean.class) })
+    public static void iteratorHasNext(HandlerContext context) {
+        Iterator<Object> it = (Iterator<Object>) context.getInputValue("iterator");
+        context.setOutputValue("hasNext", Boolean.valueOf(it.hasNext()));
+    }
+
+    /**
+     * <p>
+     * This method returns the next object in the <code>List</code> that the given <code>Iterator</code> is iterating over.
+     * The <code>Iterator</code> input value key is: "iterator". The output value key is "next".
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "iteratorNext", input = { @HandlerInput(name = "iterator", type = Iterator.class, required = true) }, output = {
+            @HandlerOutput(name = "next") })
+    public static void iteratorNext(HandlerContext context) {
+        Iterator<Object> it = (Iterator<Object>) context.getInputValue("iterator");
+        context.setOutputValue("next", it.next());
+    }
+
+    /**
+     * <p>
+     * This method creates a List. Optionally you may supply "size" to create a List of blank "" values of the specified
+     * size. The output value from this handler is "result".
+     * </p>
+     *
+     * @param context The HandlerContext
+     */
+    @Handler(id = "createList", input = { @HandlerInput(name = "size", type = Integer.class, required = true) }, output = {
+            @HandlerOutput(name = "result", type = List.class) })
+    public static void createList(HandlerContext context) {
+        int size = ((Integer) context.getInputValue("size")).intValue();
+        List<Object> list = new ArrayList<>(size);
+        for (int count = 0; count < size; count++) {
+            list.add("");
+        }
+        context.setOutputValue("result", list);
+    }
+
+    /**
+     * <p>
+     * This method creates a <code>Map</code> (<code>HashMap</code>). The output value from this handler is "result".
+     * </p>
+     *
+     * @param context The <code>HandlerContext<code>
+     */
+    @Handler(id = "createMap", output = { @HandlerOutput(name = "result", type = Map.class) })
+    public static void createMap(HandlerContext context) {
+        Map<Object, Object> map = new HashMap<>();
+        context.setOutputValue("result", map);
+    }
+
+    /**
+     * <p>
+     * This method adds a value to a <code>Map</code>. You must supply <code>map</code> to use as well as the
+     * <code>key</code> and <code>value</code> to add.
+     * </p>
+     *
+     * @param context The <code>HandlerContext<code>
+     */
+    @Handler(id = "mapPut", input = { @HandlerInput(name = "map", type = Map.class, required = true),
+            @HandlerInput(name = "key", type = Object.class, required = true),
+            @HandlerInput(name = "value", type = Object.class, required = true) })
+    public static void mapPut(HandlerContext context) {
+        Map map = (Map) context.getInputValue("map");
+        if (map == null) {
+            throw new HandlerException(context.getHandler().getInputValue("map") + " resolved to null");
+        }
+
+        Object key = context.getInputValue("key");
+        Object value = context.getInputValue("value");
+        map.put(key, value);
+    }
+
+    /**
+     * <p>
+     * This method returns true. It does not take any input or provide any output values.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}
+     */
+    @Handler(id = "returnTrue")
+    public static boolean returnTrue(HandlerContext context) {
+        return true;
+    }
+
+    /**
+     * <p>
+     * This method returns false. It does not take any input or provide any output values.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}
+     */
+    @Handler(id = "returnFalse")
+    public static boolean returnFalse(HandlerContext context) {
+        return false;
+    }
+
+    /**
+     * <p>
+     * This method enables you to retrieve the clientId for the given <code>UIComponent</code>.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}
+     */
+    @Handler(id = "getClientId", input = { @HandlerInput(name = "component", type = UIComponent.class, required = true) }, output = {
+            @HandlerOutput(name = "clientId", type = String.class) })
+    public static void getClientId(HandlerContext context) {
+        UIComponent comp = (UIComponent) context.getInputValue("component");
+        context.setOutputValue("clientId", comp.getClientId(context.getFacesContext()));
+    }
+
+    /**
+     * <p>
+     * This method enables you to retrieve the id or clientId for the given <code>Object</code> which is expected to be a
+     * <code>UIComponent</code> or a <code>String</code> that already represents the clientId.
+     * </p>
+     *
+     * @param context The {@link HandlerContext}
+     */
+    @Handler(id = "getId", input = { @HandlerInput(name = "object", required = true) }, output = {
+            @HandlerOutput(name = "id", type = String.class), @HandlerOutput(name = "clientId", type = String.class) })
+    public static void getId(HandlerContext context) {
+        Object obj = context.getInputValue("object");
+        if (obj == null) {
+            return;
+        }
+
+        String clientId = null;
+        String id = null;
+        if (obj instanceof UIComponent) {
+            clientId = ((UIComponent) obj).getClientId(context.getFacesContext());
+            id = ((UIComponent) obj).getId();
+        } else {
+            clientId = obj.toString();
+            id = clientId.substring(clientId.lastIndexOf(':') + 1);
+        }
+        context.setOutputValue("id", id);
+        context.setOutputValue("clientId", clientId);
+    }
+
+    /**
+     * <p>
+     * This handler provides a way to see the call stack by printing a stack trace. The output will go to stderr and will
+     * also be returned in the output value "stackTrace". An optional message may be provided to be included in the trace.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(
+        id = "printStackTrace",
+        input = { @HandlerInput(name = "msg", type = String.class) },
+        output = { @HandlerOutput(name = "stackTrace", type = String.class) })
+    public static void printStackTrace(HandlerContext context) {
+        // See if we have a message to print w/ it
+        String msg = (String) context.getInputValue("msg");
+        if (msg == null) {
+            msg = "";
+        }
+
+        // Get the StackTrace
+        StringWriter strWriter = new StringWriter();
+        new RuntimeException(msg).printStackTrace(new PrintWriter(strWriter));
+        String trace = strWriter.toString();
+
+        // Print it to stderr and return it
+        System.err.println(trace);
+        context.setOutputValue("stackTrace", trace);
+    }
+
+    /**
+     * <p>
+     * This handler prints out the contents of the given UIComponent's attribute map.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "dumpAttributeMap", input = { @HandlerInput(name = "component", type = UIComponent.class) })
+    public static void dumpAttributeMap(HandlerContext context) {
+        UIComponent comp = (UIComponent) context.getInputValue("component");
+        if (comp != null) {
+            Map<String, Object> map = comp.getAttributes();
+            for (Iterator iter = map.entrySet().iterator(); iter.hasNext();) {
+                Map.Entry me = (Map.Entry) iter.next();
+                System.out.println("key=" + me.getKey() + "'" + "value=" + me.getValue());
+            }
+        } else {
+            System.out.println("UIComponent is null");
+
+        }
+    }
+
+    /**
+     * <p>
+     * This handler sets the encoding type of the given UIViewRoot's attribute map.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "setEncoding", input = { @HandlerInput(name = "value", type = String.class) })
+    public static void setEncoding(HandlerContext context) {
+        String value = (String) context.getInputValue("value");
+        FacesContext fctxt = context.getFacesContext();
+        if (fctxt != null) {
+            UIViewRoot root = fctxt.getViewRoot();
+            // Get the Page Session Map
+            Map<String, Serializable> map = PageSessionResolver.getPageSession(fctxt, root);
+            if (map == null) {
+                map = PageSessionResolver.createPageSession(fctxt, root);
+            }
+
+            // Set the page session value
+            map.put(LayoutViewHandler.ENCODING_TYPE, value);
+        }
+    }
+
+    /**
+     * <p>
+     * This handler url encodes the given String. It will return null if null is given and it will use a default encoding of
+     * "UTF-8" if no encoding is specified.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "urlencode", input = { @HandlerInput(name = "value", type = String.class, required = true),
+            @HandlerInput(name = "encoding", type = String.class) }, output = { @HandlerOutput(name = "result", type = String.class) })
+    public static void urlencode(HandlerContext context) {
+        String value = (String) context.getInputValue("value");
+        String encoding = (String) context.getInputValue("encoding");
+        if (encoding == null) {
+            encoding = "UTF-8";
+        }
+        // The value could be null if an EL expression maps to null
+        if (value != null) {
+            try {
+                value = URLEncoder.encode(value, encoding);
+            } catch (UnsupportedEncodingException ex) {
+                throw new IllegalArgumentException(ex);
+            }
+        }
+        context.setOutputValue("result", value);
+    }
+
+    /**
+     * <p>
+     * This handler marks the response complete. This means that no additional response will be sent. This is useful if
+     * you've provided a response already and you don't want JSF to do it again (it may cause problems to do it 2x).
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "responseComplete")
+    public static void responseComplete(HandlerContext context) {
+        context.getFacesContext().responseComplete();
+    }
+
+    /**
+     * <p>
+     * This handler indicates to JSF that the request should proceed immediately to the render response phase. It will be
+     * ignored if rendering has already begun. This is useful if you want to stop processing and jump to the response. This
+     * is often the case when an error ocurrs or validation fails. Typically the page the user is on will be reshown
+     * (although if navigation has already occurred, the new page will be shown.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    @Handler(id = "renderResponse")
+    public static void renderResponse(HandlerContext context) {
+        context.getFacesContext().renderResponse();
+    }
+
+    /**
+     * <p>
+     * This handler gets the current system time in milliseconds. It may be used to time things.
+     * </p>
+     */
+    @Handler(id = "getDate", output = { @HandlerOutput(name = "time", type = Long.class) })
+    public static void getDate(HandlerContext context) {
+        context.setOutputValue("time", new java.util.Date().getTime());
+    }
+
+    /**
+     * <p>
+     * This method converts '&lt;' and '&gt;' characters into "&amp;lt;" and "&amp;gt;" in an effort to avoid HTML from
+     * being processed. This can be used to avoid &lt;script&gt; tags, or to show code examples which might include HTML
+     * characters. '&amp;' characters will also be converted to "&amp;amp;".
+     * </p>
+     */
+    @Handler(id = "htmlEscape", input = { @HandlerInput(name = "value", type = String.class, required = true) }, output = {
+            @HandlerOutput(name = "result", type = String.class) })
+    public static void htmlEscape(HandlerContext context) {
+        String value = (String) context.getInputValue("value");
+        value = Util.htmlEscape(value);
+        context.setOutputValue("result", value);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutDefinitionException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutDefinitionException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.TemplatingException;
+
+/**
+ * <p>
+ * This exception is thrown when a {@link LayoutDefinitionManager} is unable to locate a
+ * {@link com.sun.jsftemplating.layout.descriptors.LayoutDefinition}. This exception should not be used to indicate that
+ * a syntax error has occurred, see {@link SyntaxException}. This exception is meant for file not found, i/o problems,
+ * etc.
+ * </p>
+ */
+public class LayoutDefinitionException extends TemplatingException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     *
+     */
+    public LayoutDefinitionException(String msg, Throwable ex) {
+        super(msg, ex);
+    }
+
+    /**
+     *
+     */
+    public LayoutDefinitionException() {
+        super();
+    }
+
+    /**
+     *
+     */
+    public LayoutDefinitionException(Throwable ex) {
+        super(ex);
+    }
+
+    /**
+     *
+     */
+    public LayoutDefinitionException(String msg) {
+        super(msg);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutDefinitionManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutDefinitionManager.java
@@ -1,0 +1,1178 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.annotation.FormatDefinitionAP;
+import com.sun.jsftemplating.annotation.HandlerAP;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.UIComponentFactoryAP;
+import com.sun.jsftemplating.component.factory.basic.GenericFactory;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutComposition;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutInsert;
+import com.sun.jsftemplating.layout.descriptors.Resource;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.IODescriptor;
+import com.sun.jsftemplating.layout.facelets.DbFactory;
+import com.sun.jsftemplating.layout.facelets.NSContext;
+import com.sun.jsftemplating.layout.template.TemplateLayoutDefinitionManager;
+import com.sun.jsftemplating.util.FileUtil;
+import com.sun.jsftemplating.util.LogUtil;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * <p>
+ * This abstract class provides the base functionality for all <code>LayoutDefinitionManager</code> implementations. It
+ * provides a static method used to obtain an instance of a concrete <code>LayoutDefinitionManager</code>:
+ * {@link #getLayoutDefinitionManager(FacesContext,String)}. However, in most cases is makes the most sense to call the
+ * static method: {@link #getLayoutDefinition(FacesContext,String)}. This method ensures that the cache is checked first
+ * before going through the effort of finding a <code>LayoutDefinitionManager</code> instance.
+ * </p>
+ *
+ * <p>
+ * This class also provides access to global {@link HandlerDefinition}s, {@link Resource}s, and {@link ComponentType}s.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class LayoutDefinitionManager {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    protected LayoutDefinitionManager() {
+        super();
+    }
+
+    /**
+     * <p>
+     * This method is responsible for finding/creating the requested {@link LayoutDefinition}.
+     * </p>
+     *
+     * @param key The key used to identify the requested {@link LayoutDefinition}.
+     */
+    public abstract LayoutDefinition getLayoutDefinition(String key) throws LayoutDefinitionException;
+
+    /**
+     * <p>
+     * This method is used to determine if this <code>LayoutDefinitionManager</code> should process the given key. It does
+     * not necessarily mean that the <code>LayoutDefinitionManager</code> <em>can</em> process it. Parser errors do not
+     * necessarily mean that it should not process the file. In order to provide meaningful error messages, this method
+     * should return true if the format of the template matches the type that this <code>LayoutDefinitionManager</code>
+     * processes. It is understood that at times it may not be recognizable; in the case where no
+     * <code>LayoutDefinitionManager</code>s return <code>true</code> from this method, the parent <code>ViewHandler</code>
+     * will be used, which likely means that it will look for a .jsp and give error messages accordingly. Also, the
+     * existance of a file should not be used as a meassure of success as other <code>LayoutDefinitionManager</code>s may be
+     * more appropriate.
+     * </p>
+     */
+    public abstract boolean accepts(String key);
+
+    /**
+     * <p>
+     * This method should be used to obtain a {@link LayoutDefinition}. It first checks to see if a cached
+     * {@link LayoutDefinition} already exists, if so it returns it. If one does not already exist, it will obtain the
+     * appropriate <code>LayoutDefinitionManager</code> instance and call {@link #getLayoutDefinition} and return the
+     * result.
+     * </p>
+     */
+    public static LayoutDefinition getLayoutDefinition(FacesContext ctx, String key) throws LayoutDefinitionException {
+        // Determine the key we should use to cache this
+        String cacheKey = FileUtil.cleanUpPath(key.startsWith("/") ? key : FileUtil.getAbsolutePath(ctx, key));
+
+        // Check to see if we already have it.
+        LayoutDefinition def = getCachedLayoutDefinition(ctx, cacheKey);
+//System.out.println("GET LD (" + cacheKey + ", " + isDebug(ctx) + "):" + def);
+        if (def == null) {
+            // Obtain the correct LDM, and get the LD
+            def = getLayoutDefinitionManager(ctx, key).getLayoutDefinition(key);
+//System.out.println("  Found LD (" + cacheKey + ")?:" + def);
+            putCachedLayoutDefinition(ctx, cacheKey, def);
+        } else {
+            // In the case where we found a cached version,
+            // ensure we invoke "initPage" handlers
+            def.dispatchInitPageHandlers(ctx, def);
+        }
+// FIXME: Flag a page as *not found* for performance reasons when JSP is used (or other view technologies)
+
+        // Return the LD
+        return def;
+    }
+
+    /**
+     * <p>
+     * This method finds the (closest) requested <code>LayoutComponent</code> for the given <code>clientId</code>. If the
+     * <code>viewId</code> is not supplied, the current <code>UIViewRoot</code> will be used. If an exact match is not
+     * found, it will return the last {@link LayoutComponent} found while walking the tree -- this represents the last
+     * {@link LayoutComponent} in the hierarchy of the specified component. If nothing matches the given
+     * <code>clientId</code>, <code>null</code> will be returned.
+     * </p>
+     *
+     * <p>
+     * This is not an easy process since JSF components are not all <code>NamingContainer</code>s, so the
+     * <code>clientId</code> is not sufficient to find it. This is unfortunate, but we we deal with it.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param ldKey The {@link LayoutDefinition} key to identify the {@link LayoutDefinition} tree to be searched.
+     * @param clientId The component <code>clientId</code> for which to obtain a {@link LayoutComponent}.
+     */
+    public static LayoutComponent getLayoutComponent(FacesContext ctx, String ldKey, String clientId) throws LayoutDefinitionException {
+        // Find the page first...
+        LayoutElement layElt = null;
+        if (ldKey != null) {
+// FIXME: This fixme probably belongs in getLD(ctx, key): initPage should only be invoked if the page is accessed for the first time on the request.  This potentially calls it multiple times.
+            layElt = getLayoutDefinition(ctx, ldKey);
+            if (layElt == null) {
+                throw new LayoutDefinitionException("Unable to find LayoutDefinition ('" + ldKey + "')");
+            }
+        } else {
+            layElt = ViewRootUtil.getLayoutDefinition(FacesContext.getCurrentInstance().getViewRoot());
+        }
+
+        // Save the current LayoutComposition Stack
+        // - This is needed b/c we may be in the middle of walking the tree
+        // - already and we need ot use this Stack... so we must save the
+        // - Stack and use a fresh one. We must restore it later.
+        Stack<LayoutElement> oldStack = LayoutComposition.getCompositionStack(ctx);
+        try {
+            LayoutComposition.setCompositionStack(ctx, new Stack<>());
+
+            // Create a StringTokenizer over the clientId
+            StringTokenizer tok = new StringTokenizer(clientId, ":");
+
+            // Walk the LD looking for the individual id's specified in the
+            // clientId.
+            String id = null;
+            LayoutElement match = null;
+            while (tok.hasMoreTokens()) {
+                // I don't want to create a bunch of objects to check for
+                // instanceof NamingContainer. I can't check the class file
+                // b/c there is no way for me to know what class gets created
+                // before actually creating the UIComponent. This is because
+                // either the ComponentFactory can decide how to create the
+                // UIComponent, which it often uses the Application. The
+                // Application is driven off the faces-config.xml file(s).
+                //
+                // I will instead do a brute force search for a match. This
+                // has the potential to fail if non-naming containers have the
+                // same id's as naming containers. It may also fail for
+                // components with dynamic id's.
+                id = tok.nextToken();
+                match = findById(ctx, layElt, id);
+                if (match == null) {
+                    // Can't go any further! We're as close as we're getting.
+                    break;
+                }
+                layElt = match;
+            }
+        } finally {
+            // Restore the previous LayoutComposition Stack
+            LayoutComposition.setCompositionStack(ctx, oldStack);
+        }
+
+        // Make sure we're not still at the LayoutDefinition, if so do NOT
+        // accept this as a match.
+        if (layElt instanceof LayoutDefinition) {
+            layElt = null;
+        }
+
+        // Return the closest match (or null if nothing found)
+        return (LayoutComponent) layElt;
+    }
+
+    /**
+     * <p>
+     * This method performs a breadth-first search for a child {@link LayoutComponent} with the given <code>id</code> of the
+     * given {@link LayoutElement} (<code>elt</code>). It will return null if none of the children (or children's children,
+     * etc.) equal the given <code>id</code>.
+     * </p>
+     */
+    private static LayoutComponent findById(FacesContext ctx, LayoutElement elt, String id) {
+        boolean shouldPop = false;
+
+        // Check for special LE's
+        if (elt instanceof LayoutComposition) {
+            // We have a LayoutComposition, this includes another file... we
+            // need to look there as well.
+            String viewId = ((LayoutComposition) elt).getTemplate();
+            if (viewId != null) {
+                // Add LayoutComposition to the stack
+                LayoutComposition.push(ctx, elt);
+                shouldPop = true;
+
+                // Get the new LD to walk
+                try {
+                    elt = LayoutDefinitionManager.getLayoutDefinition(ctx, viewId);
+                } catch (LayoutDefinitionException ex) {
+                    if (((LayoutComposition) elt).isRequired()) {
+                        throw ex;
+                    }
+                }
+            }
+        } else if (elt instanceof LayoutInsert) {
+            // We found a LayoutInsert, this includes content from a previous
+            // file... we need to go back there and look now.
+        }
+
+        // First search the direct child LayoutElement
+        LayoutComponent comp = null;
+        for (LayoutElement child : elt.getChildLayoutElements()) {
+            // I am *NOT* providing the parent UIComponent as it may not be
+            // available, this function is *not* guaranteed to work for
+            // dynamic ids
+            if (child.getId(ctx, null).equals(id) && child instanceof LayoutComponent) {
+                // Found it!
+                comp = (LayoutComponent) child;
+            }
+        }
+
+        // Not found directly under it, search children...
+        // NOTE: Must do a breadth first search, so 2 loops are necessary
+        if (comp == null) {
+            for (LayoutElement child : elt.getChildLayoutElements()) {
+                comp = findById(ctx, child, id);
+                if (comp != null) {
+                    // Found it!
+                    break;
+                }
+            }
+        }
+
+        // Remove the LayoutComposition from the stack
+        if (shouldPop) {
+            LayoutComposition.pop(ctx);
+        }
+
+        // Return the result, or null if not found
+        return comp;
+    }
+
+    /**
+     * <p>
+     * This method obtains the <code>LayoutDefinitionManager</code> that is able to process the given <code>key</code>.
+     * </p>
+     *
+     * <p>
+     * This implementation uses the <code>ExternalContext</code>'s initParams to look for the
+     * <code>LayoutDefinitionManager</code> class. If it exists, the specified concrete <code>LayoutDefinitionManager</code>
+     * class will be used as the "default" (i.e. the first <code>LayoutDefinitionManager</code> checked).
+     * "{@link #LAYOUT_DEFINITION_MANAGER_KEY}" is the initParam key.
+     * </p>
+     *
+     * <p>
+     * The <code>key</code> is used to test if desired <code>LayoutDefinitionManager</code> is able to read the requested
+     * {@link LayoutDefinition}.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param key The desired {@link LayoutDefinition}.
+     * @see #LAYOUT_DEFINITION_MANAGER_KEY
+     */
+    public static LayoutDefinitionManager getLayoutDefinitionManager(FacesContext ctx, String key) throws LayoutDefinitionException {
+        List<String> ldms = getLayoutDefinitionManagers(ctx);
+//System.out.println("LDMS: " + ldms);
+        LayoutDefinitionManager mgr = null;
+        for (String className : ldms) {
+            mgr = getLayoutDefinitionManagerByClass(ctx, className);
+//System.out.println("LDM ("+className+"): " + mgr);
+            if (mgr.accepts(key)) {
+//System.out.println("Accepts!");
+                return mgr;
+            }
+        }
+        throw new LayoutDefinitionException("No LayoutDefinitionManager " + "available for '" + key + "'.  This may mean the file cannot "
+                + "be found, or is unrecognizable.");
+    }
+
+    /**
+     * <p>
+     * This method is responsible for returning a <code>List</code> of known <code>LayoutDefinitionManager</code> instances.
+     * Each value of the list is a <code>String</code> representing the classname of a <code>LayoutDefinitionManager</code>
+     * implementation.
+     * </p>
+     */
+    public static List<String> getLayoutDefinitionManagers(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        List<String> keys = null;
+        if (ctx != null) {
+            keys = (List<String>) ctx.getExternalContext().getApplicationMap().get(LDM_KEYS);
+        }
+        if (keys == null) {
+            // 1st time... initialize it
+            keys = new ArrayList<>();
+
+            // Check to see what the default should be...
+            if (ctx != null) {
+                Map initParams = ctx.getExternalContext().getInitParameterMap();
+                if (initParams.containsKey(LAYOUT_DEFINITION_MANAGER_KEY)) {
+                    keys.add(((String) initParams.get(LAYOUT_DEFINITION_MANAGER_KEY)).trim());
+                }
+            }
+
+            // Make "template" format the default (if none specified)
+            String tplFormat = TemplateLayoutDefinitionManager.class.getName();
+            if (!keys.contains(tplFormat)) {
+                keys.add(tplFormat);
+            }
+
+            try {
+                // Get all the files that define them
+                BufferedReader rdr = null;
+                InputStream is = null;
+                String line = null;
+                Enumeration<URL> urls = Util.getClassLoader(ctx).getResources(FormatDefinitionAP.FACTORY_FILE);
+                while (urls.hasMoreElements()) {
+                    // Add all lines in each file to the list of LDMs
+                    try {
+                        is = urls.nextElement().openStream();
+                        rdr = new BufferedReader(new InputStreamReader(is));
+                        for (line = rdr.readLine(); line != null; line = rdr.readLine()) {
+                            line = line.trim();
+
+                            if (line.equals("") || line.startsWith("#") || keys.contains(line)) {
+                                // Skip ones already added...
+                                continue;
+                            }
+
+                            // Add it!
+                            keys.add(line);
+                        }
+                    } finally {
+                        Util.closeStream(is);
+                    }
+                }
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+
+            if (ctx != null) {
+                // Save the result in Application Scope
+                ctx.getExternalContext().getApplicationMap().put(LDM_KEYS, keys);
+            }
+        }
+
+        // Return the LDM keys
+        return keys;
+    }
+
+    /**
+     * <p>
+     * This method is a singleton factory method for obtaining an instance of a <code>LayoutDefintionManager</code>. It is
+     * possible that multiple different implementations of <code>LayoutDefinitionManager</code>s will be used within the
+     * same application. This is OK. Someone may provide a different <code>LayoutDefinitionManager</code> to locate
+     * {@link LayoutDefinition}'s in a different way (XML, database, file, java code, new file format, etc.).
+     * </p>
+     */
+    public static LayoutDefinitionManager getLayoutDefinitionManagerByClass(FacesContext ctx, String className) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, LayoutDefinitionManager> ldms = null;
+        if (ctx != null) {
+            ldms = (Map<String, LayoutDefinitionManager>) ctx.getExternalContext().getApplicationMap().get(LDMS);
+        }
+        if (ldms == null) {
+            ldms = new HashMap<>(4);
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(LDMS, ldms);
+            }
+        }
+        LayoutDefinitionManager ldm = ldms.get(className);
+        if (ldm == null) {
+            try {
+                ldm = (LayoutDefinitionManager) Util.loadClass(className, className).getMethod("getInstance", (Class[]) null)
+                        .invoke((Object) null, (Object[]) null);
+            } catch (ClassNotFoundException ex) {
+                throw new LayoutDefinitionException("Unable to find LDM: '" + className + "'.", ex);
+            } catch (NoSuchMethodException ex) {
+                throw new LayoutDefinitionException("LDM '" + className + "' does not have a 'getInstance()' method!", ex);
+            } catch (IllegalAccessException ex) {
+                throw new LayoutDefinitionException("Unable to access LDM: '" + className + "'!", ex);
+            } catch (InvocationTargetException ex) {
+                throw new LayoutDefinitionException("Error while attempting " + "to get LDM: '" + className + "'!", ex);
+            } catch (ClassCastException ex) {
+                throw new LayoutDefinitionException("LDM '" + className + "' must extend from '" + LayoutDefinitionManager.class.getName()
+                        + " and must " + "be loaded from the same ClassLoader!", ex);
+            } catch (NullPointerException ex) {
+                throw new LayoutDefinitionException(ex);
+            }
+            ldms.put(className, ldm);
+        }
+        return ldm;
+    }
+
+    /**
+     * <p>
+     * This method may be used to obtain a cached {@link LayoutDefinition}. If it has not been cached, this method returns
+     * <code>null</code>.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param key Key for the cached {@link LayoutDefinition} to obtain.
+     *
+     * @return The {@link LayoutDefinition} or <code>null</code>.
+     */
+    private static LayoutDefinition getCachedLayoutDefinition(FacesContext ctx, String key) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        if (isDebug(ctx)) {
+            if (ctx != null) {
+                // Make sure we cache during the life of the request, even
+                // in Debug mode
+                return (LayoutDefinition) ctx.getExternalContext().getRequestMap().get(CACHE_PREFIX + key);
+            }
+
+            // Disable caching for debug mode
+            return null;
+        }
+
+        return getLayoutDefinitionMap(ctx).get(key);
+    }
+
+    /**
+     * <p>
+     * This method returns the LD Map which is stored in application scope. If it has not been created yet, it will be
+     * created as a <code>ConcurrentHashMap
+     * </p>
+     * .
+     */
+    private static Map<String, LayoutDefinition> getLayoutDefinitionMap(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, LayoutDefinition> ldMap = null;
+        if (ctx != null) {
+            ldMap = (Map<String, LayoutDefinition>) ctx.getExternalContext().getApplicationMap().get(LD_MAP);
+        }
+        if (ldMap == null) {
+            // 1st time... initialize it
+            // Consider using a SoftReference here...
+            ldMap = new ConcurrentHashMap<>(400, 0.75f, 2);
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(LD_MAP, ldMap);
+            }
+        }
+
+        // Return the map...
+        return ldMap;
+    }
+
+    /**
+     * <p>
+     * In general, this method should be used by sub-classes to store a cached {@link LayoutDefinition}. It may also be
+     * used, however, to define {@link LayoutDefinition}s on the fly (not recommended unless you know what you're doing. ;)
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param key The {@link LayoutDefinition} key to cache.
+     * @param value The {@link LayoutDefinition} to cache.
+     */
+    public static void putCachedLayoutDefinition(FacesContext ctx, String key, LayoutDefinition value) {
+//System.out.println("CACHING LD: " + key);
+        if (isDebug(ctx)) {
+            if (ctx != null) {
+                // Make sure we cache during the life of the request, even
+                // in Debug mode
+                ctx.getExternalContext().getRequestMap().put(CACHE_PREFIX + key, value);
+            }
+        } else {
+            getLayoutDefinitionMap(ctx).put(key, value);
+        }
+    }
+
+    /**
+     * <p>
+     * Retrieve an attribute by key.
+     * </p>
+     *
+     * @param key The key used to retrieve the attribute.
+     *
+     * @return The requested attribute or null
+     */
+    public Object getAttribute(String key) {
+        return _attributes.get(key);
+    }
+
+    /**
+     * <p>
+     * Associate the given key with the given Object as an attribute.
+     * </p>
+     *
+     * @param key The key associated with the given object (if this key is already in use, it will replace the previously
+     * set attribute object).
+     * @param value The Object to store.
+     */
+    public void setAttribute(String key, Object value) {
+        _attributes.put(key, value);
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>Map</code> of global {@link ComponentType}s (the {@link ComponentType}s available
+     * across the application).
+     * </p>
+     *
+     * <p>
+     * It is recommended that this method not be used directly. The map returned by this method is shared across the
+     * application and is not thread safe. Instead access this Map via
+     * {@link LayoutDefinitionManager#getGlobalComponentType(FacesContext, String)}.
+     * </p>
+     *
+     * <p>
+     * This method will initialize the global {@link ComponentType}s if they are not initialized. It does this by finding
+     * all files in the classpath named: {@link UIComponentFactoryAPFactory#FACTORY_FILE}. It then reads each of these files
+     * (which must be <code>Properties</code> files) and stores each identifier / fully qualified classname as an entry in
+     * the <code>Map&lt;String, {@link ComponentType}&gt;</code>.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     */
+    public static Map<String, ComponentType> getGlobalComponentTypes(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, ComponentType> types = null;
+        if (ctx != null) {
+            types = (Map<String, ComponentType>) ctx.getExternalContext().getApplicationMap().get(CT_MAP);
+        }
+        if (types == null) {
+            // We haven't initialized the global ComponentTypes yet...
+            types = new ConcurrentHashMap<>(200, 0.75f, 2);
+            try {
+                Properties props = null;
+                URL url = null;
+                String id = null;
+                // Get all the properties files that define them
+                Enumeration<URL> urls = Util.getClassLoader(types).getResources(UIComponentFactoryAP.FACTORY_FILE);
+                while (urls.hasMoreElements()) {
+                    url = urls.nextElement();
+                    props = new Properties();
+                    // Load each Properties file
+                    InputStream is = null;
+                    try {
+                        is = url.openStream();
+                        props.load(is);
+                        for (Map.Entry<Object, Object> entry : props.entrySet()) {
+                            // Add each property entry (key, ComponentType)
+                            id = (String) entry.getKey();
+                            types.put(id, new ComponentType(id, (String) entry.getValue()));
+                        }
+                    } finally {
+                        Util.closeStream(is);
+                    }
+                }
+                readComponentsFromTaglibXml(types);
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+
+            // Save it for next time...
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(CT_MAP, types);
+            }
+        }
+
+        // Return all the global ComponentTypes
+        return types;
+    }
+
+    private static void readComponentsFromTaglibXml(Map<String, ComponentType> types) throws IOException {
+        Enumeration<URL> urls = Util.getClassLoader(types).getResources("META-INF/");
+        Set<URL> files = new HashSet<>();
+        while (urls.hasMoreElements()) {
+            URL url = urls.nextElement();
+            URLConnection conn = url.openConnection();
+            conn.setUseCaches(false);
+            conn.setDefaultUseCaches(false);
+
+            if (conn instanceof JarURLConnection) {
+                JarURLConnection jarConn = (JarURLConnection) conn;
+                JarFile jarFile = jarConn.getJarFile();
+                Enumeration<JarEntry> entries = jarFile.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    String entryName = entry.getName();
+                    if (entryName.startsWith("META-INF") && entryName.endsWith("taglib.xml")) {
+                        Enumeration<URL> e = Util.getClassLoader(types).getResources(entryName);
+                        while (e.hasMoreElements()) {
+                            files.add(e.nextElement());
+                        }
+                    }
+                }
+            } else {
+                // TODO: I have yet to hit this branch
+//        File dir = new File(url.getFile());
+//        String fileList[] = dir.list(new FilenameFilter() {
+//            public boolean accept(File file, String fileName) {
+//            return fileName.endsWith("taglib.xml");
+//            } });
+            }
+
+        }
+        if (files.size() > 0) {
+            for (URL url : files) {
+                processTaglibXml(url, types);
+            }
+        }
+    }
+
+    private static void processTaglibXml(URL url, Map<String, ComponentType> types) {
+        InputStream is = null;
+        try {
+            is = url.openStream();
+            DocumentBuilder builder = DbFactory.getInstance();
+            Document document = builder.parse(is);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            NSContext ns = new NSContext();
+            ns.addNamespace("f", "jakarta.faces.facelets");
+            // Although the following should work, XPath doesn't attempt to
+            // get the namespace when no namespace is supplied.
+            // ns.setDefaultNSURI("http://java.sun.com/JSF/Facelet");
+            xpath.setNamespaceContext(ns);
+
+            String nameSpace = xpath.evaluate("/f:facelet-taglib/f:namespace", document);
+
+            // Process <tag> elements
+            NodeList nl = (NodeList) xpath.evaluate("/f:facelet-taglib/f:tag", document, XPathConstants.NODESET);
+            for (int i = 0; i < nl.getLength(); i++) {
+                Node node = nl.item(i);
+                String tagName = xpath.evaluate("f:tag-name", node);
+                String componentType = xpath.evaluate("f:component/f:component-type", node);
+                String id = nameSpace + ":" + tagName;
+                types.put(id, new ComponentType(id, GenericFactory.class.getName(), componentType));
+            }
+        } catch (Exception e) {
+            if (LogUtil.severeEnabled()) {
+                LogUtil.severe(e.getMessage());
+            }
+            throw new RuntimeException(e);
+        } finally {
+            Util.closeStream(is);
+        }
+    }
+
+    /**
+     * <p>
+     * This method retrieves a globally defined {@link ComponentType} (a {@link ComponentType} available across the
+     * application).
+     * </p>
+     */
+    public static ComponentType getGlobalComponentType(FacesContext ctx, String typeID) {
+        return getGlobalComponentTypes(ctx).get(typeID);
+    }
+
+    /**
+     * <p>
+     * This method allows a global {@link ComponentType} to be added. This way of adding a global {@link ComponentType} is
+     * discouraged. Instead, you should use a <code>UIComponentFactory</code> annotation in each
+     * <code>ComponentFactory</code> and compile using "<code>apt</code>".
+     * </p>
+     */
+    public static void addGlobalComponentType(FacesContext ctx, ComponentType type) {
+        getGlobalComponentTypes(ctx).put(type.getId(), type);
+    }
+
+    /**
+     * <p>
+     * This method clears the cached global {@link ComponentType}s.
+     * </p>
+     */
+    public static void clearGlobalComponentTypes(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        if (ctx != null) {
+            ctx.getExternalContext().getApplicationMap().remove(CT_MAP);
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>Map</code> of global {@link HandlerDefinition}s (the {@link HandlerDefinition}s
+     * available across the application).
+     * </p>
+     *
+     * <p>
+     * It is recommended that this method not be used. The map returned by this method is shared across the application and
+     * is not thread safe. Instead get values from the Map via:
+     * {@link LayoutDefinitionManager#getGlobalHandlerDefinition(String)}.
+     * </p>
+     *
+     * <p>
+     * This method will initialize the global {@link HandlerDefinition}s if they are not initialized. It does this by
+     * finding all files in the classpath named: {@link HandlerAPFactory#HANDLER_FILE}. It then reads each file (which must
+     * be a valid <code>Properties</code> file) and stores the information for later retrieval.
+     * </p>
+     */
+    public static Map<String, HandlerDefinition> getGlobalHandlerDefinitions() {
+        return getGlobalHandlerDefinitions(HandlerAP.HANDLER_FILE);
+    }
+
+    /**
+     * <p>
+     * This method is the same as {@link #getGlobalHandlerDefinitions()}, however, it accepts the full name of the
+     * <code>Handler.map</code> to use. This allows different filenames to be used. It will only read the same
+     * <code>filename</code> one time, however, it will read all occurances of that file name (it calls
+     * <code>ClassLoader.getResources(filename)</code>
+     * </p>
+     */
+    public synchronized static Map<String, HandlerDefinition> getGlobalHandlerDefinitions(String filename) {
+        Map<String, HandlerDefinition> handlers = getApplicationHandlerDefinitions(null);
+        if (handlers.containsKey(filename)) {
+            // We've already done this, return the answer
+            return handlers;
+        }
+
+        // Copy the old ones while we modify it...
+        handlers = new HashMap<>(handlers);
+
+        // Add the 'filename' key as a flag that we've processed these
+        handlers.put(filename, NOOP_HD);
+
+        Properties props = null;
+        URL url = null;
+        try {
+            // Get all the properties files that define them
+            Enumeration<URL> urls = Util.getClassLoader(filename).getResources(filename);
+            InputStream is = null;
+            while (urls.hasMoreElements()) {
+                try {
+                    url = urls.nextElement();
+                    props = new Properties();
+                    // Load each Properties file
+                    is = url.openStream();
+                    props.load(is);
+                    for (Map.Entry<Object, Object> entry : props.entrySet()) {
+                        if (((String) entry.getKey()).endsWith(".class")) {
+                            // We will only process .class entries.
+                            readGlobalHandlerDefinition(handlers, (Map) props, entry);
+                        }
+                    }
+                } finally {
+                    Util.closeStream(is);
+                }
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        // Store the results in application scope...
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (ctx == null) {
+            System.out.println("#### FacesContext is null!");
+        }
+        ctx.getExternalContext().getApplicationMap().put(HD_MAP, handlers);
+
+        // return the complete Map
+        return handlers;
+    }
+
+    /**
+     * <p>
+     * This method returns the current application's {@link HandlerDefinition} <code>Map</code>.
+     * </p>
+     */
+    private static Map<String, HandlerDefinition> getApplicationHandlerDefinitions(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, HandlerDefinition> map = null;
+        if (ctx != null) {
+            map = (Map<String, HandlerDefinition>) ctx.getExternalContext().getApplicationMap().get(HD_MAP);
+        }
+        if (map == null) {
+            // Initialize it...
+            map = new HashMap<>();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(HD_MAP, map);
+            }
+        }
+
+        return map;
+    }
+
+    /**
+     * <p>
+     * This method processes a single {@link HandlerDefinition}'s meta-data.
+     * </p>
+     */
+    private static void readGlobalHandlerDefinition(Map<String, HandlerDefinition> hdMap, Map<String, String> props,
+            Map.Entry<Object, Object> entry) {
+        // Get the key.class value...
+        String key = (String) entry.getKey();
+        // Strip off .class
+        key = key.substring(0, key.lastIndexOf('.'));
+
+        // Create a new HandlerDefinition
+        HandlerDefinition def = new HandlerDefinition(key);
+
+        // Set the class / method
+        String value = props.get(key + '.' + "method");
+        def.setHandlerMethod((String) entry.getValue(), value);
+
+        // Read the input defs
+        def.setInputDefs(readIODefs(props, key, true));
+
+        // Read the output defs
+        def.setOutputDefs(readIODefs(props, key, false));
+
+        // Add the Handler...
+        hdMap.put(key, def);
+    }
+
+    /**
+     * <p>
+     * This method reads and creates IODescriptors for the given key.
+     * </p>
+     */
+    private static Map<String, IODescriptor> readIODefs(Map<String, String> map, String key, boolean input) {
+        String type;
+        String inOrOut = input ? "input" : "output";
+        int count = 0;
+        IODescriptor desc = null;
+        Map<String, IODescriptor> defs = new HashMap<>(5);
+        String value = map.get(key + "." + inOrOut + "[" + count + "].name");
+        while (value != null) {
+            // Get the type
+            type = map.get(key + "." + inOrOut + "[" + count + "].type");
+            if (type == null) {
+                type = DEFAULT_TYPE;
+            }
+
+            // Create an IODescriptor
+            desc = new IODescriptor(value, type);
+            defs.put(value, desc);
+
+            // If this is an output, we're done... for input we need to do more
+            if (input) {
+                // required?
+                value = map.get(key + "." + inOrOut + "[" + count + "].required");
+                if (value != null && Boolean.valueOf(value).booleanValue()) {
+                    desc.setRequired(true);
+                }
+
+                // default?
+                value = map.get(key + "." + inOrOut + "[" + count + "].defaultValue");
+                if (value != null && !value.equals(HandlerInput.DEFAULT_DEFAULT_VALUE)) {
+                    desc.setDefault(value);
+                }
+            }
+
+            // Look for next IO declaration
+            value = map.get(key + "." + inOrOut + "[" + (++count) + "].name");
+        }
+
+        return defs;
+    }
+
+    /**
+     * <p>
+     * This method retrieves a globally defined {@link HandlerDefinition} (a {@link HandlerDefinition} available across the
+     * application).
+     * </p>
+     */
+    public static HandlerDefinition getGlobalHandlerDefinition(String id) {
+        return getGlobalHandlerDefinitions().get(id);
+    }
+
+    /**
+     * <p>
+     * This method allows a global {@link HandlerDefinition} to be added. This way of adding a global
+     * {@link HandlerDefinition} is discouraged. It should be done implicitly through annotations, placement of a properties
+     * file in the correct location, or explicitly by declaring it the page (some template formats may not support this).
+     * </p>
+     *
+     * @see LayoutDefinitionManager#getGlobalHandlerDefinitions()
+     */
+    public static void addGlobalHandlerDefinition(HandlerDefinition def) {
+        synchronized (LayoutDefinitionManager.class) {
+            getGlobalHandlerDefinitions().put(def.getId(), def);
+        }
+    }
+
+    /**
+     * <p>
+     * This method clears cached global application {@link HandlerDefinition}s.
+     * </p>
+     */
+    public static void clearGlobalHandlerDefinitions(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        if (ctx != null) {
+            ctx.getExternalContext().getApplicationMap().remove(HD_MAP);
+        }
+    }
+
+    /**
+     * <p>
+     * This method provides a means to add an additional global {@link Resource} (a {@link Resource} that is available
+     * across the application). It is recommended that this not be done using this method, but instead by registering the
+     * global {@link Resource}. This can be done by... FIXME: TBD...
+     * </p>
+     */
+    public static void addGlobalResource(Resource res) {
+        getGlobalResources(null).add(res);
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>List</code> of global {@link Resource}s. The <code>List</code> returned should not be
+     * changed, it is the actual internal <code>List</code> that is shared across the application and it is not thread safe.
+     * </p>
+     *
+     * <p>
+     * This method will find global resources by... FIXME: TBD...
+     * </p>
+     */
+    public static List<Resource> getGlobalResources(FacesContext ctx) {
+// FIXME: TBD...
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        List<Resource> globalResources = null;
+        if (ctx != null) {
+            globalResources = (List<Resource>) ctx.getExternalContext().getApplicationMap().get(RES_MAP);
+        }
+        if (globalResources == null) {
+            globalResources = new CopyOnWriteArrayList<>();
+// FIXME: Find / Initialize resources...
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(RES_MAP, globalResources);
+            }
+        }
+
+        // Return the Resources List
+        return globalResources;
+    }
+
+    /**
+     * <p>
+     * This method clears the cached global {@link Resource}s.
+     * </p>
+     */
+    public static void clearGlobalResources(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        if (ctx != null) {
+            ctx.getExternalContext().getApplicationMap().remove(RES_MAP);
+        }
+    }
+
+    /**
+     * <p>
+     * Getter for the debug flag. This version of this method invokes the isDebug(FacesContext) method.
+     * </p>
+     */
+    public static boolean isDebug() {
+        return isDebug(null);
+    }
+
+    /**
+     * <p>
+     * Returns true if this application is running in debug-mode. Note, because this method may be called during
+     * initialization before it is able to properly deterimine if this flag has been set, it will not cache its
+     * determination if it does not find an explicit setting for this flag. This means you should always set this flag for
+     * best performance since not setting it will force it to be calculated on every request for this value.
+     * </p>
+     *
+     * <p>
+     * A <code>ServletContext</code> initialization paramter by the name of <code>{@link #DEBUG_FLAG}
+     *        ("com.sun.jsftemplating.DEBUG")</code> is the recommended means of setting this flag.
+     * </p>
+     */
+    public static boolean isDebug(FacesContext ctx) {
+        // Check Application Scope First...
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Object objVal = null;
+        if (ctx != null) {
+            objVal = ctx.getExternalContext().getApplicationMap().get(DEBUG_FLAG);
+            if (objVal != null) {
+                return (Boolean) objVal;
+            }
+        }
+
+        // Not found... next check for a system property...
+        String flag = System.getProperty(DEBUG_FLAG);
+        if (flag == null) {
+            if (ctx != null) {
+                flag = ctx.getExternalContext().getInitParameter(DEBUG_FLAG);
+            }
+        }
+
+        // Figure out what we have and save it if explicitly set...
+        boolean isDebug = false;
+        if (ctx != null && flag != null) {
+            // The environment may not be fully initialized, we don't want it
+            // to cache the value we may have incorrectly discovered... so only
+            // cache if found if explicitly found.
+            //
+            // Save it in application scope for easier resolution later...
+            isDebug = Boolean.parseBoolean(flag);
+            ctx.getExternalContext().getApplicationMap().put(DEBUG_FLAG, isDebug);
+        }
+
+        // Return the flag value...
+        return isDebug;
+    }
+
+    /**
+     * <p>
+     * Setter for the debug flag. Sets {@link #DEBUG_FLAG} equal to <code>flag</code> in application scope.
+     * </p>
+     */
+    public static void setDebug(FacesContext ctx, boolean flag) {
+        ctx.getExternalContext().getApplicationMap().put(DEBUG_FLAG, flag);
+    }
+
+    /**
+     * <p>
+     * This key stores the {@link HandlerDefinition}'s for this application.
+     * </p>
+     */
+    private static final String HD_MAP = "__jsft_HandlerDefs";
+
+    /**
+     * <p>
+     * This key stores the {@link LayoutDefinitionManager} instances for this application.
+     * </p>
+     */
+    private static final String LDMS = "__jsft_LayoutDefMgrs";
+
+    /**
+     * <p>
+     * This key stores the {@link LayoutDefinitionManager} class names for this application.
+     * </p>
+     */
+    private static final String LDM_KEYS = "__jsft_LayoutDefMgrKeys";
+
+    /**
+     * <p>
+     * This key stores the {@link LayoutDefinition} instances for this application.
+     * </p>
+     */
+    private static final String LD_MAP = "__jsft_LayoutDefMap";
+
+    /**
+     * <p>
+     * This key stores the {@link ComponentType} instances for this application.
+     * </p>
+     */
+    private static final String CT_MAP = "__jsft_ComponentTypeMap";
+
+    /**
+     * <p>
+     * This key stores the global {@link Resource} instances for this application.
+     * </p>
+     */
+    private static final String RES_MAP = "__jsft_ResourceMap";
+
+    /**
+     * <p>
+     * This map contains sub-class specific attributes that may be needed by specific implementations of
+     * <code>LayoutDefinitionManager</code>s. For example, setting an <code>EntityResolver</code> on a
+     * <code>LayoutDefinitionManager</code> that creates <code>LayoutDefinitions</code> from XML files.
+     * </p>
+     */
+    private Map<String, Object> _attributes = new HashMap<>();
+
+    /**
+     * <p>
+     * This <code>Map</code> holds global {@link ComponentType}s so they can be defined once and shared across the
+     * application.
+     * </p>
+     */
+    private static Map<String, ComponentType> _globalComponentTypes = null;
+
+    private static final HandlerDefinition NOOP_HD = new HandlerDefinition("_NOOP_");
+
+    /**
+     * <p>
+     * This is the default input and output type.
+     * </p>
+     */
+    public static final String DEFAULT_TYPE = "Object";
+
+    /**
+     * <p>
+     * This constant defines the <code>LayoutDefinitionManager</code> implementation key for initParams.
+     * ("LayoutDefinitionManagerImpl")
+     * </p>
+     */
+    public static final String LAYOUT_DEFINITION_MANAGER_KEY = "LayoutDefinitionManagerImpl";
+
+    /**
+     * <p>
+     * This is the name of the initParameter or JVM variable used to set the DEBUG flag.
+     * </p>
+     */
+    public static final String DEBUG_FLAG = "com.sun.jsftemplating.DEBUG";
+
+    /**
+     * <p>
+     * This is the prefix of a request-scoped variable that caches {@link LayoutDefinition}s.
+     * </p>
+     */
+    public static final String CACHE_PREFIX = "_LDCache";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutStateManagementStrategy.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutStateManagementStrategy.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.ResponseStateManager;
+import jakarta.faces.view.StateManagementStrategy;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The state management strategy for the JSFT.
+ *
+ * @author Manfred Riem (manfred.riem@oracle.com)
+ */
+class LayoutStateManagementStrategy extends StateManagementStrategy {
+
+    /**
+     * Stores the class map.
+     */
+    private final Map<String, Class<?>> classMap;
+
+    /**
+     * Constructor.
+     */
+    public LayoutStateManagementStrategy() {
+        this.classMap = new ConcurrentHashMap<>(32);
+    }
+
+    /**
+     * Capture the child.
+     *
+     * @param tree the tree
+     * @param parent the parent
+     * @param component the component
+     */
+    private void captureChild(List<TreeNode> tree, int parent, UIComponent component) {
+        if (!component.isTransient()) {
+            TreeNode treeNode = new TreeNode(parent, component);
+            int position = tree.size();
+            tree.add(treeNode);
+            captureRest(tree, position, component);
+        }
+    }
+
+    /**
+     * Capture the facet.
+     *
+     * @param tree the tree
+     * @param parent the parent
+     * @param name the facet name
+     * @param component the component
+     */
+    private void captureFacet(List<TreeNode> tree, int parent, String name, UIComponent component) {
+        if (!component.isTransient()) {
+            FacetNode facetNode = new FacetNode(parent, name, component);
+            int position = tree.size();
+            tree.add(facetNode);
+            captureRest(tree, position, component);
+        }
+    }
+
+    /**
+     * Capture the rest.
+     *
+     * @param tree the tree
+     * @param position the position
+     * @param component the component
+     */
+    private void captureRest(List<TreeNode> tree, int position, UIComponent component) {
+        int size = component.getChildCount();
+        if (size > 0) {
+            List<UIComponent> children = component.getChildren();
+            for (int i = 0; i < size; i++) {
+                captureChild(tree, position, children.get(i));
+            }
+        }
+
+        size = component.getFacetCount();
+        if (size > 0) {
+            for (Map.Entry<String, UIComponent> facetEntry : component.getFacets().entrySet()) {
+                captureFacet(tree, position, facetEntry.getKey(), facetEntry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Create a new component instance.
+     *
+     * @param treeNode the tree node
+     * @return the UI component
+     * @throws FacesException when a serious error occurs
+     */
+    private UIComponent createComponent(TreeNode treeNode) throws FacesException {
+        try {
+            Class<?> componentClass = classMap.get(treeNode.componentType);
+            if (componentClass == null) {
+                componentClass = Util.loadClass(treeNode.componentType, treeNode);
+                classMap.put(treeNode.componentType, componentClass);
+            }
+
+            UIComponent component = (UIComponent) componentClass.getDeclaredConstructor().newInstance();
+            component.setId(treeNode.id);
+
+            return component;
+        } catch (ReflectiveOperationException e) {
+            throw new FacesException(e);
+        }
+    }
+
+    /**
+     * Restore the component tree.
+     *
+     * @param renderKitId the render kit identifier
+     * @param tree the saved tree
+     * @return the view root
+     * @throws FacesException when a serious error occurs
+     */
+    private UIViewRoot restoreTree(FacesContext facesContext, String renderKitId, Object[] tree) throws FacesException {
+        UIComponent component;
+        FacetNode facetNode;
+        TreeNode treeNode;
+        for (int i = 0; i < tree.length; i++) {
+            if (tree[i] instanceof FacetNode) {
+                facetNode = (FacetNode) tree[i];
+                component = createComponent(facetNode);
+                tree[i] = component;
+                if (i != facetNode.getParent()) {
+                    ((UIComponent) tree[facetNode.getParent()]).getFacets().put(facetNode.facetName, component);
+                }
+
+            } else {
+                treeNode = (TreeNode) tree[i];
+                component = createComponent(treeNode);
+                tree[i] = component;
+                if (i != treeNode.parent) {
+                    ((UIComponent) tree[treeNode.parent]).getChildren().add(component);
+                } else {
+                    UIViewRoot viewRoot = (UIViewRoot) component;
+                    facesContext.setViewRoot(viewRoot);
+                    viewRoot.setRenderKitId(renderKitId);
+                }
+            }
+        }
+        return (UIViewRoot) tree[0];
+    }
+
+    /**
+     * Restore the view.
+     *
+     * @param facesContext the Faces context
+     * @param viewId the view id
+     * @param renderKitId the render kit identifier
+     * @return the view root
+     */
+    @Override
+    public UIViewRoot restoreView(FacesContext facesContext, String viewId, String renderKitId) {
+        UIViewRoot viewRoot = null;
+
+        ResponseStateManager responseStateManager = RenderKitUtil.getRenderKit(facesContext, renderKitId).getResponseStateManager();
+        Object[] state = (Object[]) responseStateManager.getState(facesContext, viewId);
+
+        if (state != null && state.length >= 2) {
+            /*
+             * Restore the component tree.
+             */
+            if (state[0] != null) {
+                viewRoot = restoreTree(facesContext, renderKitId, ((Object[]) state[0]).clone());
+                facesContext.setViewRoot(viewRoot);
+            }
+            /*
+             * Restore the component state.
+             */
+            if (viewRoot != null && state[1] != null) {
+                viewRoot.processRestoreState(facesContext, state[1]);
+            }
+        }
+
+        return viewRoot;
+    }
+
+    /**
+     * Save the view.
+     *
+     * @param facesContext the Faces context
+     * @return the saved view
+     */
+    @Override
+    public Object saveView(FacesContext facesContext) {
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+
+        /*
+         * Check uniqueness.
+         */
+        checkIdUniqueness(facesContext, viewRoot, new HashSet<>(viewRoot.getChildCount() << 1));
+
+        /*
+         * Save the component state.
+         */
+        Object state = viewRoot.processSaveState(facesContext);
+
+        /*
+         * Save the tree structure.
+         */
+        List<TreeNode> treeList = new ArrayList<>(32);
+        captureChild(treeList, 0, viewRoot);
+        Object[] tree = treeList.toArray();
+
+        return new Object[] { tree, state };
+    }
+
+    /**
+     * Utility method to validate id uniqueness for the tree represented by {@code component}.
+     *
+     * @param facesContext the Faces context
+     * @param component the component represents a tree
+     * @param componentIds the component ids to be validated
+     */
+    private static void checkIdUniqueness(FacesContext facesContext, UIComponent component, Set<String> componentIds) {
+        // Deal with children/facets that are marked transient.
+        for (Iterator<UIComponent> children = component.getFacetsAndChildren(); children.hasNext();) {
+            UIComponent child = children.next();
+            // Check for id uniqueness
+            String componentId = child.getClientId(facesContext);
+            if (componentIds.add(componentId)) {
+                checkIdUniqueness(facesContext, child, componentIds);
+            } else {
+                throw new IllegalStateException("Duplicate component id found in view: " + componentId);
+            }
+        }
+    }
+
+    /**
+     * Inner class used to store a facet in the saved component tree.
+     */
+    private static final class FacetNode extends TreeNode {
+
+        /**
+         * Stores the serial version UID.
+         */
+        private static final long serialVersionUID = -3777170310958005106L;
+
+        /**
+         * Stores the facet name.
+         */
+        private String facetName;
+
+        /**
+         * Constructor.
+         */
+        public FacetNode() {
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param parent the parent
+         * @param name the facet name
+         * @param component the component
+         */
+        public FacetNode(int parent, String name, UIComponent component) {
+            super(parent, component);
+            facetName = name;
+        }
+
+        /**
+         * Read the facet node in.
+         *
+         * @param in the object input
+         * @throws IOException when an I/O error occurs
+         * @throws ClassNotFoundException when the class could not be found
+         */
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            super.readExternal(in);
+            facetName = in.readUTF();
+        }
+
+        /**
+         * Write the facet node out.
+         *
+         * @param out the object output
+         * @throws IOException when an I/O error occurs
+         */
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            super.writeExternal(out);
+            out.writeUTF(facetName);
+        }
+    }
+
+    /**
+     * Inner class used to store a node in the saved component tree.
+     */
+    private static class TreeNode implements Externalizable {
+
+        /**
+         * Stores the serial version UID.
+         */
+        private static final long serialVersionUID = -835775352718473281L;
+        /**
+         * Stores the NULL_ID constant.
+         */
+        private static final String NULL_ID = "";
+
+        /**
+         * Stores the component type.
+         */
+        private String componentType;
+
+        /**
+         * Stores the id.
+         */
+        private String id;
+
+        /**
+         * Stores the parent.
+         */
+        private int parent;
+
+        /**
+         * Constructor.
+         */
+        public TreeNode() {
+        }
+
+        /**
+         * Constructor.
+         *
+         * @param parent the parent
+         * @param component the component
+         */
+        public TreeNode(int parent, UIComponent component) {
+            this.parent = parent;
+            this.id = component.getId();
+            this.componentType = component.getClass().getName();
+
+        }
+
+        /**
+         * Read the tree node in.
+         *
+         * @param in the object input
+         * @throws IOException when an I/O error occurs
+         * @throws ClassNotFoundException when the class could not be found
+         */
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            parent = in.readInt();
+            componentType = in.readUTF();
+            id = in.readUTF();
+            if (id.length() == 0) {
+                id = null;
+            }
+        }
+
+        /**
+         * Write the tree node out.
+         *
+         * @param out the object output
+         * @throws IOException when an I/O error occurs
+         */
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeInt(parent);
+            out.writeUTF(componentType);
+            out.writeUTF(Objects.requireNonNullElse(id, NULL_ID));
+        }
+
+        public int getParent() {
+            return parent;
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutStateManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutStateManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import jakarta.faces.application.StateManager;
+import jakarta.faces.application.StateManagerWrapper;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.util.Objects;
+
+/**
+ * {@inheritDoc}
+ */
+public class LayoutStateManager extends StateManagerWrapper {
+
+    public LayoutStateManager(StateManager wrapped) {
+        super(wrapped);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getViewState(FacesContext facesContext) {
+        Objects.requireNonNull(facesContext);
+
+        Object savedView = null;
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+        if (viewRoot != null && !viewRoot.isTransient()) {
+            if (ViewRootUtil.getLayoutDefinition(viewRoot) == null) {
+                // No layout definition, fall back to default behavior
+                return getWrapped().getViewState(facesContext);
+            } else {
+                savedView = StateManagerUtil.saveView(facesContext, viewRoot.getViewId());
+            }
+        }
+
+        return facesContext.getRenderKit().getResponseStateManager().getViewState(facesContext, savedView);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutViewHandler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/LayoutViewHandler.java
@@ -1,0 +1,860 @@
+/*
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.el.PageSessionResolver;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutComposition;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutFacet;
+import com.sun.jsftemplating.layout.descriptors.LayoutInsert;
+import com.sun.jsftemplating.layout.descriptors.Resource;
+import com.sun.jsftemplating.util.LogUtil;
+import com.sun.jsftemplating.util.SimplePatternMatcher;
+import com.sun.jsftemplating.util.TypeConversion;
+import com.sun.jsftemplating.util.TypeConverter;
+import com.sun.jsftemplating.util.UIComponentTypeConversion;
+import com.sun.jsftemplating.util.fileStreamer.Context;
+import com.sun.jsftemplating.util.fileStreamer.FacesStreamerContext;
+import com.sun.jsftemplating.util.fileStreamer.FileStreamer;
+
+import jakarta.faces.FactoryFinder;
+import jakarta.faces.application.StateManager;
+import jakarta.faces.application.ViewHandler;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.render.RenderKit;
+import jakarta.faces.render.RenderKitFactory;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+// FIXME: Things to consider:
+// FIXME:   - Should I attempt to clean up old unused UIComponents?
+// FIXME:   - f:view supported setting locale, I should too...
+
+/**
+ * This class provides a custom {@link ViewHandler} that is able to create and populate a {@link UIViewRoot} from a
+ * {@link LayoutDefinition}. This is often defined by an XML document, the default implementation's DTD is defined in
+ * {@code layout.dtd}.
+ *
+ * <p>
+ * Besides the default {@link ViewHandler} behavior, this class is responsible for using the given {@code viewId} as the
+ * {@link LayoutDefinition} key and setting it on the {@link UIViewRoot} that is created. It will obtain the
+ * {@link LayoutDefinition}, initialize the declared {@link Resource}s, and instantiate {@link UIComponent} tree using
+ * the {@link LayoutDefinition}'s declared {@link LayoutComponent} structure. During rendering, it delegates to the
+ * {@link LayoutDefinition}.
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutViewHandler extends ViewHandler {
+
+    /**
+     * This is the key that may be used to identify the clientId of the UIComponent that is to be updated via an Ajax
+     * request.
+     */
+    public static final String AJAX_REQ_KEY = "ajaxReq";
+
+    public static final String RESTORE_VIEW_ID = "_resViewID";
+
+    /**
+     * This is the default prefix that must be included on all requests for resources.
+     */
+    public static final String DEFAULT_RESOURCE_PREFIX = "/resource";
+
+    /**
+     * The name of the {@code context-param} to set the resource prefix.
+     */
+    public static final String RESOURCE_PREFIX = "com.sun.jsftemplating.RESOURCE_PREFIX";
+
+    /**
+     * This key can be used to override the encoding type used in your application.
+     */
+    public static final String ENCODING_TYPE = "com.sun.jsftemplating.ENCODING";
+
+    static final String AJAX_REQ_TARGET_KEY = "_ajaxReqTarget";
+
+    /**
+     * The name of the <code>context-param</code> to set the view mappings.
+     */
+    // TODO: should these keys be added to a new Class f.e. com.sun.jsftemplating.Keys?
+    private static final String VIEW_MAPPINGS = "com.sun.jsftemplating.VIEW_MAPPINGS";
+
+    private static final TypeConversion UICOMPONENT_TYPE_CONVERSION = new UIComponentTypeConversion();
+
+    private final ViewHandler oldViewHandler;
+    private Set<String> resourcePrefix;
+    private Collection<SimplePatternMatcher> viewMappings;
+
+    /*
+     * This is intended to initialize additional type conversions for the {@link TypeConverter}. These additional type
+     * conversions are typically specific to JSF or JSFTemplating. If you are reading this and want additional custom type
+     * conversions, bug Ken Paulsen to add an init event which will allow you to easily initialize your own type
+     * conversions.
+     */
+    static {
+        // Add type conversions by class
+        TypeConverter.registerTypeConversion(null, UIComponent.class, UICOMPONENT_TYPE_CONVERSION);
+        // Add type conversions by class name
+        TypeConverter.registerTypeConversion(null, UIComponent.class.getName(), UICOMPONENT_TYPE_CONVERSION);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param oldViewHandler The old {@link ViewHandler}.
+     */
+    public LayoutViewHandler(ViewHandler oldViewHandler) {
+        this.oldViewHandler = oldViewHandler;
+
+// FIXME: Fire an initializtion event, work out how to listen for this event
+
+        // This is added here to ensure that if the ViewHandler is reloaded in
+        // a running application, that handlers, ct's, and resources will get
+        // re-read. Ryan added a feature which may introduce this code path.
+        LayoutDefinitionManager.clearGlobalComponentTypes(null);
+        LayoutDefinitionManager.clearGlobalHandlerDefinitions(null);
+        LayoutDefinitionManager.clearGlobalResources(null);
+    }
+
+//    /**
+//     * Initialize the view for the request processing lifecycle. It is called at the beginning of the Restore View phase.
+//     */
+//     public void initView(FacesContext context) throws FacesException {
+//         // Not used yet... I left this here as a reminder that it is here
+//     }
+
+    /**
+     * This method is invoked when restoreView does not yield a {@link UIViewRoot} (initial requests and new pages).
+     *
+     * <p>
+     * This implementation should work with both {@link LayoutDefinition}-based pages as well as traditional JSF pages (or
+     * other frameworks).
+     */
+    @Override
+    public UIViewRoot createView(FacesContext facesContext, String viewId) {
+        // Check to see if this is a resource request
+        String resourcePath = getResourcePath(viewId);
+        if (resourcePath != null) {
+            // Serve Resource
+            return serveResource(facesContext, resourcePath);
+        }
+
+        // Check to see if jsftemplating should create the view
+        if (!this.isMappedView(viewId)) {
+            return oldViewHandler.createView(facesContext, viewId);
+        }
+
+        Locale locale = null;
+        String renderKitId = null;
+
+        // Use the locale from the previous view if is was one which will be
+        // the case if this is called from NavigationHandler. There wouldn't be
+        // one for the initial case.
+        if (facesContext.getViewRoot() != null) {
+            UIViewRoot oldViewRoot = facesContext.getViewRoot();
+            LayoutDefinition oldLayoutDefinition = ViewRootUtil.getLayoutDefinition(oldViewRoot);
+            if (oldLayoutDefinition != null && oldViewRoot.getViewId().equals(viewId)) {
+                // If you navigate to the page you are already on, JSF will
+                // re-create the UIViewRoot of the current page. The initPage
+                // event needs to be reset so that it will re-execute itself.
+                oldLayoutDefinition.setInitPageExecuted(facesContext, Boolean.FALSE);
+            }
+            locale = facesContext.getViewRoot().getLocale();
+            renderKitId = facesContext.getViewRoot().getRenderKitId();
+        }
+
+        // Create the View Root
+        UIViewRoot viewRoot = (UIViewRoot) facesContext.getApplication().createComponent(UIViewRoot.COMPONENT_TYPE);
+        viewRoot.setViewId(viewId);
+        ViewRootUtil.setLayoutDefinitionKey(viewRoot, viewId);
+
+        // If there was no locale from the previous view, calculate the locale
+        // for this view.
+        if (locale == null) {
+            locale = calculateLocale(facesContext);
+        }
+        viewRoot.setLocale(locale);
+
+        // Set the renderKit
+        if (renderKitId == null) {
+            renderKitId = calculateRenderKitId(facesContext);
+        }
+        viewRoot.setRenderKitId(renderKitId);
+
+        // Save the current View Root, temporarily set the new UIViewRoot so
+        // beforeCreate, afterCreate will function correctly
+        UIViewRoot currentViewRoot = facesContext.getViewRoot();
+
+        // Set the View Root to the new View Root
+        // NOTE: This must happen after return oldViewHandler.createView(...)
+        // NOTE2: However, we really want the UIViewRoot available during
+        // initPage events which are fired during
+        // getLayoutDefinition()... so we need to set this, then unset
+        // it if we go through oldViewHandler.createView(...)
+        facesContext.setViewRoot(viewRoot);
+
+        // Initialize Resources / Create Tree
+        LayoutDefinition layoutDefinition;
+        try {
+            layoutDefinition = ViewRootUtil.getLayoutDefinition(viewRoot);
+        } catch (LayoutDefinitionException ex) {
+            if (LogUtil.configEnabled()) {
+                LogUtil.config("JSFT0005", (Object) viewId);
+                if (LogUtil.finestEnabled()) {
+                    LogUtil.finest("File (" + viewId + ") not found!", ex);
+                }
+            }
+
+            // Restore original View Root, we set it prematurely
+            if (currentViewRoot != null) {
+// FIXME: Talk to Ryan about restoring the ViewRoot to null!!
+                facesContext.setViewRoot(currentViewRoot);
+            }
+
+// FIXME: Provide better feedback when no .jsf & no .jsp
+// FIXME: Difficult to tell at this stage if no .jsp is present
+
+            // Not found, delegate to old ViewHandler
+            return oldViewHandler.createView(facesContext, viewId);
+        } catch (RuntimeException ex) {
+            // Restore original View Root, we set it prematurely
+            if (currentViewRoot != null) {
+// FIXME: Talk to Ryan about restoring the ViewRoot to null!!
+                facesContext.setViewRoot(currentViewRoot);
+            }
+
+            // Allow error to be thrown (this isn't the normal code path)
+            throw ex;
+        }
+
+        // We need to do this again b/c an initPage handler may have changed
+        // the viewRoot
+        viewRoot = facesContext.getViewRoot();
+
+        // Check to make sure we found a LayoutDefinition and that the response isn't
+        // already finished (initPage could complete the response...
+        // i.e. during a redirect).
+        if (layoutDefinition != null && !facesContext.getResponseComplete()) {
+            // Ensure that our Resources are available
+            for (Resource resource : layoutDefinition.getResources()) {
+                // Just calling getResource() puts it in the Request scope
+                resource.getFactory().getResource(facesContext, resource);
+            }
+
+            // Get the Tree and pre-walk it
+            if (LayoutDefinitionManager.isDebug(facesContext)) {
+                // Make sure to reset all the client ids we're about to check
+                getClientIdMap(facesContext).clear();
+            }
+            buildUIComponentTree(facesContext, viewRoot, layoutDefinition);
+        }
+
+        // Restore the current UIViewRoot.
+        if (currentViewRoot != null) {
+            facesContext.setViewRoot(currentViewRoot);
+        }
+
+        // Return the populated UIViewRoot
+        return viewRoot;
+    }
+
+    /**
+     * Tests if the provided {@code viewId} matches one of the configured view-mappings. If no view-mappings are defined,
+     * all {@code viewId}s will match.
+     *
+     * @param viewId The {@code viewId} to be tested.
+     *
+     * @return {@code true} if the viewId matched or no view-mappings are defined, {@code false} otherwise.
+     * @since 1.2
+     */
+    private boolean isMappedView(String viewId) {
+        if (viewId == null) {
+            return false;
+        }
+        if (viewMappings == null) {
+            String initParam = FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap().get(VIEW_MAPPINGS);
+            viewMappings = SimplePatternMatcher.parseMultiPatternString(initParam, ";");
+        }
+        if (viewMappings.isEmpty()) {
+            return true;
+        }
+        for (SimplePatternMatcher mapping : viewMappings) {
+            if (mapping.matches(viewId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * If this is a resource request, this method will handle the request.
+     */
+    public static UIViewRoot serveResource(FacesContext facesContext, String resourcePath) {
+        // Mark the response complete so no more processing occurs
+        facesContext.responseComplete();
+
+        // Create dummy UIViewRoot
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setRenderKitId("dummy");
+
+        // Setup the FacesStreamerContext
+        Context facesStreamerContext = new FacesStreamerContext(facesContext);
+        facesStreamerContext.setAttribute(Context.FILE_PATH, resourcePath);
+
+        // Get the HttpServletResponse
+        Object response = facesContext.getExternalContext().getResponse();
+        HttpServletResponse httpServletResponse = null;
+        if (response instanceof HttpServletResponse) {
+            httpServletResponse = (HttpServletResponse) response;
+
+            // We have an HttpServlet response, do some extra stuff...
+            // Check the last modified time to see if we need to serve the resource
+            long lastModified = facesStreamerContext.getContentSource().getLastModified(facesStreamerContext);
+            if (lastModified != -1) {
+                long ifModifiedSince = ((HttpServletRequest) facesContext.getExternalContext().getRequest())
+                        .getDateHeader("If-Modified-Since");
+                // Round down to the nearest second for a proper compare
+                if (ifModifiedSince < lastModified / 1000 * 1000) {
+                    // A ifModifiedSince of -1 will always be less
+                    httpServletResponse.setDateHeader("Last-Modified", lastModified);
+                } else {
+                    // Set not modified header and complete response
+                    httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+                    return viewRoot;
+                }
+            }
+        }
+
+        // Stream the content
+        try {
+            FileStreamer.getFileStreamer(facesContext).streamContent(facesStreamerContext);
+        } catch (FileNotFoundException ex) {
+            if (LogUtil.infoEnabled()) {
+                LogUtil.info("JSFT0004", (Object) resourcePath);
+            }
+            if (httpServletResponse != null) {
+                try {
+                    httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+                } catch (IOException ioEx) {
+                    // Ignore
+                }
+            }
+        } catch (IOException ex) {
+            if (LogUtil.infoEnabled()) {
+                LogUtil.info("JSFT0004", (Object) resourcePath);
+                if (LogUtil.fineEnabled()) {
+                    LogUtil.fine("Resource (" + resourcePath + ") not available!", ex);
+                }
+            }
+// FIXME: send 404?
+        }
+
+        // Return dummy UIViewRoot to avoid NPE
+        return viewRoot;
+    }
+
+    /**
+     * Returns the current encoding type.
+     *
+     * @param facesContext The {@link FacesContext}.
+     */
+    public static String getEncoding(FacesContext facesContext) {
+        // Sanity check
+        if (facesContext == null) {
+            return null;
+        }
+
+        String encodingType = null;
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+        Map<String, Serializable> pageSession = PageSessionResolver.getPageSession(facesContext, viewRoot);
+        if (pageSession != null) {
+            // Check for page session
+            encodingType = (String) pageSession.get(ENCODING_TYPE);
+        }
+        if (encodingType == null || encodingType.isEmpty()) {
+            // Check for application level
+            encodingType = facesContext.getExternalContext().getInitParameter(ENCODING_TYPE);
+        }
+        if (encodingType == null || encodingType.isEmpty()) {
+            ExternalContext externalContext = facesContext.getExternalContext();
+            try {
+                ServletRequest request = (ServletRequest) externalContext.getRequest();
+                encodingType = request.getCharacterEncoding();
+            } catch (Exception ex) {
+                // Ignore
+            }
+            if (encodingType == null || encodingType.isEmpty()) {
+                // Default encoding type
+                encodingType = StandardCharsets.UTF_8.name();
+            }
+        }
+        return encodingType;
+    }
+
+    /**
+     * This method checks the given viewId and returns a the path to the requested resource if it refers to a resource.
+     * Resources are things like JavaScript files, images, etc. Basically anything that is not a JSF page that you'd like to
+     * serve up via the FacesServlet. Serving resources this way allows you to bundle the resources in a jar file, this is
+     * useful if you want to package up part of an app (or a JSF component) in a single file.
+     *
+     * <p>
+     * A request for a resource must be prefixed by the resource prefix, see @{link #getResourcePrefixes}. This prefix must
+     * also be mapped to the <code>FacesServlet</code> in order for this class to handle the request.
+     */
+    public String getResourcePath(String viewId) {
+        ExternalContext externalContext = FacesContext.getCurrentInstance().getExternalContext();
+        String servletPath = externalContext.getRequestServletPath();
+        for (String resourcePrefix : getResourcePrefixes()) {
+            if (servletPath.equals(resourcePrefix)) {
+                return externalContext.getRequestPathInfo();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * This method returns the prefix that a URL must contain in order to retrieve a "resource" through this
+     * {@link ViewHandler}.
+     *
+     * <p>
+     * The prefix itself does not manifest itself in the file system / classpath.
+     *
+     * <p>
+     * If the prefix is not set, then an init parameter (see {@link #RESOURCE_PREFIX}) will be checked. If that is still not
+     * specified, then the {@link #DEFAULT_RESOURCE_PREFIX} will be used.
+     */
+    public Set<String> getResourcePrefixes() {
+        if (resourcePrefix == null) {
+            HashSet<String> prefixes = new HashSet<>();
+            // Check to see if it's specified by a context param
+            // Get context parameter map (initParams in JSF are context params)
+            String initParam = FacesContext.getCurrentInstance().getExternalContext().getInitParameterMap().get(RESOURCE_PREFIX);
+            if (initParam != null) {
+                for (String prefix : initParam.split(",")) {
+                    prefixes.add(prefix.trim());
+                }
+            }
+            // Add default...
+            prefixes.add(DEFAULT_RESOURCE_PREFIX);
+            resourcePrefix = prefixes;
+        }
+        return resourcePrefix;
+    }
+
+    /**
+     * This method allows a user to set the resource prefix which will be checked to obtain a resource via this
+     * {@link ViewHandler}. Currently, only one prefix is supported. The prefix itself does not manifest itself in the file
+     * system / classpath.
+     */
+    public void setResourcePrefixes(Set<String> prefixes) {
+        resourcePrefix = prefixes;
+    }
+
+    /**
+     * This method iterates over the child {@link LayoutElement}s of the given {@code element} to create
+     * {@link UIComponent}s for each {@link LayoutComponent}.
+     *
+     * @param facesContext The {@link FacesContext}.
+     * @param parentComponent The parent {@link UIComponent} of the {@link UIComponent} to be found or created.
+     * @param layoutElement The {@link LayoutElement} driving everything.
+     */
+    public static void buildUIComponentTree(FacesContext facesContext, UIComponent parentComponent, LayoutElement layoutElement) {
+// FIXME: Consider processing *ALL* LayoutElements so that <if> and others
+// FIXME: have meaning when inside other components.
+        for (LayoutElement childLayoutElement : layoutElement.getChildLayoutElements()) {
+            if (childLayoutElement instanceof LayoutFacet) {
+                if (!((LayoutFacet) childLayoutElement).isRendered()) {
+                    // The contents of this should be a single UIComponent
+                    buildUIComponentTree(facesContext, parentComponent, childLayoutElement);
+                }
+                // NOTE: LayoutFacets that aren't JSF facets aren't
+                // NOTE: meaningful in this context
+            } else if (childLayoutElement instanceof LayoutComposition) {
+                LayoutComposition layoutComposition = (LayoutComposition) childLayoutElement;
+                String template = layoutComposition.getTemplate();
+                if (template != null) {
+                    // Add LayoutComposition to the stack
+                    LayoutComposition.push(facesContext, childLayoutElement);
+
+                    try {
+                        // Add the template here.
+                        buildUIComponentTree(facesContext, parentComponent,
+                                LayoutDefinitionManager.getLayoutDefinition(facesContext, template));
+                    } catch (LayoutDefinitionException ex) {
+                        if (((LayoutComposition) childLayoutElement).isRequired()) {
+                            throw ex;
+                        }
+                    }
+
+                    // Remove the LayoutComposition from the stack
+                    LayoutComposition.pop(facesContext);
+                } else {
+                    // In this case we don't have a template, so instead we
+                    // render the body
+                    buildUIComponentTree(facesContext, parentComponent, childLayoutElement);
+                }
+            } else if (childLayoutElement instanceof LayoutInsert) {
+                Stack<LayoutElement> compositionStack = LayoutComposition.getCompositionStack(facesContext);
+                if (compositionStack.empty()) {
+                    // No template-client found...
+                    // Is this supposed to do nothing? Or throw an exception?
+                    throw new IllegalArgumentException("'ui:insert' encountered, however, no " + "'ui:composition' was used!");
+                }
+
+                // Get associated UIComposition
+                String insertName = ((LayoutInsert) childLayoutElement).getName();
+                if (insertName == null) {
+                    // Include everything
+                    buildUIComponentTree(facesContext, parentComponent, compositionStack.get(0));
+                } else {
+                    // First resolve any EL in the insertName
+                    insertName = "" + ((LayoutInsert) childLayoutElement).resolveValue(facesContext, parentComponent, insertName);
+
+                    // Search for specific LayoutDefine
+                    LayoutElement layoutDefine = LayoutInsert.findLayoutDefine(facesContext, parentComponent, compositionStack, insertName);
+                    if (layoutDefine == null) {
+                        // Not found include the body-content of the insert
+                        buildUIComponentTree(facesContext, parentComponent, childLayoutElement);
+                    } else {
+                        // Found, include the ui:define content
+                        buildUIComponentTree(facesContext, parentComponent, layoutDefine);
+                    }
+                }
+            } else if (childLayoutElement instanceof LayoutComponent) {
+                // Calling getChild will add the child UIComponent to tree
+                UIComponent childComponent = ((LayoutComponent) childLayoutElement).getChild(facesContext, parentComponent);
+
+                if (LayoutDefinitionManager.isDebug(facesContext)) {
+                    // To help developer avoid duplicate ids, we'll check the ids here.
+                    Map<String, String> clientIdMap = getClientIdMap(facesContext);
+                    String clientId = childComponent.getClientId(facesContext);
+                    if (clientIdMap.containsKey(clientId)) {
+                        if (!((LayoutComponent) childLayoutElement).containsOption(LayoutComponent.SKIP_ID_CHECK)
+                                && LogUtil.warningEnabled()) {
+                            LogUtil.warning("JSFT0011", (Object) clientId);
+                        }
+
+                        // Clear the map as a way to prevent this message from
+                        // being shown tons of times as may occur in some
+                        // valid use cases. Remember this is just a debug-time
+                        // only helpful message anyway...
+                        clientIdMap.clear();
+                    }
+                    clientIdMap.put(clientId, clientId);
+                }
+
+                // Check for events
+                // NOTE: For now I am only supporting "action" and
+                // NOTE: "actionListener" event types. In the future it
+                // NOTE: may be desirable to support beforeEncode /
+                // NOTE: afterEncode as well. At this time, those events
+                // NOTE: are supported by the "Event" UIComponent. That
+                // NOTE: component can wrap non-layout-based components to
+                // NOTE: achieve this functionality (supporting that
+                // NOTE: functionality here will simply do the same thing
+                // NOTE: automatically).
+
+                // Recurse
+                buildUIComponentTree(facesContext, childComponent, childLayoutElement);
+            } else {
+                buildUIComponentTree(facesContext, parentComponent, childLayoutElement);
+            }
+        }
+    }
+
+    /**
+     * This method provides access to a {@link Map} of clientIds that have been used in this page.
+     */
+    private static Map<String, String> getClientIdMap(FacesContext facesContext) {
+        Map<String, Object> requestMap = facesContext.getExternalContext().getRequestMap();
+        @SuppressWarnings("unchecked")
+        Map<String, String> debugIdMap = (Map<String, String>) requestMap.get("__debugIdMap");
+        if (debugIdMap == null) {
+            debugIdMap = new HashMap<>();
+            requestMap.put("__debugIdMap", debugIdMap);
+        }
+        return debugIdMap;
+    }
+
+    /**
+     * Reconstructs the UIViewRoot.
+     */
+    @Override
+    public UIViewRoot restoreView(FacesContext facesContext, String viewId) {
+        Map<String, Object> requestMap = facesContext.getExternalContext().getRequestMap();
+        if (requestMap.get(RESTORE_VIEW_ID) == null) {
+            requestMap.put(RESTORE_VIEW_ID, viewId);
+        } else {
+            // This request has already been processed, it must be a forward()
+            return createView(facesContext, viewId);
+        }
+
+        // Perform default behavior...
+        if (!isMappedView(viewId)) {
+            return oldViewHandler.restoreView(facesContext, viewId);
+        }
+
+        UIViewRoot viewRoot = StateManagerUtil.restoreView(facesContext, viewId,
+                facesContext.getApplication().getViewHandler().calculateRenderKitId(facesContext));
+
+        // We can check for JSFT UIViewRoots by calling
+        // getLayoutDefinitionKey(root) as this will return null if not JSFT
+        if (viewRoot != null) {
+            String layoutDefinitionKey = ViewRootUtil.getLayoutDefinitionKey(viewRoot);
+            if (layoutDefinitionKey != null) {
+                // Set the View Root to the new viewRoot (needed for initPage)
+                // NOTE: See createView note about saving / restoring the
+                // NOTE: original UIViewRoot and issue with setting it to
+                // NOTE: (null). restoreView is less important b/c it is not
+                // NOTE: normally called by a developer or framework as
+                // NOTE: navigation rules will call createView. For this
+                // NOTE: reason, I am not resetting the UIViewRoot for now.
+                facesContext.setViewRoot(viewRoot);
+
+                // Call getLayoutDefinition() to ensure initPage events are
+                // fired, only do this for JSFT ViewRoots. Its good to call
+                // this after restoreView as we need the UIViewRoot available
+                // during initPage events. Formerly this was done during the
+                // ApplyRequestValuesPhase, however, I no longer have a custom
+                // UIViewRoot to use for this purpose, so I will do it here,
+                // which should be just as good.
+                LayoutDefinition layoutDefinition = ViewRootUtil.getLayoutDefinition(layoutDefinitionKey);
+
+                // While we're at it, we should call the LD decode() event so
+                // we can provide a page-level decode() functionality. This
+                // won't effect components in the page, or JSFT-based
+                // components.
+                layoutDefinition.decode(facesContext, viewRoot);
+            }
+        }
+
+        // Return the UIViewRoot
+        return viewRoot;
+    }
+
+    /**
+     * Perform whatever actions are required to render the response view to the response object associated with the current
+     * {@link FacesContext}.
+     */
+    @Override
+    public void renderView(FacesContext facesContext, UIViewRoot viewToRender) throws IOException {
+        // Make sure we have a def
+        LayoutDefinition layoutDefinition = ViewRootUtil.getLayoutDefinition(viewToRender);
+        if (layoutDefinition == null) {
+            // PartialRequest or No def, fall back to default behavior
+            oldViewHandler.renderView(facesContext, viewToRender);
+        } else {
+            // Start document
+            if (!facesContext.getPartialViewContext().isPartialRequest() || facesContext.getPartialViewContext().isRenderAll()) {
+                ResponseWriter responseWriter = setupResponseWriter(facesContext);
+                responseWriter.startDocument();
+
+                // Render content
+                layoutDefinition.encode(facesContext, viewToRender);
+
+                // End document
+                responseWriter.endDocument();
+            } else {
+                // NOTE: This "if" branch has been added to avoid the
+                // NOTE: start/endDocument calls being called 2x on PartialView
+                // NOTE: requests. JSF Issue #1307 has been filed to resolve
+                // NOTE: this correctly (assuming checking here is not
+                // NOTE: correct... which I do not feel that it is).
+                //
+                // Render content
+                layoutDefinition.encode(facesContext, viewToRender);
+            }
+        }
+    }
+
+    private static void renderComponent(FacesContext facesContext, UIComponent component) throws IOException {
+        if (!component.isRendered()) {
+            return;
+        }
+
+        component.encodeBegin(facesContext);
+        if (component.getRendersChildren()) {
+            component.encodeChildren(facesContext);
+        } else {
+            for (UIComponent childComponent : component.getChildren()) {
+                renderComponent(facesContext, childComponent);
+            }
+        }
+        component.encodeEnd(facesContext);
+    }
+
+    /**
+     *
+     */
+    private ResponseWriter setupResponseWriter(FacesContext facesContext) throws IOException {
+        ResponseWriter responseWriter = facesContext.getResponseWriter();
+        if (responseWriter != null) {
+            // It is already setup
+            return responseWriter;
+        }
+
+        ExternalContext externalContext = facesContext.getExternalContext();
+        ServletResponse response = (ServletResponse) externalContext.getResponse();
+
+        RenderKitFactory renderKitFactory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
+        RenderKit renderKit = renderKitFactory.getRenderKit(facesContext, facesContext.getViewRoot().getRenderKitId());
+
+        // See if the user (page author) specified a ContentType...
+        String contentTypeList = null;
+// FIXME: Provide a way for the user to specify this...
+// FIXME: Test multiple browsers against this code!!
+        String userContentType = "text/html";
+        if (userContentType != null && !userContentType.isEmpty()) {
+            // User picked this, use it...
+            response.setContentType(userContentType);
+        } else {
+            // No explicit Content-type, find best match...
+            contentTypeList = externalContext.getRequestHeaderMap().get("Accept");
+            if (contentTypeList == null) {
+                contentTypeList = "text/html;q=1.0";
+            }
+        }
+        String encodingType = getEncoding(facesContext);
+
+        externalContext.getSessionMap().put(ViewHandler.CHARACTER_ENCODING_KEY, encodingType);
+// FIXME: use the external context to set the character encoding, it is supported
+        response.setCharacterEncoding(encodingType);
+
+        responseWriter = renderKit.createResponseWriter(new OutputStreamWriter(response.getOutputStream(), encodingType), contentTypeList,
+                encodingType);
+        facesContext.setResponseWriter(responseWriter);
+        // Not setting the contentType here results in XHTML which formats differently
+        // than text/html in Mozilla.. even though the documentation claims this
+        // works, it doesn't (try viewing the Tree)
+        // response.setContentType("text/html");
+
+        // As far as I can tell JSF doesn't ever set the Content-type that it
+        // works so hard to calculate... This is the code we should be
+        // calling, however we can't do this yet
+        response.setContentType(responseWriter.getContentType());
+
+        return responseWriter;
+    }
+
+    /**
+     * Take any appropriate action to either immediately write out the current state information (by calling
+     * {@link StateManager#writeState}, or noting where state information should later be written.
+     *
+     * @param facesContext {@link FacesContext} for the current request
+     * @exception IOException if an input/output error occurs
+     */
+    @Override
+    public void writeState(FacesContext facesContext) throws IOException {
+        // Check to see if we should delegate back to the legacy ViewHandler
+        UIViewRoot viewRoot = facesContext.getViewRoot();
+// FIXME: For now I am treating "@all" Ajax requests as normal requests...
+// FIXME: Otherwise the view state is not written.
+        if (viewRoot == null
+                || facesContext.getPartialViewContext().isPartialRequest() && !facesContext.getPartialViewContext().isRenderAll()
+                || ViewRootUtil.getLayoutDefinition(viewRoot) == null) {
+            // Use old behavior...
+            oldViewHandler.writeState(facesContext);
+        } else {
+            // Because we pre-processed the ViewTree, we can just add it...
+            StateManager stateManager = facesContext.getApplication().getStateManager();
+
+            // New versions of JSF 1.2 changed the contract so that state is
+            // always written (client and server state saving)
+            Object savedView = StateManagerUtil.saveView(facesContext, facesContext.getViewRoot().getViewId());
+            if (savedView != null) {
+                stateManager.writeState(facesContext, savedView);
+            }
+        }
+    }
+
+    /**
+     * Return a URL suitable for rendering (after optional encoding performed by the {@code encodeResourceURL()} method of
+     * {@code ExternalContext} that selects the specified web application resource. If the specified path starts with a
+     * slash, it must be treated as context relative; otherwise, it must be treated as relative to the action URL of the
+     * current view.
+     *
+     * @param facesContext {@link FacesContext} for the current request
+     * @param resourcePath Resource path to convert to a URL
+     * @exception IllegalArgumentException If {@code viewId} is not valid for this {@link ViewHandler}.
+     */
+    @Override
+    public String getResourceURL(FacesContext facesContext, String resourcePath) {
+        return oldViewHandler.getResourceURL(facesContext, resourcePath);
+    }
+
+    @Override
+    public String getWebsocketURL(FacesContext facesContext, String channel) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    /**
+     * Return a URL suitable for rendering (after optional encoding performed by the {@code encodeActionURL()} method of
+     * {@code ExternalContext} that selects the specified view identifier.
+     *
+     * @param facesContext {@link FacesContext} for this request
+     * @param viewId View identifier of the desired view
+     * @exception IllegalArgumentException If {@code viewId} is not valid for this {@link ViewHandler}.
+     */
+    @Override
+    public String getActionURL(FacesContext facesContext, String viewId) {
+        return oldViewHandler.getActionURL(facesContext, viewId);
+    }
+
+    /**
+     * Returns an appropriate {@link Locale} to use for this and subsequent requests for the current client.
+     *
+     * @param facesContext {@link FacesContext} for the current request
+     * @exception NullPointerException if {@code context} is {@code null}
+     */
+    @Override
+    public Locale calculateLocale(FacesContext facesContext) {
+        return oldViewHandler.calculateLocale(facesContext);
+    }
+
+    /**
+     * Return an appropriate {@code renderKitId} for this and subsequent requests from the current client.
+     *
+     * <p>
+     * The default return value is {@link jakarta.faces.render.RenderKitFactory#HTML_BASIC_RENDER_KIT}.
+     *
+     * @param facesContext {@link FacesContext} for the current request.
+     */
+    @Override
+    public String calculateRenderKitId(FacesContext facesContext) {
+        return oldViewHandler.calculateRenderKitId(facesContext);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/ProcessingCompleteException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/ProcessingCompleteException.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+
+/**
+ * <p>
+ * This exception is thrown to signal the parser to stop processing.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ProcessingCompleteException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * The constructor.
+     * </p>
+     */
+    public ProcessingCompleteException(LayoutDefinition ld) {
+        super("Processing completed early.");
+        _layoutDef = ld;
+    }
+
+    /**
+     * <p>
+     * This method is here to prevent the superclass method from eating up time. This implementation does not require a
+     * stack trace. This method simply returns <code>this</code>.
+     * </p>
+     */
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+    /**
+     * <p>
+     * Accessor for the {@link LayoutDefinition} to be used.
+     * </p>
+     */
+    public LayoutDefinition getLayoutDefinition() {
+        return _layoutDef;
+    }
+
+    /**
+     * <p>
+     * This hold the {@link LayoutDefinition} which should be used as the result of processing the file.
+     * </p>
+     */
+    private LayoutDefinition _layoutDef = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/RenderKitUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/RenderKitUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.FactoryFinder;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.RenderKit;
+import jakarta.faces.render.RenderKitFactory;
+
+import java.util.Objects;
+
+/**
+ * Render kit utility class.
+ */
+final class RenderKitUtil {
+
+    private RenderKitUtil() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Returns the {@code RenderKit} for the specified {@code renderKitId}.
+     *
+     * @param facesContext the Face context
+     * @param renderKitId identifier of the render kit
+     * @return the render kit for the specified {@code renderKitId}
+     * @throws FacesException if an exception occurs while getting the render kit
+     */
+    public static RenderKit getRenderKit(FacesContext facesContext, String renderKitId) {
+        Objects.requireNonNull(facesContext);
+        Objects.requireNonNull(renderKitId);
+
+        RenderKit renderKit = facesContext.getRenderKit();
+
+        if (renderKit == null) {
+            RenderKitFactory renderKitFactory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
+            if (renderKitFactory == null) {
+                throw new FacesException("Unable to locate factory for " + FactoryFinder.RENDER_KIT_FACTORY);
+            }
+
+            renderKit = renderKitFactory.getRenderKit(facesContext, renderKitId);
+            if (renderKit == null) {
+                UIViewRoot viewRoot = facesContext.getViewRoot();
+                if (viewRoot != null) {
+                    viewRoot.setRenderKitId(RenderKitFactory.HTML_BASIC_RENDER_KIT);
+                }
+
+                renderKit = renderKitFactory.getRenderKit(facesContext, RenderKitFactory.HTML_BASIC_RENDER_KIT);
+                if (renderKit == null) {
+                    throw new FacesException("Unable to locate render kit instance for " + RenderKitFactory.HTML_BASIC_RENDER_KIT);
+                }
+            }
+        }
+
+        return renderKit;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/StateManagerUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/StateManagerUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import jakarta.faces.application.StateManager;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.StateManagementStrategy;
+import jakarta.faces.view.ViewDeclarationLanguage;
+
+import java.util.Map;
+
+/**
+ * View state management utility class.
+ */
+final class StateManagerUtil {
+
+    private StateManagerUtil() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Return an opaque {@code Object} containing sufficient information for this same instance to restore the state of the
+     * current {@code UIViewRoot} on a subsequent request. The returned object must implement {@code java.io.Serializable}.
+     * If there is no state information to be saved, return {@code null} instead.
+     *
+     * @param facesContext the Faces context
+     * @param viewId view identifier of the view to be saved
+     * @return the saved view, or {@code null}
+     */
+    public static Object saveView(FacesContext facesContext, String viewId) {
+        Map<Object, Object> contextAttributes = facesContext.getAttributes();
+        contextAttributes.put(StateManager.IS_SAVING_STATE, Boolean.TRUE);
+        try {
+            return getStateManagementStrategy(facesContext, viewId).saveView(facesContext);
+        } finally {
+            contextAttributes.remove(StateManager.IS_SAVING_STATE);
+        }
+    }
+
+    /**
+     * Restore the tree structure and the component state of the view for specified {@code viewId} and return the restored
+     * {@code UIViewRoot}. If there is no saved state information available for this {@code viewId}, return {@code null}
+     * instead.
+     *
+     * @param facesContext the Faces context
+     * @param viewId view identifier of the view to be restored
+     * @param renderKitId identifier of the render kit used to render this response. Must not be {@code null}
+     * @return the view root, or {@code null}
+     */
+    public static UIViewRoot restoreView(FacesContext facesContext, String viewId, String renderKitId) {
+        return getStateManagementStrategy(facesContext, viewId).restoreView(facesContext, viewId, renderKitId);
+    }
+
+    /**
+     * Returns a state management strategy for the given Faces context and view id.
+     *
+     * @param facesContext the Faces context
+     * @param viewId the view id
+     * @return a state management strategy corresponds {@code facesContext} and {@code viewId}
+     */
+    private static StateManagementStrategy getStateManagementStrategy(FacesContext facesContext, String viewId) {
+        StateManagementStrategy strategy = null;
+
+        ViewDeclarationLanguage vdl = facesContext.getApplication().getViewHandler().getViewDeclarationLanguage(facesContext, viewId);
+
+        if (vdl != null) {
+            strategy = vdl.getStateManagementStrategy(facesContext, viewId);
+        }
+
+        if (strategy == null) {
+            strategy = new LayoutStateManagementStrategy();
+        }
+
+        return strategy;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/SyntaxException.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/SyntaxException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.TemplatingException;
+
+/**
+ * <p>
+ * This exception is thrown when a syntax error has occurred. For i/o related exceptions, see
+ * {@link LayoutDefinitionException}.
+ * </p>
+ */
+public class SyntaxException extends TemplatingException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     *
+     */
+    public SyntaxException(String msg, Throwable ex) {
+        super(msg, ex);
+    }
+
+    /**
+     *
+     */
+    public SyntaxException() {
+        super();
+    }
+
+    /**
+     *
+     */
+    public SyntaxException(Throwable ex) {
+        super(ex);
+    }
+
+    /**
+     *
+     */
+    public SyntaxException(String msg) {
+        super(msg);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/ViewRootUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/ViewRootUtil.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * This class provides utility methods used by JSFT for working with <code>UIViewRoot</code> instances. JSFTemplating no
+ * longer provides its own <code>UIViewRoot</code>, in an effort to make integration with other frameworks more simple.
+ * The methods in this class perform operations such as setting the {@link LayoutDefinition} key on the
+ * <code>UIViewRoot</code> as an attribute. It also allows you go obtain the {@link LayoutDefinition} used by a specific
+ * instance of the <code>UIViewRoot</code>, or the current instance set in the <code>FacesContext</code>.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ViewRootUtil {
+
+    /**
+     * <p>
+     * Constructor. All methods are static, no need to instantiate this class.
+     * </p>
+     */
+    private ViewRootUtil() {
+    }
+
+    /**
+     * // FIXME: This method was originally from the LayoutViewRoot class (which // FIXME: extended UIViewRoot). This method
+     * allowed "decode" events to work // FIXME: on pages. I still need to replace this functionality w/o extending //
+     * FIXME: the UIViewRoot (if possible).
+     *
+     * <p>
+     * This method enables the decode event to work for pages.
+     * </p>
+     *
+     * <p>
+     * This method checks for Ajax requests and treats them differently than normal requests. It only decodes the targeted
+     * UIComponent (and its children), then invokes processApplication(), and finally renders a partial response (rendering
+     * change is actually handled by LayoutViewHandler).
+     * </p>
+     *
+     * <p>
+     * When decoding template-based components, this is handled by the TemplateRenderer. However, when dealing with pages,
+     * this is done here (TemplateRenderer is not involved to fire handlers).
+     * </p>
+     *
+     * <p>
+     * This method continues to delegate to the superclass after invoking any registered handlers.
+     * </p>
+     * public void processDecodes(FacesContext context) { // PartialTraversalViewRootHelper may call us in an attempt to
+     * call // super.processDecodes(), detect this... if (!(new
+     * RuntimeException().getStackTrace()[1].getClassName().equals(HELPER_NAME)) && !helper.processDecodes(context)) { //
+     * Request already handled... return; }
+     *
+     * // BEGIN EXPERIMENTAL CODE... ExternalContext extCtx = context.getExternalContext(); String targetId =
+     * extCtx.getRequestParameterMap().get(LayoutViewHandler.AJAX_REQ_KEY); if ((targetId != null) && !targetId.equals(""))
+     * { // Detected Ajax Request // This request will only process a sub-tree of the UIComponent // tree and return the
+     * cooresponding partial HTML
+     *
+     * // First find the Ajax target UIComponent target = findComponent(":"+targetId); if (target == null) { // FIXME: Log a
+     * warning message! // FIXME: Rework this so that the following 6 lines are duplicated LayoutDefinition def =
+     * getLayoutDefinition(context); if (def != null) { def.decode(context, this); } super.processDecodes(context); return;
+     * } extCtx.getRequestMap().put(LayoutViewHandler.AJAX_REQ_TARGET_KEY, target);
+     *
+     * // Process sub-tree (similar to immedate, no validation/update) target.processDecodes(context);
+     * processApplication(context);
+     *
+     * // Mark the context that the next phase should be RenderResponse context.renderResponse(); } else { // END
+     * EXPERIMENTAL CODE...
+     *
+     * LayoutDefinition def = getLayoutDefinition(context); if (def != null) { def.decode(context, this); }
+     * super.processDecodes(context); } }
+     */
+
+    /**
+     * <p>
+     * This method provides the ability to obtain a "child" <code>UIComponent</code> from this <code>UIViewRoot</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param id The <code>id</code> of <code>UIComponent</code> child.
+     *
+     * @return The requested <code>UIComponent</code> or null if not found. public UIComponent getChild(FacesContext
+     * context, String id) { if ((id == null) || (id.trim().equals(""))) { // No id, no LayoutComponent, nothing we can do.
+     * return null; }
+     *
+     * // We have an id, use it to search for an already-created child UIComponent childComponent =
+     * ComponentUtil.getInstance(context).findChild(this, id, id); if (childComponent != null) { return childComponent; }
+     *
+     * // If we're still here, then we need to create it... hopefully we have // a LayoutComponent to tell us how to do
+     * this! LayoutDefinition ld = getLayoutDefinition(context); if (ld == null) { // No LayoutDefinition to tell us how to
+     * create it... return null return null; }
+     *
+     * // Attempt to find a LayoutComponent matching the id LayoutElement elt =
+     * LayoutDefinition.getChildLayoutElementById(context, id, ld, this);
+     *
+     * // Create the child from the LayoutComponent return getChild(context, (LayoutComponent) elt); }
+     */
+
+    /**
+     * <p>
+     * This method provides the ability to obtain a "child" <code>UIComponent</code> from this <code>UIViewRoot</code>. If
+     * the child does not already exist, it will be created using the given {@link LayoutComponent} descriptor.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param descriptor The {@link LayoutComponent} for the <code>UIComponent</code> child.
+     *
+     * @return The requested <code>UIComponent</code>.
+     *
+     * @throws IllegalArgumentException if descriptor is null. public UIComponent getChild(FacesContext context,
+     * LayoutComponent descriptor) { UIComponent childComponent = null;
+     *
+     * // Sanity check if (descriptor == null) { throw new IllegalArgumentException("The LayoutComponent is null!"); }
+     *
+     * // First pull off the id from the descriptor String id = descriptor.getId(context, this); if ((id != null) &&
+     * !(id.trim().equals(""))) { // We have an id, use it to search for an already-created child childComponent =
+     * ComponentUtil.getInstance(context).findChild(this, id, id); if (childComponent != null) { return childComponent; } }
+     *
+     * // No id, or the component hasn't been created. In either case, we // create a new component (moral: always have an
+     * id)
+     *
+     * // Invoke "beforeCreate" handlers descriptor.beforeCreate(context, this);
+     *
+     * // Create UIComponent childComponent = ComponentUtil.getInstance(context).createChildComponent(context, descriptor,
+     * this);
+     *
+     * // Invoke "afterCreate" handlers descriptor.afterCreate(context, childComponent);
+     *
+     * // Return the newly created UIComponent return childComponent; }
+     */
+
+    /**
+     * <p>
+     * Returns the {@link LayoutDefinition} used by the given <code>UIViewRoot</code>. This method retrieves the
+     * {@link LayoutDefinition} key from the given <code>UIViewRoot</code> (or gets the current <code>UIViewRoot</code> from
+     * the <code>FacesContext</code> if the value passed in is <code>null</code>. It then invokes the overloaded method
+     * ({@link #getLayoutDefinition(String)}) with this key.
+     * </p>
+     *
+     * @param root The <code>UIViewRoot</code> to use.
+     *
+     * @return The {@link LayoutDefinition} for this <code>UIViewRoot</code>.
+     */
+    public static LayoutDefinition getLayoutDefinition(UIViewRoot root) throws LayoutDefinitionException {
+        if (root == null) {
+            // Default to the current UIViewRoot
+            root = FacesContext.getCurrentInstance().getViewRoot();
+        }
+        return root == null ? null : getLayoutDefinition(getLayoutDefinitionKey(root));
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutDefinition} for the given <code>key</code>. If the {@link LayoutDefinition} has
+     * already be retrieved during this request, it will be returned. Otherwise, it will ask the
+     * {@link LayoutDefinitionManager}.
+     * </p>
+     */
+    public static LayoutDefinition getLayoutDefinition(String key) throws LayoutDefinitionException {
+        // Make sure the key is not null
+        if (key == null) {
+            return null;
+        }
+
+        // Get the FacesContext
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        // Make sure we don't already have it...
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        LayoutDefinition ld = (LayoutDefinition) requestMap.get(LAYOUT_DEFINITION_KEY + key);
+        if (ld != null) {
+            return ld;
+        }
+
+        // Find it...
+        ld = LayoutDefinitionManager.getLayoutDefinition(context, key);
+
+        // Save the LayoutDefinition for future calls to this method
+        requestMap.put(LAYOUT_DEFINITION_KEY + key, ld);
+
+        // Return the LayoutDefinition (if found)
+        return ld;
+    }
+
+    /**
+     * <p>
+     * This method gets the {@link LayoutDefinition} key from the given <code>UIViewRoot</code>.
+     * </p>
+     */
+    public static String getLayoutDefinitionKey(UIViewRoot root) {
+        return (String) root.getAttributes().get(LAYOUT_DEFINITION_KEY);
+    }
+
+    /**
+     * <p>
+     * This method sets the {@link LayoutDefinition} key on the given <code>UIViewRoot</code>.
+     * </p>
+     */
+    public static void setLayoutDefinitionKey(UIViewRoot root, String key) {
+        root.getAttributes().put(LAYOUT_DEFINITION_KEY, key);
+    }
+
+    /**
+     * <p>
+     * This is the key to be used to store the {@link LayoutDefinition} on the <code>ViewRoot</code> in its attribute map.
+     * </p>
+     */
+    public static final String LAYOUT_DEFINITION_KEY = "_ldKey";
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/ComponentType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/ComponentType.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.component.factory.ComponentFactory;
+import com.sun.jsftemplating.util.Util;
+
+import java.io.Serializable;
+import java.util.Formatter;
+
+/**
+ * <p>
+ * This class holds information that describes a {@link LayoutComponent} type. It provides access to a
+ * {@link ComponentFactory} for instantiating an instance of a the <code>UIComponent</code> described by this
+ * descriptor. See the layout.dtd file for more information on how to declare types via XML.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ComponentType implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public ComponentType(String id, String factoryClass) {
+        if (id == null) {
+            throw new NullPointerException("'id' cannot be null!");
+        }
+        if (factoryClass == null) {
+            throw new NullPointerException("'factoryClass' cannot be null!");
+        }
+        _id = id;
+        _factoryClass = factoryClass;
+    }
+
+    public ComponentType(String id, String factoryClass, Serializable extraInfo) {
+        this(id, factoryClass);
+        this.setExtraInfo(extraInfo);
+    }
+
+    public String getId() {
+        return _id;
+    }
+
+    /**
+     * <p>
+     * This method provides access to the {@link ComponentFactory}.
+     * </p>
+     *
+     * @return The {@link ComponentFactory}.
+     */
+    public ComponentFactory getFactory() {
+        if (_factory == null) {
+            _factory = createFactory();
+        }
+        return _factory;
+    }
+
+    /**
+     * <p>
+     * This method creates a new factory.
+     * </p>
+     *
+     * @return The new {@link ComponentFactory}.
+     */
+    protected ComponentFactory createFactory() {
+        // Create it...
+        ComponentFactory factory = null;
+        try {
+            Class cls = Util.loadClass(_factoryClass, this);
+            factory = (ComponentFactory) cls.newInstance();
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
+        } catch (InstantiationException ex) {
+            throw new RuntimeException(ex);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        // Set the extraInfo if any...
+        if (_extraInfo != null) {
+            factory.setExtraInfo(_extraInfo);
+        }
+
+        // Return the new ComponentFactory
+        return factory;
+    }
+
+    /**
+     * <p>
+     * This method allows you to provide extra information that can be used to initialize a <code>ComponentType</code>. For
+     * example, if you wanted to pass in the JSF component type via the property, you could do that. That would allow 1
+     * factory class to instatiate multiple components based on the JSF component type. However, it would require a
+     * differnet <code>ComponentType</code> instance for each different JSF component type.
+     * </p>
+     */
+    public void setExtraInfo(Serializable extraInfo) {
+        _extraInfo = extraInfo;
+    }
+
+    /**
+     * <p>
+     * This method returns the extraInfo that was set for this <code>ComponentType</code>. This information will be passed
+     * to the {@link ComponentFactory} when it is first created. It will only be created 1 time, not each time a Component
+     * is created.
+     * </p>
+     */
+    public Serializable getExtraInfo() {
+        return _extraInfo;
+    }
+
+    /**
+     * <p>
+     * This <code>toString()</code> method produces information about this <code>ComponentType</code>.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        Formatter println = new Formatter();
+        println.format("%-30s  %s\n", _id, _factoryClass);
+        return println.toString();
+    }
+
+    /**
+     * <p>
+     * This is the id for the ComponentType.
+     * </p>
+     */
+    private String _id = null;
+
+    /**
+     * <p>
+     * This is a String className for the Factory.
+     * </p>
+     */
+    private String _factoryClass = null;
+
+    /**
+     * <p>
+     * The {@link ComponentFactory} that produces the desired <code>UIComponent</code>.
+     * </p>
+     */
+    private transient ComponentFactory _factory = null;
+
+    /**
+     * <p>
+     * Extra information associated with this ComponentType.
+     * </p>
+     */
+    private Serializable _extraInfo = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutAttribute.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutAttribute.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This class defines a LayoutAttribute. A LayoutAttribute provides a means to write an attribute for the current markup
+ * tag. A markup tag must be started, but not yet closed for this to work.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutAttribute extends LayoutElementBase implements LayoutElement {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public LayoutAttribute(LayoutElement parent, String name, String value, String property) {
+        super(parent, name);
+        _name = name;
+        _value = value;
+        _property = property;
+    }
+
+    /**
+     *
+     */
+    public String getName() {
+        return _name;
+    }
+
+    /**
+     *
+     */
+    public String getValue() {
+        return _value;
+    }
+
+    /**
+     *
+     */
+    public String getProperty() {
+        return _property;
+    }
+
+    /**
+     * <p>
+     * This method displays the text described by this component. If the text includes an EL expression, it will be
+     * evaluated. It returns false to avoid attempting to render children.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param component The <code>UIComponent</code>
+     *
+     * @return false
+     */
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        // Get the ResponseWriter
+        ResponseWriter writer = context.getResponseWriter();
+
+        // Render...
+        Object value = resolveValue(context, component, getValue());
+        if (value != null && !value.toString().trim().equals("")) {
+            String name = getName();
+            String prop = getProperty();
+            if (prop == null) {
+                // Use the name if property is not supplied
+                prop = name;
+            } else if (prop.equals("null")) {
+                prop = null;
+            }
+            writer.writeAttribute(name, value, prop);
+        }
+
+        // No children
+        return false;
+    }
+
+    private String _name = null;
+    private String _value = null;
+    private String _property = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutComponent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutComponent.java
@@ -1,0 +1,551 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.component.ChildManager;
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.component.TemplateComponent;
+import com.sun.jsftemplating.el.VariableResolver;
+import com.sun.jsftemplating.layout.LayoutViewHandler;
+import com.sun.jsftemplating.layout.ViewRootUtil;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.event.AfterCreateEvent;
+import com.sun.jsftemplating.layout.event.AfterEncodeEvent;
+import com.sun.jsftemplating.layout.event.BeforeCreateEvent;
+import com.sun.jsftemplating.layout.event.BeforeEncodeEvent;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class defines a <code>LayoutComponent</code>. A <code>LayoutComponent</code> describes a
+ * <code>UIComponent</code> to be instantiated. The method {@link #getType()} provides a {@link ComponentType}
+ * descriptor that is capable of providing a {@link com.sun.jsftemplating.component.factory.ComponentFactory} to perform
+ * the actual instantiation. This class also stores properties and facets (children) to be set on a newly instantiated
+ * instance.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutComponent extends LayoutElementBase implements LayoutElement {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public LayoutComponent(LayoutElement parent, String id, ComponentType type) {
+        super(parent, id);
+        _type = type;
+    }
+
+    /**
+     * <p>
+     * Accessor for type.
+     * </p>
+     */
+    public ComponentType getType() {
+        return _type;
+    }
+
+    /**
+     * <p>
+     * Determines if this component should be created even if there is already an existing <code>UIComponent</code>. It will
+     * "overwrite" the existing component if this property is true.
+     * </p>
+     */
+    public void setOverwrite(boolean value) {
+        _overwrite = value;
+    }
+
+    /**
+     * <p>
+     * Determines if this component should be created even if there is already an existing <code>UIComponent</code>. It will
+     * "overwrite" the existing component if this property is true.
+     * </p>
+     */
+    public boolean isOverwrite() {
+        return _overwrite;
+    }
+
+    /**
+     * <p>
+     * This method adds an option to the LayoutComponent. Options may be useful in constructing the LayoutComponent.
+     * </p>
+     *
+     * @param name The name of the option
+     * @param value The value of the option (may be List or String)
+     */
+    public void addOption(String name, Object value) {
+        _options.put(name, value);
+    }
+
+    /**
+     * <p>
+     * This method adds all the options in the given Map to the {@link LayoutComponent}. Options may be useful in
+     * constructing the {@link LayoutComponent}.
+     * </p>
+     *
+     * @param map The map of options to add.
+     */
+    public void addOptions(Map<String, Object> map) {
+        _options.putAll(map);
+    }
+
+    /**
+     * <p>
+     * Accessor method for an option. This method does not evaluate expressions.
+     * </p>
+     *
+     * @param name The option name to retrieve.
+     *
+     * @return The option value (List or String), or null if not found.
+     *
+     * @see #getEvaluatedOption(FacesContext, String, UIComponent)
+     */
+    public Object getOption(String name) {
+        return _options.get(name);
+    }
+
+    /**
+     * <p>
+     * Accessor method for an option. This method evaluates our own expressions (not JSF expressions).
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param name The option name to retrieve.
+     * @param component The <code>UIComponent</code> (may be null).
+     *
+     * @return The option value (List or String), or null if not found.
+     *
+     * @see #getOption(String)
+     */
+    public Object getEvaluatedOption(FacesContext ctx, String name, UIComponent component) {
+        // Get the option value
+        Object value = getOption(name);
+
+        // Invoke our own EL. This is needed b/c JSF's EL is designed for
+        // Bean getters only. It does not get CONSTANTS or pull data from
+        // other sources (such as session, request attributes, etc., etc.)
+        // Resolve our variables now because we cannot depend on the
+        // individual components to do this. We may want to find a way to
+        // make this work as a regular ValueExpression... but for
+        // now, we'll just resolve it here.
+        return VariableResolver.resolveVariables(ctx, this, component, value);
+    }
+
+    /**
+     * <p>
+     * This method returns true/false based on whether the given option name has been set.
+     * </p>
+     *
+     * @param name The option name to look for.
+     *
+     * @return true/false depending on whether the options exists.
+     */
+    public boolean containsOption(String name) {
+        return _options.containsKey(name);
+    }
+
+    /**
+     * <p>
+     * This method sets the Map of options.
+     * </p>
+     *
+     * @param options <code>Map</code> of options.
+     */
+    public void setOptions(Map<String, Object> options) {
+        _options = options;
+    }
+
+    /**
+     * <p>
+     * This method returns the options as a Map. This method does not evaluate expressions.
+     * </p>
+     *
+     * @return Map of options.
+     */
+    public Map<String, Object> getOptions() {
+        return _options;
+    }
+
+    /**
+     * <p>
+     * This method is overriden so that the correct UIComponent can be passed into the events. This is important so that
+     * correct component is searched for "instance" handlers.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param parent The <code>UIComponent</code>.
+     */
+    @Override
+    public void encode(FacesContext context, UIComponent parent) throws IOException {
+        if (!this.getClass().getName().equals(CLASS_NAME)) {
+            // The sub-classes of this component shouldn't use this method,
+            // this is a hack to allow them to use LayoutElementBase.encode
+            super.encode(context, parent);
+            return;
+        }
+
+        // If overwrite...
+        if (isOverwrite()) {
+// FIXME: shouldn't this do a replace, not a remove?  Otherwise the order may change
+            String id = getId(context, parent);
+            if (parent.getFacets().remove(id) == null) {
+                UIComponent child = ComponentUtil.getInstance(context).findChild(parent, id, null);
+                if (child != null) {
+                    // Not a facet, try child...
+                    parent.getChildren().remove(child);
+                }
+            }
+        }
+
+        // Display this UIComponent
+        // First find the UIComponent
+        UIComponent childComponent = null;
+        if (parent instanceof ChildManager) {
+            // If we have a ChildManager, take advantage of it...
+            childComponent = ((ChildManager) parent).getChild(context, this);
+        } else {
+            // Use local util method for finding / creating child component...
+            childComponent = getChild(context, parent);
+        }
+
+        dispatchHandlers(context, BEFORE_ENCODE, new BeforeEncodeEvent(childComponent));
+
+        // Add child components... (needs to be done here, LE's can't do it)
+        // Use check for instance of TC. If present we must instantiate its
+        // children as they were skipped when the tree was initially created.
+        if (parent instanceof TemplateComponent) {
+            // Only do this for TemplateRenderer use-cases (LayoutViewHandler
+            // does this for pages)
+            LayoutViewHandler.buildUIComponentTree(context, childComponent, this);
+        }
+
+        // Render the child UIComponent
+        encodeChild(context, childComponent);
+
+        // Invoke "after" handlers
+        dispatchHandlers(context, AFTER_ENCODE, new AfterEncodeEvent(childComponent));
+    }
+
+    /**
+     * <p>
+     * Although this method is part of the interface, it is not used b/c I overrode the encode() method which calls this
+     * method. This method does nothing except satisfy the compiler.
+     * </p>
+     */
+    @Override
+    public boolean encodeThis(FacesContext context, UIComponent parent) throws IOException {
+        return false;
+    }
+
+    /**
+     * <p>
+     * This method will find or create a <code>UIComponent</code> as described by this <code>LayoutComponent</code>
+     * descriptor. If the component already exists as a child or facet, it will be returned. If it creates a new
+     * <code>UIComponent</code>, it will typically be added to the given parent <code>UIComponent</code> as a facet (this
+     * actually depends on the factory that instantiates the <code>UIComponent</code>).
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param parent The <code>UIComponent</code> to serve as the parent to search and to store the new
+     * <code>UIComponent</code>.
+     *
+     * @return The <code>UIComponent</code> requested (found or newly created)
+     */
+    public UIComponent getChild(FacesContext context, UIComponent parent) {
+        UIComponent childComponent = null;
+
+        // First pull off the id from the descriptor
+        String id = this.getId(context, parent);
+
+        // We have an id, use it to search for an already-created child
+        ComponentUtil compUtil = ComponentUtil.getInstance(context);
+        childComponent = compUtil.findChild(parent, id, id);
+        if (childComponent != null) {
+            return childComponent;
+        }
+
+        // Invoke "beforeCreate" handlers
+        this.beforeCreate(context, parent);
+
+        // Create UIComponent
+        childComponent = compUtil.createChildComponent(context, this, parent);
+
+        // Invoke "afterCreate" handlers
+        this.afterCreate(context, childComponent);
+
+        // Return the newly created UIComponent
+        return childComponent;
+    }
+
+    /**
+     * <p>
+     * This method retrieves the Handlers for the requested type. But also includes any handlers that are associated with
+     * the instance (i.e. the UIComponent).
+     * </p>
+     *
+     * @param type The type of <code>Handler</code>s to retrieve.
+     * @param comp The associated <code>UIComponent</code> (or null).
+     *
+     * @return A List of Handlers.
+     */
+    @Override
+    public List<Handler> getHandlers(String type, UIComponent comp) {
+        // 1st get list of handlers for definition of this LayoutElement
+        List<Handler> handlers = null;
+
+        // Now check to see if there are any on the UIComponent
+        if (comp != null) {
+            List<Handler> instHandlers = (List<Handler>) comp.getAttributes().get(type);
+            if (instHandlers != null && instHandlers.size() > 0) {
+                // NOTE: Copy b/c this is <i>instance</i> + static
+                // Add the UIComponent instance handlers
+                handlers = new ArrayList<>(instHandlers);
+
+                List<Handler> defHandlers = getHandlers(type);
+                if (defHandlers != null) {
+                    // Add the LayoutElement "definition" handlers, if any
+                    handlers.addAll(getHandlers(type));
+                }
+            }
+        }
+        if (handlers == null) {
+            handlers = getHandlers(type);
+        }
+
+        return handlers;
+    }
+
+    /**
+     * <p>
+     * This method is invoked before the Component described by this LayoutComponent is created. This allows handlers
+     * registered for "beforeCreate" functionality to be invoked.
+     * </p>
+     *
+     * @param context The FacesContext
+     *
+     * @return The result of invoking the handlers (null by default)
+     */
+    public Object beforeCreate(FacesContext context, UIComponent parent) {
+        // Invoke "beforeCreate" handlers
+        return dispatchHandlers(context, BEFORE_CREATE, new BeforeCreateEvent(parent));
+    }
+
+    /**
+     * <p>
+     * This method is invoked after the Component described by this LayoutComponent is created. This allows handlers
+     * registered for "afterCreate" functionality to be invoked.
+     * </p>
+     *
+     * @param context The FacesContext
+     *
+     * @return The result of invoking the handlers (null by default)
+     */
+    public Object afterCreate(FacesContext context, UIComponent component) {
+        // Invoke "afterCreate" handlers
+        return dispatchHandlers(context, AFTER_CREATE, new AfterCreateEvent(component));
+    }
+
+    /**
+     * <p>
+     * This method returns true if the child should be added to the parent component as a facet. Otherwise, it returns false
+     * indicating that it should exist as a real child.
+     * </p>
+     *
+     * <p>
+     * This value is calculated every time this call is made to allow for the context in which the LayoutComponent exists to
+     * determine its value. If a {@link LayoutFacet} exists as a parent {@link LayoutElement}, or a <code>UIViewRoot</code>
+     * or {@link TemplateComponent} exists as the immediate parent, it will return the facet name that should be used.
+     * Otherwise, it will return <code>null</code>.
+     * </p>
+     *
+     * @param parent This is the parent UIComponent.
+     *
+     * @return The facet name if the UIComponent should be added as a facet.
+     */
+    public String getFacetName(UIComponent parent) {
+        String name = null;
+
+        // First check to see if this LC specifies a different facet name...
+        name = (String) getOption(FACET_NAME);
+        if (name != null && name.equals(getUnevaluatedId())) {
+            // No special facet name supplied, don't assume this is a facet yet
+            name = null;
+        }
+
+        // Next check to see if we are inside a LayoutFacet
+        if (name == null) {
+            LayoutElement parentElt = getParent();
+            while (parentElt != null) {
+                if (parentElt instanceof LayoutFacet) {
+                    // Inside a LayoutFacet, use its name... only if this facet
+                    // is a child of a LayoutComponent (otherwise, it is a
+                    // layout facet used for layout, not for defining a facet
+                    // of a UIComponent)
+                    if (LayoutElementUtil.isLayoutComponentChild(parentElt)) {
+                        name = parentElt.getUnevaluatedId();
+                    } else {
+                        name = getUnevaluatedId();
+                    }
+                    if (name == null) {
+                        name = "_noname";
+                    }
+                    break;
+                }
+                if (parentElt instanceof LayoutComponent) {
+                    // No need to process further, this is not a facet child
+                    return null;
+                }
+                parentElt = parentElt.getParent();
+            }
+        }
+
+        // If not found yet, check to see if we're at the top...
+        if (name == null) {
+            if (parent instanceof TemplateComponent) {
+                // We don't know if we are adding a child of a
+                // TemplateComponent from a page, or if the TemplateComponent
+                // itself has a child... if the TemplateComponent is driving
+                // the rendering process, then we want this to be a facet. If
+                // the page is adding a child to a TemplateComponent, we do
+                // not want this to be a facet.
+
+                // Look to see if the parent LayoutDefinition == the current
+                // LayoutDefinition. If so, we're "inside" a
+                // TemplateComponent, not a page.
+                FacesContext ctx = FacesContext.getCurrentInstance();
+                if (((TemplateComponent) parent).getLayoutDefinition(ctx) == getLayoutDefinition()) {
+                    name = getUnevaluatedId();
+                }
+            } else if (parent instanceof UIViewRoot && ViewRootUtil.getLayoutDefinition((UIViewRoot) parent) != null) {
+
+                // NOTE: Only set the name if its a JSFT ViewRoot
+                name = getUnevaluatedId();
+            }
+        }
+
+        // Return the result
+        return name;
+    }
+
+    /**
+     * <p>
+     * This method returns a flag that indicates if this <code>LayoutComponent</code> is nested (directly or indirectly)
+     * inside another <code>LayoutComponent</code>. This flag is used for such purposes as deciding if "instance" handlers
+     * are appropriate.
+     * </p>
+     *
+     * @return <code>true</code> if component is nested.
+     */
+    public boolean isNested() {
+        return _nested;
+    }
+
+    /**
+     * <p>
+     * This method sets the nested flag for this <code>LayoutComponent</code>. This method is commonly only called from code
+     * that constructs the tree of {@link LayoutElement} components.
+     * </p>
+     *
+     * @param value The boolean value.
+     */
+    public void setNested(boolean value) {
+        _nested = value;
+    }
+
+    /**
+     * <p>
+     * Component type
+     * </p>
+     */
+    private ComponentType _type = null;
+
+    /**
+     * <p>
+     * Determines if this component should be created even if there is already an existing <code>UIComponent</code>. It will
+     * "overwrite" the existing component if this property is true. Usually only applies when this is used within the
+     * context of a <code>Renderer</code>.
+     * </p>
+     */
+    private boolean _overwrite = false;
+
+    /**
+     * <p>
+     * Map of options.
+     * </p>
+     */
+    private Map<String, Object> _options = new HashMap<>();
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked to handle "afterCreate" functionality for this element.
+     * </p>
+     */
+    public static final String AFTER_CREATE = "afterCreate";
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked to handle "beforeCreate" functionality for this element.
+     * </p>
+     */
+    public static final String BEFORE_CREATE = "beforeCreate";
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked to handle "command" functionality for this element.
+     * </p>
+     */
+    public static final String COMMAND = "command";
+
+    /**
+     * <p>
+     * This defines the property key for specifying the facet name in which the component should be stored under in its
+     * parent UIComponent.
+     * </p>
+     */
+    public static final String FACET_NAME = "_facetName";
+
+    /**
+     * <p>
+     * This defines the attribute name on the tag that flags that duplicate ID's should not be checked for this component.
+     * If specified on a component, the check will be skipped, regardless of the value of the attribute. The attribute name
+     * is ("skipIdCheck").
+     * </p>
+     */
+    public static final String SKIP_ID_CHECK = "skipIdCheck";
+
+    public static final String CLASS_NAME = LayoutComponent.class.getName();
+
+    /**
+     * <p>
+     * The value of the nested property.
+     * </p>
+     */
+    private boolean _nested = false;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutComposition.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutComposition.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.event.EncodeEvent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This concept is borrowed from <a href="https://facelets.dev.java.net"> Facelets</a>. A composition delegates to a
+ * "template" which performs the layout for the content which exists in the body of this composition component. The
+ * composition may have {@link LayoutDefine}s to provide named blocks which the template may "insert" at the appropriate
+ * place.
+ * </p>
+ *
+ * <p>
+ * This {@link LayoutElement} implements the behavior not only for compositions, but also decorate, and include.
+ * </p>
+ *
+ * @author Jason Lee
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutComposition extends LayoutElementBase {
+    /**
+     * @param parent
+     * @param id
+     */
+    public LayoutComposition(LayoutElement parent, String id) {
+        super(parent, id);
+    }
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public LayoutComposition(LayoutElement parent, String id, boolean trimming) {
+        super(parent, id);
+        this.trimming = trimming;
+    }
+
+    /**
+     * <p>
+     * <code>true</code> if a template filename is required to resolve to a valid file. If the template filename is null,
+     * this property is not used. <code>false</code> if it should be ignored when the does not exist. The default is
+     * <code>true</code>.
+     * </p>
+     */
+    public boolean isRequired() {
+        boolean result = true;
+        if (required != null) {
+            Object answer = resolveValue(FacesContext.getCurrentInstance(), null, required);
+            if (answer != null) {
+                result = Boolean.parseBoolean(answer.toString());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * Setter for the template filename.
+     * </p>
+     */
+    public void setRequired(String required) {
+        this.required = required;
+    }
+
+    /**
+     * <p>
+     * Accessor for the template filename.
+     * </p>
+     */
+    public String getTemplate() {
+        Object result = resolveValue(FacesContext.getCurrentInstance(), null, template);
+        return result == null ? null : result.toString();
+    }
+
+    /**
+     * <p>
+     * Setter for the template filename.
+     * </p>
+     */
+    public void setTemplate(String template) {
+        this.template = template;
+    }
+
+    /**
+     * <p>
+     * <code>true</code> if all content outside of this LayoutComposition should be thrown away.
+     * </p>
+     */
+    public boolean isTrimming() {
+        return trimming;
+    }
+
+    /**
+     * <p>
+     * Setter for the trimming property.
+     * </p>
+     */
+    public void setTrimming(boolean trimming) {
+        this.trimming = trimming;
+    }
+
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        // The child LayoutElements for a LayoutComposition are consumed by
+        // the template. The LayoutElements consumed here is the template.
+        String templateName = getTemplate();
+        boolean result = true;
+        if (templateName == null) {
+            return result;
+        }
+
+        // Add this to the stack
+        LayoutComposition.push(context, this);
+
+        // Fire an encode event
+        dispatchHandlers(context, ENCODE, new EncodeEvent(component));
+
+        LayoutElement template = null;
+        try {
+            template = LayoutDefinitionManager.getLayoutDefinition(context, templateName);
+        } catch (LayoutDefinitionException ex) {
+            if (isRequired()) {
+                throw ex;
+            }
+
+            // If the template is optional ignore this error...
+        }
+
+        // Iterate over children
+        if (template != null) {
+            LayoutElement childElt = null;
+            Iterator<LayoutElement> it = template.getChildLayoutElements().iterator();
+            while (it.hasNext()) {
+                childElt = it.next();
+                childElt.encode(context, component);
+            }
+            result = false;
+        }
+
+        // Pop this from the stack
+        LayoutComposition.pop(context);
+
+        return result;
+    }
+
+    /**
+     * <p>
+     * This handler pushes a value onto the <code>LayoutComposition</code> <code>Stack</code>. In addition it puts any
+     * parameters that are defined into the global parameter <code>Map</code> so EL expressions can test to see if they may
+     * reference one a composition parameter. However, this <code>Map</code> should not be used to determine the value --
+     * instead the value should be obtained by looking through the Stack of compositions.
+     * </p>
+     */
+    public static void push(FacesContext context, LayoutElement comp) {
+        if (comp instanceof LayoutComposition) {
+            // This should be the case...
+            Map<String, Object> params = ((LayoutComposition) comp).getParameters();
+            if (params != null) {
+                // Get the request-scoped global param map...
+                Map<String, Object> globalParamMap = LayoutComposition.getGlobalParamMap(context);
+
+                // Iterate over the params in this LayoutComposition and add
+                // them to the global parameters that we're tracking. This
+                // will flatten the hierarchy for the parameter values... but
+                // that's ok, b/c we don't use this for obtaining the values
+                // (normally), we use it to quickly detect if there are values.
+                // We'll search the composition stack to actually obtain the
+                // values.
+                Iterator<Map.Entry<String, Object>> it = params.entrySet().iterator();
+                Map.Entry<String, Object> entry = null;
+                while (it.hasNext()) {
+                    entry = it.next();
+                    globalParamMap.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        getCompositionStack(context).push(comp);
+    }
+
+    /**
+     * <p>
+     * This handler pops a value off the <code>LayoutComposition</code> <code>Stack</code>.
+     * </p>
+     */
+    public static LayoutElement pop(FacesContext context) {
+        return getCompositionStack(context).pop();
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>Stack</code> used to keep track of the {@link LayoutComposition}s that are used.
+     * </p>
+     */
+    public static Stack<LayoutElement> getCompositionStack(FacesContext context) {
+        Map<String, Object> requestMap = context == null ? getTestMap() : context.getExternalContext().getRequestMap();
+        Stack<LayoutElement> stack = (Stack<LayoutElement>) requestMap.get(COMPOSITION_STACK_KEY);
+        if (stack == null) {
+            stack = new Stack<>();
+            requestMap.put(COMPOSITION_STACK_KEY, stack);
+        }
+        return stack;
+    }
+
+    /**
+     * <p>
+     * This method retrieves a Map from the request scope for storing ui:param NVPs. If the <code>Map</code> doesn't exist,
+     * it will be created.
+     * </p>
+     */
+    public static Map<String, Object> getGlobalParamMap(FacesContext context) {
+        // First get the requestMap
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        Map<String, Object> paramMap = (Map<String, Object>) requestMap.get(GLOBAL_PARAM_MAP_KEY);
+        if (paramMap == null) {
+            // Hasn't been created yet, create it
+            paramMap = new HashMap<>();
+            requestMap.put(GLOBAL_PARAM_MAP_KEY, paramMap);
+        }
+        return paramMap;
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>Map</code> that may be used to test this code outside JSF.
+     * </p>
+     */
+    private static Map<String, Object> getTestMap() {
+// FIXME: Shouldn't we mock up the test environment instead of changing the code here?
+        if (_testMap == null) {
+            _testMap = new HashMap<String, Object>();
+        }
+        return _testMap;
+    }
+
+    /**
+     * <p>
+     * This method allows the composition stack to be set directly. Normally this isn't needed, but if a seperate walk of
+     * the tree must be done in the middle of an existing walk, this may be necessary to reset and restore the Stack.
+     * </p>
+     */
+    public static Stack<LayoutElement> setCompositionStack(FacesContext context, Stack<LayoutElement> stack) {
+        Map requestMap = context.getExternalContext().getRequestMap();
+        requestMap.put(COMPOSITION_STACK_KEY, stack);
+        return stack;
+    }
+
+    /**
+     * <p>
+     * This method searches the given the entire <code>stack</code> for a template param with the given <code>name</code>.
+     * </p>
+     *
+     * <p>
+     * A "template param" is a name-value-pair associated with a {@link LayoutComposition}. This enables overridable values
+     * to be set on a LayoutComposition and consumed by the templates. This is similar to a ui:define, except for values
+     * instead of <code>UIComponents</code>.
+     * </p>
+     *
+     * @param eltList The <code>List</code> of LayoutCompositions in which to search (must be non-null, NPE will be thrown).
+     * @param name The name of the parameter to look for.
+     */
+    public static Object findTemplateParam(List<LayoutElement> eltList, String name) {
+// FIME: Can I make this return a String?  If this is at create time I should still have #{} or maybe ${}
+        Iterator<LayoutElement> stackIt = eltList.iterator();
+        Object val = null;
+        LayoutElement elt = null;
+        LayoutComposition comp = null;
+        while (stackIt.hasNext()) {
+            elt = stackIt.next();
+            if (elt instanceof LayoutComposition) {
+                // It should always be a LayoutComposition, however, I want
+                // to be safe in case things change in the future.
+                comp = (LayoutComposition) elt;
+                if ((val = comp.getParameter(name)) != null) {
+                    break;
+                }
+            }
+        }
+
+        // Return the value (if found)
+        return val;
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>Map</code> of parameter values, or <code>null</code> if there are no parameter values
+     * for this <code>LayoutComposition</code>.
+     * </p>
+     */
+    protected Map<String, Object> getParameters() {
+        return _params;
+    }
+
+    /**
+     * <p>
+     * This method returns the parameter value for the requested parameter, or <code>null</code> if the requested parameter
+     * does not exist.
+     * </p>
+     */
+    public Object getParameter(String name) {
+        Object value = null;
+        if (_params != null) {
+            value = _params.get(name);
+        }
+        return value;
+    }
+
+    /**
+     * <p>
+     * This method sets the given parameter name with the given parameter value.
+     * </p>
+     */
+    public void setParameter(String name, Object value) {
+        if (_params == null) {
+            _params = new HashMap<>();
+        }
+        _params.put(name, value);
+    }
+
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * <p>
+     * This is the key used to store the <code>LayoutComposition</code> stack.
+     * </p>
+     */
+    private static final String COMPOSITION_STACK_KEY = "_composition";
+
+    /**
+     * <p>
+     * This is the key used to store the ui:param NVPs to assist in determining if an EL is referencing one. It also may be
+     * used in somone attempts to locate a ui:param after the composition stack is no longer available (don't do that!).
+     * </p>
+     */
+    private static final String GLOBAL_PARAM_MAP_KEY = "_uiparamCacheMap";
+
+    /**
+     * <p>
+     * This Map exists to allow test cases to run w/o an ExternalContext "request map."
+     * </p>
+     */
+    private static Map _testMap = null;
+
+    /**
+     * <p>
+     * This is a <code>Map</code> of parameters that may be passed from this <code>LayoutComposition</code> to the template.
+     * </p>
+     */
+    private Map<String, Object> _params = null;
+
+    /**
+     * <p>
+     * Flag to indicate that whether an exception should be thrown if the template is not found.
+     * </p>
+     */
+    private String required = null;
+
+    /**
+     * <p>
+     * The filename of the template.
+     * </p>
+     */
+    private String template = null;
+
+    /**
+     * <p>
+     * True if trimming should occur.
+     * </p>
+     */
+// FIXME: This info is only important at read-time, this probably should NOT exist
+    private boolean trimming = true;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutDefine.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutDefine.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This {@link LayoutElement} provides a means to identify a portion of the LayoutDefinition tree by name (id). This is
+ * used by {@link LayoutInsert} to include portions of the tree defined elsewhere at the location of the
+ * {@link LayoutInsert}.
+ * </p>
+ *
+ * @author Jason Lee
+ */
+public class LayoutDefine extends LayoutElementBase {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param parent
+     * @param id
+     */
+    public LayoutDefine(LayoutElement parent, String id) {
+        super(parent, id);
+    }
+
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        return true;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutDefinition.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutDefinition.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.component.TemplateComponent;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.event.DecodeEvent;
+import com.sun.jsftemplating.layout.event.InitPageEvent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This represents the top-level {@link LayoutElement}, it is the container for every other {@link LayoutElement}. By
+ * itself, it has no functionality. Its purpose in life is to group all top-level child {@link LayoutElement}s.
+ * LayoutDefintion objects can be registered with the {@link com.sun.jsftemplating.layout.LayoutDefinitionManager}.
+ * </p>
+ *
+ * <p>
+ * This class provide a helper method
+ * {@link #getChildLayoutElementById(FacesContext, String, LayoutElement, UIComponent)} which will search recursively
+ * for the given child LayoutElement by id.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutDefinition extends LayoutElementBase {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public LayoutDefinition(String id) {
+        // LayoutDefinition objects do not have a parent
+        super(null, id);
+
+        // Set the default StaticText ComponentType
+        addComponentType(new ComponentType(STATIC_TEXT_TYPE, STATIC_TEXT_FACTORY_CLASS_NAME));
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>Map</code> containing the {@link ComponentType}s. It ensures that the <code>Map</code>
+     * is not <code>null</code>.
+     * </p>
+     */
+    protected Map<String, ComponentType> getComponentTypes() {
+        if (_types == null) {
+            _types = new HashMap<>();
+        }
+        return _types;
+    }
+
+    /**
+     * <p>
+     * Retrieve a {@link ComponentType} by typeID.
+     * </p>
+     *
+     * @param typeID The key used to retrieve the ComponentType
+     *
+     * @return The requested ComponentType or null
+     *
+     * @deprecated Reader's should use global {@link ComponentType}s (see
+     * {@link com.sun.jsftemplating.layout.LayoutDefinitionManager#getGlobalComponentType(FacesContext, String)}) or should
+     * cache {@link ComponentType}s locally, this information is not needed in the <code>LayoutDefinition</code>.
+     */
+    @Deprecated
+    public ComponentType getComponentType(String typeID) {
+        return getComponentTypes().get(typeID);
+    }
+
+    /**
+     * <p>
+     * This will add the given <code>ComponentType</code> to the map of registered <code>ComponentType</code>'s. It will use
+     * the <code>ComponentType</code> ID as the key to the <code>Map</code>. This means that if a <code>ComponentType</code>
+     * with the same ID had previously been registered, it will be replaced with the <code>ComponentType</code> passed in.
+     * </p>
+     *
+     * @param type The <code>ComponentType</code>.
+     *
+     * @deprecated Reader's should use global {@link ComponentType}s (see
+     * {@link com.sun.jsftemplating.layout.LayoutDefinitionManager#addGlobalComponentType(FacesContext, ComponentType)}) or
+     * should cache {@link ComponentType}s locally, this information is not needed in the <code>LayoutDefinition</code>.
+     */
+    @Deprecated
+    public void addComponentType(ComponentType type) {
+        getComponentTypes().put(type.getId(), type);
+    }
+
+    /**
+     * <p>
+     * This method adds a {@link Resource}. These resources should be added to the request scope when this component is
+     * used. This is mainly used for <code>ResourceBundle<code>s (at this time).</p>
+     *
+     *    @param    res The {@link Resource} to associate with the
+     *            <code>LayoutDefinition</code>.
+     */
+    public void addResource(Resource res) {
+        _resources.add(res);
+    }
+
+    /**
+     * <p>
+     * This method returns a List of {@link Resource} objects.
+     * </p>
+     *
+     * @return This method returns a List of {@link Resource} objects.
+     */
+    public List<Resource> getResources() {
+        return _resources;
+    }
+
+    /**
+     * <p>
+     * This method allows the <code>List</code> of {@link Resource}s to be set.
+     * </p>
+     *
+     * @param resources <code>List</code> to {@link Resource}s.
+     */
+    public void setResources(List<Resource> resources) {
+        _resources = resources;
+    }
+
+    /**
+     * <p>
+     * This method searches for the requested {@link LayoutComponent} by id.
+     * </p>
+     *
+     * @param context <code>FacesContext</code>
+     * @param id id to look for
+     * @param parent Search starts from this {@link LayoutElement}
+     * @param parentComponent Parent <code>UIComponent</code>
+     *
+     * @return The matching {@link LayoutElement} if found, null otherwise.
+     */
+    public static LayoutElement getChildLayoutElementById(FacesContext context, String id, LayoutElement parent, UIComponent parentComponent) {
+        // NOTE: I may want to optimize this by putting all values in a Map so
+        // NOTE: that I don't have to do this search.
+
+        // Make sure this isn't what we're looking for
+        if (parent.getId(context, parentComponent).equals(id)) {
+            return parent;
+        }
+
+        // Not 'this' so lets check the children
+        Iterator<LayoutElement> it = parent.getChildLayoutElements().iterator();
+        LayoutElement elt = null;
+        while (it.hasNext()) {
+            elt = getChildLayoutElementById(context, id, it.next(), parentComponent);
+            if (elt != null) {
+                // Found it!
+                return elt;
+            }
+        }
+
+        // Not found...
+        return null;
+    }
+
+    /**
+     * <p>
+     * Retrieve an attribute by key.
+     * </p>
+     *
+     * @param key The key used to retrieve the attribute
+     *
+     * @return The requested attribute or null. public Object getAttribute(String key) { return _attributes.get(key); }
+     */
+
+    /**
+     * <p>
+     * Associate the given key with the given Object as an attribute.
+     * </p>
+     *
+     * @param key The key associated with the given object (if this key is already in use, it will replace the previously
+     * set attribute object).
+     *
+     * @param value The Object to store. public void setAttribute(String key, Object value) { _attributes.put(key, value); }
+     */
+
+    /**
+     * <p>
+     * This method sets a locally defined {@link HandlerDefinition}.
+     * </p>
+     */
+    public void setHandlerDefinition(String key, HandlerDefinition value) {
+        _attributes.put(key, value);
+    }
+
+    /**
+     * <p>
+     * This method accesses a locally defined {@link HandlerDefinition}.
+     * </p>
+     */
+    public HandlerDefinition getHandlerDefinition(String key) {
+        return _attributes.get(key);
+    }
+
+    /**
+     * <p>
+     * This function overrides the superclass in order to call encodeBegin / encodeEnd on the UIViewRoot (and only for
+     * UIViewRoot instances). This is especially important for Ajax requests.
+     * </p>
+     */
+    @Override
+    public void encode(FacesContext context, UIComponent component) throws IOException {
+        if (component instanceof UIViewRoot) {
+            component.encodeBegin(context);
+// FIXME: For now I am treating "@all" Ajax requests as normal requests...
+// FIXME: Otherwise the partialviewcontext tries to render the whole view, and
+// FIXME: fails b/c JSFT may use Facets for top-level components.  Need to find
+// FIXME: a better way to handle this.
+            if (context.getPartialViewContext().isPartialRequest() && !context.getPartialViewContext().isRenderAll()) {
+                // JSF is now overriding this, so this is required...
+                component.encodeChildren(context);
+            } else {
+                // This is not an ajax request... behave normal
+                super.encode(context, component);
+            }
+            component.encodeEnd(context);
+        } else {
+            super.encode(context, component);
+        }
+    }
+
+    /**
+     * <p>
+     * The <code>LayoutDefinition</code> does not encode anything for itself, this method simply returns true.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param component The <code>UIComponent</code>.
+     *
+     * @return true.
+     */
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        return true;
+    }
+
+    /**
+     * <p>
+     * This method retrieves the Handlers for the requested type. But also includes any handlers that are associated with
+     * the instance (i.e. the UIComponent).
+     * </p>
+     *
+     * @param type The type of <code>Handler</code>s to retrieve.
+     * @param comp The associated <code>UIComponent</code> (or null).
+     *
+     * @return A List of Handlers.
+     */
+    @Override
+    public List<Handler> getHandlers(String type, UIComponent comp) {
+        // 1st get list of handlers for definition of this LayoutElement
+        List<Handler> handlers = null;
+
+        // Now check to see if there are any on the UIComponent (NOTE: We do
+        // not pull off handlers if the parent is a TemplateComponent b/c it
+        // is the responsibility of the parent class to invoke handlers via
+        // its LayoutComponent. If we do it here, it will happen 2x.)
+        if (comp != null && !(comp.getParent() instanceof TemplateComponent)) {
+            List<Handler> instHandlers = (List<Handler>) comp.getAttributes().get(type);
+            if (instHandlers != null && instHandlers.size() > 0) {
+                // NOTE: Copy b/c this is <i>instance</i> + static
+                // Add the UIComponent instance handlers
+                handlers = new ArrayList<>(instHandlers);
+
+                List<Handler> defHandlers = getHandlers(type);
+                if (defHandlers != null) {
+                    // Add the LayoutElement "definition" handlers, if any
+                    handlers.addAll(getHandlers(type));
+                }
+            }
+        }
+        if (handlers == null) {
+            handlers = getHandlers(type);
+        }
+
+        return handlers;
+    }
+
+    /**
+     * <p>
+     * This decode method invokes any registered {@link #DECODE} handlers.
+     * </p>
+     *
+     * @param context The FacesContext.
+     * @param component The <code>UIComponent</code>.
+     */
+    public void decode(FacesContext context, UIComponent component) {
+        // Invoke "decode" handlers
+        dispatchHandlers(context, DECODE, new DecodeEvent(component));
+    }
+
+    /**
+     * <p>
+     * This method is responsible for dispatching the "initPage" handlers associated with this <code>LayoutDefinition</code>
+     * (if any).
+     * </p>
+     *
+     * <p>
+     * The <code>source</code> passed in should be the <code>UIViewRoot</code>. However, it is expected that in most cases
+     * this will not be available. It is reasonable for this to be <code>null</code>.
+     * </p>
+     *
+     * <p>
+     * If the <code>FacesContext</code> provided is null, this method will simply return.
+     * </p>
+     */
+    public void dispatchInitPageHandlers(FacesContext ctx, Object source) {
+        // Sanity check (this may happen if invoked outside JSF)...
+        // Check to see if we've already done this...
+        if ((ctx == null) || isInitPageExecuted(ctx)) {
+            // We've already init'd this request, do nothing
+            return;
+        }
+
+        // Dispatch Handlers
+        dispatchHandlers(ctx, INIT_PAGE, new InitPageEvent(source));
+
+        // Flag request as having processed the initPage handlers
+        setInitPageExecuted(ctx, Boolean.TRUE);
+    }
+
+    /**
+     * <p>
+     * This method checks to see if the initPage event has fired yet for this request.
+     * </p>
+     */
+    public boolean isInitPageExecuted(FacesContext ctx) {
+        Map<String, Object> reqAtts = ctx.getExternalContext().getRequestMap();
+        String key = INIT_PAGE_PREFIX + getId(ctx, (UIComponent) null);
+        return Boolean.TRUE.equals(reqAtts.get(key));
+    }
+
+    /**
+     * <p>
+     * This method marks the initPage event as fired for this request.
+     * </p>
+     */
+    public void setInitPageExecuted(FacesContext ctx, boolean value) {
+        String key = INIT_PAGE_PREFIX + getId(ctx, (UIComponent) null);
+        ctx.getExternalContext().getRequestMap().put(key, value);
+    }
+
+    /**
+     *
+     */
+    private static final String INIT_PAGE_PREFIX = "__ip";
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked to handle "decode" functionality for this element.
+     * </p>
+     */
+    public static final String DECODE = "decode";
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked to handle "initPage" functionality for this element.
+     * </p>
+     */
+    public static final String INIT_PAGE = "initPage";
+
+    /**
+     * <p>
+     * This is a hard-coded LayoutComponent type. By default it corresponds to
+     * {@link com.sun.jsftemplating.component.factory.basic.StaticTextFactory}.
+     * </p>
+     */
+    public static final String STATIC_TEXT_TYPE = "staticText";
+
+    /**
+     * <p>
+     * This is the full classname of the default StaticTextFactory.
+     * </p>
+     */
+    public static final String STATIC_TEXT_FACTORY_CLASS_NAME = "com.sun.jsftemplating.component.factory.basic.StaticTextFactory";
+
+    /**
+     * <p>
+     * This is a list of Resource objects. These resources are to be added to the Request scope when this
+     * <code>LayoutDefinition</code> is used.
+     * </p>
+     */
+    private List<Resource> _resources = new ArrayList<>();
+
+    /**
+     * <p>
+     * Map of types. This information is needed to instantiate UIComponents.
+     * </p>
+     */
+    private Map<String, ComponentType> _types = null;
+
+    /**
+     * <p>
+     * Map of attributes. Attributes can be used to store extra information about the <code>LayoutDefinition</code>.
+     * </p>
+     */
+    private Map<String, HandlerDefinition> _attributes = new HashMap<>();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutElement.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutElement.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.EventObject;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This interface is declares the methods required to be a LayoutElement. A LayoutElement is the building block of the
+ * tree structure which defines a layout for a particular component. There are different implementations of
+ * LayoutElement that provide various different types of functionality and data. Some examples are:
+ * </p>
+ *
+ * <ul>
+ * <li>Conditional ({@link LayoutIf}), this allows portions of the layout tree to be conditionally rendered.</li>
+ * <li>Iterative ({@link LayoutWhile}), this allows portions of the layout tree to be iteratively rendered.</li>
+ * <li>UIComponent ({@link LayoutComponent}), this allows concrete UIComponents to be used. If the component doesn't
+ * already exist, it will be created automatically.</li>
+ * <li>Facet place holders ({@link LayoutFacet}), this provides a means to specify where a facet should be rendered. It
+ * is not a facet itself but where a facet should be drawn. However, in addition, it may specify a default value if no
+ * facet was provided.</li>
+ * </ul>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface LayoutElement extends java.io.Serializable {
+
+    /**
+     * This method is used to add a LayoutElement. LayoutElements should be added sequentially in the order in which they
+     * are to be rendered.
+     */
+    void addChildLayoutElement(LayoutElement element);
+
+    /**
+     * This method returns the child LayoutElements as a List of LayoutElement.
+     *
+     * @return List of LayoutElements
+     */
+    List<LayoutElement> getChildLayoutElements();
+
+    /**
+     * <p>
+     * This method returns the requested child {@link LayoutElement} by <code>id</code>.
+     * </p>
+     *
+     * @param id The <code>id</code> of the child to find and return.
+     *
+     * @return The requested {@link LayoutElement}; <code>null</code> if not found.
+     */
+    LayoutElement getChildLayoutElement(String id);
+
+    /**
+     * <p>
+     * This method searches the <code>LayoutElement</code> tree breadth-first for a <code>LayoutElement</code> with the
+     * given id.
+     * </p>
+     */
+    LayoutElement findLayoutElement(String id);
+
+    /**
+     * This method returns the parent LayoutElement.
+     *
+     * @return parent LayoutElement
+     */
+    LayoutElement getParent();
+
+    /**
+     * This method returns the LayoutDefinition. If unable to, it will throw an Exception.
+     *
+     * @return The LayoutDefinition
+     */
+    LayoutDefinition getLayoutDefinition();
+
+    /**
+     * <p>
+     * This method retrieves the {@link Handler}s for the requested type.
+     * </p>
+     *
+     * @param type The event type of {@link Handler}s to retrieve.
+     *
+     * @return A List of {@link Handler}s.
+     */
+    List<Handler> getHandlers(String type);
+
+    /**
+     * <p>
+     * This method retrieves the {@link Handler}s for the requested type. This method is unique in that it looks at the
+     * <code>UIComponent</code> passed in to see if there are {@link Handler}s defined on it (instance handlers vs. those
+     * defined on the <code>LayoutElement</code>.
+     * </p>
+     *
+     * @param type The event type of {@link Handler}s to retrieve.
+     * @param comp The associated <code>UIComponent</code> (or null).
+     *
+     * @return A List of {@link Handler}s.
+     */
+    List<Handler> getHandlers(String type, UIComponent comp);
+
+    /**
+     * <p>
+     * This method provides access to the "handlersByType" <code>Map</code>.
+     * </p>
+     */
+    Map<String, List<Handler>> getHandlersByTypeMap();
+
+    /**
+     * <p>
+     * This method associates 'type' with the given list of Handlers.
+     * </p>
+     *
+     * @param type The String type for the List of Handlers
+     * @param handlers The List of Handlers
+     */
+    void setHandlers(String type, List<Handler> handlers);
+
+    /**
+     * Accessor method for id. This should always return a non-null value, it may return "" if id does not apply.
+     *
+     * @return a non-null id
+     */
+    String getId(FacesContext context, UIComponent parent);
+
+    /**
+     * <p>
+     * This method generally should not be used. It does not resolve expressions. Instead use
+     * {@link #getId(FacesContext, UIComponent)}.
+     * </p>
+     *
+     * @return The unevaluated id.
+     */
+    String getUnevaluatedId();
+
+    /**
+     * This method performs any encode action for this particular LayoutElement.
+     *
+     * @param context The FacesContext
+     * @param component The UIComponent
+     */
+    void encode(FacesContext context, UIComponent component) throws IOException;
+
+    /**
+     *
+     */
+    Object dispatchHandlers(HandlerContext handlerCtx, List<Handler> handlers);
+
+    /**
+     * <p>
+     * This method iterates over the handlers and executes each one. A HandlerContext will be created to pass to each
+     * Handler. The HandlerContext object is reused across all Handlers that are invoked; the setHandler(Handler) method is
+     * invoked with the correct Handler descriptor before the handler is executed.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param eventType The event type which is being fired
+     * @param event An optional EventObject providing more detail
+     *
+     * @return By default, (null) is returned. However, if any of the handlers produce a non-null return value, then the
+     * value from the last handler to produces a non-null return value is returned.
+     */
+    Object dispatchHandlers(FacesContext context, String eventType, EventObject event);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutElementBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutElementBase.java
@@ -1,0 +1,626 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContextImpl;
+import com.sun.jsftemplating.layout.event.AfterEncodeEvent;
+import com.sun.jsftemplating.layout.event.BeforeEncodeEvent;
+import com.sun.jsftemplating.layout.event.EncodeEvent;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EventObject;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class provides some common functionality between the various types of {@link LayoutElement}s. It is the base
+ * class of most implementations (perhaps all).
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public abstract class LayoutElementBase implements LayoutElement {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param parent The parent LayoutElement
+     * @param id Identifier for this LayoutElement
+     */
+    protected LayoutElementBase(LayoutElement parent, String id) {
+        setParent(parent);
+        _id = id;
+    }
+
+    /**
+     * <p>
+     * This method is used to add a {@link LayoutElement}. {@link LayoutElement}s should be added sequentially in the order
+     * in which they are to be rendered.
+     * </p>
+     *
+     * @param element The {@link LayoutElement} to add as a child.
+     */
+    @Override
+    public void addChildLayoutElement(LayoutElement element) {
+        _layoutElements.add(element);
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link LayoutElement}s as a <code>List</code> of {@link LayoutElement}.
+     * </p>
+     *
+     * @return List of {@link LayoutElement}s.
+     */
+    @Override
+    public List<LayoutElement> getChildLayoutElements() {
+        return _layoutElements;
+    }
+
+    /**
+     * <p>
+     * This method returns the requested child {@link LayoutElement} by <code>id</code>.
+     * </p>
+     *
+     * @param id The <code>id</code> of the child to find and return.
+     *
+     * @return The requested {@link LayoutElement}; <code>null</code> if not found.
+     */
+    @Override
+    public LayoutElement getChildLayoutElement(String id) {
+        Iterator<LayoutElement> it = getChildLayoutElements().iterator();
+        LayoutElement elt = null;
+        while (it.hasNext()) {
+            elt = it.next();
+            if (id.equals(elt.getUnevaluatedId())) {
+                return elt;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * <p>
+     * This method searches the <code>LayoutElement</code> tree breadth-first for a <code>LayoutElement</code> with the
+     * given id.
+     * </p>
+     */
+    @Override
+    public LayoutElement findLayoutElement(String id) {
+        if (id == null) {
+            return null;
+        }
+
+// FIXME: Generalize this code so we can use it when creating the tree as well as searching for stuff.
+
+        // First look at all the immediate children, save compositions if
+        // we encounter them.
+        List<LayoutElement> children = getChildLayoutElements();
+        for (LayoutElement elt : children) {
+            if (id.equals(elt.getUnevaluatedId())) {
+                // Found it!
+                return elt;
+            }
+        }
+
+        // First make sure we aren't a LayoutComposition ourselves
+        LayoutElement result = null;
+        FacesContext context = FacesContext.getCurrentInstance();
+        if (this instanceof LayoutComposition) {
+            // Add LayoutComposition to the stack
+            LayoutComposition.push(context, this);
+
+            // Find the new LD tree...
+            LayoutDefinition def = LayoutDefinitionManager.getLayoutDefinition(context, ((LayoutComposition) this).getTemplate());
+
+            // Recurse...
+            result = def.findLayoutElement(id);
+            LayoutComposition.pop(context);
+        }
+
+        // Next we need to walk deeper...
+        for (LayoutElement elt : children) {
+            if (elt instanceof LayoutComposition && ((LayoutComposition) elt).getTemplate() != null) {
+                // Add LayoutComposition to the stack
+                LayoutComposition.push(context, elt);
+
+                // Find the new LD tree...
+                LayoutDefinition def = LayoutDefinitionManager.getLayoutDefinition(context, ((LayoutComposition) elt).getTemplate());
+
+                // Recurse...
+                result = def.findLayoutElement(id);
+                LayoutComposition.pop(context);
+            } else if (elt instanceof LayoutInsert) {
+                // FIXME: Look through Stack/List of compositions we've already walked for inserted value.
+            } else {
+                // Just walk its children...
+                result = elt.findLayoutElement(id);
+            }
+            if (result != null) {
+// FIXME: Manage stack!!!
+                break;
+            }
+        }
+
+        // Return result if found
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method walks to the top-most {@link LayoutElement}, which should be a {@link LayoutDefinition}. If not, it will
+     * throw an exception.
+     * </p>
+     *
+     * @return The {@link LayoutDefinition}.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition() {
+        // Find the top-most LayoutElement
+        LayoutElement cur = this;
+        while (cur.getParent() != null) {
+            cur = cur.getParent();
+        }
+
+        // Incomplete LayoutElement trees may not have a LD at the root, make
+        // sure we have a LD.
+        if (!(cur instanceof LayoutDefinition)) {
+            // Not a LD, there is no LD... set return value to null
+            cur = null;
+        }
+
+        // This should be the LayoutDefinition, return it
+        return (LayoutDefinition) cur;
+    }
+
+    /**
+     * <p>
+     * This method returns the parent {@link LayoutElement}.
+     * </p>
+     *
+     * @return parent LayoutElement
+     */
+    @Override
+    public LayoutElement getParent() {
+        return _parent;
+    }
+
+    /**
+     * <p>
+     * This method sets the parent {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent Parent {@link LayoutElement}.
+     */
+    protected void setParent(LayoutElement parent) {
+        _parent = parent;
+    }
+
+    /**
+     * <p>
+     * Accessor method for id. This returns a non-null value, it may return "" if id is not set or does not apply.
+     * </p>
+     *
+     * <p>
+     * This method will also NOT resolve EL strings.
+     * </p>
+     *
+     * @return a non-null id
+     */
+    private String getId() {
+        if (_id == null || _id == "") {
+            // Ensure we ALWAYS have an id, however, generating ids is
+            // potentially dangerous because the results may not be the same
+            // always. Effort has been taken to avoid most problems, though.
+            _id = LayoutElementUtil.getGeneratedId((String) null);
+        }
+        return _id;
+    }
+
+    /**
+     * <p>
+     * This method generally should not be used. It does not resolve expressions. Instead use
+     * {@link #getId(FacesContext, UIComponent)}.
+     * </p>
+     *
+     * @return The unevaluated id.
+     */
+    @Override
+    public String getUnevaluatedId() {
+        return getId();
+    }
+
+    /**
+     * <p>
+     * Accessor method for id. This returns a non-null value, it may return "" if id is not set or does not apply.
+     * </p>
+     *
+     * <p>
+     * This method will also attempt to resolve EL strings.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param parent The parent <code>UIComponent</code>. This is used because the current UIComponent is typically unknown
+     * (or not even created yet).
+     *
+     * @return A non-null id.
+     */
+    @Override
+    public String getId(FacesContext context, UIComponent parent) {
+        // Evaluate the id...
+        Object value = resolveValue(context, parent, getId());
+
+        // Return the result
+        return value == null ? "" : value.toString();
+    }
+
+    /**
+     * <p>
+     * This method will attempt to resolve EL strings in the given value.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param parent The parent <code>UIComponent</code>. This is used because the current UIComponent is typically unknown
+     * (or not even created yet).
+     * @param value The String to resolve
+     *
+     * @return The evaluated value (may be null).
+     */
+    public Object resolveValue(FacesContext context, UIComponent parent, Object value) {
+        return ComponentUtil.getInstance(context).resolveValue(context, this, parent, value);
+    }
+
+    /**
+     * <p>
+     * This method allows each LayoutElement to provide it's own encode functionality. If the {@link LayoutElement} should
+     * render its children, this method should return true. Otherwise, this method should return false.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param component The UIComponent
+     *
+     * @return true if children are to be rendered, false otherwise.
+     */
+    protected abstract boolean encodeThis(FacesContext context, UIComponent component) throws IOException;
+
+    /**
+     * <p>
+     * This is the base implementation for encode. Typically each type of LayoutElement wants to do something specific then
+     * conditionally have its children rendered. This method invokes the abstract method "encodeThis" to do specific
+     * functionality, it the walks the children and renders them, if encodeThis returns true. It skips the children if
+     * encodeThis returns false.
+     * </p>
+     *
+     * <p>
+     * NOTE: Some subclasses override this method, be careful when changing/adding to this code.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param component The <code>UIComponent</code>
+     */
+    @Override
+    public void encode(FacesContext context, UIComponent component) throws IOException {
+        // Invoke "before" handlers
+        Object result = dispatchHandlers(context, BEFORE_ENCODE, new BeforeEncodeEvent(component));
+
+        if (result != null && result.toString().equals("false")) {
+            // Skip...
+            return;
+        }
+
+        // Do LayoutElement specific stuff...
+        boolean renderChildren = encodeThis(context, component);
+
+// FIXME: Consider buffering HTML and passing to "endDisplay" handlers...
+// FIXME: Storing in the EventObject may be useful if we go this route.
+
+        // Perhaps we want our own Response writer to buffer children?
+        // ResponseWriter out = context.getResponseWriter();
+
+        // Conditionally render children...
+        if (renderChildren) {
+            result = dispatchHandlers(context, ENCODE, new EncodeEvent(component));
+
+            // Iterate over children
+            LayoutElement childElt = null;
+            Iterator<LayoutElement> it = getChildLayoutElements().iterator();
+            while (it.hasNext()) {
+                childElt = it.next();
+                childElt.encode(context, component);
+            }
+        }
+
+        // Invoke "after" handlers
+        result = dispatchHandlers(context, AFTER_ENCODE, new AfterEncodeEvent(component));
+    }
+
+    /**
+     * <p>
+     * This method iterates over the {@link Handler}s and executes each one. A {@link HandlerContext} will be created to
+     * pass to each {@link Handler}. The {@link HandlerContext} object is reused across all {@link Handler}s that are
+     * invoked; the {@link HandlerContext#setHandler(Handler)} method is invoked with the correct {@link Handler} descriptor
+     * before the handler is executed.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param eventType The event type which is being fired
+     * @param event An optional <code>EventObject</code>
+     *
+     * @return By default, (null) is returned. However, if any of the {@link Handler}s produce a non-null return value, the
+     * value from the last {@link Handler} to produces a non-null return value is returned.
+     */
+    @Override
+    public Object dispatchHandlers(FacesContext context, String eventType, EventObject event) {
+        // Get the handlers for this eventType
+        Object eventObj = event.getSource();
+        if (!(eventObj instanceof UIComponent)) {
+            eventObj = null;
+        }
+        List<Handler> handlers = getHandlers(eventType, (UIComponent) eventObj);
+
+        // Make sure we have something to do...
+        if (handlers == null) {
+            return null;
+        }
+
+        // Create a HandlerContext
+        HandlerContext handlerContext = createHandlerContext(context, event, eventType);
+
+        // This method is broken down so that recursion is easier
+        return dispatchHandlers(handlerContext, handlers);
+    }
+
+    /**
+     * <p>
+     * As currently implemented, this method is essentially a utility method. It dispatches the given List of
+     * {@link Handler}s. This may be available as a static method in the future.
+     * </p>
+     */
+    @Override
+    public Object dispatchHandlers(HandlerContext handlerCtx, List<Handler> handlers) {
+        FacesContext ctx = handlerCtx.getFacesContext();
+        Object retVal = null;
+        Object result = null;
+        // Only check for renderResponse if we're not already doing it
+        boolean checkRenderResp = !ctx.getRenderResponse();
+
+        // Iterate through the handlers...
+        for (Handler handler : handlers) {
+            if (ctx.getResponseComplete() || checkRenderResp && ctx.getRenderResponse()) {
+                // If we shouldn't continue, just return the result.
+                // Should we throw an AbortProcessingException
+                return result;
+            }
+            handlerCtx.setHandler(handler);
+            try {
+                // Delegate to the Handler to perform invocation
+                retVal = handler.invoke(handlerCtx);
+            } catch (Exception ex) {
+                throw new RuntimeException(
+                        ex.getClass().getName() + " while attempting to " + "process a '" + handlerCtx.getEventType() + "' event for '" + getId() + "'.", ex);
+            }
+
+            // Check for return value
+            if (retVal != null) {
+                result = retVal;
+            }
+        }
+
+        // Return the return value (null by default)
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for creating a new HandlerContext. It does not set the Handler descriptor. This is done
+     * right before a Handler is invoked. This allows the HandlerContext object to be reused.
+     * </p>
+     *
+     * @param context The FacesContext
+     */
+    protected HandlerContext createHandlerContext(FacesContext context, EventObject event, String eventType) {
+        return new HandlerContextImpl(context, this, event, eventType);
+    }
+
+    /**
+     * <p>
+     * This method retrieves the {@link Handler}s for the requested type.
+     * </p>
+     *
+     * @param type The type of {@link Handler}s to retrieve.
+     *
+     * @return A List of {@link Handler}s.
+     */
+    @Override
+    public List<Handler> getHandlers(String type) {
+        return _handlersByType.get(type);
+    }
+
+    /**
+     * <p>
+     * This method provides access to the "handlersByType" <code>Map</code>.
+     * </p>
+     */
+    @Override
+    public Map<String, List<Handler>> getHandlersByTypeMap() {
+        return _handlersByType;
+    }
+
+    /**
+     * <p>
+     * This method provides a means to set the "handlersByType" Map. Normally this is done for each type individually via
+     * {@link #setHandlers(String, List)}. This Map may not be null (null will be ignored) and should contain entries that
+     * map to <code>List</code>s of {@link Handler}s.
+     */
+    public void setHandlersByTypeMap(Map<String, List<Handler>> map) {
+        if (map != null) {
+            _handlersByType = map;
+        }
+    }
+
+    /**
+     * <p>
+     * This method retrieves the {@link Handler}s for the requested type.
+     * </p>
+     *
+     * @param type The type of <code>Handler</code>s to retrieve.
+     * @param comp The associated <code>UIComponent</code> (or null).
+     *
+     * @return A <code>List</code> of {@link Handler}s.
+     */
+    @Override
+    public List<Handler> getHandlers(String type, UIComponent comp) {
+        // 1st get list of handlers for definition of this LayoutElement
+        List<Handler> handlers = getHandlers(type);
+
+        // NOTE: At this point, very few types should support "instance"
+        // NOTE: handlers (LayoutComponent, LayoutDefinition, more??). To
+        // NOTE: support them, the future, the specific LayoutElement subclass
+        // NOTE: will have to deal with this. For example, LayoutComponent
+        // NOTE: "instance" handlers are dealt with in LayoutComponent (it
+        // NOTE: overrides this method).
+
+        return handlers;
+    }
+
+    /**
+     * <p>
+     * This method associates 'type' with the given list of {@link Handler}s.
+     * </p>
+     *
+     * @param type The String type for the List of {@link Handler}s
+     * @param handlers The List of {@link Handler}s
+     */
+    @Override
+    public void setHandlers(String type, List<Handler> handlers) {
+        _handlersByType.put(type, handlers);
+    }
+
+    /**
+     * <p>
+     * This method is a convenience method for encoding the given <code>UIComponent</code>. It calls the appropriate
+     * encoding methods on the component and calls itself recursively for all <code>UIComponent</code> children that do not
+     * render their own children.
+     * </p>
+     *
+     * @param context <code>FacesContext</code>
+     * @param component <code>UIComponent</code> to encode
+     */
+    public static void encodeChild(FacesContext context, UIComponent component) throws IOException {
+        if (!component.isRendered()) {
+            return;
+        }
+
+        /******* REMOVE THIS IF TABLE IS EVER FIXED TO WORK RIGHT *******/
+        /*
+         * This code is removed b/c of the way the Table code is designed. It needs to recalculate the clientId all the time.
+         * Rather than deal with this in the table code, the design requires that every component regenerate its clientId every
+         * time it is rendered. Hopefully the Table code will be rewritten to not require this, or to do this task itself.
+         *
+         * For now, I will avoid doing the "right" thing and reset the id blindly. This causes the clientId to be erased and
+         * regenerated.
+         */
+        String id = component.getId();
+        if (id != null) {
+            component.setId(id);
+        }
+        /******* REMOVE THIS IF TABLE IS EVER FIXED TO WORK RIGHT *******/
+
+// FIXME: May have to change to encodeAll()!!!
+        component.encodeBegin(context);
+        if (component.getRendersChildren()) {
+            component.encodeChildren(context);
+        } else {
+            Iterator<UIComponent> it = component.getChildren().iterator();
+            while (it.hasNext()) {
+                encodeChild(context, it.next());
+            }
+        }
+        component.encodeEnd(context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer buf = new StringBuffer();
+        LayoutElementUtil.dumpTree(this, buf, "");
+
+        return buf.toString();
+    }
+
+    /**
+     * List of child LayoutElements (if, facet, UIComponents, etc.)
+     */
+    private List<LayoutElement> _layoutElements = new ArrayList<>();
+
+    /**
+     * The parent LayoutElement. This will be null for the LayoutDefinition.
+     */
+    private LayoutElement _parent = null;
+
+    /**
+     * <p>
+     * <code>Map</code> containing <code>List</code>s of {@link Handler}s.
+     * </p>
+     */
+    private Map<String, List<Handler>> _handlersByType = new HashMap<>();
+
+    /**
+     * This stores the id for the LayoutElement
+     */
+    private String _id = null;
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked after the encoding of this element.
+     * </p>
+     */
+    public static final String AFTER_ENCODE = "afterEncode";
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked before the encoding of this element.
+     * </p>
+     */
+    public static final String BEFORE_ENCODE = "beforeEncode";
+
+    /**
+     * <p>
+     * This is the "type" for handlers to be invoked during the encoding of this element. This occurs before any child
+     * LayoutElements are invoked and only if child Elements are to be invoked.
+     * </p>
+     */
+    public static final String ENCODE = "encode";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutFacet.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutFacet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This class defines the descriptor for LayoutFacet. A LayoutFacet descriptor provides information needed to attempt to
+ * obtain a Facet from the UIComponent. If the Facet doesn't exist, it also has the opportunity to provide a "default"
+ * in place of the facet.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutFacet extends LayoutElementBase implements LayoutElement {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor
+     */
+    public LayoutFacet(LayoutElement parent, String id) {
+        super(parent, id);
+    }
+
+    /**
+     * <p>
+     * Returns whether this LayoutFacet should be rendered. When this component is used to specify an actual facet (i.e.
+     * specifies a <code>UIComponent</code>), it should not be rendred. When it defines a place holder for a facet, then it
+     * should be rendered.
+     * </p>
+     *
+     * <p>
+     * This property is normally set when the LayoutElement tree is created (i.e. <code>XMLLayoutDefinitionReader</code>).
+     * One way to know what to do is to see if the is <code>LayoutFacet</code> is used inside a <code>LayoutComponent</code>
+     * or not. If it is, it can be assumed that it represents an actual facet, not a place holder.
+     * </p>
+     *
+     * @return true if {@link #encodeThis(FacesContext, UIComponent)} should execute
+     */
+    public boolean isRendered() {
+        return _rendered;
+    }
+
+    /**
+     *
+     */
+    public void setRendered(boolean render) {
+        _rendered = render;
+    }
+
+    /**
+     * <p>
+     * This method looks for the facet on the component. If found, it renders it and returns false (so children will not be
+     * rendered). If not found, it returns true so that children will be rendered. Children of a LayoutFacet represent the
+     * default value for the Facet.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param component The parent <code>UIComponent</code>.
+     *
+     * @return true if children are to be rendered, false otherwise.
+     */
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        // Make sure we are supposed to render facets
+        if (!isRendered()) {
+            return false;
+        }
+
+        // Look for Facet
+        component = component.getFacets().get(getId(context, component));
+        if (component != null) {
+            // Found Facet, Display UIComponent
+            encodeChild(context, component);
+
+            // Return false so the default won't be rendered
+            return false;
+        }
+
+        // Return true so that the default will be rendered
+        return true;
+    }
+
+    private boolean _rendered = true;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutForEach.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutForEach.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.event.AfterLoopEvent;
+import com.sun.jsftemplating.layout.event.BeforeLoopEvent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class defines a LayoutForEach {@link LayoutElement}. The LayoutForEach provides the functionality necessary to
+ * iteratively display a portion of the layout tree. The list property contains the <code>List</code> of items to
+ * iterate over.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutForEach extends LayoutComponent {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}
+     * @param listBinding The <code>List</code> to iterate over
+     * @param key The <code>ServletRequest</code> attribute key used to store the object being processed
+     */
+    public LayoutForEach(LayoutElement parent, String listBinding, String key) {
+        super(parent, null, LayoutDefinitionManager.getGlobalComponentType(null, "foreach"));
+        if (listBinding == null || listBinding.equals("")) {
+            throw new IllegalArgumentException("'listBinding' is required!");
+        }
+        if (key == null || key.equals("")) {
+            throw new IllegalArgumentException("'key' is required!");
+        }
+        addOption("list", listBinding);
+        addOption("key", key);
+        if (listBinding.equals("$property{list}")) {
+            _doubleEval = true;
+        }
+    }
+
+    /**
+     * <p>
+     * This method always returns true. The condition is based on an <code>Iterator.hasNext()</code> call instead of here
+     * because the {@link #encode(FacesContext, UIComponent)} method evaluates this and then calls the super. Performing the
+     * check here would cause the condition to be evaluated twice.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>.
+     * @param component The <code>UIComponent</code>.
+     *
+     * @return true
+     */
+    @Override
+    public boolean encodeThis(FacesContext context, UIComponent component) {
+        return true;
+    }
+
+    /**
+     * <p>
+     * This method evaluates the list binding for this <code>LayoutForEach</code>. This is expected to evaulate to a
+     * <code>List</code> object. If it doesn't, this method will throw a <code>NullPointerException</code> (if it evaulates
+     * to <code>null</code>), or an <code>IllegalArgumentException</code> if it doesn't evaluate to a <code>List</code>.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     *
+     * return The <code>List</code> of objects to iterate over
+     */
+    protected List<Object> getList(FacesContext context, UIComponent comp) {
+        Object value = resolveValue(context, comp, getOption("list"));
+        if (_doubleEval) {
+// FIXME: Generalize double evaluation... all $property{} calls from inside a component??
+            value = resolveValue(context, comp, value);
+        }
+
+        // Make sure we found something...
+        if (value == null) {
+            throw new NullPointerException("List not found via expression: '" + getOption("list") + "'.");
+        }
+
+        // Make sure we have a List...
+        if (!(value instanceof List)) {
+            throw new IllegalArgumentException("Expression '" + getOption("list") + "' did not resolve to a List! Found: '" + value.getClass().getName() + "'");
+        }
+
+        // Return the List
+        return (List<Object>) value;
+    }
+
+    /**
+     * <p>
+     * This method sets the <code>Object</code> that is currently being processed by this <code>LayoutForEach</code>. This
+     * implementation stores this value in the request attribute map undert the key provided to this
+     * <code>LayoutForEach</code>.
+     * </p>
+     *
+     * <p>
+     * As an added convenience, this method will also set an attribute that contains the current index number. The attribute
+     * key will be the same key the <code>Object</code> is stored under plus "-index". The index is stored as a String.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param value The <code>Object</code> to store
+     * @param index The current index number of the <code>Object</code>
+     */
+    private void setCurrentForEachValue(FacesContext context, Object value, int index, String key) {
+        Map<String, Object> map = context.getExternalContext().getRequestMap();
+        map.put(key, value);
+        map.put(key + "-index", "" + index);
+    }
+
+    /**
+     * <p>
+     * This implementation overrides the parent <code>encode</code> method. It does this to cause the encode process to loop
+     * as long as there are more <code>List</code> entries to process.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param component The UIComponent
+     */
+    @Override
+    public void encode(FacesContext context, UIComponent component) throws IOException {
+        // Before events..
+        dispatchHandlers(context, BEFORE_LOOP, new BeforeLoopEvent(component));
+
+        String key = resolveValue(context, component, getOption("key")).toString();
+
+        // Get the List
+        List<Object> list = getList(context, component);
+
+        // Save the list size in case it is needed.
+        context.getExternalContext().getRequestMap().put(key + "-size", list.size());
+
+        // Iterate over the values in the list and perform the requested
+        // action(s) per the body of the LayoutForEach
+        Iterator<Object> it = list.iterator();
+        for (int index = 1; it.hasNext(); index++) {
+            setCurrentForEachValue(context, it.next(), index, key);
+            super.encode(context, component);
+        }
+
+        // Invoke any "after" handlers
+        dispatchHandlers(context, AFTER_LOOP, new AfterLoopEvent(component));
+    }
+
+    /**
+     * <p>
+     * This method retrieves the Handlers for the requested type. But does *NOT* includes any handlers that are associated
+     * with the instance (i.e. the UIComponent). This is desired behavior when this is *not* a component. I am not sure if
+     * this is correct if we support a foreach() component. FIXME: think about this.
+     * </p>
+     */
+    @Override
+    public List<Handler> getHandlers(String type, UIComponent comp) {
+        return super.getHandlers(type, null);
+    }
+
+    /**
+     * <p>
+     * This is the event "type" for {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} elements to be invoked
+     * after this LayoutForEach is processed (outside loop).
+     * </p>
+     */
+    public static final String AFTER_LOOP = "afterLoop";
+
+    /**
+     * <p>
+     * This is the event "type" for {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} elements to be invoked
+     * before this LayoutForEach is processed (outside loop).
+     * </p>
+     */
+    public static final String BEFORE_LOOP = "beforeLoop";
+
+    /**
+     * <p>
+     * This flag is set to true when the condition equals "$property{condition}". This is a special case where the value to
+     * be evaluated is not $property{condition}, but rather the value of this expression. This requires double evaluation to
+     * correct interpret the expression. For now this is a hack for this case only. In the future we may want to support an
+     * $eval{} or something more general syntax for doing this declaratively.
+     * </p>
+     *
+     * See LayoutIf also.
+     */
+    private boolean _doubleEval = false;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutIf.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutIf.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.el.PermissionChecker;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This class defines a LayoutIf {@link LayoutElement}. The LayoutIf provides the functionality necessary to
+ * conditionally display a portion of the layout tree. The condition is a boolean equation and may use "$...{...}" type
+ * expressions to substitute in values.
+ * </p>
+ *
+ * <p>
+ * Depending on its environment, this {@link LayoutElement} can represent an {@link com.sun.jsftemplating.component.If}
+ * <code>UIComponent</code> or simply exist as a {@link LayoutElement}. When its {@link #encode} method is called, the
+ * if functionality will act as a {@link LayoutElement}. When the
+ * {@link LayoutComponent#getChild(FacesContext, UIComponent)} method is called, it will create an
+ * {@link com.sun.jsftemplating.component.If} <code>UIComponent</code>.
+ * </p>
+ *
+ * @see com.sun.jsftemplating.el.VariableResolver
+ * @see com.sun.jsftemplating.el.PermissionChecker
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutIf extends LayoutComponent {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor.
+     */
+    public LayoutIf(LayoutElement parent, String condition) {
+        this(parent, condition, LayoutDefinitionManager.getGlobalComponentType(null, "if"));
+    }
+
+    /**
+     * <p>
+     * This constructor may be used by subclasses which wish to provide an alternate {@link ComponentType}. The
+     * {@link ComponentType} is used to instantiate an {@link com.sun.jsftemplating.component.If} <code>UIComponent</code>
+     * (or whatever the given {@link ComponentType} specifies). This occurs when this {@link LayoutElement} is nested inside
+     * a {@link LayoutComponent}. It must create a <code>UIComponent</code> in order to ensure it is executed because during
+     * rendering there is no other way to get control to perform the functionality provided by this {@link LayoutElement}.
+     * </p>
+     */
+    protected LayoutIf(LayoutElement parent, String condition, ComponentType type) {
+        super(parent, (String) null, type);
+        addOption("condition", condition);
+        if (condition.equals("$property{condition}")) {
+            _doubleEval = true;
+        }
+    }
+// FIXME: getHandlers() may need to be overriden to prevent beforeEncode/afterEncode from being called multiple times in some cases.  I may also need to explicitly invoke these Handlers in some cases (in the Component??); See LayoutForEach for example of what may need to be done...
+
+    /**
+     * This method returns true if the condition of this LayoutIf is met, false otherwise. This provides the functionality
+     * for conditionally displaying a portion of the layout tree.
+     *
+     * @param ctx The FacesContext
+     * @param comp The UIComponent
+     *
+     * @return true if children are to be rendered, false otherwise.
+     */
+    @Override
+    public boolean encodeThis(FacesContext ctx, UIComponent comp) {
+        PermissionChecker checker = new PermissionChecker(this, comp,
+                _doubleEval ? (String) getEvaluatedOption(ctx, "condition", comp) : (String) getOption("condition"));
+        return checker.hasPermission();
+    }
+
+    /**
+     * <p>
+     * This flag is set to true when the condition equals "$property{condition}". This is a special case where the value to
+     * be evaluated is not $property{condition}, but rather the value of this expression. This requires double evaluation to
+     * correct interpret the expression. For now this is a hack for this case only. In the future we may want to support an
+     * $eval{} or something more general syntax for doing this declaratively.
+     * </p>
+     *
+     * See LayoutForEach also.
+     */
+    private boolean _doubleEval = false;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutInsert.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutInsert.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.layout.event.EncodeEvent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This class represents a <code>ui:insert</code>.
+ * </p>
+ *
+ * @author Jason Lee
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutInsert extends LayoutElementBase {
+    private static final long serialVersionUID = 1L;
+    private String name;
+
+    /**
+     * @param parent
+     * @param id
+     */
+    public LayoutInsert(LayoutElement parent, String id) {
+        super(parent, id);
+    }
+
+    /**
+     * <p>
+     * Returns the name of the {@link LayoutDefine} to look for when including content for this <code>LayoutInsert</code>.
+     * This value may be <code>null</code> to indicate that it should use its body content.
+     * </p>
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * <p>
+     * Sets the name of the {@link LayoutDefine} to look for when including content for this <code>LayoutInsert</code>. This
+     * value may be <code>null</code> to indicate that it should use its body content.
+     * </p>
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * <p>
+     * This method is override to enable searching of its content via the name of this insert (if supplied), or the
+     * rendering of its body if not supplied, or not found. If this is encountered outside the context of a composition, it
+     * will render its body content also.
+     * </p>
+     *
+     * @see LayoutElementBase#encodeThis(jakarta.faces.context.FacesContext, jakarta.faces.component.UIComponent)
+     */
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        Stack<LayoutElement> stack = LayoutComposition.getCompositionStack(context);
+        if (stack.empty()) {
+            // Render whatever is inside the insert
+            return true;
+        }
+
+        // Get assoicated UIComposition
+        String name = getName();
+        if (name == null) {
+            encodeChildren(context, component, stack.get(0));
+        } else {
+            // First resolve any EL in the insertName
+            name = "" + resolveValue(context, component, name);
+
+            // Search for specific LayoutDefine
+            LayoutElement def = LayoutInsert.findLayoutDefine(context, component, stack, name);
+            if (def == null) {
+                // Render whatever is inside the insert
+                return true;
+            } else {
+                // Found ui:define, render it
+                encodeChildren(context, component, def);
+            }
+        }
+        return false; // Already rendered it
+    }
+
+    /**
+     * <p>
+     * Encode the appropriate children...
+     * </p>
+     */
+    private void encodeChildren(FacesContext context, UIComponent component, LayoutElement parentElt) throws IOException {
+        // Fire an encode event
+        dispatchHandlers(context, ENCODE, new EncodeEvent(component));
+
+        // Iterate over children
+        LayoutElement childElt = null;
+        Iterator<LayoutElement> it = parentElt.getChildLayoutElements().iterator();
+        while (it.hasNext()) {
+            childElt = it.next();
+            childElt.encode(context, component);
+        }
+    }
+
+    /**
+     * <p>
+     * This method searches the given the entire <code>stack</code> for a {@link LayoutDefine} with the given
+     * <code>name</code>.
+     * </p>
+     */
+    public static LayoutDefine findLayoutDefine(FacesContext context, UIComponent parent, List<LayoutElement> eltList, String name) {
+        Iterator<LayoutElement> stackIt = eltList.iterator();
+        LayoutDefine define = null;
+        while (stackIt.hasNext()) {
+            define = findLayoutDefine(context, parent, stackIt.next(), name);
+            if (define != null) {
+                return define;
+            }
+        }
+
+        // Not found!
+        return null;
+    }
+
+    /**
+     * <p>
+     * This method searches the given {@link LayoutElement} for a {@link LayoutDefine} with the given <code>name</code>.
+     * </p>
+     */
+    private static LayoutDefine findLayoutDefine(FacesContext context, UIComponent parent, LayoutElement elt, String name) {
+        Iterator<LayoutElement> it = elt.getChildLayoutElements().iterator();
+        LayoutElement def = null;
+        while (it.hasNext()) {
+            def = it.next();
+            if (def instanceof LayoutDefine && def.getId(context, parent).equals(name)) {
+                // We found what we're looking for...
+                return (LayoutDefine) def;
+            }
+        }
+
+        // We still haven't found it, search the child LayoutElements
+        it = elt.getChildLayoutElements().iterator();
+        while (it.hasNext()) {
+            def = findLayoutDefine(context, parent, it.next(), name);
+            if (def != null) {
+                return (LayoutDefine) def;
+            }
+        }
+
+        // Not found!
+        return null;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutMarkup.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutMarkup.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * <p>
+ * This class defines a LayoutMarkup. A LayoutMarkup provides a means to start a markup tag and associate the current
+ * UIComponent with it for tool support. It also has the benefit of properly closing the markup tag for you.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutMarkup extends LayoutElementBase implements LayoutElement {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public LayoutMarkup(LayoutElement parent, String tag, String type) {
+        super(parent, tag);
+        _tag = tag;
+        _type = type;
+
+        // Add "afterEncode" handler to close the tag (if there is a close tag)
+        if (!type.equals(TYPE_OPEN)) {
+            ArrayList<Handler> handlers = new ArrayList<>();
+            handlers.add(afterEncodeHandler);
+            setHandlers(AFTER_ENCODE, handlers);
+        }
+    }
+
+    /**
+     *
+     */
+    public String getTag() {
+        return _tag;
+    }
+
+    /**
+     *
+     */
+    public String getType() {
+        return _type;
+    }
+
+    /**
+     * <p>
+     * This method displays the text described by this component. If the text includes an EL expression, it will be
+     * evaluated. It returns true to render children.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param component The <code>UIComponent</code>
+     *
+     * @return false
+     */
+    @Override
+    protected boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        if (getType().equals(TYPE_CLOSE)) {
+            return true;
+        }
+
+        // Get the ResponseWriter
+        ResponseWriter writer = context.getResponseWriter();
+
+        // Render...
+        Object value = resolveValue(context, component, getTag());
+        if (value != null) {
+            writer.startElement(value.toString(), component);
+        }
+
+        // Always render children
+        return true;
+    }
+
+    /**
+     * <p>
+     * This handler takes care of closing the tag.
+     * </p>
+     *
+     * @param context The HandlerContext.
+     */
+    public static void afterEncodeHandler(HandlerContext context) throws IOException {
+        FacesContext ctx = context.getFacesContext();
+        ResponseWriter writer = ctx.getResponseWriter();
+        LayoutMarkup markup = (LayoutMarkup) context.getLayoutElement();
+        Object value = ComponentUtil.getInstance(ctx).resolveValue(ctx, markup, (UIComponent) context.getEventObject().getSource(), markup.getTag());
+        if (value != null) {
+            writer.endElement(value.toString());
+        }
+    }
+
+    /**
+     *
+     */
+    public static final HandlerDefinition afterEncodeHandlerDef = new HandlerDefinition("_markupAfterEncode");
+
+    /**
+     *
+     */
+    public static final Handler afterEncodeHandler = new Handler(afterEncodeHandlerDef);
+
+    static {
+        afterEncodeHandlerDef.setHandlerMethod(LayoutMarkup.class.getName(), "afterEncodeHandler");
+    }
+
+    /**
+     * <p>
+     * This markup type writes out both the opening and closing tags.
+     * </p>
+     */
+    public static final String TYPE_BOTH = "both";
+
+    /**
+     * <p>
+     * This markup type writes out the closing tag.
+     * </p>
+     */
+    public static final String TYPE_CLOSE = "close";
+
+    /**
+     * <p>
+     * This markup type writes out the opening tag.
+     * </p>
+     */
+    public static final String TYPE_OPEN = "open";
+
+    private String _tag = null;
+    private String _type = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutStaticText.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutStaticText.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This class defines a LayoutStaticText. A LayoutStaticText describes a text to be output to the screen. This element
+ * is NOT a <code>UIComponent</code>.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutStaticText extends LayoutComponent {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public LayoutStaticText(LayoutElement parent, String id, String value) {
+        super(parent, id, LayoutDefinitionManager.getGlobalComponentType(null, "staticText"));
+        addOption("value", value);
+        _value = value;
+    }
+
+    /**
+     *
+     */
+    public String getValue() {
+        return _value;
+    }
+
+    /**
+     * <p>
+     * This method displays the text described by this component. If the text includes an EL expression, it will be
+     * evaluated. It returns false to avoid attempting to render children.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param component The <code>UIComponent</code>
+     *
+     * @return false
+     */
+    @Override
+    public boolean encodeThis(FacesContext context, UIComponent component) throws IOException {
+        // Get the ResponseWriter
+        ResponseWriter writer = context.getResponseWriter();
+
+        // Render the child UIComponent
+//    if (staticText.isEscape()) {
+//        writer.writeText(getValue(), "value");
+//    } else {
+        // This code depends on the side-effect of Util.setOption
+        // converting the string to a ValueExpression if needed. The
+        // "__value" is arbitrary.
+        Object value = ComponentUtil.getInstance(context).setOption(context, "__value", getValue(), getLayoutDefinition(), component);
+
+        // JSF 1.2 VB:
+        if (value instanceof ValueExpression) {
+            value = ((ValueExpression) value).getValue(context.getELContext());
+        }
+
+        if (value != null) {
+            writer.write(value.toString());
+        }
+//    }
+
+        // No children
+        return false;
+    }
+
+    private String _value = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutWhile.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/LayoutWhile.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.el.PermissionChecker;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.event.AfterLoopEvent;
+import com.sun.jsftemplating.layout.event.BeforeLoopEvent;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This class defines a LayoutWhile {@link LayoutElement}. The LayoutWhile provides the functionality necessary to
+ * iteratively display a portion of the layout tree. The condition is a boolean equation and may use "$...{...}" type
+ * expressions to substitute values.
+ * </p>
+ *
+ * @see com.sun.jsftemplating.el.VariableResolver
+ * @see com.sun.jsftemplating.el.PermissionChecker
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutWhile extends LayoutIf {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructor
+     */
+    public LayoutWhile(LayoutElement parent, String condition) {
+        super(parent, condition, LayoutDefinitionManager.getGlobalComponentType(null, "while"));
+    }
+
+    /**
+     * <p>
+     * This method always returns true. The condition is checked in {@link #shouldContinue(UIComponent)} instead of here
+     * because the {@link #encode(FacesContext, UIComponent)} method evaluates the condition and calls the super. Performing
+     * the check here would cause the condition to be evaluated twice.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param component The UIComponent
+     *
+     * @return true
+     */
+    @Override
+    public boolean encodeThis(FacesContext context, UIComponent component) {
+        return true;
+    }
+
+    /**
+     * <p>
+     * This method returns true if the condition of this LayoutWhile is met, false otherwise. This provides the
+     * functionality for iteratively displaying a portion of the layout tree.
+     * </p>
+     *
+     * @param component The UIComponent
+     *
+     * @return true if children are to be rendered, false otherwise.
+     */
+    protected boolean shouldContinue(UIComponent component) {
+        PermissionChecker checker = new PermissionChecker(this, component, (String) getOption("condition"));
+        return checker.hasPermission();
+    }
+
+    /**
+     * <p>
+     * This implementation overrides the parent <code>encode</code> method. It does this to cause the encode process to loop
+     * while {@link #shouldContinue(UIComponent)} returns true. Currently there is no infinite loop checking, so be careful.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param component The UIComponent
+     */
+    @Override
+    public void encode(FacesContext context, UIComponent component) throws IOException {
+        dispatchHandlers(context, BEFORE_LOOP, new BeforeLoopEvent(component));
+        while (shouldContinue(component)) {
+            super.encode(context, component);
+        }
+        dispatchHandlers(context, AFTER_LOOP, new AfterLoopEvent(component));
+    }
+
+    /**
+     * <p>
+     * This is the event "type" for {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} elements to be invoked
+     * after this LayoutWhile is processed (outside loop).
+     * </p>
+     */
+    public static final String AFTER_LOOP = "afterLoop";
+
+    /**
+     * <p>
+     * This is the event "type" for {@link com.sun.jsftemplating.layout.descriptors.handler.Handler} elements to be invoked
+     * before this LayoutWhile is processed (outside loop).
+     * </p>
+     */
+    public static final String BEFORE_LOOP = "beforeLoop";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/Resource.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/Resource.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors;
+
+import com.sun.jsftemplating.resource.ResourceFactory;
+import com.sun.jsftemplating.util.Util;
+
+/**
+ * <p>
+ * This class holds information that describes a Resource. It provides access to a {@link ResourceFactory} for obtaining
+ * the actual Resource object described by this descriptor. See the layout.dtd file for more information on how to
+ * define a Resource via XML. The LayoutDefinition will add all defined Resources to the request scope for easy access
+ * (including via JSF EL).
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class Resource implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * This is the id for the Resource.
+     * </p>
+     */
+    private String _id = null;
+
+    /**
+     * <p>
+     * This holds "extraInfo" for the Resource, such as a ResourceBundle baseName.
+     * </p>
+     */
+    private String _extraInfo = null;
+
+    /**
+     * <p>
+     * This is a String className for the Factory.
+     * </p>
+     */
+    private String _factoryClass = null;
+
+    /**
+     * <p>
+     * The Factory that produces the desired <code>UIComponent</code>.
+     * </p>
+     */
+    private transient ResourceFactory _factory = null;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public Resource(String id, String extraInfo, String factoryClass) {
+        if (id == null) {
+            throw new NullPointerException("'id' cannot be null!");
+        }
+        if (factoryClass == null) {
+            throw new NullPointerException("'factoryClass' cannot be null!");
+        }
+        _id = id;
+        _extraInfo = extraInfo;
+        _factoryClass = factoryClass;
+        _factory = createFactory();
+    }
+
+    /**
+     * <p>
+     * Accessor method for ID. This is the key the resource will be stored under in the Request scope.
+     * </p>
+     */
+    public String getId() {
+        return _id;
+    }
+
+    /**
+     * <p>
+     * This holds "extraInfo" for the Resource, such as a <code>ResourceBundle</code> baseName.
+     * </p>
+     */
+    public String getExtraInfo() {
+        return _extraInfo;
+    }
+
+    /**
+     * <p>
+     * This method provides access to the {@link ResourceFactory}.
+     * </p>
+     *
+     * @return The {@link ResourceFactory}.
+     */
+    public ResourceFactory getFactory() {
+        if (_factory == null) {
+            _factory = createFactory();
+        }
+        return _factory;
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link ResourceFactory}.
+     * </p>
+     *
+     * @return The new {@link ResourceFactory}.
+     */
+    protected ResourceFactory createFactory() {
+        try {
+            Class cls = Util.loadClass(_factoryClass, _factoryClass);
+            return (ResourceFactory) cls.newInstance();
+        } catch (ClassNotFoundException ex) {
+            throw new RuntimeException(ex);
+        } catch (InstantiationException ex) {
+            throw new RuntimeException(ex);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/ApplicationAttributeOutputType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/ApplicationAttributeOutputType.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+/**
+ * <p>
+ * This class implements the OutputType interface to provide a way to get/set Output values from the Application
+ * Attribute Map.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ApplicationAttributeOutputType implements OutputType {
+
+    /**
+     * <p>
+     * This method is responsible for retrieving the value of the Output from a Application attribute. 'key' may be null, if
+     * this occurs, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when retrieving the value from the Application attribute Map.
+     *
+     * @return The requested value.
+     */
+    @Override
+    public Object getValue(HandlerContext context, IODescriptor outDesc, String key) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get it from the Application attribute map
+        return context.getFacesContext().getExternalContext().getApplicationMap().get(key);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the value of the Output to a Application attribute. 'key' may be null, in this
+     * case, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when setting the value into the Application attribute Map
+     *
+     * @param value The value to set
+     */
+    @Override
+    public void setValue(HandlerContext context, IODescriptor outDesc, String key, Object value) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get it from the Application attribute map
+        context.getFacesContext().getExternalContext().getApplicationMap().put(key, value);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/ELOutputType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/ELOutputType.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ValueExpression;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This class implements the OutputType interface to provide a way to get/set Output values via standard EL.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ELOutputType implements OutputType {
+
+    /**
+     * <p>
+     * This method is responsible for retrieving the value of the output from EL. The "key" is expected to be the EL
+     * expression, including the opening and closing delimiters: #{some.el}
+     * </p>
+     *
+     * @param context The HandlerContext.
+     *
+     * @param outDesc The {@link IODescriptor} for this output in which we are obtaining a value (not used).
+     *
+     * @param key The EL expression to evaluate.
+     *
+     * @return The requested value.
+     */
+    @Override
+    public Object getValue(HandlerContext context, IODescriptor outDesc, String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("ELOutputType's key may not be null!");
+        }
+
+        // Make sure it is an EL expression...
+        if (!key.startsWith("#{")) {
+            // If the key is not an EL expression, make it one... while this
+            // may cover some user-errors, I think it adds a nice ease-of-use
+            // feature that people may like...
+            key = "#{requestScope['" + key + "']}";
+        }
+
+        // See if we can find the UIComp...
+        UIComponent uicomp = null;
+        Object eventObj = context.getEventObject();
+        if (eventObj instanceof UIComponent) {
+            uicomp = (UIComponent) eventObj;
+        }
+
+        // Get it from the EL expression
+        FacesContext ctx = context.getFacesContext();
+        return ComponentUtil.getInstance(ctx).resolveValue(ctx, context.getLayoutElement(), uicomp, key);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the value of the output via EL. The "key" is expected to be the EL expression,
+     * including the opening and closing delimiters: #{some.el}
+     * </p>
+     *
+     * @param context The HandlerContext.
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value. Used to pull EL expression from
+     * the Handler.
+     *
+     * @param key The EL expression to evaluate.
+     *
+     * @param value The value to set.
+     */
+    @Override
+    public void setValue(HandlerContext context, IODescriptor outDesc, String key, Object value) {
+        // It should never be null...
+        if (key == null) {
+            throw new IllegalArgumentException("ELOutputType's key may not be null!");
+        }
+
+        // Make sure it is an EL expression...
+        if (!key.startsWith("#{")) {
+            // If the key is not an EL expression, make it one... while this
+            // may cover some user-errors, I think it adds a nice ease-of-use
+            // feature that people may like...
+            key = "#{requestScope['" + key + "']}";
+        }
+
+        // Set it in EL
+        FacesContext facesContext = context.getFacesContext();
+        ELContext elctx = facesContext.getELContext();
+        ValueExpression ve = facesContext.getApplication().getExpressionFactory().createValueExpression(elctx, key, Object.class);
+        try {
+            ve.setValue(elctx, value);
+        } catch (ELException ex) {
+            throw new RuntimeException("Unable to set handler output value named \"" + outDesc.getName() + "\" mapped to EL expression \"" + key
+                    + "\" on the \"" + context.getLayoutElement().getUnevaluatedId() + "\" element.", ex);
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/Handler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/Handler.java
@@ -1,0 +1,509 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.component.ComponentUtil;
+import com.sun.jsftemplating.el.PermissionChecker;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.event.UIComponentHolder;
+import com.sun.jsftemplating.util.LogUtil;
+import com.sun.jsftemplating.util.TypeConverter;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.EventObject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class contains the information necessary to invoke a Handler. The {@link HandlerDefinition} class provides a
+ * definition of how to invoke a Handler, this class uses that information with in conjuction with information provided
+ * in this class to execute the <strong>handler method</strong>. This class typically will hold input values and specify
+ * where output should be stored.
+ * </p>
+ *
+ * <p>
+ * The <strong>handler method</strong> to be invoked must have the following method signature:
+ * </p>
+ *
+ * <p>
+ * <BLOCKQUOTE> <CODE>
+ *        public void doSomething(HandlerContext handlerCtx)
+ *        </CODE> </BLOCKQUOTE>
+ * </p>
+ *
+ * <p>
+ * <code>void</code> be replaced with any type. Depending on the type of event, return values may be handled
+ * differently.
+ * </p>
+ *
+ * <p>
+ * It is advisable to use Java annotations when defining a <strong>handler method</strong>. See examples of annotations
+ * in the <code>com.sun.jsftemplating.handlers package</code>. Here is an example:
+ * </p>
+ *
+ * <p>
+ * <BLOCKQUOTE> <CODE>
+ *        &#64;Handler(id="abc:doSomething",<br />
+ *            input={<br />
+ *            &#64;HandlerInput(name="foo", type=Integer.class),<br />
+ *            &#64;HandlerInput(name="bar", type=My.class, required=true)<br />
+ *            },<br />
+ *            output={<br />
+ *            &#64;HandlerOutput(name="result", type=String.class)<br />
+ *            })<br />
+ *        public void doSomething(HandlerContext handlerCtx)
+ *        </CODE> </BLOCKQUOTE>
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class Handler implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public Handler(HandlerDefinition handlerDef) {
+        setHandlerDefinition(handlerDef);
+    }
+
+    /**
+     * <p>
+     * Accessor for the {@link HandlerDefinition}.
+     * </p>
+     */
+    public HandlerDefinition getHandlerDefinition() {
+        return _handlerDef;
+    }
+
+    /**
+     * <p>
+     * This method sets the HandlerDefinition used by this Handler.
+     * </p>
+     */
+    protected void setHandlerDefinition(HandlerDefinition handler) {
+        _handlerDef = handler;
+    }
+
+    /**
+     * <p>
+     * This method is invoked by a parser to help populate this <code>Handler</code>. This information is generally static
+     * but may contain expressions to make the value dynamic.
+     * </p>
+     */
+    public void setInputValue(String name, Object value) {
+        IODescriptor inDesc = getHandlerDefinition().getInputDef(name);
+        if (inDesc == null) {
+            throw new RuntimeException("Attempted to set input value '" + name + "' with value '" + value + "', however, '" + name
+                    + "' is not a declared input parameter in HandlerDefinition '" + getHandlerDefinition().getId() + "'!");
+        }
+        _inputs.put(name, value);
+    }
+
+    /**
+     * <p>
+     * This method returns a Map of NVPs representing the input to this handler.
+     * </p>
+     */
+    protected Map<String, Object> getInputMap() {
+        return _inputs;
+    }
+
+    /**
+     * <p>
+     * This method simply returns the named input value, null if not found. It will not attempt to resolve $...{...}
+     * expressions or do modifications of any kind. If you are looking for a method to do these types of operations, try
+     * {@link #getInputValue(HandlerContext, String)}.
+     * </p>
+     *
+     * @param name The name used to identify the input value.
+     */
+    public Object getInputValue(String name) {
+        return _inputs.get(name);
+    }
+
+    /**
+     * <p>
+     * This method returns the value for the named input. Input values are not stored in this HandlerContext itself, but in
+     * the Handler. If you are trying to set input values for a handler, you must create a new Handler object and set its
+     * input values.
+     * </p>
+     *
+     * <p>
+     * This method attempts to resolve $...{...} expressions. It also will return the default value if the value is null. If
+     * you don't want these things to happen, look at Handler.getInputValue(String).
+     * </p>
+     *
+     * @param name The input name
+     *
+     * @return The value of the input (null if not found)
+     */
+    public Object getInputValue(HandlerContext ctx, String name) {
+        // Make sure the requested name is valid
+        IODescriptor inDesc = getHandlerDefinition().getInputDef(name);
+        FacesContext facesCtx = ctx.getFacesContext();
+        if (inDesc == null) {
+            throw new RuntimeException("Attempted to get input value '" + name + "', however, this is not a declared input "
+                    + "parameter in handler definition '" + getHandlerDefinition().getId() + "'!  Check your handler " + " and/or the XML (near LayoutElement '"
+                    + ctx.getLayoutElement().getId(facesCtx, null) + "')");
+        }
+
+        // Get the value, and parse it
+        Object value = getInputValue(name);
+        if (value == null) {
+            if (inDesc.isRequired()) {
+                throw new RuntimeException("'" + name + "' is required for handler '" + getHandlerDefinition().getId() + "'!");
+            }
+            value = inDesc.getDefault();
+        }
+
+        // Resolve any expressions
+        EventObject event = ctx.getEventObject();
+        UIComponent component = null;
+        if (event instanceof UIComponentHolder) {
+            component = ((UIComponentHolder) event).getUIComponent();
+        } else if (event != null) {
+            Object src = event.getSource();
+            if (src instanceof UIComponent) {
+                component = (UIComponent) src;
+            }
+        }
+        value = ComponentUtil.getInstance(facesCtx).resolveValue(facesCtx, ctx.getLayoutElement(), component, value);
+
+        // Make sure the value is the correct type...
+        value = TypeConverter.asType(inDesc.getType(), value);
+
+        return value;
+    }
+
+    /**
+     * <p>
+     * This method retrieves an output value. Output values are stored in the location specified by the {@link OutputType}
+     * in the Handler.
+     * </p>
+     *
+     * @param context The HandlerContext
+     * @param name The output name
+     *
+     * @return The value of the output (null if not set)
+     */
+    public Object getOutputValue(HandlerContext context, String name) {
+        // Make sure the requested name is valid
+        HandlerDefinition handlerDef = getHandlerDefinition();
+        IODescriptor outIODesc = handlerDef.getOutputDef(name);
+        if (outIODesc == null) {
+            throw new RuntimeException("Attempted to get output value '" + name + "' from handler '" + handlerDef.getId()
+                    + "', however, this is not a declared output parameter!  " + "Check your handler and/or the XML.");
+        }
+
+        // Get the OutputMapping that describes how to store this output
+        OutputMapping outputDesc = getOutputValue(name);
+
+        // NOTE: Interesting that this method does not evaluate the EL in
+        // NOTE: getOutputKey... probably a bug. Although it is very uncommon
+        // NOTE: (to get a output types output key which is dynamic from a
+        // NOTE: handler which just set the output value). It is uncommon to
+        // NOTE: use this method at all, let alone for dynamicly key'd
+        // NOTE: OutputTypes, so this code path probably hasn't ever been
+        // NOTE: executed.
+        // Return the value
+        return outputDesc.getOutputType().getValue(context, outIODesc, outputDesc.getOutputKey());
+    }
+
+    /**
+     * <p>
+     * This method stores an output value. Output values are stored as specified by the {@link OutputType} in the Handler.
+     * This method is not used to create the "mapping" of an output value, for that see
+     * {@link #setOutputMapping(String, String, String)}.
+     * </p>
+     *
+     * @param context The HandlerContext
+     * @param name The name the Handler uses for the output
+     * @param value The value to set
+     */
+    public void setOutputValue(HandlerContext context, String name, Object value) {
+        // Make sure the requested name is valid
+        HandlerDefinition handlerDef = getHandlerDefinition();
+        IODescriptor outIODesc = handlerDef.getOutputDef(name);
+        if (outIODesc == null) {
+            throw new RuntimeException("Attempted to set output value '" + name + "' from handler '" + handlerDef.getId()
+                    + "', however, this is not a declared output parameter!  " + "Check your handler and/or the XML.");
+        }
+
+        // Get the OutputMapping that describes how to store this output
+        OutputMapping outputMapping = getOutputValue(name);
+        if (outputMapping == null) {
+            // They did not Map the output, do nothing...
+            return;
+        }
+
+        // Make sure the value is the correct type...
+        value = TypeConverter.asType(outIODesc.getType(), value);
+
+        // Set the value
+        EventObject event = context.getEventObject();
+        UIComponent component = null;
+        if (event instanceof UIComponentHolder) {
+            component = ((UIComponentHolder) event).getUIComponent();
+        }
+
+        // Most output types appreciate resolving EL for the "key", however
+        // in some cases (such as the EL output type), resolving the key
+        // is counterproductive. Check output type to see if the output
+        // key should be resolved.
+        OutputType outType = outputMapping.getOutputType();
+        String outputKey = outputMapping.getOutputKey();
+// FIXME: For now I'm going to do instanceof instead of modifying the
+// FIXME: OutputType interface.  I can't think of another OutputType that would
+// FIXME: want this... if anyone ever has a use case, I'll happily modify the
+// FIXME: OutputType interface, or add a new interface to flag this code-path.
+        if (!(outType instanceof ELOutputType)) {
+            FacesContext ctx = context.getFacesContext();
+            outputKey = "" + ComponentUtil.getInstance(ctx).resolveValue(ctx, context.getLayoutElement(), component, outputKey);
+        }
+        outType.setValue(context, outIODesc, outputKey, value);
+    }
+
+    /**
+     * <p>
+     * This method adds a new OutputMapping to this handler. An OutputMapping allows the handler to return a value and have
+     * it "mapped" to the location of your choice. The "outputType" corresponds to a registered {@link OutputType} (see
+     * {@link OutputTypeManager}).
+     * </p>
+     *
+     * @param outputName The Handler's name for the output value
+     * @param targetKey The 'key' the OutputType uses to store the output
+     * @param targetType The OutputType implementation map the output
+     */
+    public void setOutputMapping(String outputName, String targetKey, String targetType) {
+        // Ensure we have a valid outputName (check HandlerDefinition)
+        if (getHandlerDefinition().getOutputDef(outputName) == null) {
+            throw new IllegalArgumentException(
+                    "Handler named '" + getHandlerDefinition().getId() + "' does not declare output " + "mapping named '" + outputName + "'.");
+        }
+
+        // Ensure the data is trim
+        if (targetKey != null) {
+            targetKey = targetKey.trim();
+            if (targetKey.length() == 0) {
+                targetKey = null;
+            }
+        }
+        targetType = targetType.trim();
+
+        try {
+            _outputs.put(outputName, new OutputMapping(outputName, targetKey, targetType));
+        } catch (IllegalArgumentException ex) {
+            throw new RuntimeException("Unable to create OutputMapping with given information: " + "outputName='" + outputName + "', targetKey='" + targetKey
+                    + "', targetType=" + targetType + "'", ex);
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the {@link OutputMapping} for the given <code>name</code>. If not found, it will return
+     * <code>null</code>.
+     * </p>
+     */
+    public OutputMapping getOutputValue(String name) {
+        return _outputs.get(name);
+    }
+
+    /**
+     * <p>
+     * This method returns the condition that must be true in order for this <code>Handler</code> (or its child
+     * <code>Handler</code>s) to be invoked. If this condition is empty ("") or <code>null</code>, it is considered to be
+     * true.
+     * </p>
+     */
+    public String getCondition() {
+        return _condition;
+    }
+
+    /**
+     * <p>
+     * This method sets the condition that must evaluate to true in order for this <code>Handler</code> to be invoked.
+     * </p>
+     */
+    public void setCondition(String cond) {
+        if (cond != null) {
+            cond = cond.trim();
+        }
+        _condition = cond;
+    }
+
+    /**
+     * <p>
+     * This method determines if the handler is static.
+     * </p>
+     */
+    public boolean isStatic() {
+        return getHandlerDefinition().isStatic();
+    }
+
+    /**
+     * <p>
+     * This method adds a <code>Handler</code> to the list of child <code>Handler</code>s. Child <code>Handler</code>s are
+     * executed AFTER this <code>Handler</code> is executed.
+     * </p>
+     *
+     * @param desc The <code>Handler</code> to add.
+     */
+    public void addChildHandler(Handler desc) {
+        if (_childHandlers == _emptyList) {
+            _childHandlers = new ArrayList();
+        }
+        _childHandlers.add(desc);
+    }
+
+    /**
+     * <p>
+     * This method sets the <code>List</code> of child <code>Handler</code>s.
+     * </p>
+     *
+     * @param childHandlers The <code>List</code> of child <code>Handler</code>s.
+     */
+    public void setChildHandlers(List<Handler> childHandlers) {
+        if (childHandlers == null || childHandlers.size() == 0) {
+            childHandlers = _emptyList;
+        }
+        _childHandlers = childHandlers;
+    }
+
+    /**
+     * <p>
+     * This method retrieves the <code>List</code> of child {@link Handler}s. This <code>List</code> should not be changed
+     * directly. Call {@link #addChildHandler(Handler)}, or make a copy and call {@link #setChildHandlers(List)}.
+     * </p>
+     *
+     * @return The <code>List</code> of child {@link Handler}s.
+     */
+    public List<Handler> getChildHandlers() {
+        return _childHandlers;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for invoking this <code>Handler</code> as well as all child <code>Handler</code>s. Neither
+     * will be invoked if this methods condition is non-null and unstatisfied (see {@link #getCondition()}). The method
+     * associated with this <code>Handler</code> will be invoked first, then any child <code>Handler</code>s.
+     * </p>
+     *
+     * @param handlerContext The {@link HandlerContext}.
+     */
+    public Object invoke(HandlerContext handlerContext) throws InstantiationException, IllegalAccessException, InvocationTargetException {
+        Object result = null;
+        HandlerDefinition handlerDef = getHandlerDefinition();
+
+        // Invoke
+        if (hasPermission(handlerContext)) {
+            // Only attempt to do this if there is a handler method, there
+            // might only be child handlers
+            Method method = handlerDef.getHandlerMethod();
+            if (method != null) {
+                Object instance = null;
+                if (!isStatic()) {
+                    // Get the class that contains the method
+                    instance = method.getDeclaringClass().newInstance();
+                }
+
+                // Invoke the Method
+                result = method.invoke(instance, handlerContext);
+            }
+
+            // Execute all the child handlers
+            if (result == null || !result.toString().equals("false")) {
+                // NOTE: 'handler' in handlerContext will change.
+                // before we execute this Handler.
+                // FIRST: Execute handlerDef child handlers
+                List<Handler> handlers = handlerDef.getChildHandlers();
+                Object retVal = null;
+                LayoutElement elt = handlerContext.getLayoutElement();
+                if (handlers.size() > 0) {
+                    retVal = elt.dispatchHandlers(handlerContext, handlers);
+                    if (retVal != null) {
+                        result = retVal;
+                    }
+                }
+
+                // NEXT: Execute instance child handlers
+                // Useful for applying a condition to a group
+                handlers = getChildHandlers();
+                if (handlers.size() > 0) {
+                    retVal = elt.dispatchHandlers(handlerContext, handlers);
+                    if (retVal != null) {
+                        result = retVal;
+                    }
+                }
+            }
+        } else {
+            if (LogUtil.finerEnabled()) {
+                LogUtil.finer("Handler '" + handlerDef.getId() + "' skipped because condition not met: '" + getCondition() + "'.");
+            }
+        }
+
+        // Return the result (null if no result)
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method determines if the condition (see {@link #getCondition()}) is satisfied.
+     * </p>
+     *
+     * @return true if the condition is met.
+     */
+    public boolean hasPermission(HandlerContext handlerContext) {
+        String cond = getCondition();
+        if (cond == null || cond.equals("")) {
+            return true;
+        }
+
+        // Try to get the UIComponent
+        UIComponent comp = null;
+        Object obj = handlerContext.getEventObject().getSource();
+        if (obj instanceof UIComponent) {
+            comp = (UIComponent) obj;
+        }
+
+        // Create a PermissionChecker
+        PermissionChecker checker = new PermissionChecker(handlerContext.getLayoutElement(), comp, cond);
+
+        // Return the result
+        return checker.hasPermission();
+    }
+
+    private HandlerDefinition _handlerDef = null;
+
+    private String _condition = null;
+
+    private List<Handler> _childHandlers = _emptyList;
+
+    private Map<String, Object> _inputs = new HashMap<>();
+    private Map<String, OutputMapping> _outputs = new HashMap<>();
+
+    private static final List<Handler> _emptyList = new ArrayList<>(0);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/HandlerContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/HandlerContext.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.EventObject;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface HandlerContext {
+
+    /**
+     * <p>
+     * Accessor for the FacesContext.
+     * </p>
+     *
+     * @return FacesContext
+     */
+    FacesContext getFacesContext();
+
+    /**
+     * <p>
+     * Accessor for the LayoutElement associated with this Handler. The LayoutElement associated with this Handler is the
+     * LayoutElement which declared the handler. This provides a way for the handler to obtain access to the LayoutElement
+     * which is responsible for it being invoked.
+     * </p>
+     */
+    LayoutElement getLayoutElement();
+
+    /**
+     * <p>
+     * Accessor for the EventObject associated with this Handler. This may be null if an EventObject was not created for
+     * this handler. An EventObject, if it does exist, may provide additional details describing the context in which this
+     * Event is invoked.
+     * </p>
+     */
+    EventObject getEventObject();
+
+    /**
+     * <p>
+     * This method provides access to the EventType. This is mostly helpful for diagnostics, but may be used in a handler to
+     * determine more information about the context in which the code is executing.
+     * </p>
+     */
+    String getEventType();
+
+    /**
+     * <p>
+     * Accessor for the Handler descriptor for this Handler. The Handler descriptor object contains specific meta
+     * information describing the invocation of this handler. This includes details such as input values, and where output
+     * values are to be set.
+     * </p>
+     */
+    Handler getHandler();
+
+    /**
+     * <p>
+     * Setter for the Handler descriptor for this Handler.
+     * </p>
+     *
+     * @param handler The Handler
+     */
+    void setHandler(Handler handler);
+
+    /**
+     * <p>
+     * Accessor for the Handler descriptor for this Handler. The HandlerDefinition descriptor contains meta information
+     * about the actual Java handler that will handle the processing. This includes the inputs required, outputs produces,
+     * and the types for both.
+     * </p>
+     */
+    HandlerDefinition getHandlerDefinition();
+
+    /**
+     * <p>
+     * This method returns the value for the named input. Input values are not stored in this Context itself, but in the
+     * Handler. If you are trying to set input values for a handler, you must create a new Handler object and set its input
+     * values.
+     * </p>
+     *
+     * @param name The input name
+     *
+     * @return The value of the input (null if not found)
+     */
+    Object getInputValue(String name);
+
+    /**
+     * <p>
+     * This method retrieves an Output value. Output values must not be stored in this Context itself (remember
+     * HandlerContext objects are shared). Output values are stored according to what is specified in the HandlerDefintion.
+     * </p>
+     *
+     * @param name The output name
+     *
+     * @return The value of the output (null if not found)
+     */
+    Object getOutputValue(String name);
+
+    /**
+     * <p>
+     * This method sets an Output value. Output values must not be stored in this Context itself (remember HandlerContext
+     * objects are shared). Output values are stored according to what is specified in the HandlerDefintion.
+     * </p>
+     */
+    void setOutputValue(String name, Object value);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/HandlerContextImpl.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/HandlerContextImpl.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.EventObject;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class HandlerContextImpl implements HandlerContext {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public HandlerContextImpl(FacesContext context, LayoutElement layoutDesc, EventObject event, String eventType) {
+        _facesContext = context;
+        _layoutDesc = layoutDesc;
+        _event = event;
+        _eventType = eventType;
+    }
+
+    /**
+     * <p>
+     * Constructor that gets all its values from the given HandlerContext.
+     * </p>
+     *
+     * @param context The HandlerContext to clone.
+     */
+    public HandlerContextImpl(HandlerContext context) {
+        _facesContext = context.getFacesContext();
+        _layoutDesc = context.getLayoutElement();
+        _event = context.getEventObject();
+        _eventType = context.getEventType();
+        _handler = context.getHandler();
+    }
+
+    /**
+     * <p>
+     * Accessor for the FacesContext.
+     * </p>
+     *
+     * @return FacesContext
+     */
+    @Override
+    public FacesContext getFacesContext() {
+        return _facesContext;
+    }
+
+    /**
+     * <p>
+     * Accessor for the LayoutElement associated with this Handler.
+     * </p>
+     */
+    @Override
+    public LayoutElement getLayoutElement() {
+        return _layoutDesc;
+    }
+
+    /**
+     * <p>
+     * Accessor for the EventObject associated with this Handler. This may be null if an EventObject was not created for
+     * this handler. An EventObject, if it does exist, may provide additional details describing the context in which this
+     * Event is invoked.
+     * </p>
+     */
+    @Override
+    public EventObject getEventObject() {
+        return _event;
+    }
+
+    /**
+     * <p>
+     * This method provides access to the EventType. This is mostly helpful for diagnostics, but may be used in a handler to
+     * determine more information about the context in which the code is executing.
+     * </p>
+     */
+    @Override
+    public String getEventType() {
+        return _eventType;
+    }
+
+    /**
+     * <p>
+     * Accessor for the Handler descriptor for this Handler. The Handler descriptor object contains specific meta
+     * information describing the invocation of this handler. This includes details such as input values, and where output
+     * values are to be set.
+     * </p>
+     */
+    @Override
+    public Handler getHandler() {
+        return _handler;
+    }
+
+    /**
+     * <p>
+     * Setter for the Handler descriptor for this Handler.
+     * </p>
+     */
+    @Override
+    public void setHandler(Handler handler) {
+        _handler = handler;
+    }
+
+    /**
+     * <p>
+     * Accessor for the Handler descriptor for this Handler. The HandlerDefinition descriptor contains meta information
+     * about the actual Java handler that will handle the processing. This includes the inputs required, outputs produces,
+     * and the types for both.
+     * </p>
+     */
+    @Override
+    public HandlerDefinition getHandlerDefinition() {
+        return _handler.getHandlerDefinition();
+    }
+
+    /**
+     * <p>
+     * This method returns the value for the named input. Input values are not stored in this HandlerContext itself, but in
+     * the Handler. If you are trying to set input values for a handler, you must create a new Handler object and set its
+     * input values.
+     * </p>
+     *
+     * <p>
+     * This method attempts to resolve $...{...} expressions. It also will return the default value if the value is null. If
+     * you don't want these things to happen, look at Handler.getInputValue(String).
+     * </p>
+     *
+     * @param name The input name
+     *
+     * @return The value of the input (null if not found)
+     */
+    @Override
+    public Object getInputValue(String name) {
+        return getHandler().getInputValue(this, name);
+    }
+
+    /**
+     * <p>
+     * This method retrieves an Output value. Output values must not be stored in this Context itself (remember
+     * HandlerContext objects are shared). Output values are stored according to what is specified in the HandlerDefintion.
+     * </p>
+     *
+     * @param name The output name
+     *
+     * @return The value of the output (null if not found)
+     */
+    @Override
+    public Object getOutputValue(String name) {
+        return getHandler().getOutputValue(this, name);
+    }
+
+    /**
+     * <p>
+     * This method sets an Output value. Output values must not be stored in this Context itself (remember HandlerContext
+     * objects are shared). Output values are stored according to what is specified in the HandlerDefintion.
+     * </p>
+     */
+    @Override
+    public void setOutputValue(String name, Object value) {
+        getHandler().setOutputValue(this, name, value);
+    }
+
+    private String _eventType = null;
+    private FacesContext _facesContext = null;
+    private LayoutElement _layoutDesc = null;
+    private EventObject _event = null;
+    private Handler _handler = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/HandlerDefinition.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/HandlerDefinition.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.util.Util;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * A HandlerDefinition defines a "handler" that may be invoked in the process of executing an event. A HandlerDefinition
+ * has an <strong>id</strong>, <strong>java method</strong>, <strong>input definitions</strong>, <strong>output
+ * definitions</strong>, and <strong>child handlers</strong>.
+ * </p>
+ *
+ * <p>
+ * The <strong>java method</strong> to be invoked must have the following method signature:
+ * </p>
+ *
+ * <p>
+ * <BLOCKQUOTE><CODE> public void beginDisplay(HandlerContext handlerCtx) </CODE></BLOCKQUOTE>
+ * </p>
+ *
+ * <p>
+ * <code>void</code> above can return a value. Depending on the type of event, return values may be handled differently.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class HandlerDefinition implements java.io.Serializable {
+
+    /**
+     * Constructor
+     */
+    public HandlerDefinition(String id) {
+        _id = id;
+    }
+
+    /**
+     * This method returns the id for this handler.
+     */
+    public String getId() {
+        return _id;
+    }
+
+    /**
+     * For future tool support
+     */
+    public String getDescription() {
+        return _description;
+    }
+
+    /**
+     * For future tool support
+     */
+    public void setDescription(String desc) {
+        _description = desc;
+    }
+
+    /**
+     * <p>
+     * This method sets the event handler (method) to be invoked. The method should be public and accept a prameter of type
+     * "HandlerContext" Example:
+     * </p>
+     *
+     * <p>
+     * <BLOCKQUOTE> public void beginDisplay(HandlerContext handlerCtx) </BLOCKQUOTE>
+     * </p>
+     *
+     * @param cls The full class name containing method
+     * @param methodName The method name of the handler within class
+     */
+    public void setHandlerMethod(String cls, String methodName) {
+        if (cls == null || methodName == null) {
+            throw new IllegalArgumentException("Class name and method name must be non-null!");
+        }
+        _methodClass = cls;
+        _methodName = methodName;
+    }
+
+    /**
+     *
+     */
+    public void setHandlerMethod(Method method) {
+        if (method != null) {
+            _methodName = method.getName();
+            _methodClass = method.getDeclaringClass().getName();
+        } else {
+            _methodName = null;
+            _methodClass = null;
+        }
+        _method = method;
+    }
+
+    /**
+     * <p>
+     * This method determines if the handler is static.
+     * </p>
+     */
+    public boolean isStatic() {
+        if (_static == null) {
+            _static = Boolean.valueOf(Modifier.isStatic(getHandlerMethod().getModifiers()));
+        }
+        return _static.booleanValue();
+    }
+
+    /**
+     *
+     */
+    public Method getHandlerMethod() {
+        if (_method != null) {
+            // return cached Method
+            return _method;
+        }
+
+        // See if we have the info to find it
+        if (_methodClass != null && _methodName != null) {
+            // Find the class
+            Class clzz = null;
+            try {
+                clzz = Util.loadClass(_methodClass, _methodClass);
+            } catch (ClassNotFoundException ex) {
+                throw new RuntimeException("'" + _methodClass + "' not found for method '" + _methodName + "'!", ex);
+            }
+
+            // Find the method on the class
+            Method method = null;
+            try {
+                method = clzz.getMethod(_methodName, EVENT_ARGS);
+            } catch (NoSuchMethodException ex) {
+                throw new RuntimeException("Method '" + _methodName + "' not found!", ex);
+            }
+
+            // Cache the _method
+            _method = method;
+        }
+
+        // Return the Method if there is one
+        return _method;
+    }
+
+    /**
+     * This method adds an IODescriptor to the list of input descriptors. These descriptors define the input parameters to
+     * this handler.
+     *
+     * @param desc The input IODescriptor to add
+     */
+    public void addInputDef(IODescriptor desc) {
+        _inputDefs.put(desc.getName(), desc);
+    }
+
+    /**
+     * This method sets the input IODescriptors for this handler.
+     *
+     * @param inputDefs The Map of IODescriptors
+     */
+    public void setInputDefs(Map<String, IODescriptor> inputDefs) {
+        if (inputDefs == null) {
+            throw new IllegalArgumentException("inputDefs cannot be null!");
+        }
+        _inputDefs = inputDefs;
+    }
+
+    /**
+     * This method retrieves the Map of input IODescriptors.
+     *
+     * @return The Map of IODescriptors
+     */
+    public Map<String, IODescriptor> getInputDefs() {
+        return _inputDefs;
+    }
+
+    /**
+     * This method returns the requested IODescriptor, null if not found.
+     */
+    public IODescriptor getInputDef(String name) {
+        return _inputDefs.get(name);
+    }
+
+    /**
+     * This method adds an IODescriptor to the list of output descriptors. These descriptors define the output parameters to
+     * this handler.
+     *
+     * @param desc The IODescriptor to add
+     */
+    public void addOutputDef(IODescriptor desc) {
+        _outputDefs.put(desc.getName(), desc);
+    }
+
+    /**
+     * This method sets the output IODescriptors for this handler.
+     *
+     * @param outputDefs The Map of output IODescriptors
+     */
+    public void setOutputDefs(Map<String, IODescriptor> outputDefs) {
+        if (outputDefs == null) {
+            throw new IllegalArgumentException("outputDefs cannot be null!");
+        }
+        _outputDefs = outputDefs;
+    }
+
+    /**
+     * This method retrieves the Map of output IODescriptors.
+     *
+     * @return The Map of output IODescriptors
+     */
+    public Map<String, IODescriptor> getOutputDefs() {
+        return _outputDefs;
+    }
+
+    /**
+     * This method returns the requested IODescriptor, null if not found.
+     */
+    public IODescriptor getOutputDef(String name) {
+        return _outputDefs.get(name);
+    }
+
+    /**
+     * <p>
+     * This method adds a {@link Handler} to the list of child {@link Handler}s. Child {@link Handler}s are executed AFTER
+     * this {@link Handler} is executed.
+     * </p>
+     *
+     * @param desc The {@link Handler} to add.
+     */
+    public void addChildHandler(Handler desc) {
+        if (_childHandlers == _emptyList) {
+            _childHandlers = new ArrayList();
+        }
+        _childHandlers.add(desc);
+    }
+
+    /**
+     * <p>
+     * This method sets the <code>List</code> of child {@link Handler}s for this <code>HandlerDefinition</code>.
+     *
+     * @param childHandlers The <code>List</code> of child {@link Handler}s.
+     */
+    public void setChildHandlers(List<Handler> childHandlers) {
+        if (childHandlers == null || childHandlers.size() == 0) {
+            childHandlers = _emptyList;
+        }
+        _childHandlers = childHandlers;
+    }
+
+    /**
+     * <p>
+     * This method retrieves the <code>List</code> of child {@link Handler}s. This <code>List</code> should not be changed
+     * directly. Call {@link #addChildHandler(Handler)}, or make a copy and call {@link #setChildHandlers(List)}.
+     * </p>
+     *
+     * @return The <code>List</code> of child {@link Handler}s for this <code>HandlerDefinition</code>.
+     */
+    public List<Handler> getChildHandlers() {
+        return _childHandlers;
+    }
+
+    /**
+     * <p>
+     * This toString() provides detailed information about this <code>HandlerDefinition</code>.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        // Print the basic info...
+        Formatter printf = new Formatter();
+        printf.format("%-40s  %s.%s\n", _id, _methodClass, _methodName);
+
+        // Print the description
+        if (_description != null) {
+            printf.format("%s\n", _description);
+        }
+
+        // Print the Inputs
+        Iterator<IODescriptor> it = _inputDefs.values().iterator();
+        while (it.hasNext()) {
+            printf.format("    INPUT>  %s\n", it.next().toString());
+        }
+
+        // Print the Outputs
+        it = _outputDefs.values().iterator();
+        while (it.hasNext()) {
+            printf.format("    OUTPUT> %s\n", it.next().toString());
+        }
+
+        // Print the Child Handlers (TBD...)
+
+        // Return the result
+        return printf.toString();
+    }
+
+    public static final Class[] EVENT_ARGS = new Class[] { HandlerContext.class };
+
+    private String _id = null;
+    private String _description = null;
+    private String _methodClass = null;
+    private String _methodName = null;
+    private transient Method _method = null;
+    private Map<String, IODescriptor> _inputDefs = new HashMap<>(5);
+    private Map<String, IODescriptor> _outputDefs = new HashMap<>(5);
+    private List<Handler> _childHandlers = _emptyList;
+    private transient Boolean _static = null;
+
+    private static final List<Handler> _emptyList = new ArrayList<>(0);
+    private static final long serialVersionUID = 0xA8B7C6D5E4F30211L;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/IODescriptor.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/IODescriptor.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.util.Util;
+
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class describes an input or output parameter.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class IODescriptor implements java.io.Serializable {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param name The name of the input/output field.
+     * @param type The type of the input/output field.
+     */
+    public IODescriptor(String name, String type) {
+        setName(name);
+        setType(type);
+    }
+
+    /**
+     * <p>
+     * This method returns the name for this handler definition.
+     * </p>
+     */
+    public String getName() {
+        if (_name == null) {
+            throw new NullPointerException("Name cannot be null!");
+        }
+        return _name;
+    }
+
+    /**
+     * <p>
+     * This method sets the handler definitions name (used by the contsrutor).
+     * </p>
+     */
+    protected void setName(String name) {
+        _name = name;
+    }
+
+    /**
+     * <p>
+     * For future tool support.
+     * </p>
+     */
+    public String getDescription() {
+        return _description;
+    }
+
+    /**
+     * <p>
+     * For future tool support.
+     * </p>
+     */
+    public void setDescription(String desc) {
+        _description = desc;
+    }
+
+    /**
+     * <p>
+     * This method returns the type for this parameter.
+     * </p>
+     */
+    public Class getType() {
+        return _type;
+    }
+
+    /**
+     * <p>
+     * This method sets the type for this parameter.
+     * </p>
+     */
+    public void setType(Class type) {
+        _type = type;
+    }
+
+    /**
+     * <p>
+     * This method sets the type for this parameter.
+     * </p>
+     */
+    public void setType(String type) {
+        if (type == null || type.trim().length() == 0) {
+            return;
+        }
+        Class cls = _typeMap.get(type);
+        if (cls == null) {
+            try {
+                cls = Util.loadClass(type, type);
+            } catch (Exception ex) {
+                throw new RuntimeException("Unable to determine parameter type '" + type + "' for parameter named '" + getName() + "'.", ex);
+            }
+        }
+        _type = cls;
+    }
+
+    /**
+     * <p>
+     * This method returns the default for this parameter (valid for input only).
+     * </p>
+     */
+    public Object getDefault() {
+        return _default;
+    }
+
+    /**
+     * <p>
+     * This method sets the default for this parameter (valid for input only).
+     * </p>
+     */
+    public void setDefault(Object def) {
+        _default = def;
+    }
+
+    /**
+     * <p>
+     * This method inidicates if the input is required (valid for input only).
+     * </p>
+     */
+    public boolean isRequired() {
+        return _required;
+    }
+
+    /**
+     * <p>
+     * This method specifies whether this input field is required.
+     * </p>
+     */
+    public void setRequired(boolean required) {
+        _required = required;
+    }
+
+    /**
+     * <p>
+     * This <code>toString()</code> method provides detailed information about this <code>IODescriptor</code>.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        // Print the info...
+        Formatter printf = new Formatter();
+        printf.format("%-28s  %-40s  %s", _name + (_required ? "(required)" : ""), _type, _default == null ? "" : "DEFAULT: " + _default.toString());
+
+        // Print description if available
+        if (_description != null) {
+            printf.format("\n\t%s", _description);
+        }
+
+        // Return the result...
+        return printf.toString();
+    }
+
+    // The following provides some basic pre-defined types
+    private static Map<String, Class> _typeMap = new HashMap<>();
+    static {
+        _typeMap.put("boolean", Boolean.class);
+        _typeMap.put("Boolean", Boolean.class);
+        _typeMap.put("byte", Byte.class);
+        _typeMap.put("Byte", Byte.class);
+        _typeMap.put("char", Character.class);
+        _typeMap.put("Character", Character.class);
+        _typeMap.put("double", Double.class);
+        _typeMap.put("Double", Double.class);
+        _typeMap.put("float", Float.class);
+        _typeMap.put("Float", Float.class);
+        _typeMap.put("int", Integer.class);
+        _typeMap.put("Integer", Integer.class);
+        _typeMap.put("long", Long.class);
+        _typeMap.put("Long", Long.class);
+        _typeMap.put("short", Short.class);
+        _typeMap.put("Short", Short.class);
+        _typeMap.put("char[]", String.class);
+        _typeMap.put("String", String.class);
+        _typeMap.put("Object", Object.class);
+    }
+
+    private String _name = null;
+    private String _description = null;
+    private Object _default = null; // Input only
+    private Class _type = Object.class;
+    private boolean _required = false; // Input only
+
+    private static final long serialVersionUID = 0xA9B8C7D6E5F40312L;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/OutputMapping.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/OutputMapping.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This class holds OutputMapping value meta information for individual instances of Handler Objects. This information
+ * is necessary to provide the location to store the output value for a specific invocation of a handler. This is data
+ * consists of the name the Handler uses for the output, the OutputType, and optionally the OutputType key to use when
+ * storing/retrieving the output value.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class OutputMapping implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor with targetKey as null. This constructor will throw an IllegalArgumentException if outputName or
+     * targetOutputType is null.
+     * </p>
+     *
+     * @param outputName The name the Handler uses for output value
+     * @param targetOutputType OutputType that will store the output value
+     *
+     * @see OutputTypeManager
+     *
+     * @throws IllegalArumentException If outputName / targetOutputType is null
+     */
+    public OutputMapping(String outputName, String targetOutputType) {
+        this(outputName, null, targetOutputType);
+    }
+
+    /**
+     * <p>
+     * Constructor with all values supplied as Strings. This constructor will throw an IllegalArgumentException if
+     * outputName or targetOutputType is null.
+     * </p>
+     *
+     * @param outputName The name the Handler uses for output value
+     * @param targetKey The key the OutputType will use
+     * @param targetOutputType OutputType that will store the output value
+     *
+     * @see OutputTypeManager
+     *
+     * @throws NullPointerException If outputName / targetOutputType is null
+     */
+    public OutputMapping(String outputName, String targetKey, String targetOutputType) {
+        // Sanity checks...
+        if (outputName == null || outputName.length() == 0) {
+            throw new NullPointerException("'outputName' is required!");
+        }
+        if (targetOutputType == null) {
+            throw new NullPointerException("'targetOutputType' is required!");
+        }
+        _outputName = outputName;
+        _targetKey = targetKey;
+        _targetOutputType = targetOutputType;
+    }
+
+    /**
+     * Accessor for outputName.
+     */
+    public String getOutputName() {
+        return _outputName;
+    }
+
+    /**
+     * Accessor for targetKey.
+     */
+    public String getOutputKey() {
+        return _targetKey;
+    }
+
+    /**
+     * Accessor for targetOutputType.
+     */
+    public OutputType getOutputType() {
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        return OutputTypeManager.getManager(ctx).getOutputType(ctx, _targetOutputType);
+    }
+
+    /**
+     * <p>
+     * Accessor for targetOutputType as a String.
+     * </p>
+     */
+    public String getStringOutputType() {
+        return _targetOutputType;
+    }
+
+    private String _outputName = null;
+    private String _targetKey = null;
+    private String _targetOutputType = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/OutputType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/OutputType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+/**
+ * <p>
+ * This interface provides an abstraction for different locations for storing output from a handler. Implementations may
+ * store values in Session, request attributes, databases, etc.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface OutputType {
+
+    /**
+     * <p>
+     * This method is responsible for retrieving the value of the Output from the destination that was specified by handler.
+     * 'key' may be null. In cases where it is not needed, it can be ignored. If it is needed, the implementation may either
+     * provide a default or throw an exception.
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when retrieving the value from the OutputType
+     *
+     * @return The requested value.
+     */
+    Object getValue(HandlerContext context, IODescriptor outDesc, String key);
+
+    /**
+     * <p>
+     * This method is responsible for setting the value of the Output to the destination that was specified by handler.
+     * 'key' may be null. In cases where it is not needed, it can be ignored. If it is needed, the implementation may either
+     * provide a default or throw an exception.
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when setting the value from the OutputType
+     *
+     * @param value The value to set
+     */
+    void setValue(HandlerContext context, IODescriptor outDesc, String key, Object value);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/OutputTypeManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/OutputTypeManager.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * <code>OutputTypeManager</code> manages the various {@link OutputType}s that can be used. The {@link OutputType}s are
+ * managed statically.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class OutputTypeManager {
+
+    /**
+     * Constructor.
+     */
+    protected OutputTypeManager() {
+    }
+
+    /**
+     * <p>
+     * Attempts to get the <code>FacesContext</code> and returns the results from {@link #getManager(FacesContext)}.
+     * </p>
+     */
+    public static OutputTypeManager getInstance() {
+        return getManager(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * <p>
+     * This is a factory method for obtaining an OutputTypeManager instance. This implementation uses the external context's
+     * initParams to look for the OutputTypeManager class. If it exists, the specified concrete OutputTypeManager class will
+     * be used. Otherwise, the default will be used -- which is an instance of this class. The initParam key is:
+     * {@link #OUTPUT_TYPE_MANAGER_KEY}.
+     * </p>
+     *
+     * @param context The FacesContext
+     *
+     * @see #OUTPUT_TYPE_MANAGER_KEY
+     */
+    public static OutputTypeManager getManager(FacesContext context) {
+        if (context == null) {
+            return _defaultInstance;
+        }
+
+        // If the context is non-null, check for init parameter specifying
+        // the Manager
+        String className = null;
+        Map initParams = context.getExternalContext().getInitParameterMap();
+        if (initParams.containsKey(OUTPUT_TYPE_MANAGER_KEY)) {
+            className = (String) initParams.get(OUTPUT_TYPE_MANAGER_KEY);
+        }
+        return getManager(context, className);
+    }
+
+    /**
+     * <p>
+     * This method is a singleton factory method for obtaining an instance of an <code>OutputTypeManager</code>. It is
+     * possible that multiple different implementations of <code>OutputTypeManager</code>s will be used within the same
+     * application. This is fine. Someone may provide a different <code>OutputTypeManager</code> to locate
+     * <code>OutputType</code>'s in a different way (XML, database, file, java code, etc.).
+     * </p>
+     */
+    public static OutputTypeManager getManager(FacesContext ctx, String className) {
+        if (className == null) {
+            // Default case...
+            return _defaultInstance;
+        }
+        OutputTypeManager ldm = null;
+
+        // FacesContext
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, OutputTypeManager> instances = null;
+        if (ctx != null) {
+            instances = (Map<String, OutputTypeManager>) ctx.getExternalContext().getApplicationMap().get(OTM_INSTANCES);
+        }
+        if (instances == null) {
+            // NO instances defined yet...
+            instances = new HashMap<>(2);
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(OTM_INSTANCES, instances);
+            }
+        } else {
+            // See if we've found this before...
+            ldm = instances.get(className);
+        }
+        if (ldm == null) {
+            // Not found yet, try to find it...
+            try {
+                ldm = (OutputTypeManager) Util.loadClass(className, className).getMethod("getInstance", (Class[]) null).invoke((Object) null, (Object[]) null);
+            } catch (ClassNotFoundException ex) {
+                throw new RuntimeException(ex);
+            } catch (NoSuchMethodException ex) {
+                throw new RuntimeException(ex);
+            } catch (IllegalAccessException ex) {
+                throw new RuntimeException(ex);
+            } catch (InvocationTargetException ex) {
+                throw new RuntimeException(ex);
+            } catch (NullPointerException ex) {
+                throw new RuntimeException(ex);
+            } catch (ClassCastException ex) {
+                throw new RuntimeException(ex);
+            }
+
+            // We found it
+            instances.put(className, ldm);
+        }
+        return ldm;
+    }
+
+    /**
+     * <p>
+     * This method retrieves a <code>List</code> of {@link OutputType}. Changes to this <code>List</code> have no effect.
+     * </p>
+     *
+     * @return The {@link OutputType}s.
+     */
+    public List<OutputType> getOutputTypes(FacesContext ctx) {
+        return new ArrayList<>(getOutputTypeMap(ctx).values());
+    }
+
+    /**
+     * <p>
+     * Returns the application scope <code>Map</code> which holds all the {@link OutputType}s.
+     * </p>
+     */
+    private Map<String, OutputType> getOutputTypeMap(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, OutputType> outputTypeMap = null;
+        if (ctx != null) {
+            outputTypeMap = (Map<String, OutputType>) ctx.getExternalContext().getApplicationMap().get(OTM_TYPE_MAP);
+        }
+        if (outputTypeMap == null) {
+            // 1st time for this app... initialize it
+            outputTypeMap = new HashMap<>(8);
+            PageAttributeOutputType pageType = new PageAttributeOutputType();
+            outputTypeMap.put(EL_TYPE, new ELOutputType());
+            outputTypeMap.put(PAGE_ATTRIBUTE_TYPE, pageType);
+            outputTypeMap.put(PAGE_ATTRIBUTE_TYPE2, pageType);
+            outputTypeMap.put(APP_ATTRIBUTE_TYPE, new ApplicationAttributeOutputType());
+            outputTypeMap.put(REQUEST_ATTRIBUTE_TYPE, new RequestAttributeOutputType());
+            outputTypeMap.put(SESSION_ATTRIBUTE_TYPE, new SessionAttributeOutputType());
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(OTM_TYPE_MAP, outputTypeMap);
+            }
+        }
+
+        // Return the OutputType Map
+        return outputTypeMap;
+    }
+
+    /**
+     * <p>
+     * This method retrieves an OutputType.
+     * </p>
+     *
+     * @param name The name of the OutputType.
+     *
+     * @return The requested OutputType.
+     */
+    public OutputType getOutputType(FacesContext ctx, String name) {
+        return getOutputTypeMap(ctx).get(name);
+    }
+
+    /**
+     * <p>
+     * This method sets an OutputType.
+     * </p>
+     *
+     * @param name The name of the OutputType.
+     * @param outputType The OutputType.
+     */
+    public void setOutputType(FacesContext ctx, String name, OutputType outputType) {
+        // Not thread safe...
+        getOutputTypeMap(ctx).put(name, outputType);
+    }
+
+    /**
+     * <p>
+     * This is the default implementation of the OutputTypeManager, which happens to be an instance of this class (because
+     * I'm too lazy to do this right).
+     * </p>
+     */
+    private static final OutputTypeManager _defaultInstance = new OutputTypeManager();
+
+    /**
+     * <p>
+     * This constant defines the layout definition manager implementation key for initParams. The value for this initParam
+     * should be the full class name of an {@link OutputTypeManager}. ("outputTypeManagerImpl")
+     * </p>
+     */
+    public static final String OUTPUT_TYPE_MANAGER_KEY = "outputTypeManagerImpl";
+    private static final String OTM_INSTANCES = "__jsft_OutputTypeManagers";
+    private static final String OTM_TYPE_MAP = "__jsft_OutputType_map";
+
+    public static final String REQUEST_ATTRIBUTE_TYPE = "attribute";
+    public static final String PAGE_ATTRIBUTE_TYPE = "page";
+    public static final String PAGE_ATTRIBUTE_TYPE2 = "pageSession";
+    public static final String SESSION_ATTRIBUTE_TYPE = "session";
+    public static final String APP_ATTRIBUTE_TYPE = "application";
+    public static final String EL_TYPE = "el";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/PageAttributeOutputType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/PageAttributeOutputType.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+import com.sun.jsftemplating.el.PageSessionResolver;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class implements the OutputType interface to provide a way to get/set Output values from the Page attribute Map
+ * (see {@link PageSessionResolver}).
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class PageAttributeOutputType implements OutputType {
+
+    /**
+     * <p>
+     * This method is responsible for retrieving the value of the Output from a Page Session Attribute. 'key' may be null,
+     * if this occurs, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The {@link IODescriptor} for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when retrieving the value from the Page Session Attribute Map.
+     *
+     * @return The requested value, <code>null</code> if not found.
+     */
+    @Override
+    public Object getValue(HandlerContext context, IODescriptor outDesc, String key) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get the Page Session Map
+        Map<String, Serializable> map = PageSessionResolver.getPageSession(context.getFacesContext(), (UIViewRoot) null);
+
+        // Get the value to return
+        Serializable value = null;
+        if (map != null) {
+            value = map.get(key);
+        }
+
+        // Return it...
+        return value;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the value of the Output to a Page Session Attribute. 'key' may be null, in
+     * this case, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The {@link HandlerContext}
+     *
+     * @param outDesc The {@link IODescriptor} for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when setting the value into the Page Session Attribute Map
+     *
+     * @param value The value to set
+     */
+    @Override
+    public void setValue(HandlerContext context, IODescriptor outDesc, String key, Object value) {
+        // Ensure we have a key...
+        if (key == null) {
+            // We don't, provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get the Page Session Map
+        FacesContext ctx = context.getFacesContext();
+        Map<String, Serializable> map = PageSessionResolver.getPageSession(ctx, (UIViewRoot) null);
+        if (map == null) {
+            map = PageSessionResolver.createPageSession(ctx, (UIViewRoot) null);
+        }
+
+        // Set the Page Session Attribute Map
+        map.put(key, (Serializable) value);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/RequestAttributeOutputType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/RequestAttributeOutputType.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+/**
+ * <p>
+ * This class implements the OutputType interface to provide a way to get/set Output values from a ServletRequest
+ * attribute Map.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class RequestAttributeOutputType implements OutputType {
+
+    /**
+     * <p>
+     * This method is responsible for retrieving the value of the Output from a Request attribute. 'key' may be null, if
+     * this occurs, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when retrieving the value from the ServletRequest attribute Map.
+     *
+     * @return The requested value.
+     */
+    @Override
+    public Object getValue(HandlerContext context, IODescriptor outDesc, String key) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get it from the Request attribute map
+        return context.getFacesContext().getExternalContext().getRequestMap().get(key);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the value of the Output to a ServletRequest attribute. 'key' may be null, in
+     * this case, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when setting the value into the ServletRequest attribute Map
+     *
+     * @param value The value to set
+     */
+    @Override
+    public void setValue(HandlerContext context, IODescriptor outDesc, String key, Object value) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get it from the Request attribute map
+        context.getFacesContext().getExternalContext().getRequestMap().put(key, value);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/SessionAttributeOutputType.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/descriptors/handler/SessionAttributeOutputType.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.descriptors.handler;
+
+/**
+ * <p>
+ * This class implements the OutputType interface to provide a way to get/set Output values from the Session attribute
+ * Map.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class SessionAttributeOutputType implements OutputType {
+
+    /**
+     * <p>
+     * This method is responsible for retrieving the value of the Output from a Session attribute. 'key' may be null, if
+     * this occurs, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when retrieving the value from the Session attribute Map.
+     *
+     * @return The requested value.
+     */
+    @Override
+    public Object getValue(HandlerContext context, IODescriptor outDesc, String key) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get it from the Session attribute map
+        return context.getFacesContext().getExternalContext().getSessionMap().get(key);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the value of the Output to a Session attribute. 'key' may be null, in this
+     * case, a default name will be provided. That name will follow the following format:
+     * </p>
+     *
+     * <p>
+     * [handler-id]:[output-name]
+     * </p>
+     *
+     * @param context The HandlerContext
+     *
+     * @param outDesc The IODescriptor for this Output value in which to obtain the value
+     *
+     * @param key The optional 'key' to use when setting the value into the Session attribute Map
+     *
+     * @param value The value to set
+     */
+    @Override
+    public void setValue(HandlerContext context, IODescriptor outDesc, String key, Object value) {
+        if (key == null) {
+            // Provide a reasonably unique default
+            key = context.getHandlerDefinition().getId() + ':' + outDesc.getName();
+        }
+
+        // Get it from the Session attribute map
+        context.getFacesContext().getExternalContext().getSessionMap().put(key, value);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/AfterCreateEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/AfterCreateEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class AfterCreateEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public AfterCreateEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/AfterEncodeEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/AfterEncodeEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class AfterEncodeEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public AfterEncodeEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/AfterLoopEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/AfterLoopEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class AfterLoopEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public AfterLoopEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/BeforeCreateEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/BeforeCreateEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class BeforeCreateEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public BeforeCreateEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/BeforeEncodeEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/BeforeEncodeEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class BeforeEncodeEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public BeforeEncodeEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/BeforeLoopEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/BeforeLoopEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class BeforeLoopEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public BeforeLoopEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/CommandActionListener.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/CommandActionListener.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.ActionEvent;
+import jakarta.faces.event.ActionListener;
+import jakarta.inject.Named;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * <p>
+ * The purpose of this class is to provide an <code>ActionListener</code> that can delegate to handlers (that are likely
+ * defined via XML). It is safe to register this class as a managed bean at the Application scope. Or to use it directly
+ * as an <code>ActionListener</code>.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class CommandActionListener implements ActionListener, Serializable {
+
+    /**
+     * <p>
+     * Constructor. It is not recommended this constructor be used, however, it is available so that it may be used as a
+     * managed bean. Instead call {@link #getInstance()}.
+     * </p>
+     */
+    public CommandActionListener() {
+        super();
+    }
+
+    /**
+     * <p>
+     * This delegates to {@link #getInstance(FacesContext)}.
+     * </p>
+     */
+    @Produces
+    @ApplicationScoped
+    @Named("lfCommand")
+    public static CommandActionListener getInstance() {
+        return getInstance(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * <p>
+     * This is the preferred way to obtain an instance of this object.
+     * </p>
+     */
+    public static CommandActionListener getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        CommandActionListener instance = null;
+        if (ctx != null) {
+            instance = (CommandActionListener) ctx.getExternalContext().getApplicationMap().get(CAL_INSTANCE);
+        }
+        if (instance == null) {
+            instance = new CommandActionListener();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(CAL_INSTANCE, instance);
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * <p>
+     * This method is invoked, when used directly as an <code>ActionListener</code>.
+     */
+    @Override
+    public void processAction(ActionEvent event) {
+        invokeCommandHandlers(event);
+    }
+
+    /**
+     * <p>
+     * This is an ActionListener that delegates to handlers to process the action.
+     * </p>
+     */
+    public void invokeCommandHandlers(ActionEvent event) {
+        // Get the UIComponent source associated w/ this command
+        UIComponent command = (UIComponent) event.getSource();
+        if (command == null) {
+            throw new IllegalArgumentException("Action invoked, however, no source was given!");
+        }
+
+        // Get the FacesContext
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        // Look on the UIComponent for the CommandHandlers
+        LayoutElement desc = null;
+        List<Handler> handlers = (List<Handler>) command.getAttributes().get(LayoutComponent.COMMAND);
+        if (handlers != null && handlers.size() > 0) {
+            // This is needed for components that don't have corresponding
+            // LayoutElements, it is also useful for dynamically defining
+            // Handlers (advanced and not recommended unless you have a good
+            // reason). May also happen if "id" for any component in
+            // hierarchy is not a simple String.
+
+            // No parent (null) or ComponentType, just pass (null)
+            desc = new LayoutComponent((LayoutElement) null, command.getId(), (ComponentType) null);
+        } else {
+            // Attempt to find LayoutElement based on command's client id
+            // "desc" may be null
+            String viewId = getViewId(command);
+            desc = findLayoutElementByClientId(context, viewId, command.getClientId(context));
+            if (desc == null) {
+                // Do a brute force search for the LE
+                desc = findLayoutElementById(context, viewId, command.getId());
+            }
+        }
+
+        // If We still don't have a desc, we're stuck
+        if (desc == null) {
+            throw new IllegalArgumentException("Unable to locate handlers for '" + command.getClientId(context) + "'.");
+        }
+
+        // Dispatch the Handlers from the LayoutElement
+        desc.dispatchHandlers(context, COMMAND_EVENT_TYPE, event);
+    }
+
+    /**
+     * <p>
+     * This method returns the "viewId" of the <code>ViewRoot</code> given a <code>UIComponent</code> that is part of that
+     * <code>ViewRoot</code>.
+     * </p>
+     */
+    public static String getViewId(UIComponent comp) {
+        String result = null;
+        while (comp != null && !(comp instanceof UIViewRoot)) {
+            // Searching for the UIViewRoot...
+            comp = comp.getParent();
+        }
+        if (comp != null) {
+            // Found the UIViewRoot, get its "ViewId"
+            result = ((UIViewRoot) comp).getViewId();
+        }
+        // Return the result (or null)
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method searches for the LayoutComponent that matches the given client ID. Although this is often possible, it
+     * won't work all the time. This is because there is no way to ensure a 1-to-1 mapping between the UIComponent and the
+     * LayoutComponent tree. A given LayoutComponent may create multiple UIComponent, the LayoutComponent tree may itself be
+     * dynamic, and the UIComponent tree may change after it is initially created from the LayoutComponent tree. For these
+     * reasons, this method may fail. In these circumstances, it is critical to store the necessary information with the
+     * UIComponent itself.
+     * </p>
+     */
+    public static LayoutElement findLayoutElementByClientId(FacesContext ctx, String layoutDefKey, String clientId) {
+        LayoutElement result = null;
+        try {
+            result = findLayoutElementByClientId(LayoutDefinitionManager.getLayoutDefinition(ctx, layoutDefKey), clientId);
+        } catch (LayoutDefinitionException ex) {
+            if (LogUtil.configEnabled()) {
+                LogUtil.config("Unable to resolve client id '" + clientId + "' for LayoutDefinition key: '" + layoutDefKey + "'.", ex);
+            }
+        }
+        return result;
+    }
+
+    public static LayoutElement findLayoutElementByClientId(LayoutDefinition def, String clientId) {
+// FIXME: TBD...
+// FIXME: Walk LE tree, ignore non-LayoutComponent entries (this may cause a problem itself b/c of conditional statements & loops)
+// FIXME: Handle LayoutCompositions / LayoutInserts
+        return null;
+    }
+
+    /**
+     * <p>
+     * This method simply searches the LayoutElement tree using the given id. As soon as it matches any LayoutElement in the
+     * tree w/ the given id, it returns it. This method does *not* respect NamingContainers as the only information given to
+     * this method is a simple "id".
+     * </p>
+     */
+    public static LayoutElement findLayoutElementById(FacesContext ctx, String layoutDefKey, String id) {
+        // Sanity check
+        if (id == null) {
+            return null;
+        }
+
+        LayoutElement result = null;
+        try {
+            result = findLayoutElementById(LayoutDefinitionManager.getLayoutDefinition(ctx, layoutDefKey), id);
+        } catch (LayoutDefinitionException ex) {
+            if (LogUtil.configEnabled()) {
+                LogUtil.config("Unable to resolve id '" + id + "' for LayoutDefinition key: '" + layoutDefKey + "'.", ex);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method does not evaluate the id field of the LayoutElement when checking for a match, this means it will not
+     * find values where the LayoutComponent's id must be evaulated. Store the handlers on the UIComponent in this case.
+     * </p>
+     */
+    public static LayoutElement findLayoutElementById(LayoutElement elt, String id) {
+        // First check to see if the given LayoutElement is it
+        if (elt.getUnevaluatedId().equals(id)) {
+            return elt;
+        }
+
+        // Iterate over children and recurse (depth first)
+        LayoutElement child = null;
+        Iterator<LayoutElement> it = elt.getChildLayoutElements().iterator();
+        while (it.hasNext()) {
+            child = it.next();
+// FIXME: Handle LayoutCompositions / LayoutInserts
+            if (child instanceof LayoutComponent) {
+                child = findLayoutElementById(child, id);
+                if (child != null) {
+                    return child;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Application scope key for an instance of this class.
+     */
+    private static final String CAL_INSTANCE = "__jsft_CommandActionListener";
+
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * <p>
+     * The "command" event type. ("command")
+     * </p>
+     */
+    public static final String COMMAND_EVENT_TYPE = "command";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/CreateChildEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/CreateChildEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ * <p>
+ * This event is typically invoked when a factory not only creates a component, but creates children under that
+ * component. This event may be invoked to allow a page author to have greater control over what happens during the
+ * child creation. See individual factory JavaDocs to see which factories support this and what may be done during this
+ * event.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class CreateChildEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public CreateChildEvent(UIComponent component) {
+        super(component);
+    }
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public CreateChildEvent(UIComponent component, Object data) {
+        super(component);
+        setData(data);
+    }
+
+    /**
+     * <p>
+     * This method provides access to extra data that is set by the creator of this Event. See documentation of the code
+     * that fires this event to learn what (if anything) is stored here.
+     * </p>
+     */
+    public Object getData() {
+        return _data;
+    }
+
+    /**
+     * <p>
+     * This setter allows extending classes to set this value via this setter. Normally this value is passed into the
+     * constructor.
+     * <p>
+     */
+    protected void setData(Object data) {
+        _data = data;
+    }
+
+    /**
+     * <p>
+     * The "createChild" event type. ("createChild")
+     * </p>
+     */
+    public static final String EVENT_TYPE = "createChild";
+
+    /**
+     * <p>
+     * This value provides extra information that can be associated with this event. See code that uses this event to learn
+     * more about what (if anything) this information is used for.
+     * </p>
+     */
+    private Object _data = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/DecodeEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/DecodeEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class DecodeEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public DecodeEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/EncodeEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/EncodeEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class EncodeEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    public EncodeEvent(UIComponent component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/EventObjectBase.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/EventObjectBase.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+import java.util.EventObject;
+
+/**
+ * <p>
+ * This class serves as the base class for <code>EventObject</code>s in this package.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class EventObjectBase extends EventObject implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * This constructor should not be used.
+     * </p>
+     */
+    private EventObjectBase() {
+        super(null);
+    }
+
+    /**
+     * <p>
+     * This constructor is protected to avoid direct instantiation, one of the sub-classes of this class should be used
+     * instead.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code>.
+     */
+    protected EventObjectBase(UIComponent component) {
+        super(component);
+    }
+
+    /**
+     * <p>
+     * This constructor should only be used when a <code>UIComponent</code> is not available.
+     * </p>
+     */
+    protected EventObjectBase(Object obj) {
+        super(obj);
+    }
+
+    /**
+     * <P>
+     * This method returns the <code>UIComponent</code> held by the <code>Object</code> implementing this interface (or null
+     * if the event source is not a UIComponent).
+     * </p>
+     *
+     * @return The <code>UIComponent</code>.
+     */
+    @Override
+    public UIComponent getUIComponent() {
+        Object source = getSource();
+        if (source instanceof UIComponent) {
+            return (UIComponent) getSource();
+        }
+        return null;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/InitPageEvent.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/InitPageEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+/**
+ * <p>
+ * This event is fired for each page accessed during each request. This may be fired during the UIComponent tree
+ * creation time, while restoring the View, when forwarding to a new page, or when simply accessing a page via Java
+ * code.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class InitPageEvent extends EventObjectBase implements UIComponentHolder {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param component The <code>UIComponent</code> associated with this <code>EventObject</code> (likely null).
+     */
+    public InitPageEvent(Object component) {
+        super(component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/UIComponentHolder.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/UIComponentHolder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import jakarta.faces.component.UIComponent;
+
+/**
+ * <p>
+ * This interface defines a method for obtaining a <code>UIComponent</code>. This is used by various
+ * <code>EventObject<code> implementations which hold
+ *    <code>UIComponent</code>. This allows event handling code to access the <code>UIComponent</code> related to the
+ * event.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface UIComponentHolder {
+
+    /**
+     * <p>
+     * This method returns the <code>UIComponent</code> held by the <code>Object</code> implementing this interface.
+     * </p>
+     *
+     * @return The <code>UIComponent</code>.
+     */
+    UIComponent getUIComponent();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/ValueChangeListener.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/event/ValueChangeListener.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.event;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.ValueChangeEvent;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * <p>
+ * This class provides a <code>ValueChangeListener</code> that can delegate to handlers (that are likely defined via the
+ * template). It is safe to register this class as a managed bean at the Application scope. Or to use it directly as a
+ * <code>ValueChangeListener</code>.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ValueChangeListener implements jakarta.faces.event.ValueChangeListener, Serializable {
+
+    /**
+     * <p>
+     * Constructor. It is not recommended this constructor be used, however, it is available so that it may be used as a
+     * managed bean. Instead call {@link #getInstance()}.
+     * </p>
+     */
+    public ValueChangeListener() {
+        super();
+    }
+
+    /**
+     * <p>
+     * This delegates to {@link #getInstance(FacesContext)}.
+     * </p>
+     */
+    public static ValueChangeListener getInstance() {
+        return getInstance(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * <p>
+     * This is the preferred way to obtain an instance of this object.
+     * </p>
+     */
+    public static ValueChangeListener getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        ValueChangeListener instance = null;
+        if (ctx != null) {
+            instance = (ValueChangeListener) ctx.getExternalContext().getApplicationMap().get(VCL_INSTANCE);
+        }
+        if (instance == null) {
+            instance = new ValueChangeListener();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(VCL_INSTANCE, instance);
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * <p>
+     * This method is invoked, when used directly as a <code>ValueChangeListener</code>.
+     */
+    @Override
+    public void processValueChange(ValueChangeEvent event) {
+        invokeValueChangeHandlers(event);
+    }
+
+    /**
+     * <p>
+     * This is an ValueChangeListener that delegates to handlers to process the action.
+     * </p>
+     */
+    public void invokeValueChangeHandlers(ValueChangeEvent event) {
+        // Get the UIComponent (evh) source associated w/ this valueChangeEvent
+        UIComponent evh = (UIComponent) event.getSource();
+        if (evh == null) {
+            throw new IllegalArgumentException("ValueChange invoked, however, no source was given!");
+        }
+
+        // Get the FacesContext
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        // Look on the UIComponent for the ValueChangeHandlers
+        LayoutElement desc = null;
+        List<Handler> handlers = (List<Handler>) evh.getAttributes().get(VALUE_CHANGE);
+        if (handlers != null && handlers.size() > 0) {
+            // This is needed for components that don't have corresponding
+            // LayoutElements, it is also useful for dynamically defining
+            // Handlers (advanced and not recommended unless you have a good
+            // reason). May also happen if "id" for any component in
+            // hierarchy is not a simple String.
+
+            // No parent (null) or ComponentType, just pass (null)
+            desc = new LayoutComponent((LayoutElement) null, evh.getId(), (ComponentType) null);
+        } else {
+            // Attempt to find LayoutElement based on evh's client id
+            // "desc" may be null
+            String viewId = getViewId(evh);
+            desc = findLayoutElementByClientId(context, viewId, evh.getClientId(context));
+            if (desc == null) {
+                // Do a brute force search for the LE
+                desc = findLayoutElementById(context, viewId, evh.getId());
+            }
+        }
+
+        // If We still don't have a desc, we're stuck
+        if (desc == null) {
+            throw new IllegalArgumentException("Unable to locate handlers for '" + evh.getClientId(context) + "'.");
+        }
+
+        // Dispatch the Handlers from the LayoutElement
+        desc.dispatchHandlers(context, VALUE_CHANGE, event);
+    }
+
+    /**
+     * <p>
+     * This method returns the "viewId" of the <code>ViewRoot</code> given a <code>UIComponent</code> that is part of that
+     * <code>ViewRoot</code>.
+     * </p>
+     */
+    public static String getViewId(UIComponent comp) {
+// FIXME: This should be a util method. (Same as CommandActionListener)
+        String result = null;
+        while (comp != null && !(comp instanceof UIViewRoot)) {
+            // Searching for the UIViewRoot...
+            comp = comp.getParent();
+        }
+        if (comp != null) {
+            // Found the UIViewRoot, get its "ViewId"
+            result = ((UIViewRoot) comp).getViewId();
+        }
+        // Return the result (or null)
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method searches for the LayoutComponent that matches the given client ID. Although this is often possible, it
+     * won't work all the time. This is because there is no way to ensure a 1-to-1 mapping between the UIComponent and the
+     * LayoutComponent tree. A given LayoutComponent may create multiple UIComponent, the LayoutComponent tree may itself be
+     * dynamic, and the UIComponent tree may change after it is initially created from the LayoutComponent tree. For these
+     * reasons, this method may fail. In these circumstances, it is critical to store the necessary information with the
+     * UIComponent itself.
+     * </p>
+     */
+    public static LayoutElement findLayoutElementByClientId(FacesContext ctx, String layoutDefKey, String clientId) {
+// FIXME: This should be a util method. (Same as CommandActionListener)
+        LayoutElement result = null;
+        try {
+            result = findLayoutElementByClientId(LayoutDefinitionManager.getLayoutDefinition(ctx, layoutDefKey), clientId);
+        } catch (LayoutDefinitionException ex) {
+            if (LogUtil.configEnabled()) {
+                LogUtil.config("Unable to resolve client id '" + clientId + "' for LayoutDefinition key: '" + layoutDefKey + "'.", ex);
+            }
+        }
+        return result;
+    }
+
+    public static LayoutElement findLayoutElementByClientId(LayoutDefinition def, String clientId) {
+// FIXME: This should be a util method. (Same as CommandActionListener)
+//
+// FIXME: TBD...
+// FIXME: Walk LE tree, ignore non-LayoutComponent entries (this may cause a problem itself b/c of conditional statements & loops)
+// FIXME: Handle LayoutCompositions / LayoutInserts
+        return null;
+    }
+
+    /**
+     * <p>
+     * This method simply searches the LayoutElement tree using the given id. As soon as it matches any LayoutElement in the
+     * tree w/ the given id, it returns it. This method does *not* respect NamingContainers as the only information given to
+     * this method is a simple "id".
+     * </p>
+     */
+    public static LayoutElement findLayoutElementById(FacesContext ctx, String layoutDefKey, String id) {
+// FIXME: This should be a util method. (Same as CommandActionListener)
+        // Sanity check
+        if (id == null) {
+            return null;
+        }
+
+        LayoutElement result = null;
+        try {
+            result = findLayoutElementById(LayoutDefinitionManager.getLayoutDefinition(ctx, layoutDefKey), id);
+        } catch (LayoutDefinitionException ex) {
+            if (LogUtil.configEnabled()) {
+                LogUtil.config("Unable to resolve id '" + id + "' for LayoutDefinition key: '" + layoutDefKey + "'.", ex);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method does not evaluate the id field of the LayoutElement when checking for a match, this means it will not
+     * find values where the LayoutComponent's id must be evaulated. Store the handlers on the UIComponent in this case.
+     * </p>
+     */
+    public static LayoutElement findLayoutElementById(LayoutElement elt, String id) {
+// FIXME: This should be a util method. (Same as CommandActionListener)
+        // First check to see if the given LayoutElement is it
+        if (elt.getUnevaluatedId().equals(id)) {
+            return elt;
+        }
+
+        // Iterate over children and recurse (depth first)
+        LayoutElement child = null;
+        Iterator<LayoutElement> it = elt.getChildLayoutElements().iterator();
+        while (it.hasNext()) {
+            child = it.next();
+// FIXME: Handle LayoutCompositions / LayoutInserts
+            if (child instanceof LayoutComponent) {
+                child = findLayoutElementById(child, id);
+                if (child != null) {
+                    return child;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Application scope key for an instance of this class.
+     */
+    private static final String VCL_INSTANCE = "__jsft_ValueChangeListener";
+
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * <p>
+     * This is the "event type" for handlers to be invoked to handle value change event for this component.
+     * </p>
+     */
+    public static final String VALUE_CHANGE = "valueChange";
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/DbFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/DbFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *
+ */
+package com.sun.jsftemplating.layout.facelets;
+
+import com.sun.jsftemplating.layout.xml.XMLErrorHandler;
+
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * This class provides a convenient way to create a DocumentBuilder using the JSFTemplating entity resolver.
+ *
+ * @author Jason Lee
+ *
+ */
+public class DbFactory {
+    public static DocumentBuilder getInstance() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        String FEATURE = null;
+        try {
+            FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+            factory.setFeature(FEATURE, false);
+
+            FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            factory.setFeature(FEATURE, false);
+
+            FEATURE = "http://xml.org/sax/features/external-general-entities";
+            factory.setFeature(FEATURE, false);
+
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("The feature '"
+            + FEATURE + "' is not supported by your XML processor.", e);
+        }
+        factory.setNamespaceAware(true);
+        factory.setValidating(false);
+        factory.setIgnoringComments(true);
+        factory.setIgnoringElementContentWhitespace(false);
+        factory.setCoalescing(false);
+        factory.setExpandEntityReferences(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        try {
+            builder.setErrorHandler(new XMLErrorHandler(new PrintWriter(new OutputStreamWriter(System.err, "UTF-8"), true)));
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        builder.setEntityResolver(new FaceletsClasspathEntityResolver());
+
+        return builder;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/FaceletsClasspathEntityResolver.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/FaceletsClasspathEntityResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *
+ */
+package com.sun.jsftemplating.layout.facelets;
+
+import com.sun.jsftemplating.util.ClasspathEntityResolver;
+
+import org.xml.sax.InputSource;
+
+/**
+ * @author Jason Lee
+ *
+ */
+public class FaceletsClasspathEntityResolver extends ClasspathEntityResolver {
+    @Override
+    public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId) {
+        String grammarName = systemId.substring(systemId.lastIndexOf('/') + 1);
+        return super.resolveEntity(name, publicId, baseURI, grammarName);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/FaceletsLayoutDefinitionManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/FaceletsLayoutDefinitionManager.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.facelets;
+
+import com.sun.jsftemplating.annotation.FormatDefinition;
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.template.TemplateParser;
+import com.sun.jsftemplating.util.FileUtil;
+
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ *
+ * @author Jason Lee
+ * @author Ken Paulsen
+ */
+@FormatDefinition
+public class FaceletsLayoutDefinitionManager extends LayoutDefinitionManager {
+
+    /**
+     * Default Constructor.
+     */
+    public FaceletsLayoutDefinitionManager() {
+        super();
+    }
+
+    @Override
+    public boolean accepts(String key) {
+        boolean accept = false;
+        URL url = null;
+        try {
+            url = FileUtil.searchForFile(key, defaultSuffix);
+        } catch (IOException ex) {
+            // Ignore this b/c we're just trying to detect if we're the right
+            // LDM... if we're here, probably we're not.
+        }
+        if (url == null) {
+            return false;
+        }
+
+        // Eventually, we may want this check to be configurable via a
+        // context-param...
+        if (url.getPath().contains(".xhtml")) {
+            accept = true;
+        } else {
+            // Use the TemplateParser to help us read the file to see if it is a
+            // valid XML-format file
+            TemplateParser parser = new TemplateParser(url);
+            accept = true;
+            try {
+                parser.open();
+                parser.readUntil("=\"http://java.sun.com/jsf/facelets\"", true);
+            } catch (Exception ex) {
+                // Didn't work...
+                accept = false;
+            } finally {
+                parser.close();
+            }
+        }
+
+        return accept;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for finding the requested {@link LayoutDefinition} for the given <code>key</code>.
+     * </p>
+     *
+     * @param key Key identifying the desired {@link LayoutDefinition}.
+     *
+     * @return The requested {@link LayoutDefinition}.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition(String key) throws LayoutDefinitionException {
+        // Make sure we found the url
+        URL url = null;
+        try {
+            url = FileUtil.searchForFile(key, defaultSuffix);
+        } catch (IOException ex) {
+            throw new LayoutDefinitionException("Unable to locate '" + key + "'", ex);
+        }
+        if (url == null) {
+            throw new LayoutDefinitionException("Unable to locate '" + key + "'");
+        }
+
+        // Read the template file
+        LayoutDefinition ld = null;
+        try {
+            ld = new FaceletsLayoutDefinitionReader(key, url).read();
+        } catch (IOException ex) {
+            throw new LayoutDefinitionException("Unable to process '" + url.toString() + "'.", ex);
+        }
+
+        // Dispatch "initPage" handlers
+        ld.dispatchInitPageHandlers(FacesContext.getCurrentInstance(), ld);
+
+        // Return the LayoutDefinition
+        return ld;
+    }
+
+    /**
+     * <p>
+     * This method returns an instance of this LayoutDefinitionManager. The object returned is a singleton (only 1 instance
+     * will be created per application).
+     * </p>
+     *
+     * @return <code>FaceletsLayoutDefinitionManager</code> instance
+     */
+    public static LayoutDefinitionManager getInstance() {
+        return getInstance(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * <p>
+     * This method provides access to the application-scoped instance of the <code>FaceletsLayoutDefinitionManager</code>.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code> (may be null).
+     */
+    public static LayoutDefinitionManager getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        FaceletsLayoutDefinitionManager instance = null;
+        if (ctx != null) {
+            instance = (FaceletsLayoutDefinitionManager) ctx.getExternalContext().getApplicationMap().get(FLDM_INSTANCE);
+        }
+        if (instance == null) {
+            instance = new FaceletsLayoutDefinitionManager();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(FLDM_INSTANCE, instance);
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * <p>
+     * Application scope key for an instance of this class.
+     * </p>
+     */
+    private static final String FLDM_INSTANCE = "__jsft_FaceletsLDM";
+
+    private static final String defaultSuffix = ".xhtml";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/FaceletsLayoutDefinitionReader.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/FaceletsLayoutDefinitionReader.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.facelets;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.SyntaxException;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutComposition;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefine;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutFacet;
+import com.sun.jsftemplating.layout.descriptors.LayoutForEach;
+import com.sun.jsftemplating.layout.descriptors.LayoutIf;
+import com.sun.jsftemplating.layout.descriptors.LayoutInsert;
+import com.sun.jsftemplating.layout.descriptors.LayoutStaticText;
+import com.sun.jsftemplating.layout.template.BaseProcessingContext;
+import com.sun.jsftemplating.layout.template.EventParserCommand;
+import com.sun.jsftemplating.layout.template.ProcessingContextEnvironment;
+import com.sun.jsftemplating.layout.template.TemplateParser;
+import com.sun.jsftemplating.layout.template.TemplateReader;
+import com.sun.jsftemplating.util.IncludeInputStream;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+import com.sun.jsftemplating.util.Util;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import javax.xml.parsers.DocumentBuilder;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.DocumentType;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * @author Jason Lee
+ *
+ */
+public class FaceletsLayoutDefinitionReader {
+    private URL url;
+    private String key;
+    private Document document;
+    private int _idNumber;
+
+    public FaceletsLayoutDefinitionReader(String key, URL url) {
+        _idNumber = LayoutElementUtil.getStartingIdNumber(null, key);
+        InputStream is = null;
+        BufferedInputStream bs = null;
+        try {
+            this.key = key;
+            this.url = url;
+
+            DocumentBuilder builder = DbFactory.getInstance();
+            builder.setErrorHandler(new ParsingErrorHandler());
+            is = this.url.openStream();
+            bs = new BufferedInputStream(is);
+            document = builder.parse(new IncludeInputStream(bs));
+        } catch (Exception e) {
+            throw new LayoutDefinitionException(e);
+        } finally {
+            Util.closeStream(bs);
+            Util.closeStream(is);
+        }
+    }
+
+    public LayoutDefinition read() throws IOException {
+        LayoutDefinition layoutDefinition = new LayoutDefinition(key);
+        NodeList nodeList = document.getChildNodes();
+        boolean abortProcessing = false;
+        DocumentType docType = document.getDoctype();
+        if (docType != null) {
+            LayoutStaticText stDocType = new LayoutStaticText(layoutDefinition, "",
+                    "<!DOCTYPE " + docType.getName() + " PUBLIC \"" + docType.getPublicId() + "\" \"" + docType.getSystemId() + "\">");
+            layoutDefinition.addChildLayoutElement(stDocType);
+        }
+        for (int i = 0; i < nodeList.getLength() && !abortProcessing; i++) {
+            abortProcessing = process(layoutDefinition, nodeList.item(i), false);
+        }
+        return layoutDefinition;
+    }
+
+    public boolean process(LayoutElement parent, Node node, boolean nested) throws IOException {
+        boolean abortProcessing = false;
+        LayoutElement element = null;
+        LayoutElement newParent = parent;
+        boolean endElement = false;
+
+        String value = node.getNodeValue();
+//    TODO:  find out what "name" should be in the ctors
+        switch (node.getNodeType()) {
+        case Node.TEXT_NODE:
+            if (!value.trim().equals("")) {
+                element = new LayoutStaticText(parent, LayoutElementUtil.getGeneratedId(node.getNodeName(), getNextIdNumber()), value);
+            }
+            break;
+        case Node.ELEMENT_NODE:
+            element = createComponent(parent, node, nested);
+            if (element instanceof LayoutStaticText) {
+                // We have a element node that needs to be static text
+                endElement = true;
+            } else if ((element instanceof LayoutForEach) || (element instanceof LayoutIf)) {
+                newParent = element;
+            } else if (element instanceof LayoutComponent) {
+                nested = true;
+                newParent = element;
+            } else if (element instanceof LayoutComposition) {
+                abortProcessing = ((LayoutComposition) element).isTrimming();
+                newParent = element;
+            } else if (element instanceof LayoutDefine) {
+                newParent = element;
+            } else if (element instanceof LayoutFacet) {
+                newParent = element;
+            } else if (element instanceof LayoutInsert) {
+                newParent = element;
+            }
+//        FIXME: Jason, this code may need to be refactored.  I think almost
+//        FIXME: everything should have newParent = element.  The problem comes when
+//        FIXME: you are turning <html> and </html> into 2 separate staticText
+//        FIXME: components.  This should be a single component, then it could contain
+//        FIXME: children also.  You may want a to create a component like Woodstock's
+//        FIXME: "markup" component to do this.
+            break;
+        default:
+            // just because... :P
+        }
+
+        if (element != null) {
+            parent.addChildLayoutElement(element);
+
+            NodeList nodeList = node.getChildNodes();
+            boolean abortChildProcessing = false;
+            for (int i = 0; i < nodeList.getLength() && !abortChildProcessing; i++) {
+                abortChildProcessing = process(newParent, nodeList.item(i), nested);
+            }
+            if (abortChildProcessing) {
+                abortProcessing = abortChildProcessing;
+            } else {
+
+                if (endElement) {
+                    String nodeName = node.getNodeName();
+                    element = new LayoutStaticText(parent, LayoutElementUtil.getGeneratedId(nodeName, getNextIdNumber()), "</" + nodeName + ">");
+                    parent.addChildLayoutElement(element);
+                }
+            }
+        }
+
+        return abortProcessing;
+    }
+
+    private LayoutComposition processComposition(LayoutElement parent, String attrName, NamedNodeMap attrs, String id, boolean trimming) {
+        LayoutComposition lc = new LayoutComposition(parent, id);
+        lc.setTrimming(trimming);
+        if (trimming) {
+            parent = parent.getLayoutDefinition(); // parent to the LayoutDefinition
+            parent.getChildLayoutElements().clear(); // a ui:composition clears everything outside of it
+        }
+        Node fileNameNode = attrs.getNamedItem(attrName);
+        String fileName = fileNameNode != null ? fileNameNode.getNodeValue() : null;
+        lc.setTemplate(fileName);
+
+        return lc;
+    }
+
+    private LayoutComponent processComponent(LayoutElement parent, Node node, NamedNodeMap attrs, String id, boolean trimming) {
+        if (trimming) {
+            parent = parent.getLayoutDefinition(); // parent to the LayoutDefinition
+            parent.getChildLayoutElements().clear(); // a ui:composition clears everything outside of it
+        }
+        LayoutComponent lc = new LayoutComponent(parent, id, LayoutDefinitionManager.getGlobalComponentType(null, "event"));
+        parent.addChildLayoutElement(lc);
+        LayoutComposition comp = processComposition(lc, "template", attrs, id + "_lc", trimming);
+
+        NodeList nodeList = node.getChildNodes();
+        boolean abortChildProcessing = false;
+        for (int i = 0; i < nodeList.getLength() && !abortChildProcessing; i++) {
+            try {
+                abortChildProcessing = process(comp, nodeList.item(i), true);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        lc.addChildLayoutElement(comp);
+
+        return lc;
+    }
+
+    /*
+     * This code is not used and does not appear to be correct, it should use FacesContext.getApplication() private
+     * Application getApplication() { ApplicationFactory appFactory = (ApplicationFactory) FactoryFinder
+     * .getFactory(FactoryFinder.APPLICATION_FACTORY); return appFactory.getApplication(); }
+     *
+     * private Object getElValue(String el) { FacesContext context = FacesContext.getCurrentInstance(); return
+     * getApplication() .evaluateExpressionGet(context, el, Object.class); }
+     */
+
+    private LayoutElement createComponent(LayoutElement parent, Node node, boolean nested) {
+        LayoutElement element = null;
+        String nodeName = node.getNodeName();
+        NamedNodeMap attrs = node.getAttributes();
+        Node nameNode = attrs.getNamedItem("id");
+        String id = nameNode != null ? nameNode.getNodeValue() : LayoutElementUtil.getGeneratedId(nodeName, getNextIdNumber());
+
+        if ("ui:composition".equals(nodeName)) {
+            element = processComposition(parent, "template", attrs, id, true);
+        } else if ("ui:decorate".equals(nodeName)) {
+            element = processComposition(parent, "template", attrs, id, false);
+        } else if ("ui:define".equals(nodeName)) {
+            String name = attrs.getNamedItem("name").getNodeValue();
+            element = new LayoutDefine(parent, name);
+        } else if ("ui:insert".equals(nodeName)) {
+            LayoutInsert li = new LayoutInsert(parent, id);
+            Node nameAttr = attrs.getNamedItem("name");
+            String name = nameAttr != null ? nameAttr.getNodeValue() : null;
+            li.setName(name);
+            element = li;
+            // Let these be handled by the else below, and let's see what happens :)
+        } else if ("ui:component".equals(nodeName)) {
+            element = processComponent(parent, node, attrs, id, true);
+        } else if ("ui:fragment".equals(nodeName)) {
+            element = processComponent(parent, node, attrs, id, false);
+            /*
+             * Node bindingAttr = attrs.getNamedItem("binding"); if (bindingAttr == null) { throw new
+             * LayoutDefinitionException("ui:fragment requires a binding attribute"); } String bindingEl =
+             * bindingAttr.getNodeValue(); Object obj = getElValue(bindingEl); if (!(obj instanceof UIComponent)) { throw new
+             * LayoutDefinitionException("Binding EL must return a UIComponent"); } UIComponent comp = (UIComponent) obj; String
+             * family = comp.getFamily(); // TODO: is the correct?
+             * System.out.println(LayoutDefinitionManager.getGlobalComponentTypes(null)); ComponentType componentType =
+             * LayoutDefinitionManager.getGlobalComponentType(null, family); LayoutComponent lc = new LayoutComponent(parent, id,
+             * componentType); addAttributesToComponent(lc, node); lc.setFacetChild(false); lc.setNested(nested); element = lc;
+             */
+        } else if ("ui:debug".equals(nodeName)) {
+        } else if ("ui:include".equals(nodeName)) {
+            element = processComposition(parent, "src", attrs, id, false);
+        } else if ("ui:param".equals(nodeName)) {
+            // Handle "param"
+            Node nameAttNode = attrs.getNamedItem("name");
+            if (nameAttNode == null) {
+                throw new SyntaxException("The 'name' attribute is required on 'param'.");
+            }
+            Node valueNode = attrs.getNamedItem("value");
+            if (valueNode == null) {
+                throw new SyntaxException("The 'value' attribute is required on 'param'.");
+            }
+
+            // For now only handle cases where the parent is a LayoutComposition
+            if (!(parent instanceof LayoutComposition)) {
+                throw new SyntaxException("<" + nodeName + " name='" + nameAttNode.getNodeValue() + "' value='" + valueNode.getNodeValue()
+                        + "'> must be child of a 'composition' element!");
+            }
+            // Set the name=value on the parent LayoutComposition
+            ((LayoutComposition) parent).setParameter(nameAttNode.getNodeValue(), valueNode.getNodeValue());
+        } else if ("ui:remove".equals(nodeName) || "ui:repeat".equals(nodeName)) {
+            // Let the element remain null
+        } else if ("ui:event".equals(nodeName)) {
+            // per Ken, we need to append "/>" to allow the handler parser code
+            // to end correctly
+            String body = node.getTextContent();
+            body = body == null ? "/>" : body.trim() + "/>";
+            Node type = node.getAttributes().getNamedItem("type");
+            if (type == null) {
+                // Ensure type != null
+                throw new SyntaxException("The 'type' attribute is required on 'ui:event'!");
+            }
+            String eventName = type.getNodeValue();
+            InputStream is = new ByteArrayInputStream(body.getBytes());
+            EventParserCommand command = new EventParserCommand();
+            try {
+                TemplateParser parser = new TemplateParser(is);
+                parser.open(); // Needed to initialize things.
+                // Setup the reader...
+                TemplateReader reader = new TemplateReader("foo", parser); // TODO: get a real ID
+                reader.pushTag("event"); // The tag will be popped at the end
+                // Read the handlers...
+                command.process(new BaseProcessingContext(), new ProcessingContextEnvironment(reader, parent, true), eventName);
+                // Clean up
+                parser.close();
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            } finally {
+                if (is != null) {
+                    try {
+                        is.close();
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+            }
+        } else if ("ui:if".equals(nodeName)) {
+            // Handle "if" conditions
+            String condition = attrs.getNamedItem("condition").getNodeValue();
+            element = new LayoutIf(parent, condition);
+        } else if ("ui:foreach".equals(nodeName)) {
+            // Handle "foreach" conditions
+            Node valueNode = attrs.getNamedItem("value");
+            if (valueNode == null) {
+                throw new SyntaxException("The 'value' property is required on 'foreach'.");
+            }
+            Node varNode = attrs.getNamedItem("var");
+            if (varNode == null) {
+                throw new SyntaxException("The 'var' property is required on 'foreach'.");
+            }
+
+            element = new LayoutForEach(parent, valueNode.getNodeValue(), varNode.getNodeValue());
+        } else if ("f:facet".equals(nodeName)) {
+            // FIXME: Need to take NameSpace into account
+            nameNode = attrs.getNamedItem("name");
+            if (nameNode == null) {
+                throw new IllegalArgumentException(
+                        "You must provide a name " + "attribute for all facets!  Parent component is: '" + parent.getUnevaluatedId() + "'.");
+            }
+            LayoutFacet facetElt = new LayoutFacet(parent, nameNode.getNodeValue());
+
+            // Determine if this is a facet place holder (i.e. we're defining
+            // a renderer w/ a facet), or if it is a facet value to set on a
+            // containing component.
+            boolean isRendered = !LayoutElementUtil.isNestedLayoutComponent(facetElt);
+            facetElt.setRendered(isRendered);
+            element = facetElt;
+        } else {
+            LayoutComponent lc = null;
+            ComponentType componentType = null;
+            String nsURI = node.getNamespaceURI();
+            if (nsURI != null) {
+                // Do lookup using namespace...
+                componentType = LayoutDefinitionManager.getGlobalComponentType(null, nsURI + ':' + node.getLocalName());
+            }
+            if (componentType == null) {
+                // Try w/o using namespace
+                componentType = LayoutDefinitionManager.getGlobalComponentType(null, nodeName);
+            }
+            if (componentType == null) {
+                String value = node.getNodeValue();
+                if (value == null) {
+                    value = "";
+                }
+//        FIXME: This needs to account for beginning and ending tags....
+                lc = new LayoutStaticText(parent, id, "<" + nodeName + buildAttributeList(node) + ">");
+            } else {
+                lc = new LayoutComponent(parent, id, componentType);
+                addAttributesToComponent(lc, node);
+            }
+            lc.setNested(nested);
+//        FIXME: Because of the way pages are composed in facelets, the parent
+//        FIXME: LayoutComponent may not exist in this LD.  In that case it is not
+//        FIXME: a "facet child", but it appears to be according to the following
+//        FIXME: method.  We need a better way to mark children as facets or real
+//        FIXME: children.  This may even require diverging the LD into 1 for
+//        FIXME: components and 1 for pages. :(
+            // LayoutElementUtil.checkForFacetChild(parent, lc);
+            // lc.setFacetChild(false); This is done by checkForFacetChild(...)
+            element = lc;
+        }
+
+        return element;
+    }
+
+    private void addAttributesToComponent(LayoutComponent lc, Node node) {
+        NamedNodeMap map = node.getAttributes();
+        for (int i = 0; i < map.getLength(); i++) {
+            Node attr = map.item(i);
+            lc.addOption(attr.getNodeName(), attr.getNodeValue());
+        }
+    }
+
+    private String buildAttributeList(Node node) {
+        StringBuilder attrs = new StringBuilder();
+
+        NamedNodeMap map = node.getAttributes();
+        for (int i = 0; i < map.getLength(); i++) {
+            Node attr = map.item(i);
+            attrs.append(" ").append(attr.getNodeName()).append("=\"").append(attr.getNodeValue()).append("\"");
+        }
+
+        return attrs.toString();
+    }
+
+    /**
+     * <p>
+     * This method returns the next ID number. Calling this method will increment the id number.
+     * </p>
+     */
+    public int getNextIdNumber() {
+        // Make sure we increment the global counter, if appropriate
+        LayoutElementUtil.incHighestId(_idNumber);
+        return _idNumber++;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/NSContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/NSContext.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.facelets;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.xml.XMLConstants;
+
+/**
+ * <p>
+ * This class provides namespace support for facelets taglib.xml files.
+ * </p>
+ *
+ * @author Ken Paulsen
+ */
+public class NSContext implements javax.xml.namespace.NamespaceContext {
+
+    /**
+     * <p>
+     * Creates a default NSContext.
+     * </p>
+     */
+    public NSContext() {
+        addNamespace("xml", XMLConstants.XML_NS_URI);
+        addNamespace("xmlns", XMLConstants.XMLNS_ATTRIBUTE_NS_URI);
+    }
+
+    /**
+     * <p>
+     * Returns the namespace for the given prefix.
+     * </p>
+     *
+     * @throws IllegalArgumentException If <code>null</code> prefix is given.
+     */
+    @Override
+    public String getNamespaceURI(String prefix) {
+        if (prefix == null) {
+            throw new IllegalArgumentException("null is not allowed.");
+        }
+        String result = _uris.get(prefix);
+        if (result == null) {
+            if (prefix.equals(XMLConstants.DEFAULT_NS_PREFIX)) {
+                result = _defaultNSURI;
+            }
+            if (result == null) {
+                result = XMLConstants.NULL_NS_URI;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * Returns the prefix for the given namespace. If not mapped, <code>null</code> is returned.
+     * </p>
+     *
+     * @throws IllegalArgumentException If <code>null</code> prefix is given.
+     */
+    @Override
+    public String getPrefix(String namespaceURI) {
+        if (namespaceURI == null) {
+            throw new IllegalArgumentException("null is not allowed.");
+        }
+        String result = _prefixes.get(namespaceURI);
+        if (result == null) {
+            if (namespaceURI.equals(_defaultNSURI)) {
+                result = XMLConstants.DEFAULT_NS_PREFIX;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * This implementation doesn't support this functionality. Instead returns the same result as {@link #getPrefix(String)}
+     * via an <code>Iterator</code>.
+     * </p>
+     */
+    @Override
+    public Iterator<String> getPrefixes(String namespaceURI) {
+        ArrayList list = new ArrayList<String>();
+        list.add(getPrefix(namespaceURI));
+        return list.iterator();
+    }
+
+    /**
+     * <p>
+     * This method sets the default NS URI to be used when the default prefix (<code>XMLConstants.DEFAULT_NS_PREFIX</code>)
+     * is supplied.
+     * </p>
+     */
+    public void setDefaultNSURI(String defaultNSURI) {
+        _defaultNSURI = defaultNSURI;
+    }
+
+    /**
+     * <p>
+     * This method returns the default NS URI (null if not set).
+     * </p>
+     */
+    public String getDefaultNSURI() {
+        return _defaultNSURI;
+    }
+
+    /**
+     * <p>
+     * This method registers a Namespace mapping.
+     * </p>
+     */
+    public void addNamespace(String prefix, String uri) {
+        _uris.put(prefix, uri);
+        _prefixes.put(uri, prefix);
+    }
+
+    private String _defaultNSURI = null;
+
+    private Map<String, String> _uris = new HashMap<>();
+    private Map<String, String> _prefixes = new HashMap<>();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/ParsingErrorHandler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/facelets/ParsingErrorHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *
+ */
+package com.sun.jsftemplating.layout.facelets;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * @author Jason Lee
+ *
+ */
+public class ParsingErrorHandler implements ErrorHandler {
+    // Log logger = LogFactory.getLog(this.getClass());
+
+    public ParsingErrorHandler() {
+        super();
+    }
+
+    @Override
+    public void warning(SAXParseException arg0) throws SAXException {
+//        logger.warn(arg0.getMessage());
+    }
+
+    @Override
+    public void error(SAXParseException arg0) throws SAXException {
+        // logger.error(arg0.getMessage());
+        fatalError(arg0);
+    }
+
+    @Override
+    public void fatalError(SAXParseException arg0) throws SAXException {
+//        logger.error(arg0.getMessage());
+        System.err.println(arg0.getMessage());
+//        System.exit(-1);
+    }
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/BaseProcessingContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/BaseProcessingContext.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.SyntaxException;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutStaticText;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+import com.sun.jsftemplating.util.Util;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * Since many contexts share common functionality (i.e. processing static text elements), it makes sense to have a base
+ * {@link ProcessingContext} which may be specialized as needed.
+ * </p>
+ */
+public class BaseProcessingContext implements ProcessingContext {
+
+    /**
+     * <p>
+     * This is called when a component tag is found (&lt;tagname ...).
+     * </p>
+     */
+    @Override
+    public void beginComponent(ProcessingContextEnvironment env, String content) throws IOException {
+        // We have a UIComponent tag... first get the parser
+        // Skip white Space
+        TemplateReader reader = env.getReader();
+        TemplateParser parser = reader.getTemplateParser();
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+
+// tagStack.push(content);
+        // Create the LayoutComponent
+        LayoutElement parent = env.getParent();
+        LayoutComponent child = reader.createLayoutComponent(parent, env.isNested(), content);
+        parent.addChildLayoutElement(child);
+
+        // See if this is a single tag or if there is a closing tag
+        boolean single = false;
+        int ch = parser.nextChar();
+        if (ch == '/') {
+            // Single Tag
+            ch = parser.nextChar(); // Throw away '>'
+            single = true;
+            reader.popTag(); // Don't look for ending tag
+        }
+        if (ch != '>') {
+            throw new SyntaxException("Expected '>' found '" + (char) ch + "'.");
+        }
+
+        if (single) {
+            // This is also the end of the component in this case...
+            endComponent(env, content);
+        } else {
+            // Process child LayoutElements (recurse)
+            reader.process(TemplateReader.LAYOUT_COMPONENT_CONTEXT, child, true);
+        }
+    }
+
+    /**
+     * <p>
+     * This is called when an end component tag is found (&lt;/tagname&gt; or &lt;tagname ... /&gt;). Because it may be
+     * called for either of the above syntaxes, the caller of this method is responsible for maintaining the parser
+     * position, this method (or its subclasses) should not effect the parser position.
+     * </p>
+     */
+    @Override
+    public void endComponent(ProcessingContextEnvironment env, String content) throws IOException {
+    }
+
+    /**
+     * <p>
+     * This is called when a special tag is found (&lt;!tagname ...).
+     * </p>
+     */
+    @Override
+    public void beginSpecial(ProcessingContextEnvironment env, String content) throws IOException {
+        CustomParserCommand command = env.getReader().getCustomParserCommand(content);
+        if (command == null) {
+            // If there is no Custom command for this, use the default...
+            command = TemplateReader.EVENT_PARSER_COMMAND;
+        }
+        command.process(this, env, content);
+    }
+
+    /**
+     * <p>
+     * This is called when a special end tag is found (&lt;/tagname ... or &lt;!tagname ... /&gt;).
+     * </p>
+     */
+    @Override
+    public void endSpecial(ProcessingContextEnvironment env, String content) throws IOException {
+    }
+
+    /**
+     * <p>
+     * This is called when static text is found (").
+     * </p>
+     */
+    @Override
+    public void staticText(ProcessingContextEnvironment env, String content) throws IOException {
+        LayoutElement parent = env.getParent();
+
+        // Create a LayoutStaticText
+        LayoutComponent child = new LayoutStaticText(parent, LayoutElementUtil.getGeneratedId("txt", env.getReader().getNextIdNumber()), content);
+        child.addOption("value", content);
+        child.setNested(env.isNested());
+
+        parent.addChildLayoutElement(child);
+    }
+
+    /**
+     * <p>
+     * This is called when escaped static text is found ('). The difference between this and staticText is that HTML is
+     * expected to be escaped so the browser does not parse it.
+     * </p>
+     */
+    @Override
+    public void escapedStaticText(ProcessingContextEnvironment env, String content) throws IOException {
+        staticText(env, Util.htmlEscape(content));
+    }
+
+    /**
+     * <p>
+     * This method is invoked when nothing else matches.
+     * </p>
+     *
+     * <p>
+     * This implementation reads a character and does nothing with it.
+     * </p>
+     */
+    @Override
+    public void handleDefault(ProcessingContextEnvironment env, String content) throws IOException {
+        env.getReader().getTemplateParser().nextChar();
+    }
+
+    /**
+     * <p>
+     * This is a static reference to the "staticText" {@link ComponentType}.
+     * </p>
+     * public static final ComponentType STATIC_TEXT = LayoutDefinitionManager.getGlobalComponentType(null, "staticText");
+     */
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/CompositionParserCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/CompositionParserCommand.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.ProcessingCompleteException;
+import com.sun.jsftemplating.layout.descriptors.LayoutComposition;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * <p>
+ * This {@link CustomParserCommand} handles "composition" statements. TBD...
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class CompositionParserCommand implements CustomParserCommand {
+
+    /**
+     * <p>
+     * Constructor. This constructor requires a flag to be passed in indicating wether content outside this component should
+     * be ignored (trimmed) or left alone.
+     * </p>
+     *
+     * @param trim <code>true</code> if content outside this component should be thrown away.
+     *
+     * @param templateAttName The name of the attribute for the template name.
+     */
+    public CompositionParserCommand(boolean trim, String templateAttName) {
+        this.trimming = trim;
+        this.templateAttName = templateAttName;
+    }
+
+    /**
+     * <p>
+     * This method processes a "custom" command. These are commands that start with a !. When this method receives control,
+     * the <code>name</code> (i.e. the token after the '!' character) has already been read. It is passed via the
+     * <code>name</code> parameter.
+     * </p>
+     *
+     * <p>
+     * The {@link ProcessingContext} and {@link ProcessingContextEnvironment} are both available.
+     * </p>
+     */
+    @Override
+    public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+        // Get the reader
+        TemplateReader reader = env.getReader();
+
+        LayoutElement parent = env.getParent();
+        if (trimming) {
+            // First remove the current children on the LD (trimming == true)
+            parent = parent.getLayoutDefinition();
+            parent.getChildLayoutElements().clear();
+        }
+
+        // Next get the attributes
+        List<NameValuePair> nvps = reader.readNameValuePairs(name, templateAttName, true);
+
+        // Create new LayoutComposition
+        LayoutComposition compElt = new LayoutComposition(parent, LayoutElementUtil.getGeneratedId(name, reader.getNextIdNumber()), trimming);
+
+        // Look for required attribute
+        // Find the template name
+        for (NameValuePair nvp : nvps) {
+            if (nvp.getName().equals(templateAttName)) {
+                compElt.setTemplate((String) nvp.getValue());
+            } else if (nvp.getName().equals(REQUIRED_ATTRIBUTE)) {
+                compElt.setRequired(nvp.getValue().toString());
+            } else {
+                // We are going to treat extra attributes on compositions to be
+                // ui:param values
+                compElt.setParameter(nvp.getName(), nvp.getValue());
+            }
+        }
+
+        parent.addChildLayoutElement(compElt);
+
+        // See if this is a single tag or not...
+        TemplateParser parser = reader.getTemplateParser();
+        int ch = parser.nextChar();
+        if (ch == '/') {
+            reader.popTag(); // Don't look for end tag
+        } else {
+            // Unread the ch we just read
+            parser.unread(ch);
+
+            // Process child LayoutElements (recurse)
+            reader.process(LAYOUT_COMPOSITION_CONTEXT, compElt, LayoutElementUtil.isLayoutComponentChild(compElt));
+        }
+
+        if (trimming) {
+            // End processing... (trimming == true)
+            throw new ProcessingCompleteException((LayoutDefinition) parent);
+        }
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutComposition}s.
+     * </p>
+     */
+    protected static class LayoutCompositionContext extends BaseProcessingContext {
+        /**
+         * <p>
+         * This is called when a special tag is found (&lt;!tagname ...).
+         * </p>
+         *
+         * <p>
+         * This implementation looks for "define" tags and handles them specially. These tags are only valid in this context.
+         * </p>
+         */
+        @Override
+        public void beginSpecial(ProcessingContextEnvironment env, String content) throws IOException {
+            if (content.equals("define")) {
+                DEFINE_PARSER_COMMAND.process(this, env, content);
+            } else {
+                super.beginSpecial(env, content);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This indicates whether content outside of this tag should be left alone or used.
+     * </p>
+     */
+    private boolean trimming = true;
+    private String templateAttName = null;
+
+    public static final String REQUIRED_ATTRIBUTE = "required";
+    /**
+     * <p>
+     * The {@link ProcessingContext} to be used when processing children of a {@link LayoutComposition}. This
+     * {@link ProcessingContext} may have special meaning for {@link com.sun.jsftemplating.layout.descriptors.LayoutDefine}s
+     * and other tags.
+     * </p>
+     */
+    public static final ProcessingContext LAYOUT_COMPOSITION_CONTEXT = new LayoutCompositionContext();
+
+    public static final CustomParserCommand DEFINE_PARSER_COMMAND = new DefineParserCommand();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/CustomParserCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/CustomParserCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This interface provides a way to process "custom" parser commands. These commands are in the format: "&lt;![custom
+ * command name] ...". They must be registered with the TemplateParser to be recognized. See
+ * {@link TemplateReader#setCustomParserCommand(String, CustomParserCommand)}.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface CustomParserCommand {
+
+    /**
+     * <p>
+     * This method processes a "custom" command. These are commands that start with a !. When this method receives control,
+     * the <code>name</code> (i.e. the token after the '!' character) has already been read. It is passed via the
+     * <code>name</code> parameter.
+     * </p>
+     *
+     * <p>
+     * The {@link ProcessingContext} and {@link ProcessingContextEnvironment} are both available.
+     * </p>
+     */
+    void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/DefineParserCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/DefineParserCommand.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutDefine;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This {@link CustomParserCommand} handles "composition" statements. TBD...
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class DefineParserCommand implements CustomParserCommand {
+
+    /**
+     * <p>
+     * This method processes a "custom" command. These are commands that start with a !. When this method receives control,
+     * the <code>name</code> (i.e. the token after the '!' character) has already been read. It is passed via the
+     * <code>name</code> parameter.
+     * </p>
+     *
+     * <p>
+     * The {@link ProcessingContext} and {@link ProcessingContextEnvironment} are both available.
+     * </p>
+     */
+    @Override
+    public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+        // Get the reader and parser
+        TemplateReader reader = env.getReader();
+        TemplateParser parser = reader.getTemplateParser();
+
+        // Skip any white space...
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+
+        // Get the parent and define name
+        LayoutElement parent = env.getParent();
+        String id = (String) parser.getNVP(NAME_ATTRIBUTE, true).getValue();
+
+        // Create new LayoutDefine
+        LayoutDefine compElt = new LayoutDefine(parent, id);
+        parent.addChildLayoutElement(compElt);
+
+        // Skip any white space or extra junk...
+        String theRest = parser.readUntil('>', true).trim();
+        if (theRest.endsWith("/")) {
+            reader.popTag(); // Don't look for end tag
+        } else {
+            // Process child LayoutElements (recurse)
+            reader.process(LAYOUT_DEFINE_CONTEXT, compElt, LayoutElementUtil.isLayoutComponentChild(compElt));
+        }
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutDefine}s.
+     * </p>
+     */
+    protected static class LayoutDefineContext extends BaseProcessingContext {
+    }
+
+    /**
+     * <p>
+     * A String containing "template". This is the attribute name of the template file to use in the {@link LayoutDefine}.
+     * </p>
+     */
+    public static final String NAME_ATTRIBUTE = "name";
+
+    /**
+     * <p>
+     * The {@link ProcessingContext} to be used when processing children of a {@link LayoutDefine}. This
+     * {@link ProcessingContext} may have special meaning for {@link LayoutDefine}s and other tags.
+     * </p>
+     */
+    public static final ProcessingContext LAYOUT_DEFINE_CONTEXT = new LayoutDefineContext();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/EventParserCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/EventParserCommand.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.SyntaxException;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.OutputTypeManager;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This {@link CustomParserCommand} implementation processes handlers for an event.
+ * </p>
+ */
+public class EventParserCommand implements CustomParserCommand {
+    /**
+     * <p>
+     * This method processes a "custom" command. These are commands that start with a !. When this method receives control,
+     * the <code>name</code> (i.e. the token after the '!' character) has already been read. It is passed via the
+     * <code>name</code> parameter.
+     * </p>
+     *
+     * <p>
+     * This implementation processes events and their handlers. 2 syntaxes are supported:
+     * </p>
+     *
+     * <ul>
+     * <li>&lt;event type="beforeCreate"&gt;handler1(input="foo" output="bar"); ... &lt;/event&gt;
+     * <li>
+     * <li>&lt;!beforeCreate handler1(input="foo" output="bar"); ... /&gt;</li>
+     * </ul>
+     *
+     * <p>
+     * The first format should be preferred.
+     * </p>
+     *
+     * <p>
+     * The {@link ProcessingContext} and {@link ProcessingContextEnvironment} are both available.
+     * </p>
+     */
+    @Override
+    public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String eventName) throws IOException {
+        Handler handler = null;
+        List<Handler> handlers = new ArrayList<>();
+        TemplateReader reader = env.getReader();
+        TemplateParser parser = reader.getTemplateParser();
+        Handler parentHandler = null;
+        Stack<Handler> handlerStack = new Stack<>();
+        LayoutElement parent = env.getParent();
+
+        // Skip whitespace...
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+        int ch = -1;
+
+        // We now support 2 syntaxes:
+        // <!event type="beforeCreate">[handlers]</event>
+        // <!beforeCreate [handlers] />
+        // If "eventName" is event, look for type and the closing '>' before
+        // trying to parse the handlers.
+        boolean useBodyContent = false;
+        boolean createHandlerDefinitionOnLayoutDefinition = false;
+        if (eventName.equals("handler")) {
+            // We have a <handler id="foo"> tag...
+            createHandlerDefinitionOnLayoutDefinition = true;
+            useBodyContent = true;
+
+            // Read type="...", no other options are supported at this time
+            NameValuePair nvp = parser.getNVP(null);
+            if (!nvp.getName().equals("id")) {
+                throw new SyntaxException("When defining and event, you must supply the event type! " + "Found \"...event " + nvp.getName() + "\" instead.");
+            }
+            eventName = nvp.getValue().toString();
+
+            // Ensure the next character is '>'
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            ch = parser.nextChar();
+            if (ch != '>') {
+                throw new SyntaxException("Syntax error in event definition, found: '...handler id=\"" + eventName + "\" " + (char) ch
+                        + "\'.  Expected closing '>' for opening handler element.");
+            }
+
+            // Get ready to read the handlers now...
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            ch = parser.nextChar();
+        } else if (eventName.equals("event")) {
+            // We have the new syntax...
+            useBodyContent = true;
+
+            // Read type="...", no other options are supported at this time
+            NameValuePair nvp = parser.getNVP(null);
+            if (!nvp.getName().equals("type")) {
+                throw new SyntaxException("When defining and event, you must supply the event type! " + "Found \"...event " + nvp.getName() + "\" instead.");
+            }
+            eventName = nvp.getValue().toString();
+
+            // Ensure the next character is '>'
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            ch = parser.nextChar();
+            if (ch != '>') {
+                throw new SyntaxException("Syntax error in event definition, found: '...event type=\"" + eventName + "\" " + (char) ch
+                        + "\'.  Expected closing '>' for opening event element.");
+            }
+
+            // Get ready to read the handlers now...
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            ch = parser.nextChar();
+        } else {
+            // Make sure to read the first char for the old syntax...
+            ch = parser.nextChar();
+        }
+
+        // Read the Handler(s)...
+        while (ch != -1) {
+            if (useBodyContent) {
+                // If we're using the new format.... check for "</event>"
+                if (ch == '<') {
+                    // Just unread the '<', framework will validate the rest
+                    parser.unread('<');
+                    break;
+                }
+            } else {
+                if (ch == '/' || ch == '>') {
+                    // We found the end in the case where the handlers are
+                    // inside the tag (old syntax).
+                    break;
+                }
+            }
+            // Check for {}'s
+            if (ch == LEFT_CURLY || ch == RIGHT_CURLY) {
+                if (ch == LEFT_CURLY) {
+                    // We are defining child handlers
+                    handlerStack.push(parentHandler);
+                    parentHandler = handler;
+                } else {
+                    // We are DONE defining child handlers
+                    if (handlerStack.empty()) {
+                        throw new SyntaxException("Encountered unmatched '" + RIGHT_CURLY + "' when parsing handlers for '" + eventName + "' event.");
+                    }
+                    parentHandler = handlerStack.pop();
+                }
+
+                // ';' or ',' characters may appear between handlers
+                parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE + ",;");
+
+                // We need to "continue" b/c we need to check next ch again
+                ch = parser.nextChar();
+                continue;
+            }
+
+            // Get Handler ID / Definition
+            parser.unread(ch);
+
+            // Read a Handler
+            handler = readHandler(parser, eventName, parent);
+
+            // Add the handler to the appropriate place
+            if (parentHandler == null) {
+                handlers.add(handler);
+            } else {
+                parentHandler.addChildHandler(handler);
+            }
+
+            // Look at the next character...
+            ch = parser.nextChar();
+        }
+        if (ch == -1) {
+            // Make sure we didn't get to the end of the file
+            throw new SyntaxException("Unexpected EOF encountered while " + "parsing handlers for event '" + eventName + "'!");
+        }
+
+        // Do some checks to make sure everything is good...
+        if (!handlerStack.empty()) {
+            throw new SyntaxException("Unmatched '" + LEFT_CURLY + "' when parsing handlers for '" + eventName + "' event.");
+        }
+        if (!useBodyContent) {
+            // Additional checks for old syntax...
+            if (ch == '>') {
+                throw new SyntaxException("Handlers for event '" + eventName + "' did not end with '/&gt;' but instead ended with '&gt;'!");
+            }
+            if (ch == '/') {
+                // Make sure we have a "/>"...
+                parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+                ch = parser.nextChar();
+                if (ch != '>') {
+                    throw new SyntaxException("Expected '/&gt;' a end of '" + eventName + "' event.  But found '/" + (char) ch + "'.");
+                }
+                reader.popTag(); // Get rid of this event tag from the Stack
+                ctx.endSpecial(env, eventName);
+            }
+        } else {
+            // We need to recurse in order for the end-tag code to properly
+            // close out the context and make everything run correctly...
+            // Process child LayoutElements (should be none)
+            reader.process(EVENT_PROCESSING_CONTEXT, parent, LayoutElementUtil.isLayoutComponentChild(parent));
+        }
+
+        // Set the Handlers on the parent...
+        if (createHandlerDefinitionOnLayoutDefinition) {
+            HandlerDefinition def = new HandlerDefinition(eventName);
+            def.setChildHandlers(handlers);
+            parent.getLayoutDefinition().setHandlerDefinition(eventName, def);
+        } else {
+            parent.setHandlers(eventName, handlers);
+        }
+    }
+
+    /**
+     * <p>
+     * This method parses and creates an individual <code>Handler</code>.
+     * </p>
+     */
+    private Handler readHandler(TemplateParser parser, String eventName, LayoutElement parent) throws IOException {
+        String target = null;
+        String defVal = null;
+        NameValuePair nvp = null;
+        HandlerDefinition def = null;
+
+        String handlerId = parser.readToken();
+        // Check locally defined Handler
+        def = parent.getLayoutDefinition().getHandlerDefinition(handlerId);
+        if (def == null) {
+            // Check globally defined Handler
+            def = LayoutDefinitionManager.getGlobalHandlerDefinition(handlerId);
+            if (def == null) {
+                throw new SyntaxException(
+                        "Handler '" + handlerId + "' in event '" + eventName + "' is not declared!  " + "Ensure the '@Handler' annotation has been defined "
+                                + "on the handler Java method, that it has been " + "compiled with the annotation processing tool, and " + "that the resulting"
+                                + " 'META-INF/jsftemplating/Handler.map' is located " + "in your classpath (you may need to do a clean " + "build).");
+            }
+        }
+
+        // Create a Handler
+        Handler handler = new Handler(def);
+
+        // Get the default name
+        Map inputs = def.getInputDefs();
+// FIXME: Allow for HandlerDefs to declare their default input
+        if (inputs.size() == 1) {
+            defVal = inputs.keySet().toArray()[0].toString();
+        }
+
+        // Get the outputs so we can see what outputs have been declared
+        Map outputs = def.getOutputDefs();
+
+        // Ensure we have an opening parenthesis
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+        int ch = parser.nextChar();
+        if (ch != '(') {
+            throw new SyntaxException("While processing '&lt;!" + eventName + "...' the handler '" + handlerId + "' was missing the '(' character!");
+        }
+
+        // Move to the first char inside the parenthesis
+        parser.skipWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+        ch = parser.nextChar();
+
+        // We should not ignore '#' characters for 'if' (Issue #5)
+        if (ch != '#' || !handlerId.equals(IF_HANDLER)) {
+            parser.unread(ch);
+            parser.skipCommentsAndWhiteSpace(""); // Already skipped white
+            ch = parser.nextChar();
+        }
+
+        // Allow if() handlers to be more flexible...
+        if (handlerId.equals(IF_HANDLER) && ch != '\'' && ch != '"' && ch != 'c') {
+// FIXME: check for "condition", otherwise expressions starting with 'c' will
+// FIXME: not parse correctly
+            // We have an if() w/o a condition="" && w/o quotes...
+            // Take the entire value inside the ()'s to be the expression
+            parser.unread(ch);
+            handler.setCondition(parser.readUntil(')', false).trim());
+            ch = ')';
+        }
+
+        // Read NVP(s)...
+        while (ch != -1 && ch != ')') {
+            // Read NVP
+            parser.unread(ch);
+            try {
+                nvp = parser.getNVP(defVal);
+            } catch (SyntaxException ex) {
+                throw new SyntaxException("Unable to process handler '" + handlerId + "'!", ex);
+            }
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE + ",;");
+            ch = parser.nextChar();
+
+            // Store the NVP..
+            target = nvp.getTarget();
+            if (target != null) {
+                // "old-style" OutputMapping (key=>$attribute{value})
+                // NOTE: 'value' must be a String for an OutputMapping
+                handler.setOutputMapping(nvp.getName(), nvp.getValue().toString(), target);
+            } else {
+                // First check for special input value (condition)
+                String name = nvp.getName();
+                if (name.equals(CONDITION_ATTRIBUTE) && (inputs.get(CONDITION_ATTRIBUTE) == null || handlerId.equals(IF_HANDLER))) {
+                    // We have a Handler condition, set it
+                    handler.setCondition(nvp.getValue().toString());
+                } else {
+                    // We still don't know if this is an input, output, or both
+                    // (EL is now supported as an output mapping: out="#{el}")
+                    boolean validIO = false;
+                    // We also check to see if the "old" output mapping was
+                    // used and DO NOT override it if it was. This is useful
+                    // if there are cases where an input and output share a
+                    // name and the user does not fix this... the old syntax
+                    // can reliably declare an output without a namespace
+                    // problem.
+                    if (outputs.containsKey(name) && handler.getOutputValue(name) == null) {
+                        // We have an Output... use 2 arg method for this
+                        // syntax (expects EL, or uses simple String for a
+                        // request attribute).
+                        handler.setOutputMapping(name, nvp.getValue().toString(), OutputTypeManager.EL_TYPE);
+                        validIO = true;
+                    }
+                    // Don't do "else" b/c it may be BOTH an input AND output
+                    if (inputs.containsKey(name)) {
+                        // We have an Input
+                        handler.setInputValue(name, nvp.getValue());
+                        validIO = true;
+                    }
+                    if (!validIO) {
+                        throw new IllegalArgumentException("Input or output named \"" + name + "\" was declared for handler \"" + handlerId + "\" in event \""
+                                + eventName + "\", however, no such input or output exists!");
+                    }
+                }
+            }
+        }
+
+        // ';' or ',' characters may appear between handlers
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE + ",;");
+
+        // Return the Handler
+        return handler;
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for events. Currently does nothing.
+     * </p>
+     */
+    protected static class EventProcessingContext extends BaseProcessingContext {
+    }
+
+    public static final String IF_HANDLER = "if";
+    public static final String CONDITION_ATTRIBUTE = "condition";
+    public static final ProcessingContext EVENT_PROCESSING_CONTEXT = new EventProcessingContext();
+
+    public static final char LEFT_CURLY = '{';
+    public static final char RIGHT_CURLY = '}';
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/InsertParserCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/InsertParserCommand.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutInsert;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This {@link CustomParserCommand} handles "insert" statements. TBD...
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class InsertParserCommand implements CustomParserCommand {
+
+    /**
+     * <p>
+     * This method processes a "custom" command. These are commands that start with a !. When this method receives control,
+     * the <code>name</code> (i.e. the token after the '!' character) has already been read. It is passed via the
+     * <code>name</code> parameter.
+     * </p>
+     *
+     * <p>
+     * The {@link ProcessingContext} and {@link ProcessingContextEnvironment} are both available.
+     * </p>
+     */
+    @Override
+    public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+        // Get the reader and parser
+        TemplateReader reader = env.getReader();
+        TemplateParser parser = reader.getTemplateParser();
+
+        // Skip any white space...
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+
+        // Get the parent and insert name
+        LayoutElement parent = env.getParent();
+        String id = (String) parser.getNVP(NAME_ATTRIBUTE, true).getValue();
+
+        // Create new LayoutInsert
+        LayoutInsert compElt = new LayoutInsert(parent, id);
+        compElt.setName(id);
+        parent.addChildLayoutElement(compElt);
+
+        // Skip any white space or extra junk...
+        String theRest = parser.readUntil('>', true).trim();
+        if (theRest.endsWith("/")) {
+            reader.popTag(); // Don't look for end tag
+        } else {
+            // Process child LayoutElements (recurse)
+            reader.process(LAYOUT_INSERT_CONTEXT, compElt, LayoutElementUtil.isLayoutComponentChild(compElt));
+        }
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutInsert}s.
+     * </p>
+     */
+    protected static class LayoutInsertContext extends BaseProcessingContext {
+    }
+
+    /**
+     * <p>
+     * A String containing "template". This is the attribute name of the template file to use in the {@link LayoutInsert}.
+     * </p>
+     */
+    public static final String NAME_ATTRIBUTE = "name";
+
+    /**
+     * <p>
+     * The {@link ProcessingContext} to be used when processing children of a {@link LayoutInsert}. This
+     * {@link ProcessingContext} may have special meaning for {@link LayoutInsert}s and other tags.
+     * </p>
+     */
+    public static final ProcessingContext LAYOUT_INSERT_CONTEXT = new LayoutInsertContext();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/NameValuePair.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/NameValuePair.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+/**
+ * <p>
+ * This class is used to represent NVP information. This information consists of 2 or 3 parts. If this is a simple Name
+ * Value Pair, it will contain a <code>name</code> and a <code>value</code>. If it is an NVP that is used to map a
+ * return value, then it also contains a <code>target</code> as well (which should be set to "session" or "attribute").
+ * <code>name</code> and <code>target</code> contain <code>String</code> values. The <code>value</code> property
+ * contains an <code>Object</code> value because it may be a <code>String</code>, <code>java.util.List</code>, or an
+ * <code>array[]</code>.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class NameValuePair {
+    public NameValuePair(String name, Object value, String target) {
+        _name = name;
+        _value = value;
+        _target = target;
+    }
+
+    /**
+     * <p>
+     * Name accessor.
+     * </p>
+     */
+    public String getName() {
+        return _name;
+    }
+
+    /**
+     * <p>
+     * Value accessor.
+     * </p>
+     */
+    public Object getValue() {
+        return _value;
+    }
+
+    /**
+     * <p>
+     * Target accessor. If this value is non-null it can be assumed that this is an output mapping. However, if it is null
+     * it cannot be assumed to be an input mapping -- it may still be an output mapping or an in-out mapping which uses EL.
+     * Valid values for this are currently: (null), "pageSession", "attribute", or "session" (this list may be expanded in
+     * the future).
+     * </p>
+     */
+    public String getTarget() {
+        return _target;
+    }
+
+    /**
+     * <p>
+     * Customized to reconstruct the NVP.
+     * </p>
+     */
+    @Override
+    public String toString() {
+        if (getTarget() == null) {
+            return getName() + "=\"" + getValue() + '"';
+        } else {
+            return getName() + "=>$" + getTarget() + '{' + getValue() + '}';
+        }
+    }
+
+    private String _name = null;
+    private Object _value = null;
+    private String _target = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/NamespaceParserCommand.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/NamespaceParserCommand.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This {@link CustomParserCommand} handles "namespace" declarations. The format of this command should be:
+ * </p>
+ *
+ * <ul>
+ * <li>&lt;!namespace "longname"="shortname" /&gt;</li>
+ * </ul>
+ *
+ * <p>
+ * For example:
+ * </p>
+ *
+ * <ul>
+ * <li>&lt;!namespace "http://java.sun.com/mojarra/scales"="sc" /&gt;</li>
+ * </ul>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class NamespaceParserCommand implements CustomParserCommand {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public NamespaceParserCommand() {
+    }
+
+    /**
+     * <p>
+     * This method processes a "custom" command. These are commands that start with a !. When this method receives control,
+     * the <code>name</code> (i.e. the token after the '!' character) has already been read. It is passed via the
+     * <code>name</code> parameter.
+     * </p>
+     *
+     * <p>
+     * The {@link ProcessingContext} and {@link ProcessingContextEnvironment} are both available.
+     * </p>
+     */
+    @Override
+    public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+        // Get the reader
+        TemplateReader reader = env.getReader();
+        TemplateParser parser = reader.getTemplateParser();
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+        int ch = parser.nextChar();
+        if (ch == '>' || ch == '/') {
+            // Nothing specified, throw exception!
+            throw new IllegalArgumentException("Found an empty \"<!namespace />\" delcaration!  The long and" + " short namespace names must be provided.");
+        }
+        parser.unread(ch);
+
+        // Next get the next NVP...
+        NameValuePair nvp = parser.getNVP(null, true);
+
+        // Make sure we read the WS after the data...
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+
+        // Now make sure this is an end tag...
+        ch = parser.nextChar();
+        int ch2 = parser.nextChar();
+        if (ch != '/' || ch2 != '>') {
+            throw new IllegalArgumentException("[<!namespace " + nvp.getName() + "=" + nvp.getValue() + (char) ch + (char) ch2 + "] does not end with \"/>\"!");
+        }
+        reader.popTag(); // Don't look for end tag
+
+        // Save the mapping...
+        reader.setNamespace(nvp.getName(), nvp.getValue().toString());
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/ProcessingContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/ProcessingContext.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import java.io.IOException;
+
+/**
+ * <p>
+ * This interface defines the operations that may be acted upon while a "template" document is traversed. The intent is
+ * that this interface may be implemented by the different "processing contexts" which occur throught the template file.
+ * This provides the opportunity for context sensitive syntax in an easy to provide way.
+ * </p>
+ *
+ * <p>
+ * While the standard <code>ProcessingContext</code> instances are likely to be sufficient, there may be cases where a
+ * custom <code>ProcessingContext</code> may be needed to process the children of a {@link CustomParserCommand}. This
+ * may be done by implementing this interface, or extending one of the existing implementations. Typically this object
+ * is used by passing it to the {@link TemplateReader#process(ProcessingContext, LayoutElement, boolean)} method -- this
+ * method will delegate actions back to the given <code>ProcessingContext</code>.
+ * </p>
+ */
+public interface ProcessingContext {
+
+    /**
+     * <p>
+     * This is called when a component tag is found (&lt;tagname ...).
+     * </p>
+     */
+    void beginComponent(ProcessingContextEnvironment env, String content) throws IOException;
+
+    /**
+     * <p>
+     * This is called when an end component tag is found (&lt;/tagname ... or &lt;tagname ... /&gt;).
+     * </p>
+     */
+    void endComponent(ProcessingContextEnvironment env, String content) throws IOException;
+
+    /**
+     * <p>
+     * This is called when a special tag is found (&lt;!tagname ...).
+     * </p>
+     */
+    void beginSpecial(ProcessingContextEnvironment env, String content) throws IOException;
+
+    /**
+     * <p>
+     * This is called when a special end tag is found (&lt;/tagname ... or &lt;!tagname ... /&gt;).
+     * </p>
+     */
+    void endSpecial(ProcessingContextEnvironment env, String content) throws IOException;
+
+    /**
+     * <p>
+     * This is called when static text is found (").
+     * </p>
+     */
+    void staticText(ProcessingContextEnvironment env, String content) throws IOException;
+
+    /**
+     * <p>
+     * This is called when escaped static text is found ('). The difference between this and staticText is that HTML is
+     * expected to be escaped so the browser does not parse it.
+     * </p>
+     */
+    void escapedStaticText(ProcessingContextEnvironment env, String content) throws IOException;
+
+    /**
+     * <p>
+     * This method is invoked when nothing else matches.
+     * </p>
+     */
+    void handleDefault(ProcessingContextEnvironment env, String content) throws IOException;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/ProcessingContextEnvironment.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/ProcessingContextEnvironment.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+/**
+ * <p>
+ * This class hold environmental information needed while a parsing. This information is specific to the nested level
+ * that is currently being processed. This is unlike the {@link ProcessingContext} which is related to the "type" of
+ * element that is being processed. Or said another way, the {@link ProcessingContext} specifies how / what sub-elements
+ * are to be processed based on the context; this class provides the "where" information for that processing. Another
+ * difference is this class is stateful, the {@link ProcessingContext} has stateless methods that parse specific
+ * portions of the document.
+ * </p>
+ *
+ * @see TemplateReader
+ * @see ProcessingContext
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ProcessingContextEnvironment {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public ProcessingContextEnvironment(TemplateReader reader, LayoutElement parent, boolean nested) {
+        _reader = reader;
+        _parent = parent;
+        _nested = nested;
+    }
+
+    /**
+     * @return The <code>TemplateReader</code> instance.
+     */
+    public TemplateReader getReader() {
+        return _reader;
+    }
+
+    /**
+     * @return <code>true</code> if nested in a LayoutComponent.
+     */
+    public boolean isNested() {
+        return _nested;
+    }
+
+    /**
+     * @return The parent {@link LayoutElement}.
+     */
+    public LayoutElement getParent() {
+        return _parent;
+    }
+
+    /**
+     * <p>
+     * This method marks the current {@link ProcessingContext} as complete.
+     * </p>
+     */
+    public void setFinished(boolean finished) {
+        _finished = finished;
+    }
+
+    /**
+     * <p>
+     * This method indicates if the current {@link ProcessingContext} is still valid.
+     * </p>
+     */
+    public boolean isFinished() {
+        return _finished;
+    }
+
+    boolean _finished = false;
+    boolean _special = false;
+    boolean _nested = false;
+    LayoutElement _parent = null;
+    TemplateReader _reader = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateLayoutDefinitionManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateLayoutDefinitionManager.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.annotation.FormatDefinition;
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.util.FileUtil;
+
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * <p>
+ * This class is a concrete implmentation of the abstract class {@link LayoutDefinitionManager}. It obtains
+ * {@link LayoutDefinition} objects by interpreting the <code>key</code> passed to {@link #getLayoutDefinition(String)}
+ * as a path to a template file describing the {@link LayoutDefinition}. It will first attempt to resolve this path from
+ * the document root of the ServletContext or PortletCotnext. If that fails, it will attempt to use the Classloader to
+ * resolve it.
+ * </p>
+ *
+ * <p>
+ * This class is a singleton.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@FormatDefinition
+public class TemplateLayoutDefinitionManager extends LayoutDefinitionManager {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    protected TemplateLayoutDefinitionManager() {
+        super();
+    }
+
+    /**
+     * <p>
+     * This method returns an instance of this LayoutDefinitionManager. The object returned is a singleton (only 1 instance
+     * will be created per application).
+     * </p>
+     *
+     * @return <code>TemplateLayoutDefinitionManager</code> instance
+     */
+    public static LayoutDefinitionManager getInstance() {
+        return getInstance(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * <p>
+     * This method provides access to the application-scoped instance of the <code>TemplateLayoutDefinitionManager</code>.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code> (may be null).
+     */
+    public static LayoutDefinitionManager getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        TemplateLayoutDefinitionManager instance = null;
+        if (ctx != null) {
+            instance = (TemplateLayoutDefinitionManager) ctx.getExternalContext().getApplicationMap().get(TLDM_INSTANCE);
+        }
+        if (instance == null) {
+            instance = new TemplateLayoutDefinitionManager();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(TLDM_INSTANCE, instance);
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * <p>
+     * This method uses the key to determine if this {@link LayoutDefinitionManager} is responsible for handling the key.
+     * </p>
+     *
+     * <p>
+     * The template format is very flexible which makes it difficult to detect this vs. another format. For this reason, it
+     * is suggested that this format be attempted last (or at least after more detectable formats).
+     * </p>
+     *
+     * <p>
+     * This method checks the first character that is not a comment or whitespace (according to the TemplateParser). If this
+     * first character is a single quote or double quote it return <code>true</code>. If it is a "&lt;" character, it looks
+     * to see if it starts with "&lt;?" or "&lt;!DOCTYPE". If it does start that way, it returns <code>false</code>;
+     * otherwise it returns <code>true</code>. If any other character is found or an exception is thrown, it will return
+     * <code>false</code>.
+     * </p>
+     */
+    @Override
+    public boolean accepts(String key) {
+        URL url = null;
+        try {
+            url = FileUtil.searchForFile(key, ".jsf");
+        } catch (IOException ex) {
+            // Ignore this b/c we're just trying to detect if we're the right
+            // LDM... if we're here, probably we're not.
+        }
+        if (url == null) {
+            return false;
+        }
+
+        // Use the TemplateParser to help us read the file to see if it is a
+        // valid XML-format file
+        TemplateParser parser = new TemplateParser(url);
+        try {
+            parser.open();
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            int ch = parser.nextChar();
+            switch (ch) {
+            case '<':
+                ch = parser.nextChar();
+                if (ch == '?') {
+                    // XML Documents often start with "<?xml...>", '?' is
+                    // not valid after '<' in this format
+                    return false;
+                }
+                if (ch == '!') {
+                    String token = parser.readToken();
+                    if (token.equalsIgnoreCase("doctype")) {
+                        // <!DOCTYPE ... is also indicates an XML syntax
+                        // and should be ignored for this format
+                        return false;
+                    }
+                } else if (ch == '%') {
+                    // "<%@page ..."-type JSP stuff not valid
+                    return false;
+                }
+                return true;
+            case '\"':
+            case '\'':
+                return true;
+            default:
+                return false;
+            }
+        } catch (Exception ex) {
+            // Didn't work...
+            return false;
+        } finally {
+            parser.close();
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for finding the requested {@link LayoutDefinition} for the given <code>key</code>.
+     * </p>
+     *
+     * @param key Key identifying the desired {@link LayoutDefinition}.
+     *
+     * @return The requested {@link LayoutDefinition}.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition(String key) throws LayoutDefinitionException {
+        // Make sure we found the url
+        URL url = null;
+        try {
+            url = FileUtil.searchForFile(key, ".jsf");
+        } catch (IOException ex) {
+            throw new LayoutDefinitionException("Unable to locate '" + key + "'", ex);
+        }
+        if (url == null) {
+            throw new LayoutDefinitionException("Unable to locate '" + key + "'");
+        }
+
+        // Read the template file
+        LayoutDefinition ld = null;
+        try {
+            ld = new TemplateReader(key, url).read();
+        } catch (IOException ex) {
+            throw new LayoutDefinitionException("Unable to process '" + url.toString() + "'.", ex);
+        }
+
+        // Dispatch "initPage" handlers
+        ld.dispatchInitPageHandlers(FacesContext.getCurrentInstance(), ld);
+
+        // Return the LayoutDefinition
+        return ld;
+    }
+
+    /**
+     * <p>
+     * Application scope key for an instance of this class.
+     * </p>
+     */
+    private static final String TLDM_INSTANCE = "__jsft_TemplateLDM";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateParser.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateParser.java
@@ -1,0 +1,780 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.SyntaxException;
+import com.sun.jsftemplating.layout.descriptors.handler.OutputTypeManager;
+import com.sun.jsftemplating.util.IncludeInputStream;
+import com.sun.jsftemplating.util.LogUtil;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This class is responsible for the actual parsing of a template.
+ * </p>
+ *
+ * <p>
+ * This class is intended to read the template one time. Often it may be useful to cache the result as it would be
+ * inefficient to reread a template multiple times. Templates that are generated from this class are intended to be
+ * static and safe to share. However, this class itself is not thread safe.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class TemplateParser {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param url <code>URL</code> pointing to the template.
+     */
+    public TemplateParser(URL url) {
+        _url = url;
+    }
+
+    /**
+     * <p>
+     * Constructor which accepts a <code>InputStream</code>.
+     * </p>
+     *
+     * @param stream <code>InputStream</code> for the template.
+     */
+    public TemplateParser(InputStream stream) {
+        _inputStream = stream;
+    }
+
+    /**
+     * <p>
+     * Accessor for the URL.
+     * </p>
+     */
+    public URL getURL() {
+        return _url;
+    }
+
+    /**
+     * <p>
+     * Accessor for the <code>InputStream</code>. This either comes from the supplied <code>URL</code>, or simply from the
+     * supplied <code>InputStream</code>.
+     * </p>
+     */
+    public InputStream getInputStream() throws IOException {
+        if (_inputStream == null && _url != null) {
+            _inputStream = getURL().openStream();
+        }
+        return _inputStream;
+    }
+
+    /**
+     * <p>
+     * The init method opens the given <code>URL</code> pointing to a template and prepares to parses it.
+     * </p>
+     *
+     * @throws IOException
+     */
+    public void open() throws IOException {
+        if (_reader != null) {
+            // Generally this should not happen, but just in case... start over
+            close();
+        }
+
+// FIXME: It is possible while evaluating the file an #include may need to log a message to the screen!  Provide a callback mechanism to do this in a Template-specific way
+        // Create the reader from the stream
+        _reader = new BufferedReader(new InputStreamReader(new IncludeInputStream(new BufferedInputStream(getInputStream()))));
+
+        // Initialize the queue we will use to push values back
+        _stack = new Stack<>();
+    }
+
+    /**
+     * <p>
+     * This method closes the stream if it is open. It doesn't throw an exception, instead it logs any exceptions at the
+     * CONFIG level.
+     * </p>
+     */
+    public void close() {
+        try {
+            if (_reader != null) {
+                _reader.close();
+            }
+        } catch (Exception ex) {
+            if (LogUtil.configEnabled(this)) {
+                LogUtil.config("Exception while closing stream for url: '" + getURL() + "'.", ex);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method returns the next character.
+     * </p>
+     */
+    public int nextChar() throws IOException {
+        if (!_stack.empty()) {
+            // We have values in the queue
+            return _stack.pop().charValue();
+        }
+        return _reader.read();
+    }
+
+    /**
+     * <p>
+     * This method pushes a character on the read queue so that it will be read next.
+     * </p>
+     */
+    public void unread(int ch) {
+        _stack.push(new Character((char) ch));
+    }
+
+    /**
+     * <p>
+     * This method reads a "Name Value Pair" from the stream. For the purposes of this method, a "Name Value Pair" may look
+     * like like one of these formats:
+     * </p>
+     *
+     * <code>
+     *    <ul><li>keyName="keyValue"</li>
+     *        <li>keyName='keyValue'</li>
+     *        <li>"keyValue" (only if defName is supplied)</li>
+     *        <li>'keyValue' (only if defName is supplied)</li>
+     *        <li>keyName=&gt;$attribute{attributeKey}</li>
+     *        <li>keyName=&gt;$session{sessionKey}</li>
+     *        <li>keyName=&gt;$page{pageSessionKey}</li>
+     *        <li>keyName=&gt;$pageSession{pageSessionKey}</li></ul>
+     *    </code>
+     *
+     * <p>
+     * In the first two formats, <code>keyName</code> must consist of letters, numbers, or the underscore '_' character.
+     * <code>keyValue</code> must be wrapped in single or double quotes. The backslash '\' character may be used to escape
+     * characters, this may be useful if a backslash, single, or double quote exists in the string.
+     * </p>
+     *
+     * <p>
+     * The last four formats are only used for mapping return values. This is necessary when a handler returns a value so
+     * that the value can be stored somewhere. <code>keyName</code> in these cases is the name of the return value to map.
+     * The value after the dollar '$' character (which is either "attribute", "page", "pageSession", or "session") specifies
+     * the type of storage the value should be saved. The value inside the curly braces "{}" specifies the key that should
+     * be used when saving the value as a request, page, or session attribute.
+     * </p>
+     *
+     * <p>
+     * The return value is of type {@link NameValuePair}. This object contains the necessary information to interpret this
+     * NVP.
+     * </p>
+     *
+     * @param defName The default name to use if ommitted. If <code>null</code>, no default will be used -- a
+     * {@link SyntaxException} will be generated.
+     *
+     * @return A {@link NameValuePair} object containing the NVP info.
+     */
+    public NameValuePair getNVP(String defName) throws IOException {
+        return getNVP(defName, true);
+    }
+
+    /**
+     * <p>
+     * This method behaves the same as {@link #getNVP(String)}, however, it adds the ability to make quotes around the value
+     * optional. This is done by passing in <code>false</code> for <code>requireQuotes</code>. This is used by some special
+     * commands which only take a single argument with no property name. In this case, the value will be read until a '&gt;'
+     * is encountered (if "/&gt;" is encountered, it will stop before the '/').
+     * </p>
+     *
+     * <p>
+     * Also, in cases where quotes are optional, output NVPs will not be allowed. The rationale is that the "=&gt;$...{...}"
+     * syntax did not require quotes already, and use cases which allow for omitting quotes do not use output mappings.
+     * </p>
+     *
+     * @param defName The default name to use if ommitted. If <code>null</code>, no default will be used -- a
+     * {@link SyntaxException} will be generated.
+     *
+     * @param requireQuotes Flag indicating whether enforce the use of quotes or not.
+     *
+     * @return A {@link NameValuePair} object containing the NVP info.
+     *
+     * @throws SyntaxException if the syntax is not correct.
+     */
+    public NameValuePair getNVP(String defName, boolean requireQuotes) throws IOException {
+        return getNVP(defName, requireQuotes, "_.");
+    }
+
+    /**
+     * <p>
+     * This method behaves the same as {@link #getNVP(String, boolean)}, however, it adds the ability to specify the valid
+     * characters which may appear in the parameter name (via <code>otherChars</code>).
+     * </p>
+     *
+     * @param defName The default name to use if ommitted. If <code>null</code>, no default will be used -- a
+     * {@link SyntaxException} will be generated.
+     *
+     * @param requireQuotes Flag indicating whether enforce the use of quotes or not.
+     *
+     * @param otherChars Other valid characters.
+     *
+     * @return A {@link NameValuePair} object containing the NVP info.
+     *
+     * @throws SyntaxException if the syntax is not correct.
+     */
+    public NameValuePair getNVP(String defName, boolean requireQuotes, String otherChars) throws IOException {
+        // Read the name
+        String name = readToken(otherChars);
+        Object value = null;
+
+        // Check for empty name
+        if (name.length() == 0 && defName != null) {
+            name = defName; // Use default name
+            unread('='); // Add '=' character
+        }
+
+        // Skip White Space
+        skipCommentsAndWhiteSpace(SIMPLE_WHITE_SPACE);
+
+        // Ensure next character is '='
+        int next = nextChar();
+        if (next != '=' && next != ':') {
+            if (!requireQuotes && !name.equals(defName)) {
+                // This is the case where there is no property name and no
+                // quotes, the whole string is the value.
+                value = name;
+                name = defName;
+                // Add a flag to ensure the next switch goes to the "default" case
+                unread(next);
+                unread('f');
+            } else {
+                throw new SyntaxException("'=' or ':' missing for Name Value Pair: '" + name + "'!");
+            }
+        }
+
+        // Skip whitespace...
+        skipCommentsAndWhiteSpace(SIMPLE_WHITE_SPACE);
+
+        // Check for '>' character (means we're mapping an output value)
+        String target = null;
+        int endingChar = -1;
+        next = nextChar();
+        switch (next) {
+        case '>':
+            if (!requireQuotes) {
+                // This means output mappings are not allowed, this must
+                // be the end of the input (meaning there was no input
+                // since we're at the beginning also)
+                unread(next);
+                value = "";
+                break;
+            }
+
+            // We are mapping an output value, this should look like:
+            // keyName => $attribute{attKey}
+            // keyName => $application{appKey}
+            // keyName => $session{sessionKey}
+            // keyName => $pageSession{pageSessionKey}
+
+            // First skip any whitespace after the '>'
+            skipCommentsAndWhiteSpace(SIMPLE_WHITE_SPACE);
+
+            // Next Make sure we have a '$' character
+            next = nextChar();
+            if (next != '$') {
+                throw new SyntaxException("'$' missing for Name Value Pair named: '" + name + "=>'!  This NVP appears to be a mapping expression, "
+                        + "therefor requires a format similar to:\n\t" + name + " => $attribute{attKey}\nor:\n\t" + name
+                        + " => $application{applicationKey}\nor:\n\t" + name + " => $session{sessionKey}\nor:\n\t" + name + " => $pageSession{pageSessionKey}");
+            }
+
+            // Next look for valid type...
+            target = readToken();
+            OutputTypeManager otm = OutputTypeManager.getInstance();
+            if (otm.getOutputType(null, target) == null) {
+                throw new SyntaxException("Invalid OutputType ('" + target + "') for Name Value " + "Pair named: '" + name + "=>$" + target + "{...}'!  "
+                        + "This NVP appears to be a mapping expression, " + "therefor requires a format similar to:\n\t" + name
+                        + " => $attribute{attKey}\nor:\n\t" + name + " => $application{applicationKey}\nor:\n\t" + name + " => $session{sessionKey}\nor:\n\t"
+                        + name + " => $pageSession{pageSessionKey}");
+            }
+
+            // Skip whitespace again...
+            skipCommentsAndWhiteSpace(SIMPLE_WHITE_SPACE);
+
+            // Now look for '{'
+            next = nextChar();
+            if (next != '{') {
+                throw new SyntaxException("'{' missing for Name Value Pair: '" + name + "=>$" + target + "'!  The format must resemble the following:\n\t"
+                        + name + " => $" + target + "{key}");
+            }
+            endingChar = '}';
+            break;
+        case '{':
+            // NVP w/ a List as its value
+            value = parseList('}');
+            break;
+        case '[':
+            // NVP w/ an array as its value
+            value = parseList(']').toArray();
+            break;
+        case '"':
+        case '\'':
+            // Regular NVP...
+            // Set the ending character to the same type of quote
+            endingChar = next;
+            break;
+        case 'f':
+            if (value != null && value.toString().length() > 0) {
+                // We have the case where the whole string is the value
+                // Get the next character so we can fall through w/ it
+                // to the default case
+                next = nextChar();
+            }
+            // Don't break here, fall through...
+        default:
+            // See if we require quotes around the value...
+            if (!requireQuotes) {
+                unread(next); // Include "next" when getting the value
+                // Read the value until '>'
+                String strVal = readUntil('>', true);
+
+                // Unread the '>'
+                unread('>');
+
+                // See if we also need put back a '/'...
+                if (strVal.endsWith("/")) {
+                    // Remove the '/' and place back in the read buffer
+                    strVal = strVal.substring(0, strVal.length() - 1).trim();
+                    unread('/');
+                }
+                value = value == null ? strVal : value.toString() + strVal;
+                break;
+            }
+
+            // This isn't legal, throw an exception
+            throw new SyntaxException("Name Value Pair named '" + name + "' is missing single or double quotes enclosing "
+                    + "its value.  It must follow one of these formats:\n\t" + name + "=\"value\"\nor:\n\t" + name + "='value'");
+        }
+
+        // Read the value
+        if (endingChar != -1) {
+            value = readUntil(endingChar, false);
+        }
+
+        // Create the NVP object and return it
+        return new NameValuePair(name, value, target);
+    }
+
+    /**
+     * <p>
+     * This method processes lists of String values in the format:
+     * </p>
+     *
+     * <p>
+     * <code>"value1", "value2", ...}</code>
+     * </p>
+     *
+     * <p>
+     * The content inside the Strings can be anything. The double quotes can also be single quotes. The separators can be
+     * spaces, tabs, new lines, commas, semi-colons, or colons. The terminating character is whatever is passed in for
+     * <code>endChar</code> (shown as '}' above).
+     * </p>
+     */
+    protected List<String> parseList(int endChar) throws IOException {
+        List<String> list = new ArrayList<>();
+        skipCommentsAndWhiteSpace(SIMPLE_WHITE_SPACE);
+        int next = nextChar();
+        while (next != endChar) {
+            // We should start w/ a single or double quote
+            if (next != '\'' && next != '"') {
+                throw new IllegalArgumentException("A List or array is missing a single or double quotes " + "enclosing one or more of its values.  It must "
+                        + "follow:\n\tname={\"value\", ...}\nor:\n\tname={'value'," + "...}\n\n[]'s may be used in place of {}'s to specify "
+                        + "an array instead of a List.");
+            }
+
+            // Read everything inside the quotes
+            list.add(readUntil(next, false));
+
+            // Skip white space (including the seperators ",:;");
+            skipCommentsAndWhiteSpace(SIMPLE_WHITE_SPACE + ",:;");
+            next = nextChar();
+        }
+        return list;
+    }
+
+    /**
+     * <p>
+     * This method reads while the stream contains letters, numbers, the colon character ':', a dot '.', or the underscore
+     * '_' character, and returns the result.
+     * </p>
+     */
+    public String readToken() throws IOException {
+        return readToken("_:.");
+    }
+
+    /**
+     * <p>
+     * This method reads while the stream contains letters or numbers and returns the result.
+     * </p>
+     *
+     * <p>
+     * It also allows any charcters specified by <code>otherChars</code> to be considered as part of the token. This allows
+     * tokens with additional valid characters to be read. <code>otherChars</code> may be null if no additional chars are
+     * valid.
+     * </p>
+     *
+     * @param otherChars Other valid characters.
+     */
+    public String readToken(String otherChars) throws IOException {
+        if (otherChars == null) {
+            otherChars = "";
+        }
+
+        StringBuffer buf = new StringBuffer();
+        int next = nextChar();
+        while (Character.isLetterOrDigit(next) || otherChars.indexOf(next) != -1) {
+            buf.append((char) next);
+            next = nextChar();
+        }
+        unread(next);
+
+        // Return the result
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>String</code> of characters from the current position in the file until the given
+     * character (or end of file) is encountered. It will not leave the given character in the buffer, so the next character
+     * to be read will be the character following the given character.
+     * </p>
+     *
+     * @param skipComments <code>true</code> to strip comments.
+     */
+    public String readUntil(int endingChar, boolean skipComments) throws IOException {
+        if (skipComments) {
+            // In case we start on a comment and should skip it...
+            skipCommentsAndWhiteSpace("");
+        }
+        int tmpch;
+        int next = nextChar();
+        StringBuffer buf = new StringBuffer();
+        while (next != endingChar && next != -1) {
+            switch (next) {
+            case '\'':
+            case '\"':
+                if (skipComments && next != endingChar) {
+                    // In this case, we want to make sure no comments are
+                    // skipped when inside a quote
+                    //
+                    // NOTE: Also means endingChar will not be found in
+                    // a quote.
+                    buf.append((char) next);
+                    buf.append(readUntil(next, false));
+                    buf.append((char) next);
+                } else {
+                    buf.append((char) next);
+                }
+                break;
+            case '#':
+            case '/':
+            case '<':
+                // When reading we want to ignore comments, don't skip
+                // whitespace, though...
+                if (skipComments) {
+                    unread(next);
+                    skipCommentsAndWhiteSpace("");
+                    // If same char, read next to prevent infinite loop
+                    // We don't have to go through switch again b/c its
+                    // not the ending char and its not escaped -- so it is
+                    // safe to add.
+                    tmpch = nextChar();
+                    if (next == tmpch) {
+                        buf.append((char) next);
+                    } else {
+                        // We're somewhere different, unread
+                        unread(tmpch);
+                    }
+                } else {
+                    buf.append((char) next);
+                }
+                break;
+            case '\\':
+                // Escape Character...
+                next = nextChar();
+                if (next == 'n') {
+                    // Special case, insert a '\n' character.
+                    buf.append('\n');
+                } else if (next == 't') {
+                    // Special case, insert a '\t' character.
+                    buf.append('\t');
+                } else if (next != '\n') {
+                    // add the next char unless it's a return char
+                    buf.append((char) next);
+                }
+                break;
+            default:
+                buf.append((char) next);
+                break;
+            }
+            next = nextChar();
+        }
+
+        // Return the result
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>String</code> of characters from the current position in the file until the given String
+     * (or end of file) is encountered. It will not leave the given String in the buffer, so the next character to be read
+     * will be the character following the given character.
+     * </p>
+     *
+     * @param endingStr The terminating <code>String</code>.
+     * @param skipComments <code>true</code> to ignore comments.
+     */
+    public String readUntil(String endingStr, boolean skipComments) throws IOException {
+        // Sanity Check
+        if (endingStr == null || endingStr.length() == 0) {
+            return "";
+        }
+
+        // Break String into characters
+        char arr[] = endingStr.toCharArray();
+        int arrlen = arr.length;
+
+        StringBuffer buf = new StringBuffer("");
+        int ch = nextChar(); // Read a char to unread
+        int idx = 1;
+        do {
+            // We didn't find the end, push read values back on queue
+            unread(ch);
+            for (int cnt = idx - 1; cnt > 0; cnt--) {
+                unread(arr[cnt]);
+            }
+
+            // Read until the beginning of the end (maybe)
+            buf.append(readUntil(arr[0], skipComments));
+            buf.append(arr[0]); // readUntil reads but doesn't return this char
+
+            // Check to see if we are at the end
+            for (idx = 1; idx < arrlen; idx++) {
+                ch = nextChar();
+                if (ch != arr[idx]) {
+                    // This is not the end!
+                    break;
+                }
+            }
+        } while (ch != -1 && idx < arrlen);
+
+        // Append the remaining characters (use idx in case we hit eof)...
+        for (int cnt = 1; cnt < idx; cnt++) {
+            buf.append(arr[cnt]);
+        }
+
+        if (arrlen != idx) {
+            // Didn't find it!
+            throw new SyntaxException("Unable to find: '" + endingStr + "'.  Read to EOF and gave up.  Read: \n" + buf.toString());
+        }
+
+        // Return the result
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method skips the given String of characters (usually used to skip white space. The contents of the String that
+     * is skipped is lost. Often you may wish to skip comments as well, use
+     * {@link TemplateParser#skipCommentsAndWhiteSpace(String)} in this case.
+     * </p>
+     *
+     * @param skipChars The white space characters to skip.
+     *
+     * @see TemplateParser#skipCommentsAndWhiteSpace(String)
+     */
+    public void skipWhiteSpace(String skipChars) throws IOException {
+        int next = nextChar();
+        while (next != -1 && skipChars.indexOf(next) != -1) {
+            // Skip...
+            next = nextChar();
+        }
+
+        // This will skip one too many
+        unread(next);
+    }
+
+    /**
+     * <p>
+     * Normally you don't just want to skip white space, you also want to skip comments. This method allows you to do that.
+     * It skips comments of the following types:
+     * </p>
+     *
+     * <code>
+     *        <ul><li>//        -   Comment extends to the rest of the line.</li>
+     *        <li>#        -   Comment extends to the rest of the line.</li>
+     *        <li>/*        -   Comment extends until closing '*' and '/'.</li>
+     *        <li>&lt;!-- -   Comment extends until closing --&gt;.</li></ul>
+     *    </code>
+     *
+     * @param skipChars The white space characters to skip
+     *
+     * @see TemplateParser#skipWhiteSpace(String)
+     */
+    public void skipCommentsAndWhiteSpace(String skipChars) throws IOException {
+        int ch = 0;
+        while (ch != -1) {
+            ch = nextChar();
+            switch (ch) {
+            case '#':
+                // Skip rest of line
+                readLine();
+                break;
+            case '/':
+                ch = nextChar();
+                if (ch == '/') {
+                    // Skip rest of line
+                    readLine();
+                } else if (ch == '*') {
+                    // Throw away everything until '*' & '/'.
+                    readUntil("*/", false);
+                } else {
+                    // Not a comment, don't read
+                    unread(ch);
+                    unread('/');
+                    ch = -1; // Exit loop
+                }
+                break;
+            case '<':
+                ch = nextChar(); // !
+                if (ch == '!') {
+                    ch = nextChar(); // -
+                    if (ch == '-') {
+                        ch = nextChar(); // -
+                        if (ch == '-') {
+                            // Ignore HTML-style comment
+                            readUntil("-->", false);
+                        } else {
+                            // Not a comment, probably a mistake... lets
+                            // throw an exception
+                            unread(ch);
+                            unread('-');
+                            unread('!');
+                            unread('<');
+                            throw new IllegalArgumentException("Invalid " + "comment!  Expected comment to begin " + "with \"<!--\", but found: " + readLine());
+                        }
+                    } else {
+                        // Not a comment, probably an event.. back out
+                        unread(ch);
+                        unread('!');
+                        unread('<');
+                        ch = -1; // Cause loop to end
+                    }
+                } else {
+                    // '!' not found, not a comment... we shouldn't be here
+                    // skipping this back out
+                    unread(ch);
+                    unread('<');
+                    ch = -1; // Cause loop to end
+                }
+                break;
+            case -1: // Ignore this case
+                break;
+            default:
+                // See if this is white space...
+                if (skipChars.indexOf(ch) == -1) {
+                    // Nope... we're done skipping (undo last read)
+                    unread(ch);
+                    ch = -1; // Exit loop
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method reads the rest of the line. This can be used to read entire lines (obviously), or as a means of skipping
+     * the remainder of a line (i.e. to ignore line comments).
+     * </p>
+     */
+    public String readLine() throws IOException {
+        StringBuffer buf = new StringBuffer();
+        int ch = -1;
+        while (!_stack.empty()) {
+            // We have values in the queue
+            ch = _stack.pop().charValue();
+            if (ch == '\r' || ch == '\n') {
+                // We hit the EOL...
+                // Check to see if there are 2...
+                if (!_stack.empty()) {
+                    ch = _stack.peek().charValue();
+                    if (ch == '\r' || ch == '\n') {
+                        // Remove this one too...
+                        _stack.pop().charValue();
+                    }
+                }
+                return buf.toString();
+            }
+            buf.append((char) ch);
+        }
+
+        // Read the rest of the line
+        buf.append(_reader.readLine());
+
+        int idx = buf.indexOf("\\n");
+        while (idx != -1) {
+            // Replace '\\n' with '\n'
+            buf.replace(idx, idx + 2, "\n");
+            idx = buf.indexOf("\\n", idx + 1);
+        }
+
+        // Check to see if '\' character is at eol, if so read next line too
+        int lastChar = buf.length() - 1;
+        if (lastChar >= 0 && buf.charAt(lastChar) == '\\') {
+            buf.deleteCharAt(lastChar);
+            buf.append(readLine());
+        }
+
+        return buf.toString();
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Constants
+    //////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This String constant defines the characters that are interpretted to be basic white space characters. The value of
+     * this is:
+     * </p>
+     *
+     * <p>
+     * <ul>
+     * <li><code>" \t\r\n"</code></li>
+     * </ul>
+     * </p>
+     */
+    public static final String SIMPLE_WHITE_SPACE = " \t\r\n";
+
+    private URL _url = null;
+    private InputStream _inputStream = null;
+    private transient BufferedReader _reader = null;
+    private transient Stack<Character> _stack = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateReader.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateReader.java
@@ -1,0 +1,981 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.ProcessingCompleteException;
+import com.sun.jsftemplating.layout.SyntaxException;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutFacet;
+import com.sun.jsftemplating.layout.descriptors.LayoutForEach;
+import com.sun.jsftemplating.layout.descriptors.LayoutIf;
+import com.sun.jsftemplating.layout.descriptors.LayoutWhile;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * <p>
+ * This class is responsible for parsing templates. It produces a {@link LayoutElement} tree with a
+ * {@link LayoutDefinition} object at the root of the tree.
+ * </p>
+ *
+ * <p>
+ * This class is intended to "read" the template one time. Often it may be useful to cache the result as it would be
+ * inefficient to call {@link TemplateReader#read()} multiple time (and therefor parse the template multiple times).
+ * Templates that are generated from this class are intended to be static and safe to share (but not alter).
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class TemplateReader {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param id The identifier of the {@link LayoutDefinition} to read.
+     * @param url <code>URL</code> to the {@link LayoutDefinition} file.
+     */
+    public TemplateReader(String id, URL url) {
+        if (id == null) {
+            throw new IllegalArgumentException("Template id's may not be null!");
+        }
+        _id = id;
+        _idNumber = LayoutElementUtil.getStartingIdNumber(null, id);
+        _tpl = new TemplateParser(url);
+    }
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param stream The <code>InputStream</code> for the {@link LayoutDefinition}.
+     * @param id The identifier of the {@link LayoutDefinition} to read.
+     */
+    public TemplateReader(String id, InputStream stream) {
+        if (id == null) {
+            throw new IllegalArgumentException("Template id's may not be null!");
+        }
+        _id = id;
+        _tpl = new TemplateParser(stream);
+    }
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param id The identifier of the {@link LayoutDefinition} to read.
+     * @param parser {@link TemplateParser} ready to read the {@link LayoutDefinition}.
+     */
+    public TemplateReader(String id, TemplateParser parser) {
+        _id = id;
+        _tpl = parser;
+    }
+
+    /**
+     * <p>
+     * Accessor for the {@link TemplateParser}.
+     * </p>
+     *
+     * @return The {@link TemplateParser}.
+     */
+    public TemplateParser getTemplateParser() {
+        return _tpl;
+    }
+
+    /**
+     * <p>
+     * The read method uses the {@link TemplateParser} to parses the template. It populates a {@link LayoutDefinition}
+     * structure, which is returned.
+     * </p>
+     *
+     * @return The {@link LayoutDefinition}
+     *
+     * @throws IOException
+     */
+    public LayoutDefinition read() throws IOException {
+        // Open the Template
+        TemplateParser parser = getTemplateParser();
+        parser.open();
+
+        try {
+            // Populate the LayoutDefinition from the Document
+            return readLayoutDefinition();
+        } finally {
+            parser.close();
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for creating and populating the {@link LayoutDefinition}.
+     * </p>
+     *
+     * @return The new {@link LayoutDefinition} Object.
+     */
+    private LayoutDefinition readLayoutDefinition() throws IOException {
+        // Create a new LayoutDefinition (the id is not propagated here)
+        LayoutDefinition ld = new LayoutDefinition(_id);
+
+        // For now we will only support global resources. In the future, we
+        // may want to allow resources to be overriden at the page level and /
+        // or additional page-specific resources to be added.
+        //
+        // NOTE: Resources may be locale specific, so we can't easily share
+        // this at the application scope. Here, "global" means across
+        // pages, not across sessions.
+// FIXME: This isn't implemented yet...
+        ld.setResources(LayoutDefinitionManager.getGlobalResources(null));
+
+        /*
+         * // Look to see if there is an EVENT_ELEMENT defined childElements = getChildElements(node, EVENT_ELEMENT); it =
+         * childElements.iterator(); if (it.hasNext()) { // Found the EVENT_ELEMENT, there is at most 1 // Get the event type
+         * Node eventNode = (Node) it.next(); String type = (String) getAttributes(eventNode). get(TYPE_ATTRIBUTE);
+         *
+         * // Set the Handlers for the given event type (name) List<Handler> handlers = ld.getHandlers(type);
+         * ld.setHandlers(type, getHandlers(eventNode, handlers)); }
+         */
+        try {
+            ld = (LayoutDefinition) process(LAYOUT_DEFINITION_CONTEXT, ld, false);
+        } catch (ProcessingCompleteException pc) {
+            // Some tags can abort processing early. This isn't an error, but
+            // we use this exception to abort immediately.
+            ld = pc.getLayoutDefinition();
+        }
+        return ld;
+    }
+
+    /**
+     * <p>
+     * This method does the walking through the file. The file has different "contexts" in which it may be processing. For
+     * example, when processing at the top-level, certain syntax is valid. However, when processing content inside a
+     * component, the valid syntax may be different. This method delegates handling of various syntaxes to the
+     * {@link ProcessingContext}. This enables the walking and the processing to be separated.
+     * </p>
+     *
+     * <p>
+     * The <code>nested</code> flag is used to indicate whether processing is nested inside a {@link LayoutComponent}. This
+     * is important to know because the rules change when <code>UIComponent</code>s become nested. The
+     * <code>ViewHandler</code> has control at the top level (non-nested), but does not have control inside
+     * <code>UIComponent</code>s. When nested often a <code>UIComponent</code> must be utilized instead of a
+     * {@link LayoutElement}. In a page situation, most tags will be nested; when defining a <code>Renderer</code> most tags
+     * are not likely to be nested.
+     * </p>
+     *
+     * @param ctx The {@link ProcessingContext}
+     * @param parent The parent {@link LayoutElement}
+     * @param nested <code>true</code> if nested in a {@link LayoutComponent}
+     */
+    public LayoutElement process(ProcessingContext ctx, LayoutElement parent, boolean nested) throws IOException {
+        // Get the parser...
+        TemplateParser parser = getTemplateParser();
+
+        // Skip White Space...
+        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+
+        ProcessingContextEnvironment env = new ProcessingContextEnvironment(this, parent, nested);
+        int ch = parser.nextChar();
+        String startTag = null;
+        String tmpstr = null;
+        boolean finished = false;
+        while (ch != -1) {
+            switch (ch) {
+            case '<':
+                parser.skipCommentsAndWhiteSpace( // Skip white space
+                        TemplateParser.SIMPLE_WHITE_SPACE);
+                ch = parser.nextChar();
+                if (ch == '/') {
+                    // Closing tag
+                    parser.skipCommentsAndWhiteSpace( // Skip white space
+                            TemplateParser.SIMPLE_WHITE_SPACE);
+                    // Get the expected String
+                    if (isTagStackEmpty()) {
+                        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE + '!');
+                        throw new SyntaxException("Found end tag '&lt;/" + parser.readToken() + "...' but did not find matching begin tag!");
+                    }
+                    startTag = popTag();
+                    if (startTag.length() > 0 && startTag.charAt(0) == '!') {
+                        // Check for special flag, might have a '!'
+                        ch = parser.nextChar();
+                        // Ignore the '!' if there, if not push it back
+                        if (ch == '!') {
+                            // Ignore '!', but skip white space after it
+                            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+                        } else {
+                            // No optional '!', push back extra read char
+                            parser.unread(ch);
+                        }
+                        tmpstr = parser.readToken();
+                        if (!startTag.contains(tmpstr)) {
+                            throw new SyntaxException("Expected to find closing tag '&lt;/" + startTag + "...&gt;' but instead found '&lt;/'"
+                                    + (ch == '!' ? '!' : "") + tmpstr + "...&gt;'.");
+                        }
+                        ctx.endSpecial(env, tmpstr);
+                    } else {
+                        tmpstr = parser.readToken();
+                        if (!startTag.equals(tmpstr)) {
+                            throw new SyntaxException(
+                                    "Expected to find closing tag '&lt;/" + startTag + "...&gt;' but instead found '&lt;/'" + tmpstr + "...&gt;'.");
+                        }
+                        ctx.endComponent(env, tmpstr);
+                    }
+                    finished = true; // Indicate done with this context
+                    parser.skipCommentsAndWhiteSpace( // Skip white space
+                            TemplateParser.SIMPLE_WHITE_SPACE);
+                    ch = parser.nextChar(); // Throw away '>' character
+                    if (ch != '>') {
+                        throw new SyntaxException("While processing closing tag '&lt;/" + tmpstr + "...' expected to encounter closing '&gt;' but" + " found '"
+                                + (char) ch + "' instead!");
+                    }
+                } else if (ch == '!') {
+                    // We have a reserved tag...
+                    tmpstr = parser.readToken();
+                    pushTag("!" + tmpstr);
+                    ctx.beginSpecial(env, tmpstr);
+                } else {
+                    // Open tag
+                    parser.unread(ch);
+                    tmpstr = parser.readToken();
+                    if (tmpstr.equals("f:verbatim")) {
+                        parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+                        parser.nextChar(); // Get rid of '>'
+                        tmpstr = parser.readUntil("</f:verbatim>", false);
+                        tmpstr = tmpstr.substring(0, tmpstr.length() - "</f:verbatim>".length());
+                        ctx.staticText(env, tmpstr);
+                    } else if (tmpstr.equals("ui:event")) {
+                        // Hard-code special case for event...
+// FIXME: Should also support substituting ! for a custom prefix
+                        pushTag("!" + tmpstr); // Mark as special
+                        // Must pass in "event" to get correct behavior
+                        ctx.beginSpecial(env, "event");
+                    } else if (tmpstr.equals("handler")) {
+                        // Hard-code special case for handler...
+// FIXME: Should also support substituting ! for a custom prefix
+                        pushTag("!" + tmpstr); // Mark as special
+                        // Must pass in "handler" to get correct behavior
+                        ctx.beginSpecial(env, "handler");
+                    } else {
+                        pushTag(tmpstr);
+                        ctx.beginComponent(env, tmpstr);
+                    }
+                }
+                break;
+            case '\'':
+                // Escape HTML
+                ctx.escapedStaticText(env, parser.readLine());
+                break;
+            case '"':
+                // Write output directly to stdout
+                ctx.staticText(env, parser.readLine());
+                break;
+            default:
+                parser.unread(ch);
+                ctx.handleDefault(env, null);
+            }
+            if (finished) {
+                // Done w/ this context...
+                return parent;
+            }
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            ch = parser.nextChar();
+        }
+
+        // Return the LayoutElement
+        return parent;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for parsing and creating a {@link LayoutComponent}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param nested <code>true</code> if nested inside another {@link LayoutComponent}.
+     * @param type The type of component to create.
+     */
+    public LayoutComponent createLayoutComponent(LayoutElement parent, boolean nested, String type) throws IOException {
+        // Ensure type is defined
+        ComponentType componentType = LayoutDefinitionManager.getGlobalComponentType(null, type);
+        if (componentType == null) {
+            // Look for local mapping...
+            String mappedType = getMappedType(type);
+            if (mappedType != null) {
+                componentType = LayoutDefinitionManager.getGlobalComponentType(null, mappedType);
+            }
+            if (componentType == null) {
+                // Still not found...
+                throw new IllegalArgumentException("ComponentType '" + type + "' not defined!");
+            }
+        }
+
+        // Get the NVPs
+        List<NameValuePair> nvps = readNameValuePairs(type, null, true);
+
+        // Check to see if this is a single tag (start and close)
+        boolean single = false;
+        TemplateParser parser = getTemplateParser();
+        int ch = parser.nextChar();
+        if (ch == '/') {
+            single = true;
+        } else {
+            parser.unread(ch);
+        }
+
+        // Check for id / overwrite attributes
+        NameValuePair nvpID = null;
+        String id = null;
+        NameValuePair overwrite = null;
+        for (NameValuePair nvp : nvps) {
+            if (nvp.getName().equals(ID_ATTRIBUTE)) {
+                // Found id...
+                nvpID = nvp;
+            } else if (nvp.getName().equals(OVERWRITE_ATTRIBUTE)) {
+                // Found overwrite... (must be a String, not an array / List)
+                overwrite = nvp;
+            }
+        }
+        if (nvpID != null) {
+            id = nvpID.getValue().toString();
+            nvps.remove(nvpID);
+        }
+
+        // Create the LayoutComponent
+        if (id == null) {
+            id = LayoutElementUtil.getGeneratedId(type, getNextIdNumber());
+        }
+        LayoutComponent component = new LayoutComponent(parent, id, componentType);
+
+        // Set Overwrite flag if needed
+        if (overwrite != null) {
+            nvps.remove(overwrite);
+            component.setOverwrite(Boolean.valueOf(overwrite.getValue().toString()).booleanValue());
+        }
+
+        // Set options...
+        for (NameValuePair np : nvps) {
+            component.addOption(np.getName(), np.getValue());
+        }
+
+        // Set flag to indicate if this LayoutComponent is nested in another
+        // LayoutComponent. This is significant b/c during rendering, events
+        // will need to be fired differently (the TemplateRenderer /
+        // LayoutElements will not have any control). The strategy used will
+        // rely on "instance" handlers, this flag indicates that "instance"
+        // handlers should be used.
+        // NOTE: While this could be implemented on the LayoutComponent
+        // itself, I decided not to for performance reasons and to
+        // allow this value to be overruled if desired.
+        component.setNested(nested);
+
+        // Let calling method see if this is a single tag, or if there should
+        // be a closing tag as well
+        parser.unread('>');
+        if (single) {
+            parser.unread('/');
+        }
+
+        return component;
+    }
+
+    /**
+     * <p>
+     * Attempt to find the correct component type after applying a locally defined mapping.
+     * </p>
+     */
+    private String getMappedType(String compType) {
+        int colonIdx = compType.indexOf(NAMESPACE_SEPARATOR);
+        String result = null;
+        if (colonIdx != -1) {
+            // It appears we have a namespace prefix...
+            String newPrefix = getNamespace(compType.substring(0, colonIdx));
+            if (newPrefix != null) {
+                result = newPrefix + compType.substring(colonIdx);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method attempts to find a mapping for the requested component type.
+     * </p>
+     */
+    public String getNamespace(String compType) {
+        return _nsMappings.get(compType);
+    }
+
+    /**
+     * <p>
+     * This method creates a namespace mapping.
+     * </p>
+     *
+     * @param longName The long name (i.e. http://foo/bar/).
+     * @param shortName The short name (i.e. foo).
+     */
+    public void setNamespace(String shortName, String longName) {
+        _nsMappings.put(shortName, longName);
+    }
+
+    /**
+     * <p>
+     * This method read all the {@link NameValuePair}s, usually for a component. It assumes the {@link TemplateParser} is
+     * ready to start reading the NVPs.
+     * </p>
+     *
+     * @param tagName The name of the tag for which we are reading attributes.
+     */
+    protected List<NameValuePair> readNameValuePairs(String tagName, String defAttName, boolean requireQuotes) throws IOException {
+        // Continue until we find "[/]>".
+        List<NameValuePair> nvps = new ArrayList<>();
+        int ch = 0;
+        TemplateParser parser = getTemplateParser();
+        while (ch != -1) {
+            parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+            ch = parser.nextChar();
+            if (ch == '>') {
+                // We're at the end of the parameters
+                break;
+            }
+            if (ch == '/') {
+                parser.skipCommentsAndWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+                ch = parser.nextChar();
+                if (ch != '>') {
+                    throw new SyntaxException("'" + tagName + "' tag contained " + "'/' that was not followed by a '&gt;' character!");
+                }
+
+                // We're at the end of the parameters and the component,
+                // put this information back into the parser
+                parser.unread('/');
+                break;
+            }
+            parser.unread(ch);
+// FIXME: An Illegal argument exception may be thrown, in this case the
+// FIXME: component name is not available and is hard to find.  Catch this
+// FIXME: error here and add more information so the stack trace is readable.
+            nvps.add(parser.getNVP(defAttName, requireQuotes));
+        }
+
+        // Return the result
+        return nvps;
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutForEach} {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #FOREACH_ELEMENT} node to extract information from when creating the {@link LayoutForEach}.
+     *
+     * @return The new {@link LayoutForEach} {@link LayoutElement}. private LayoutElement createLayoutForEach(LayoutElement
+     * parent, Node node) { // Pull off attributes... String list = (String) getAttributes(node).get( LIST_ATTRIBUTE); if
+     * ((list == null) || (list.trim().equals(""))) { throw new RuntimeException("'" + LIST_ATTRIBUTE + "' attribute not
+     * found on '" + FOREACH_ELEMENT + "' Element!"); } String key = (String) getAttributes(node).get( KEY_ATTRIBUTE); if
+     * ((key == null) || (key.trim().equals(""))) { throw new RuntimeException("'" + KEY_ATTRIBUTE + "' attribute not found
+     * on '" + FOREACH_ELEMENT + "' Element!"); }
+     *
+     * // Create new LayoutForEach LayoutElement forEachElt = new LayoutForEach(parent, list, key);
+     *
+     * // Add children... addChildLayoutElements(forEachElt, node);
+     *
+     * // Return the forEach return forEachElt; }
+     */
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutWhile} {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #WHILE_ELEMENT} node to extract information from when creating the LayoutWhile.
+     *
+     * @return The new {@link LayoutWhile} {@link LayoutElement}. private LayoutElement createLayoutWhile(LayoutElement
+     * parent, Node node) { // Pull off attributes... String condition = (String) getAttributes(node).get(
+     * CONDITION_ATTRIBUTE); if ((condition == null) || (condition.trim().equals(""))) { throw new RuntimeException("'" +
+     * CONDITION_ATTRIBUTE + "' attribute not found on '" + WHILE_ELEMENT + "' Element!"); }
+     *
+     * // Create new LayoutWhile LayoutElement whileElt = new LayoutWhile(parent, condition);
+     *
+     * // Add children... addChildLayoutElements(whileElt, node);
+     *
+     * // Return the while return whileElt; }
+     */
+
+    /**
+     *
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #ATTRIBUTE_ELEMENT} node to extract information from when creating the {@link LayoutAttribute}
+     * private LayoutElement createLayoutAttribute(LayoutElement parent, Node node) { // Pull off attributes... Map
+     * attributes = getAttributes(node); String name = (String) attributes.get(NAME_ATTRIBUTE); if ((name == null) ||
+     * (name.trim().equals(""))) { throw new RuntimeException("'" + NAME_ATTRIBUTE + "' attribute not found on '" +
+     * ATTRIBUTE_ELEMENT + "' Element!"); } LayoutElement attributeElt = null;
+     *
+     * // Check if we're setting this on a LayoutComponent vs. LayoutMarkup // Do this after checking for "name" to show
+     * correct error message LayoutComponent comp = null; if (parent instanceof LayoutComponent) { comp = (LayoutComponent)
+     * parent; } else { comp = getParentLayoutComponent(parent); } if (comp != null) { // Treat this as a LayoutComponent
+     * "option" instead of "attribute" addOption(comp, node); } else { String value = (String)
+     * attributes.get(VALUE_ATTRIBUTE); String property = (String) attributes.get(PROPERTY_ATTRIBUTE);
+     *
+     * // Create new LayoutAttribute attributeElt = new LayoutAttribute(parent, name, value, property);
+     *
+     * // Add children... (event children are supported) addChildLayoutElements(attributeElt, node); }
+     *
+     * // Return the LayoutAttribute (or null if inside LayoutComponent) return attributeElt; }
+     */
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutMarkup}.
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link MARKUP_ELEMENT} node to extract information from when creating the {@link LayoutMarkup}.
+     * private LayoutElement createLayoutMarkup(LayoutElement parent, Node node) { // Pull off attributes... Map attributes
+     * = getAttributes(node); String tag = (String) attributes.get(TAG_ATTRIBUTE); if ((tag == null) ||
+     * (tag.trim().equals(""))) { throw new RuntimeException("'" + TAG_ATTRIBUTE + "' attribute not found on '" +
+     * MARKUP_ELEMENT + "' Element!"); }
+     *
+     * // Check to see if this is inside a LayoutComponent, if so, we must // use a LayoutComponent for it to get rendered
+     * LayoutElement markupElt = null; if ((parent instanceof LayoutComponent) ||
+     * LayoutElementUtil.isNestedLayoutComponent(parent)) { // Make a "markup" LayoutComponent.. ComponentType type =
+     * ensureMarkupType(parent); markupElt = new LayoutComponent( parent, MARKUP_ELEMENT + _markupCount++, type);
+     * LayoutComponent markupComp = ((LayoutComponent) markupElt); markupComp.addOption("tag", tag);
+     * markupComp.setNested(true); markupComp.setFacetChild(false);
+     *
+     * // Add children... addChildLayoutComponentChildren(markupComp, node); } else { // Create new LayoutMarkup String type
+     * = (String) attributes.get(TYPE_ATTRIBUTE); markupElt = new LayoutMarkup(parent, tag, type);
+     *
+     * // Add children... addChildLayoutElements(markupElt, node); }
+     *
+     * // Return the LayoutMarkup return markupElt; }
+     */
+
+    /**
+     * <p>
+     * This method removes a tag from the Stack. This should be called outside of <code>TemplateReader</code> when writing
+     * {@link ProcessingContext} code and a tag starts and ends in a single tag (i.e. &lt;tag /&gt;). In other cases, it
+     * should be handled within the <code>TemplateReader</code>.
+     * </p>
+     */
+    public String popTag() {
+        return _tagStack.pop();
+    }
+
+    /**
+     * <p>
+     * This method exists because popTag() does, it likely doesn't have much use outside of <code>TemplateReader</code>.
+     * </p>
+     */
+    public void pushTag(String tag) {
+        _tagStack.push(tag);
+    }
+
+    /**
+     * /**
+     * <p>
+     * This method checks to see if the tag <code>Stack</code> is empty.
+     * </p>
+     */
+    public boolean isTagStackEmpty() {
+        return _tagStack.empty();
+    }
+
+    /**
+     * <p>
+     * This method returns the next ID number. Calling this method will increment the id number.
+     * </p>
+     */
+    public int getNextIdNumber() {
+        // Make sure we increment the global counter, if appropriate
+        LayoutElementUtil.incHighestId(_idNumber);
+        return _idNumber++;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Utility Methods
+    //////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This method provides access to registered {@link CustomParserCommand}s.
+     * </p>
+     */
+    public CustomParserCommand getCustomParserCommand(String id) {
+        return parserCmds.get(id);
+    }
+
+    /**
+     * <p>
+     * Provides access to the application-scoped Map which stores the parser commands for this application.
+     * </p>
+     */
+    private Map<String, CustomParserCommand> getCustomParserCommandMap(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, CustomParserCommand> commandMap = null;
+        if (ctx != null) {
+            commandMap = (Map<String, CustomParserCommand>) ctx.getExternalContext().getApplicationMap().get(PARSER_COMMANDS);
+        }
+        if (commandMap == null) {
+            // 1st time... initialize it
+            commandMap = initCustomParserCommands();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(PARSER_COMMANDS, commandMap);
+            }
+        }
+
+        // Return the map...
+        return commandMap;
+    }
+
+    /**
+     * <p>
+     * This method allows you to set a {@link CustomParserCommand}.
+     * </p>
+     */
+    public void setCustomParserCommand(String id, CustomParserCommand command) {
+        // Shared application-scope map, but not synchronized!
+        parserCmds.put(id, command);
+    }
+
+    /**
+     * <p>
+     * This method initializes the {@link CustomParserCommand}s.
+     * </p>
+     */
+    protected Map<String, CustomParserCommand> initCustomParserCommands() {
+// FIXME: Do initialization via @annotations??
+        Map<String, CustomParserCommand> map = new HashMap<>();
+        map.put("if", new IfParserCommand());
+        map.put("while", new WhileParserCommand());
+        map.put("foreach", new ForeachParserCommand());
+        map.put("facet", new FacetParserCommand());
+        map.put("composition", new CompositionParserCommand(true, TEMPLATE_ATTRIBUTE));
+        map.put("include", new CompositionParserCommand(false, SRC_ATTRIBUTE));
+        map.put("decorate", new CompositionParserCommand(false, TEMPLATE_ATTRIBUTE));
+        map.put("insert", new InsertParserCommand());
+        map.put("namespace", new NamespaceParserCommand());
+        map.put("event", EVENT_PARSER_COMMAND);
+        return map;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Inner Classes
+    //////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for the {@link LayoutDefinition}.
+     * </p>
+     */
+    protected static class LayoutDefinitionContext extends BaseProcessingContext {
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutIf}s.
+     * </p>
+     */
+    protected static class LayoutIfContext extends BaseProcessingContext {
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutForEach}es.
+     * </p>
+     */
+    protected static class LayoutForEachContext extends BaseProcessingContext {
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutWhile}s.
+     * </p>
+     */
+    protected static class LayoutWhileContext extends BaseProcessingContext {
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutComponent}s.
+     * </p>
+     */
+    protected static class LayoutComponentContext extends BaseProcessingContext {
+
+        /**
+         * <p>
+         * This method is invoked when nothing else matches.
+         * </p>
+         *
+         * <p>
+         * This implementation uses this to store "body content". This content is used as the <code>value</code> of the
+         * component. If a value is already set, then this content will be ignored.
+         * </p>
+         */
+        @Override
+        public void handleDefault(ProcessingContextEnvironment env, String content) throws IOException {
+            TemplateParser parser = env.getReader().getTemplateParser();
+// FIXME: **ignore comments and allow escaping**
+// Store body content in env until end component, set as 'value' if value is not set?
+            parser.readUntil('<', true);
+            parser.unread('<');
+        }
+
+        /**
+         *
+         */
+        @Override
+        public void beginSpecial(ProcessingContextEnvironment env, String content) throws IOException {
+            super.beginSpecial(env, content);
+        }
+    }
+
+    /**
+     * <p>
+     * This is the {@link ProcessingContext} for {@link LayoutFacet}s.
+     * </p>
+     */
+    protected static class LayoutFacetContext extends BaseProcessingContext {
+// FIXME: May want to do some special processing to ensure a single
+// FIXME: UIComponent is used, create a panel group if not.
+    }
+
+    /**
+     * <p>
+     * This {@link CustomParserCommand} handles "if" statements. To obtain the condition, it simply reads until it finds
+     * '&gt;'. This means '&gt;' must be escaped if it appears in the condition.
+     * </p>
+     */
+    public static class IfParserCommand implements CustomParserCommand {
+        @Override
+        public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+            // Get the condition for this if statement. We simply read until
+            // we find '>'. This means '>' must be escaped if it appears in
+            // the condition.
+            TemplateReader reader = env.getReader();
+            TemplateParser parser = reader.getTemplateParser();
+            String condition = parser.readUntil('>', false).trim();
+
+            // Create new LayoutIf
+            LayoutElement parent = env.getParent();
+// FIXME: the 'if' below checks to see if 'condition' ends with '/', yet I don't see this code removing the '/'... isn't that a problem?  Test and fix!
+            LayoutElement ifElt = new LayoutIf(parent, condition);
+            parent.addChildLayoutElement(ifElt);
+
+            if (condition.endsWith("/")) {
+                reader.popTag(); // Don't look for end tag
+            } else {
+                // Process child LayoutElements (recurse)
+                reader.process(TemplateReader.LAYOUT_IF_CONTEXT, ifElt, LayoutElementUtil.isLayoutComponentChild(ifElt));
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link CustomParserCommand} handles "while" statements. To obtain the condition, it simply reads until it finds
+     * '&gt;'. This means '&gt;' must be escaped if it appears in the condition.
+     * </p>
+     */
+    public static class WhileParserCommand extends IfParserCommand {
+        @Override
+        public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+            // Get the condition for this while statement. We simply read
+            // until we find '>'. This means '>' must be escaped if it
+            // appears in the condition.
+            TemplateReader reader = env.getReader();
+            TemplateParser parser = reader.getTemplateParser();
+            String condition = parser.readUntil('>', false).trim();
+
+            // Create new LayoutWhile
+            LayoutElement parent = env.getParent();
+// FIXME: Support condition="..."
+            LayoutElement elt = new LayoutWhile(parent, condition);
+            parent.addChildLayoutElement(elt);
+
+            if (condition.endsWith("/")) {
+                reader.popTag(); // Don't look for end tag
+            } else {
+                // Process child LayoutElements (recurse)
+                reader.process(TemplateReader.LAYOUT_WHILE_CONTEXT, elt, LayoutElementUtil.isLayoutComponentChild(elt));
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link CustomParserCommand} handles "foreach" statements.
+     * </p>
+     *
+     * <p>
+     * The syntax must look like:
+     * </p>
+     *
+     * <code>
+     *        &lt;!foreach key : $something{something}>
+     *        ...
+     *        &lt;/!foreach>
+     *    </code>
+     *
+     * <p>
+     * The "key" is a <code>String</code> that will be used to store each <code>Object</code> in a request attribute on each
+     * iteration. $something{something} must resolve to a <code>List</code>. It may also be in the form
+     * <code>#{value.binding}</code> if you prefer, in either case it must resolve to a <code>List</code>.
+     * </p>
+     */
+    public static class ForeachParserCommand implements CustomParserCommand {
+        @Override
+        public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+            TemplateReader reader = env.getReader();
+            TemplateParser parser = reader.getTemplateParser();
+
+            // First get the key
+// FIXME: Don't do it this way... read until the '>' first then split the String.  This will allow detecting the missing ':' much more easily.
+// FIXME: Consider allowing #{} expressions -- they're interpretted as comments as written... fix this.
+            String key = parser.readUntil(':', true).trim();
+            String listExp = parser.readUntil('>', true).trim();
+
+            // Create new LayoutForEach
+            LayoutElement parent = env.getParent();
+            LayoutElement elt = new LayoutForEach(parent, listExp, key);
+            parent.addChildLayoutElement(elt);
+
+            if (listExp.endsWith("/")) {
+                reader.popTag(); // Don't look for end tag
+            } else {
+                // Process child LayoutElements (recurse)
+                reader.process(TemplateReader.LAYOUT_FOREACH_CONTEXT, elt, LayoutElementUtil.isLayoutComponentChild(elt));
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This {@link CustomParserCommand} handles "facets".
+     * </p>
+     */
+    public static class FacetParserCommand implements CustomParserCommand {
+        @Override
+        public void process(ProcessingContext ctx, ProcessingContextEnvironment env, String name) throws IOException {
+            // Get the facet id
+            TemplateReader reader = env.getReader();
+            TemplateParser parser = reader.getTemplateParser();
+            String id = parser.readUntil('>', true).trim();
+
+            // Check to see if this is a single tag
+            boolean singleTag = false;
+            if (id.endsWith("/")) {
+                reader.popTag(); // Don't look for end tag
+                id = id.substring(0, id.length() - 1).trim();
+                singleTag = true;
+            }
+
+            // Check to see if the 'id' is wrapped in quotes.
+            char first = id.charAt(0);
+            if (first == '"' || first == '\'') {
+                if (id.indexOf('>') != -1) {
+                    // Means we didn't have an ending quote before '>'
+                    throw new SyntaxException("Unable to find ending (" + first + ") on !facet declaration with id (" + id.substring(0, id.indexOf('>'))
+                            + ") on component (" + env.getParent().getUnevaluatedId() + ").");
+                }
+                id = id.substring(1, id.length() - 1).trim();
+            }
+
+            // Create new LayoutFacet
+            LayoutElement parent = env.getParent();
+            LayoutFacet facetElt = new LayoutFacet(parent, id);
+            parent.addChildLayoutElement(facetElt);
+
+            // Determine if this is a facet place holder (i.e. we're defining
+            // a renderer w/ a facet), or if it is a facet value to set on a
+            // containing component.
+            boolean isRendered = !LayoutElementUtil.isNestedLayoutComponent(facetElt);
+            facetElt.setRendered(isRendered);
+            if (singleTag && !isRendered && LogUtil.configEnabled()) {
+                LogUtil.config(this, "Facet (" + id + ") specified, however, there is no component specified " + "inside this facet.  Nothing will happen.");
+            }
+
+            // Process child LayoutElements (recurse)
+            reader.process(TemplateReader.LAYOUT_FACET_CONTEXT, facetElt, LayoutElementUtil.isLayoutComponentChild(facetElt));
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Constants
+    //////////////////////////////////////////////////////////////////////
+
+    public static final String FACET_ELEMENT = "facet";
+    public static final String FOREACH_ELEMENT = "foreach";
+    public static final String IF_ELEMENT = "if";
+    public static final String LIST_ELEMENT = "list";
+    public static final String MARKUP_ELEMENT = "markup";
+    public static final String WHILE_ELEMENT = "while";
+
+    public static final String ID_ATTRIBUTE = "id";
+    public static final String OVERWRITE_ATTRIBUTE = "overwrite";
+    public static final String TEMPLATE_ATTRIBUTE = "template";
+    public static final String SRC_ATTRIBUTE = "src";
+    public static final char NAMESPACE_SEPARATOR = ':';
+
+    public static final ProcessingContext LAYOUT_DEFINITION_CONTEXT = new LayoutDefinitionContext();
+
+    public static final ProcessingContext LAYOUT_COMPONENT_CONTEXT = new LayoutComponentContext();
+
+    public static final ProcessingContext LAYOUT_FACET_CONTEXT = new LayoutFacetContext();
+
+    public static final ProcessingContext LAYOUT_IF_CONTEXT = new LayoutIfContext();
+
+    public static final ProcessingContext LAYOUT_FOREACH_CONTEXT = new LayoutForEachContext();
+
+    public static final ProcessingContext LAYOUT_WHILE_CONTEXT = new LayoutWhileContext();
+
+    public static final CustomParserCommand EVENT_PARSER_COMMAND = new EventParserCommand();
+
+    private Map<String, CustomParserCommand> parserCmds = getCustomParserCommandMap(null);
+
+    private static final String PARSER_COMMANDS = "__jsft_CustParserCMDs";
+
+    /**
+     * <p>
+     * This <code>Stack</code> keep track of the nesting.
+     * </p>
+     */
+    private Stack<String> _tagStack = new Stack<>();
+    private Map<String, String> _nsMappings = new HashMap<>();
+
+    private TemplateParser _tpl = null;
+    private int _idNumber;
+    private String _id = null; // The id of the LayoutDefinition
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateWriter.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/template/TemplateWriter.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutStaticText;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.OutputMapping;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>
+ * This class is responsible for writing templates. It processes a {@link LayoutElement} tree with a
+ * {@link LayoutDefinition} object at the root of the tree and writes it to a file.
+ * </p>
+ *
+ * <p>
+ * This class is intended to "write" one template, however, it does not close the given <code>OutputStream</code> or
+ * prevent the {@link #write(LayoutDefinition)} method from being called multiple times.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class TemplateWriter {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param stream <code>OutputStream</code> to the {@link LayoutDefinition} file.
+     */
+    public TemplateWriter(OutputStream stream) {
+        _writer = new PrintWriter(stream);
+    }
+
+    /**
+     * <p>
+     * This method should be invoked to write the given {@link LayoutDefinition} to the <code>OutputStream</code>. This is
+     * the primary method of this Class.
+     * </p>
+     *
+     * @param def The {@link LayoutDefinition}.
+     *
+     * @throws IOException
+     */
+    public void write(LayoutDefinition def) throws IOException {
+        // Write out the LayoutDefinition (nothing to do except body for LDs)
+        writeBody("", def);
+
+        // Flush @ the end...
+        _writer.flush();
+    }
+
+    /**
+     * <p>
+     * This method writes {@link Handler}s and child {@link LayoutElement}s.
+     * </p>
+     */
+    protected void writeBody(String prefix, LayoutElement elt) throws IOException {
+        writeHandlers(prefix, elt.getHandlersByTypeMap());
+        for (LayoutElement child : elt.getChildLayoutElements()) {
+            if (child instanceof LayoutStaticText) {
+                writeLayoutStaticText(prefix, (LayoutStaticText) child);
+            } else if (child instanceof LayoutComponent) {
+                writeLayoutComponent(prefix, (LayoutComponent) child);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method simply writes the given <code>str</code> to the <code>OutputStream</code>.
+     * </p>
+     */
+    protected void write(String str) throws IOException {
+        _writer.print(str);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for producing the output for {@link Handler}s.
+     * </p>
+     */
+    protected void writeHandlers(String prefix, Map<String, List<Handler>> handlerMap) throws IOException {
+        for (String eventType : handlerMap.keySet()) {
+            write(prefix + "<!" + eventType + "\n");
+            for (Handler handler : handlerMap.get(eventType)) {
+                writeHandler(INDENT + prefix, handler);
+            }
+            write(prefix + "/>\n");
+        }
+    }
+
+    /**
+     * <p>
+     * This method writes output for the given {@link Handler}.
+     * </p>
+     */
+    protected void writeHandler(String prefix, Handler handler) throws IOException {
+        // Start the handler...
+        HandlerDefinition def = handler.getHandlerDefinition();
+        write(prefix + def.getId() + "(");
+
+        // Add inputs
+        String seperator = "";
+        for (String inputKey : def.getInputDefs().keySet()) {
+            write(seperator + inputKey + "=\"" + handler.getInputValue(inputKey) + "\"");
+            seperator = ", ";
+        }
+
+        // Add outputs
+        OutputMapping output = null;
+// FIXME: Support EL output mappings, e.g.: output1="#{requestScope.bar}"
+        for (String outputKey : def.getOutputDefs().keySet()) {
+            output = handler.getOutputValue(outputKey);
+            write(seperator + outputKey + "=>$" + output.getStringOutputType() + "{" + output.getOutputKey() + "}");
+            seperator = ", ";
+        }
+
+        // Close the Handler
+        write(");\n");
+    }
+
+    /**
+     * <p>
+     * Write a {@link LayoutStaticText} to the <code>OutputStream</code>.
+     * </p>
+     */
+    protected void writeLayoutStaticText(String prefix, LayoutStaticText text) throws IOException {
+        String value = "" + text.getOptions().get("value");
+        if (value.contains("\n")) {
+            // Check for multi-line comment
+            write(prefix + "<f:verbatim>" + value + "</f:verbatim>\n");
+        } else {
+            write(prefix + "\"" + text.getOptions().get("value") + "\n");
+        }
+    }
+
+    /**
+     * <p>
+     * Write a {@link LayoutComponent} to the <code>OutputStream</code>.
+     * </p>
+     */
+    protected void writeLayoutComponent(String prefix, LayoutComponent comp) throws IOException {
+        String type = comp.getType().getId();
+        write(prefix + "<" + type);
+        write(" id=\"" + comp.getUnevaluatedId() + "\"");
+        if (comp.isOverwrite()) {
+            write(" overwrite=\"true\"");
+        }
+        Map<String, Object> options = comp.getOptions();
+        for (String key : options.keySet()) {
+            write(" " + key + "=\"" + options.get(key) + "\"");
+        }
+        write(">\n");
+        writeBody(INDENT + prefix, comp);
+        write(prefix + "</" + type + ">\n");
+    }
+
+    /**
+     * <p>
+     * The <code>PrintWriter</code> used to send output the the <code>OutputStream</code>.
+     * </p>
+     */
+    private PrintWriter _writer = null;
+
+    /**
+     * <p>
+     * This is the value used when indenting is needed.
+     * </p>
+     */
+    private static final String INDENT = "  ";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/xml/XMLErrorHandler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/xml/XMLErrorHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *
+ */
+package com.sun.jsftemplating.layout.xml;
+
+import java.io.PrintWriter;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * <p>
+ * This class handles XML parser errors.
+ * </p>
+ *
+ * @author Ken Paulsen
+ *
+ */
+public class XMLErrorHandler implements ErrorHandler {
+    /** Error handler output goes here */
+    private PrintWriter out;
+
+    public XMLErrorHandler(PrintWriter outWriter) {
+        this.out = outWriter;
+    }
+
+    /**
+     * <p>
+     * Returns a string describing parse exception details.
+     * </p>
+     */
+    private String getParseExceptionInfo(SAXParseException spe) {
+        String systemId = spe.getSystemId();
+        if (systemId == null) {
+            systemId = "null";
+        }
+        String info = "URI=" + systemId + " Line=" + spe.getLineNumber() + ": " + spe.getMessage();
+        return info;
+    }
+
+    // The following methods are standard SAX ErrorHandler methods.
+    // See SAX documentation for more info.
+
+    @Override
+    public void warning(SAXParseException spe) throws SAXException {
+        out.println("Warning: " + getParseExceptionInfo(spe));
+    }
+
+    @Override
+    public void error(SAXParseException spe) throws SAXException {
+        String message = "Error: " + getParseExceptionInfo(spe);
+        throw new SAXException(message, spe);
+    }
+
+    @Override
+    public void fatalError(SAXParseException spe) throws SAXException {
+        String message = "Fatal Error: " + getParseExceptionInfo(spe);
+        throw new SAXException(message, spe);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/xml/XMLLayoutDefinitionManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/xml/XMLLayoutDefinitionManager.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.xml;
+
+import com.sun.jsftemplating.annotation.FormatDefinition;
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.template.TemplateParser;
+import com.sun.jsftemplating.util.ClasspathEntityResolver;
+import com.sun.jsftemplating.util.FileUtil;
+
+import jakarta.faces.context.FacesContext;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+
+/**
+ * <p>
+ * This class is a concrete implmentation of the abstract class {@link LayoutDefinitionManager}. It obtains
+ * {@link LayoutDefinition} objects by interpreting the <code>key</code> passed to {@link #getLayoutDefinition(String)}
+ * as a path to an XML file describing the {@link LayoutDefinition}. It will first attempt to resolve this path from the
+ * document root of the ServletContext or PortletCotnext. If that fails, it will attempt to use the Classloader to
+ * resolve it.
+ * </p>
+ *
+ * <p>
+ * Locating the dtd for the XML file is done in a similar manner. It will first attempt to locate the dtd relative to
+ * the ServletContext (or PortletContext) root. If that fails it will attempt to use the ClassLoader to resolve it.
+ * Optionally a different EntityResolver may be supplied to provide a custom way of locating the dtd, this is done via
+ * {@link #setEntityResolver}.
+ * </p>
+ *
+ * <p>
+ * This class is a singleton. This means modifications to this class effect all threads using this class. This includes
+ * setting EntityResolvers and ErrorHandlers. These values only need to be set once to remain in effect as long as the
+ * JVM is running.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+@FormatDefinition
+public class XMLLayoutDefinitionManager extends LayoutDefinitionManager {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    protected XMLLayoutDefinitionManager() {
+        super();
+
+        // Set the default XMLError Handler
+        try {
+            setErrorHandler(new XMLErrorHandler(new PrintWriter(new OutputStreamWriter(System.err, "UTF-8"), true)));
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        // Set the default EntityResolver
+        setEntityResolver(new ClasspathEntityResolver());
+    }
+
+    /**
+     * <p>
+     * This method returns an instance of this LayoutDefinitionManager. The object returned is a singleton (only 1 instance
+     * will be created per JVM).
+     * </p>
+     *
+     * @return <code>XMLLayoutDefinitionManager</code> instance
+     */
+    public static LayoutDefinitionManager getInstance() {
+        return getInstance(FacesContext.getCurrentInstance());
+    }
+
+    /**
+     * <p>
+     * This method returns an instance of this LayoutDefinitionManager. The object returned is a singleton (only 1 instance
+     * will be created per application).
+     * </p>
+     *
+     * @return <code>XMLLayoutDefinitionManager</code> instance
+     */
+    public static LayoutDefinitionManager getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        XMLLayoutDefinitionManager instance = null;
+        if (ctx != null) {
+            instance = (XMLLayoutDefinitionManager) ctx.getExternalContext().getApplicationMap().get(XLDM_INSTANCE);
+        }
+        if (instance == null) {
+            instance = new XMLLayoutDefinitionManager();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(XLDM_INSTANCE, instance);
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * <p>
+     * This method uses the key to determine if this {@link LayoutDefinitionManager} is responsible for handling the key.
+     * </p>
+     */
+    @Override
+    public boolean accepts(String key) {
+        URL url = null;
+        try {
+            url = FileUtil.searchForFile(key, ".jsf");
+        } catch (IOException ex) {
+            // Ignore this b/c we're just trying to detect if we're the right
+            // LDM... if we're here, probably we're not.
+        }
+        if (url == null) {
+            return false;
+        }
+
+        // Use the TemplateParser to help us read the file to see if it is a
+        // valid XML-format file
+        TemplateParser parser = new TemplateParser(url);
+        try {
+            parser.open();
+            parser.readUntil("<layoutDefinition>", true);
+        } catch (Exception ex) {
+            // Didn't work...
+            return false;
+        } finally {
+            parser.close();
+        }
+        return true;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for finding the requested {@link LayoutDefinition} for the given <code>key</code>.
+     * </p>
+     *
+     * @param key Key identifying the desired {@link LayoutDefinition}
+     *
+     * @return The requested {@link LayoutDefinition}.
+     */
+    @Override
+    public LayoutDefinition getLayoutDefinition(String key) throws LayoutDefinitionException {
+        // Make sure we found the url
+        URL url = null;
+        try {
+            url = FileUtil.searchForFile(key, ".jsf");
+        } catch (IOException ex) {
+            throw new LayoutDefinitionException("Unable to locate '" + key + "'", ex);
+        }
+        if (url == null) {
+            throw new LayoutDefinitionException("Unable to locate '" + key + "'");
+        }
+
+        // Read the XML file
+        LayoutDefinition ld = null;
+        String baseURI = getBaseURI();
+        try {
+            ld = new XMLLayoutDefinitionReader(url, getEntityResolver(), getErrorHandler(), baseURI).read();
+        } catch (IOException ex) {
+            throw new LayoutDefinitionException("Unable to process '" + url + "'.  EntityResolver: '" + getEntityResolver() + "'.  ErrorHandler: '"
+                    + getErrorHandler() + "'.  baseURI: '" + baseURI + "'.", ex);
+        }
+
+        // Dispatch "initPage" handlers
+        ld.dispatchInitPageHandlers(FacesContext.getCurrentInstance(), ld);
+
+        // Return the LayoutDefinition
+        return ld;
+    }
+
+    /**
+     * <p>
+     * This returns the LDM's entity resolver, null if not set.
+     * </p>
+     *
+     * @return EntityResolver
+     */
+    public EntityResolver getEntityResolver() {
+        return (EntityResolver) getAttribute(ENTITY_RESOLVER);
+    }
+
+    /**
+     * <p>
+     * This method sets the LDM's entity resolver.
+     * </p>
+     *
+     * @param entityResolver The EntityResolver to use.
+     */
+    public void setEntityResolver(EntityResolver entityResolver) {
+        setAttribute(ENTITY_RESOLVER, entityResolver);
+    }
+
+    /**
+     * <p>
+     * This returns the LDM's XML parser ErrorHandler, null if not set.
+     * </p>
+     *
+     * @return ErrorHandler
+     */
+    public ErrorHandler getErrorHandler() {
+        return (ErrorHandler) getAttribute(ERROR_HANDLER);
+    }
+
+    /**
+     * <p>
+     * This method sets the LDM's ErrorHandler.
+     * </p>
+     *
+     * @param errorHandler The ErrorHandler to use.
+     */
+    public void setErrorHandler(ErrorHandler errorHandler) {
+        setAttribute(ERROR_HANDLER, errorHandler);
+    }
+
+    /**
+     * <p>
+     * This returns the LDM's XML parser baseURI which will be used to resolve relative URI's, null if not set.
+     * </p>
+     *
+     * @return The base URI as a String.
+     */
+    public String getBaseURI() {
+        String baseURI = (String) getAttribute(BASE_URI);
+        if (baseURI == null) {
+            // Use docroot for the baseURI.
+            baseURI = FileUtil.getResource("").toString();
+        }
+        return baseURI;
+    }
+
+    /**
+     * <p>
+     * This method sets the LDM's BaseURI.
+     * </p>
+     *
+     * @param baseURI The BaseURI to use.
+     */
+    public void setBaseURI(String baseURI) {
+        setAttribute(BASE_URI, baseURI);
+    }
+
+    /**
+     * <p>
+     * Application scope key for an instance of this class.
+     * </p>
+     */
+    private static final String XLDM_INSTANCE = "__jsft_XML_LDM";
+
+    /**
+     * <p>
+     * This is an attribute key which can be used to provide an EntityResolver to the XML parser.
+     * </p>
+     */
+    public static final String ENTITY_RESOLVER = "entityResolver";
+
+    /**
+     *
+     */
+    public static final String ERROR_HANDLER = "errorHandler";
+
+    /**
+     *
+     */
+    public static final String BASE_URI = "baseURI";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/xml/XMLLayoutDefinitionReader.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/layout/xml/XMLLayoutDefinitionReader.java
@@ -1,0 +1,1429 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.xml;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.SyntaxException;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.LayoutAttribute;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutFacet;
+import com.sun.jsftemplating.layout.descriptors.LayoutForEach;
+import com.sun.jsftemplating.layout.descriptors.LayoutIf;
+import com.sun.jsftemplating.layout.descriptors.LayoutMarkup;
+import com.sun.jsftemplating.layout.descriptors.LayoutStaticText;
+import com.sun.jsftemplating.layout.descriptors.LayoutWhile;
+import com.sun.jsftemplating.layout.descriptors.Resource;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.IODescriptor;
+import com.sun.jsftemplating.util.IncludeInputStream;
+import com.sun.jsftemplating.util.LayoutElementUtil;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+
+/**
+ * <p>
+ * This class is responsible for doing the actual parsing of an XML document following the <code>layout.dtd</code>. It
+ * produces a {@link LayoutElement} tree with a {@link LayoutDefinition} object at the root of the tree.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class XMLLayoutDefinitionReader {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     *
+     * @param url A URL pointing to the {@link LayoutDefinition}
+     * @param entityResolver EntityResolver to use, may be (null)
+     * @param errorHandler ErrorHandler to use, may be (null)
+     * @param baseURI The base URI passed to DocumentBuilder.parse()
+     */
+    public XMLLayoutDefinitionReader(URL url, EntityResolver entityResolver, ErrorHandler errorHandler, String baseURI) {
+        _url = url;
+        _entityResolver = entityResolver;
+        _errorHandler = errorHandler;
+        _baseURI = baseURI;
+    }
+
+    /**
+     * <p>
+     * Accessor for the URL.
+     * </p>
+     */
+    public URL getURL() {
+        return _url;
+    }
+
+    /**
+     * <p>
+     * Accessor for the entityResolver.
+     * </p>
+     */
+    public EntityResolver getEntityResolver() {
+        return _entityResolver;
+    }
+
+    /**
+     * <p>
+     * Accessor for the ErrorHandler.
+     * </p>
+     */
+    public ErrorHandler getErrorHandler() {
+        return _errorHandler;
+    }
+
+    /**
+     * <p>
+     * Accessor for the base URI.
+     * </p>
+     */
+    public String getBaseURI() {
+        return _baseURI;
+    }
+
+    /**
+     * <p>
+     * The read method opens the given URL and parses the XML document that it points to. It then walks the DOM and
+     * populates a {@link LayoutDefinition} structure, which is returned.
+     * </p>
+     *
+     * @return The {@link LayoutDefinition}
+     *
+     * @throws IOException
+     */
+    public LayoutDefinition read() throws IOException {
+        // Open the URL
+        InputStream inputStream = new IncludeInputStream(new BufferedInputStream(getURL().openStream()));
+        Document doc = null;
+
+        try {
+            // Get a DocumentBuilderFactory and set it up
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            String FEATURE = null;
+            try {
+                FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+                dbf.setFeature(FEATURE, false);
+
+                FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+                dbf.setFeature(FEATURE, false);
+
+                FEATURE = "http://xml.org/sax/features/external-general-entities";
+                dbf.setFeature(FEATURE, false);
+
+                dbf.setXIncludeAware(false);
+                dbf.setExpandEntityReferences(false);
+
+                dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+            } catch (ParserConfigurationException e) {
+                throw new IllegalStateException("The feature '"
+                + FEATURE + "' is not supported by your XML processor.", e);
+            }
+            dbf.setNamespaceAware(true);
+            dbf.setValidating(true);
+            dbf.setIgnoringComments(true);
+            dbf.setIgnoringElementContentWhitespace(false);
+            dbf.setCoalescing(false);
+            // The opposite of creating entity ref nodes is expanding inline
+            dbf.setExpandEntityReferences(true);
+
+            // Get a DocumentBuilder...
+            DocumentBuilder db = null;
+            try {
+                db = dbf.newDocumentBuilder();
+            } catch (ParserConfigurationException ex) {
+                throw new RuntimeException(ex);
+            }
+            if (getEntityResolver() != null) {
+                db.setEntityResolver(getEntityResolver());
+            }
+            if (getErrorHandler() != null) {
+                db.setErrorHandler(getErrorHandler());
+            }
+
+            // Parse the XML file
+            try {
+                doc = db.parse(inputStream, getBaseURI());
+            } catch (IOException ex) {
+                throw new SyntaxException("Unable to parse XML file!", ex);
+            } catch (SAXException ex) {
+                throw new SyntaxException(ex);
+            }
+        } finally {
+            try {
+                inputStream.close();
+            } catch (Exception ex) {
+                // Ignore...
+            }
+        }
+
+        // Populate the LayoutDefinition from the Document
+        return createLayoutDefinition(doc);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for extracting all the information out of the supplied document and filling the
+     * {@link LayoutDefinition} structure.
+     * </p>
+     *
+     * @param doc The <code>Document</code> object to read.
+     *
+     * @return The new {@link LayoutDefinition} Object.
+     */
+    private LayoutDefinition createLayoutDefinition(Document doc) {
+        // Get the document element (LAYOUT_DEFINITION_ELEMENT)
+        Node node = doc.getDocumentElement();
+        if (!node.getNodeName().equalsIgnoreCase(LAYOUT_DEFINITION_ELEMENT)) {
+            throw new RuntimeException("Document Element must be '" + LAYOUT_DEFINITION_ELEMENT + "'");
+        }
+
+        // Create a new LayoutDefinition (the id is not propagated here)
+        LayoutDefinition ld = new LayoutDefinition("");
+
+        // Do "resources" first, they are defined at the top of the document
+        List<Node> childElements = getChildElements(node, RESOURCES_ELEMENT);
+        Iterator<Node> it = childElements.iterator();
+        if (it.hasNext()) {
+            // Found the RESOURCES_ELEMENT, there is at most 1
+            addResources(ld, it.next());
+        }
+
+        // Do "types", they need to be defined before parsing the layout
+        childElements = getChildElements(node, TYPES_ELEMENT);
+        it = childElements.iterator();
+        if (it.hasNext()) {
+            // Found the TYPES_ELEMENT, there is at most 1
+            addTypes(ld, it.next());
+        }
+
+        // Do "handlers" next, they need to be defined before parsing the layout
+        childElements = getChildElements(node, HANDLERS_ELEMENT);
+        it = childElements.iterator();
+        if (it.hasNext()) {
+            // Found the HANDLERS_ELEMENT, there is at most 1
+            cacheHandlerDefs(it.next());
+        }
+
+        // Look to see if there is an EVENT_ELEMENT defined
+        childElements = getChildElements(node, EVENT_ELEMENT);
+        it = childElements.iterator();
+        if (it.hasNext()) {
+            // Found the EVENT_ELEMENT, there is at most 1
+            // Get the event type
+            Node eventNode = it.next();
+            String type = getAttributes(eventNode).get(TYPE_ATTRIBUTE);
+
+            // Set the Handlers for the given event type (name)
+            List<Handler> handlers = ld.getHandlers(type);
+            ld.setHandlers(type, getHandlers(eventNode, handlers));
+        }
+
+        // Next look for "layout", there is exactly 1
+        childElements = getChildElements(node, LAYOUT_ELEMENT);
+        it = childElements.iterator();
+        if (it.hasNext()) {
+            // Found the LAYOUT_ELEMENT, there is only 1
+            addChildLayoutElements(ld, it.next());
+        } else {
+            throw new RuntimeException("A '" + LAYOUT_ELEMENT + "' element is required in the XML document!");
+        }
+
+        // Return the LayoutDefinition
+        return ld;
+    }
+
+    /**
+     * <p>
+     * This method iterates throught the child RESOURCE_ELEMENT nodes and adds new resource objects to the
+     * {@link LayoutDefinition}.
+     * </p>
+     *
+     * @param ld The {@link LayoutDefinition}
+     * @param node Parent <code>Node</code> containing the {@link #RESOURCE_ELEMENT} nodes.
+     */
+    private void addResources(LayoutDefinition ld, Node node) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(node, RESOURCE_ELEMENT).iterator();
+
+        // Walk children (we only care about RESOURCE_ELEMENT)
+        while (it.hasNext()) {
+            // Found a RESOURCE_ELEMENT
+            ld.addResource(createResource(it.next()));
+        }
+    }
+
+    /**
+     * <p>
+     * This method takes the given Resource Element node and reads the {@link #ID_ATTRIBUTE}, {@link #EXTRA_INFO_ATTRIBUTE}
+     * and {@link #FACTORY_CLASS_ATTRIBUTE} attributes. It then instantiates a new {@link Resource} with the values of these
+     * two attributes.
+     * </p>
+     *
+     * @param node The {@link Resource} node to extract information from when creating the {@link Resource}.
+     */
+    private Resource createResource(Node node) {
+        // Pull off the attributes
+        Map<String, String> attributes = getAttributes(node);
+        String id = attributes.get(ID_ATTRIBUTE);
+        String extraInfo = attributes.get(EXTRA_INFO_ATTRIBUTE);
+        String factoryClass = attributes.get(FACTORY_CLASS_ATTRIBUTE);
+
+        // Make sure required values are present
+        if (factoryClass == null || id == null || extraInfo == null || factoryClass.trim().equals("") || id.trim().equals("") || extraInfo.trim().equals("")) {
+            throw new RuntimeException("'" + ID_ATTRIBUTE + "', '" + EXTRA_INFO_ATTRIBUTE + "', and '" + FACTORY_CLASS_ATTRIBUTE
+                    + "' are required attributes of '" + RESOURCE_ELEMENT + "' Element!");
+        }
+
+        // Create the new Resource
+        return new Resource(id, extraInfo, factoryClass);
+    }
+
+    /**
+     * <p>
+     * This method iterates through the child {@link #COMPONENT_TYPE_ELEMENT} nodes and adds new {@link ComponentTypes} to
+     * the {@link LayoutDefinition}.
+     * </p>
+     *
+     * @param ld The {@link LayoutDefinition}
+     * @param node Parent <code>Node</code> containing the {@link #COMPONENT_TYPE_ELEMENT} nodes
+     */
+    private void addTypes(LayoutDefinition ld, Node node) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(node, COMPONENT_TYPE_ELEMENT).iterator();
+
+        // Walk the COMPONENT_TYPE_ELEMENT elements
+        while (it.hasNext()) {
+            ld.addComponentType(createComponentType(it.next()));
+        }
+    }
+
+    /**
+     * <p>
+     * This method takes the given {@link ComponentType} Element node and reads the {@link #ID_ATTRIBUTE} and
+     * {@link #FACTORY_CLASS_ATTRIBUTE} attributes. It then instantiates a new {@link ComponentType} with the values of
+     * these two attributes.
+     * </p>
+     *
+     * @param node The {@link ComponentType} node to extract information from when creating the {@link ComponentType}.
+     */
+    private ComponentType createComponentType(Node node) {
+        // Pull off the attributes
+        Map<String, String> attributes = getAttributes(node);
+        String id = attributes.get(ID_ATTRIBUTE);
+        String factoryClass = attributes.get(FACTORY_CLASS_ATTRIBUTE);
+
+        // Make sure required values are present
+        if (factoryClass == null || id == null || factoryClass.trim().equals("") || id.trim().equals("")) {
+            throw new RuntimeException(
+                    "Both '" + ID_ATTRIBUTE + "' and '" + FACTORY_CLASS_ATTRIBUTE + "' are required attributes of '" + COMPONENT_TYPE_ELEMENT + "' Element!");
+        }
+
+        // Create the new ComponentType
+        return new ComponentType(id, factoryClass);
+    }
+
+    /**
+     * <p>
+     * This method iterates through the child {@link #HANDLER_DEFINITION_ELEMENT} nodes and caches them, so they may be
+     * retrieved later by {@link Handlers} referring to them.
+     * </p>
+     *
+     * @param node Parent <code>Node</code> containing {@link #HANDLER_DEFINITION_ELEMENT} nodes.
+     */
+    private void cacheHandlerDefs(Node node) {
+        HandlerDefinition def = null;
+
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(node, HANDLER_DEFINITION_ELEMENT).iterator();
+        while (it.hasNext()) {
+            // Found a HANDLER_DEFINITION_ELEMENT, cache it
+            def = createHandlerDefinition(it.next());
+            _handlerDefs.put(def.getId(), def);
+        }
+    }
+
+    /**
+     * <p>
+     * This method takes the given {@link #HANDLER_DEFINITION_ELEMENT} node and reads the {@link #ID_ATTRIBUTE},
+     * {@link #CLASS_NAME_ATTRIBUTE}, and {@link #METHOD_NAME_ATTRIBUTE} attributes. It then instantiates a new
+     * {@link HandlerDefinition} object.
+     * </p>
+     *
+     * <p>
+     * Next it looks to see if the {@link HandlerDefinition} has child inputDef, outputDef, and/or nested handler elements.
+     * If so it processes them.
+     * </p>
+     *
+     * @param node The {@link #HANDLER_DEFINITION_ELEMENT} node to extract information from when creating the
+     * {@link HandlerDefinition}.
+     *
+     * @return The newly created {@link HandlerDefinition}.
+     */
+    public HandlerDefinition createHandlerDefinition(Node node) {
+
+        // Create he HandlerDefinition
+        Map<String, String> attributes = getAttributes(node);
+        String value = attributes.get(ID_ATTRIBUTE);
+        HandlerDefinition hd = new HandlerDefinition(value);
+
+// hd.setDescription(_description)
+
+        // Check for a className
+        value = attributes.get(CLASS_NAME_ATTRIBUTE);
+        if (value != null && !value.equals("")) {
+            // Found a className, now get the methodName
+            String tmpStr = attributes.get(METHOD_NAME_ATTRIBUTE);
+            if (tmpStr == null || tmpStr.equals("")) {
+                throw new IllegalArgumentException("You must provide a '" + METHOD_NAME_ATTRIBUTE + "' attribute on the '" + HANDLER_DEFINITION_ELEMENT
+                        + "' element with " + CLASS_NAME_ATTRIBUTE + " atttribute equal to '" + value + "'.");
+            }
+            hd.setHandlerMethod(value, tmpStr);
+        }
+
+        // Add child handlers to this HandlerDefinition. This allows a
+        // HandlerDefinition to define handlers that should be invoked before
+        // the method defined by this handler definition is invoked.
+        List<Handler> handlers = new ArrayList(hd.getChildHandlers());
+        hd.setChildHandlers(getHandlers(node, handlers));
+
+        // Add InputDef objects to the HandlerDefinition
+        addInputDefs(hd, node);
+
+        // Add OutputDef objects to the HandlerDefinition
+        addOutputDefs(hd, node);
+
+        // Return the newly created HandlerDefinition object
+        return hd;
+    }
+
+    /**
+     * <p>
+     * This method creates a <code>List</code> of {@link Handler}s from the provided <code>Node</code>. It will look at the
+     * child <code>Element</code>s for {@link #HANDLER_ELEMENT} elements. When found, it will create a new {@link Handler}
+     * object and add it to a <code>List</code> that is created internally. This <code>List</code> is returned.
+     * </p>
+     *
+     * @param node <code>Node</code> containing {@link #HANDLER_ELEMENT} elements.
+     * @param handlers <code>List</code> of existing {@link Handler}s.
+     *
+     * @return A <code>List</code> of {@link Handler} objects, empty <code>List</code> if no {@link Handler}s found
+     */
+    private List<Handler> getHandlers(Node node, List<Handler> handlers) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(node, HANDLER_ELEMENT).iterator();
+
+        // Walk children (we only care about HANDLER_ELEMENT)
+        if (handlers == null) {
+            handlers = new ArrayList<>();
+        }
+        while (it.hasNext()) {
+            // Found a HANDLER_ELEMENT
+            handlers.add(createHandler(it.next()));
+        }
+
+        // Return the handlers
+        return handlers;
+    }
+
+    /**
+     * <p>
+     * This method creates a {@link Handler} from the given handler <code>Node</code>. It will add input and/or output
+     * mappings specified by any child Elements named {@link #INPUT_ELEMENT} or {@link #OUTPUT_MAPPING_ELEMENT}.
+     * </p>
+     *
+     * @param handlerNode The <code>Node</code> describing the {@link Handler} to be created.
+     *
+     * @return The newly created {@link Handler}.
+     */
+    private Handler createHandler(Node handlerNode) {
+        // Pull off attributes...
+        String id = getAttributes(handlerNode).get(ID_ATTRIBUTE);
+        if (id == null || id.trim().equals("")) {
+            throw new RuntimeException("'" + ID_ATTRIBUTE + "' attribute not found on '" + HANDLER_ELEMENT + "' Element!");
+        }
+
+        // Find the HandlerDefinition associated with this Handler
+        HandlerDefinition handlerDef = getHandlerDef(id);
+        if (handlerDef == null) {
+            throw new IllegalArgumentException(HANDLER_ELEMENT + " elements " + ID_ATTRIBUTE + " attribute must match the " + ID_ATTRIBUTE + " attribute of a "
+                    + HANDLER_DEFINITION_ELEMENT + ".  A HANDLER_ELEMENT with '" + id + "' was specified, however there is no cooresponding "
+                    + HANDLER_DEFINITION_ELEMENT + " with a matching " + ID_ATTRIBUTE + " attribute.");
+        }
+
+        // Create new Handler
+        Handler handler = new Handler(handlerDef);
+
+        // Add the inputs
+        Map<String, String> attributes = null;
+        Node inputNode = null;
+        Iterator<Node> it = getChildElements(handlerNode, INPUT_ELEMENT).iterator();
+        while (it.hasNext()) {
+            // Processing an INPUT_ELEMENT
+            inputNode = it.next();
+            attributes = getAttributes(inputNode);
+            handler.setInputValue(attributes.get(NAME_ATTRIBUTE), getValueFromNode(inputNode, attributes));
+        }
+
+        // Add the OutputMapping objects
+        it = getChildElements(handlerNode, OUTPUT_MAPPING_ELEMENT).iterator();
+        while (it.hasNext()) {
+            // Processing an OUTPUT_MAPPING_ELEMENT
+            attributes = getAttributes(it.next());
+            handler.setOutputMapping(attributes.get(OUTPUT_NAME_ATTRIBUTE), attributes.get(TARGET_KEY_ATTRIBUTE), attributes.get(TARGET_TYPE_ATTRIBUTE));
+        }
+
+        // Return the newly created handler
+        return handler;
+    }
+
+    /**
+     * <p>
+     * This method first attempts to find a locally defined {@link HandlerDefinition} with the given <code>id</code>. If
+     * found, it will be returned, otherwise it attempts to return a globally defined {@link HandlerDefinition} via
+     * {@link LayoutDefinitionManager#getGlobalHandlerDefinition(String)}.
+     * </p>
+     *
+     * @param id The desired {@link HandlerDefinition}'s id.
+     *
+     * @return The desired {@link HandlerDefinition} or <code>null</code>.
+     */
+    private HandlerDefinition getHandlerDef(String id) {
+        // Try local...
+        HandlerDefinition def = _handlerDefs.get(id);
+        if (def == null) {
+            // Try global...
+            def = LayoutDefinitionManager.getGlobalHandlerDefinition(id);
+        }
+        return def;
+    }
+
+    /**
+     * <p>
+     * This method adds InputDefs to the given {@link HandlerDefinition} object. It will look at the child elements for
+     * those named {@link #INPUT_DEF_ELEMENT}. It will create an {@link #IODescriptor} for each and add it to the
+     * {@link HandlerDefinition}.
+     * </p>
+     *
+     * @param hd {@link HandlerDefinition}.
+     * @param hdNode {@link HandlerDefinition} <code>Node</code>, its children will be searched
+     */
+    private void addInputDefs(HandlerDefinition hd, Node hdNode) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(hdNode, INPUT_DEF_ELEMENT).iterator();
+
+        // Walk children (we only care about INPUT_DEF_ELEMENT)
+        while (it.hasNext()) {
+            // Found a INPUT_DEF_ELEMENT
+            hd.addInputDef(createIODescriptor(it.next()));
+        }
+    }
+
+    /**
+     * <p>
+     * This method adds OutputDefs to the given {@link HandlerDefinition} object. It will look at the child elements for
+     * those named {@link #OUTPUT_DEF_ELEMENT}. It will create an {@link #IODescriptor} for each and add it to the
+     * {@link HandlerDefinition}.
+     * </p>
+     *
+     * @param hd {@link HandlerDefinition}.
+     * @param hdNode {@link HandlerDefinition} <code>Node</code>, its children will be searched.
+     */
+    private void addOutputDefs(HandlerDefinition hd, Node hdNode) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(hdNode, OUTPUT_DEF_ELEMENT).iterator();
+
+        // Walk children (we only care about OUTPUT_DEF_ELEMENT)
+        while (it.hasNext()) {
+            // Found a OUTPUT_DEF_ELEMENT
+            hd.addOutputDef(createIODescriptor(it.next()));
+        }
+    }
+
+    /**
+     * <p>
+     * This method will create an {@link #IODescriptor} from the given node. The node must contain atleast a
+     * {@link #NAME_ATTRIBUTE} and a {@link #TYPE_ATTRIBUTE} attribute. It may also contain a {@link #DEFAULT_ATTRIBUTE} and
+     * a {@link #REQUIRED_ATTRIBUTE}. These are only meaningful for input {@link IODescriptors}, however -- this method does
+     * not know the difference between input and output descriptors.
+     * </p>
+     *
+     * @param node The <code>Node</code> holding info used to create an {@link IODescriptor}.
+     *
+     * @return A newly created {@link IODescriptor}.
+     */
+    private IODescriptor createIODescriptor(Node node) {
+        // Get the attributes
+        Map<String, String> attributes = getAttributes(node);
+        String name = attributes.get(NAME_ATTRIBUTE);
+        if (name == null || name.equals("")) {
+            throw new IllegalArgumentException("Name must be provided!");
+        }
+        String type = attributes.get(TYPE_ATTRIBUTE);
+        if (type == null || type.equals("")) {
+            throw new IllegalArgumentException("Type must be provided!");
+        }
+        Object def = attributes.get(DEFAULT_ATTRIBUTE);
+        String req = attributes.get(REQUIRED_ATTRIBUTE);
+
+        // Create the IODescriptor
+        IODescriptor ioDesc = new IODescriptor(name, type);
+        ioDesc.setDefault(def);
+        if (req != null) {
+            ioDesc.setRequired(Boolean.valueOf(req).booleanValue());
+        }
+// ioDesc.setDescription(attributes.get(DESCRIPTION_ATTRIBUTE))
+
+        // Return the new IODescriptor
+        return ioDesc;
+    }
+
+    /**
+     * <p>
+     * This method adds child LayoutElements.
+     * </p>
+     *
+     * @param layoutDefinition
+     * @param node
+     */
+    private void addChildLayoutElements(LayoutElement layElt, Node node) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(node).iterator();
+
+        // Walk children (we care about IF_ELEMENT, ATTRIBUTE_ELEMENT,
+        // MARKUP_ELEMENT, FACET_ELEMENT, STATIC_TEXT_ELEMENT,
+        // COMPONENT_ELEMENT, EVENT_ELEMENT, FOREACH_ELEMENT, EDIT_ELEMENT, and
+        // WHILE_ELEMENT)
+        Node childNode = null;
+        String name = null;
+        while (it.hasNext()) {
+            childNode = it.next();
+            name = childNode.getNodeName();
+            if (name.equalsIgnoreCase(IF_ELEMENT)) {
+                // Found a IF_ELEMENT
+                layElt.addChildLayoutElement(createLayoutIf(layElt, childNode));
+            } else if (name.equalsIgnoreCase(ATTRIBUTE_ELEMENT)) {
+                // Found a ATTRIBUTE_ELEMENT
+                LayoutElement childElt = createLayoutAttribute(layElt, childNode);
+                if (childElt != null) {
+                    layElt.addChildLayoutElement(childElt);
+                }
+            } else if (name.equalsIgnoreCase(MARKUP_ELEMENT)) {
+                // Found a MARKUP_ELEMENT
+                layElt.addChildLayoutElement(createLayoutMarkup(layElt, childNode));
+            } else if (name.equalsIgnoreCase(FACET_ELEMENT)) {
+                // Found a FACET_ELEMENT
+                layElt.addChildLayoutElement(createLayoutFacet(layElt, childNode));
+            } else if (name.equalsIgnoreCase(STATIC_TEXT_ELEMENT)) {
+                // Found a STATIC_TEXT_ELEMENT
+                layElt.addChildLayoutElement(createLayoutStaticText(layElt, childNode));
+            } else if (name.equalsIgnoreCase(COMPONENT_ELEMENT)) {
+                // Found a COMPONENT_ELEMENT
+                layElt.addChildLayoutElement(createLayoutComponent(layElt, childNode));
+            } else if (name.equalsIgnoreCase(EVENT_ELEMENT)) {
+                // Found a EVENT_ELEMENT
+                // Get the event type
+                name = getAttributes(childNode).get(TYPE_ATTRIBUTE);
+                // Set the Handlers for the given event type (name)
+                List<Handler> handlers = layElt.getHandlers(name);
+                layElt.setHandlers(name, getHandlers(childNode, handlers));
+            } else if (name.equalsIgnoreCase(FOREACH_ELEMENT)) {
+                // Found a FOREACH_ELEMENT
+                layElt.addChildLayoutElement(createLayoutForEach(layElt, childNode));
+            } else if (name.equalsIgnoreCase(WHILE_ELEMENT)) {
+                // Found a WHILE_ELEMENT
+                layElt.addChildLayoutElement(createLayoutWhile(layElt, childNode));
+            } else if (name.equalsIgnoreCase(EDIT_ELEMENT)) {
+                // Found an EDIT_ELEMENT
+                layElt.addChildLayoutElement(createEditLayoutComponent(layElt, childNode));
+            } else {
+                throw new RuntimeException("Unknown Element Found: '" + childNode.getNodeName() + "' under '" + node.getNodeName() + "'.");
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutIf} {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #IF_ELEMENT} node to extract information from when creating the {@link LayoutIf}
+     */
+    private LayoutElement createLayoutIf(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        String condition = getAttributes(node).get(CONDITION_ATTRIBUTE);
+        if (condition == null || condition.trim().equals("")) {
+            throw new RuntimeException("'" + CONDITION_ATTRIBUTE + "' attribute not found on '" + IF_ELEMENT + "' Element!");
+        }
+
+        // Create new LayoutIf
+        LayoutElement ifElt = new LayoutIf(parent, condition);
+
+        // Add children...
+        addChildLayoutElements(ifElt, node);
+
+        // Return the if
+        return ifElt;
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutForEach} {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #FOREACH_ELEMENT} node to extract information from when creating the {@link LayoutForEach}.
+     *
+     * @return The new {@link LayoutForEach} {@link LayoutElement}.
+     */
+    private LayoutElement createLayoutForEach(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        String list = getAttributes(node).get(LIST_ATTRIBUTE);
+        if (list == null || list.trim().equals("")) {
+            throw new RuntimeException("'" + LIST_ATTRIBUTE + "' attribute not found on '" + FOREACH_ELEMENT + "' Element!");
+        }
+        String key = getAttributes(node).get(KEY_ATTRIBUTE);
+        if (key == null || key.trim().equals("")) {
+            throw new RuntimeException("'" + KEY_ATTRIBUTE + "' attribute not found on '" + FOREACH_ELEMENT + "' Element!");
+        }
+
+        // Create new LayoutForEach
+        LayoutElement forEachElt = new LayoutForEach(parent, list, key);
+
+        // Add children...
+        addChildLayoutElements(forEachElt, node);
+
+        // Return the forEach
+        return forEachElt;
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutWhile} {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #WHILE_ELEMENT} node to extract information from when creating the LayoutWhile.
+     *
+     * @return The new {@link LayoutWhile} {@link LayoutElement}.
+     */
+    private LayoutElement createLayoutWhile(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        String condition = getAttributes(node).get(CONDITION_ATTRIBUTE);
+        if (condition == null || condition.trim().equals("")) {
+            throw new RuntimeException("'" + CONDITION_ATTRIBUTE + "' attribute not found on '" + WHILE_ELEMENT + "' Element!");
+        }
+
+        // Create new LayoutWhile
+        LayoutElement whileElt = new LayoutWhile(parent, condition);
+
+        // Add children...
+        addChildLayoutElements(whileElt, node);
+
+        // Return the while
+        return whileElt;
+    }
+
+    /**
+     *
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #ATTRIBUTE_ELEMENT} node to extract information from when creating the {@link LayoutAttribute}
+     */
+    private LayoutElement createLayoutAttribute(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        Map<String, String> attributes = getAttributes(node);
+        String name = attributes.get(NAME_ATTRIBUTE);
+        if (name == null || name.trim().equals("")) {
+            throw new RuntimeException("'" + NAME_ATTRIBUTE + "' attribute not found on '" + ATTRIBUTE_ELEMENT + "' Element!");
+        }
+        LayoutElement attributeElt = null;
+
+        // Check if we're setting this on a LayoutComponent vs. LayoutMarkup
+        // Do this after checking for "name" to show correct error message
+        LayoutComponent comp = null;
+        if (parent instanceof LayoutComponent) {
+            comp = (LayoutComponent) parent;
+        } else {
+            comp = LayoutElementUtil.getParentLayoutComponent(parent);
+        }
+        if (comp != null) {
+            // Treat this as a LayoutComponent "option" instead of "attribute"
+            addOption(comp, node);
+        } else {
+            String value = attributes.get(VALUE_ATTRIBUTE);
+            String property = attributes.get(PROPERTY_ATTRIBUTE);
+
+            // Create new LayoutAttribute
+            attributeElt = new LayoutAttribute(parent, name, value, property);
+
+            // Add children... (event children are supported)
+            addChildLayoutElements(attributeElt, node);
+        }
+
+        // Return the LayoutAttribute (or null if inside LayoutComponent)
+        return attributeElt;
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link LayoutMarkup}.
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #MARKUP_ELEMENT} node to extract information from when creating the {@link LayoutMarkup}.
+     */
+    private LayoutElement createLayoutMarkup(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        Map<String, String> attributes = getAttributes(node);
+        String tag = attributes.get(TAG_ATTRIBUTE);
+        if (tag == null || tag.trim().equals("")) {
+            throw new RuntimeException("'" + TAG_ATTRIBUTE + "' attribute not found on '" + MARKUP_ELEMENT + "' Element!");
+        }
+
+        // Check to see if this is inside a LayoutComponent, if so, we must
+        // use a LayoutComponent for it to get rendered
+        LayoutElement markupElt = null;
+        if (parent instanceof LayoutComponent || LayoutElementUtil.isNestedLayoutComponent(parent)) {
+            // Make a "markup" LayoutComponent..
+            ComponentType type = ensureMarkupType(parent);
+            markupElt = new LayoutComponent(parent, MARKUP_ELEMENT + _markupCount++, type);
+            LayoutComponent markupComp = (LayoutComponent) markupElt;
+            markupComp.addOption("tag", tag);
+            markupComp.setNested(true);
+
+            // Add children...
+            addChildLayoutComponentChildren(markupComp, node);
+        } else {
+            // Create new LayoutMarkup
+            String type = attributes.get(TYPE_ATTRIBUTE);
+            markupElt = new LayoutMarkup(parent, tag, type);
+
+            // Add children...
+            addChildLayoutElements(markupElt, node);
+        }
+
+        // Return the LayoutMarkup
+        return markupElt;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for Creating a {@link LayoutFacet} {@link LayoutElement}.
+     * </p>
+     *
+     * @param parent The parent {@link LayoutElement}.
+     * @param node The {@link #FACET_ELEMENT} node to extract information from when creating the {@link LayoutFacet}.
+     *
+     * @return The new {@link LayoutFacet} {@link LayoutElement}.
+     */
+    private LayoutElement createLayoutFacet(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        // id
+        String id = getAttributes(node).get(ID_ATTRIBUTE);
+        if (id == null || id.trim().equals("")) {
+            throw new RuntimeException("'" + ID_ATTRIBUTE + "' attribute not found on '" + FACET_ELEMENT + "' Element!");
+        }
+
+        // Create new LayoutFacet
+        LayoutFacet facetElt = new LayoutFacet(parent, id);
+
+        // Set isRendered
+        String rendered = getAttributes(node).get(RENDERED_ATTRIBUTE);
+        boolean isRendered = true;
+        if (rendered == null || rendered.trim().equals("") || rendered.equals(AUTO_RENDERED)) {
+            // Automatically determine if this LayoutFacet should be rendered
+            isRendered = !LayoutElementUtil.isNestedLayoutComponent(facetElt);
+        } else {
+            isRendered = Boolean.getBoolean(rendered);
+        }
+        facetElt.setRendered(isRendered);
+
+        // Add children...
+        addChildLayoutElements(facetElt, node);
+
+        // Return the LayoutFacet
+        return facetElt;
+    }
+
+    /**
+     *
+     * @param node The {@link #COMPONENT_ELEMENT} node to extract information from when creating the
+     * {@link LayoutComponent}.
+     */
+    private LayoutElement createLayoutComponent(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        Map<String, String> attributes = getAttributes(node);
+        String id = attributes.get(ID_ATTRIBUTE);
+        String type = attributes.get(TYPE_ATTRIBUTE);
+        if (type == null || type.trim().equals("")) {
+            throw new RuntimeException("'" + TYPE_ATTRIBUTE + "' attribute not found on '" + COMPONENT_ELEMENT + "' Element!");
+        }
+
+        // Create new LayoutComponent
+        LayoutComponent component = new LayoutComponent(parent, id, getComponentType(parent, type));
+
+        // Check for overwrite flag
+        String overwrite = attributes.get(OVERWRITE_ATTRIBUTE);
+        if (overwrite != null && overwrite.length() > 0) {
+            component.setOverwrite(Boolean.valueOf(overwrite).booleanValue());
+        }
+
+        // Set flag to indicate if this LayoutComponent is nested in another
+        // LayoutComponent. This is significant b/c during rendering, events
+        // will need to be fired differently (the TemplateRenderer /
+        // LayoutElements will not have any control). The strategy used will
+        // rely on "instance" handlers, this flag indicates that "instance"
+        // handlers should be used.
+        // NOTE: While this could be implemented on the LayoutComponent
+        // itself, I decided not to for performance reasons and to
+        // allow this value to be overruled if desired.
+        component.setNested(LayoutElementUtil.isNestedLayoutComponent(component));
+
+        // Figure out if this should be stored as a facet, if so under what id
+        if (!LayoutElementUtil.isLayoutComponentChild(component)) {
+            // Need to add this so that it has the correct facet name
+            // Check to see if this LayoutComponent is inside a LayoutFacet
+            while (parent != null) {
+                if (parent instanceof LayoutFacet) {
+                    // Inside a LayoutFacet, use its id... only if this facet
+                    // is a child of a LayoutComponent (otherwise, it is a
+                    // layout facet used for layout, not for defining a facet
+                    // of a UIComponent)
+                    if (LayoutElementUtil.isLayoutComponentChild(parent)) {
+                        id = parent.getUnevaluatedId();
+                    }
+                    break;
+                }
+                parent = parent.getParent();
+            }
+
+            // Set the facet name
+            component.addOption(LayoutComponent.FACET_NAME, id);
+        }
+
+        // Add children... (different for component LayoutElements)
+        addChildLayoutComponentChildren(component, node);
+
+        // Return the LayoutComponent
+        return component;
+    }
+
+    /**
+     *
+     */
+    private void addChildLayoutComponentChildren(LayoutComponent component, Node node) {
+        // Get the child nodes
+        Iterator<Node> it = getChildElements(node).iterator();
+
+        // Walk children (we care about COMPONENT_ELEMENT, FACET_ELEMENT,
+        // OPTION_ELEMENT, EVENT_ELEMENT, MARKUP_ELEMENT, and EDIT_ELEMENT)
+        Node childNode = null;
+        String name = null;
+        while (it.hasNext()) {
+            childNode = it.next();
+            name = childNode.getNodeName();
+            if (name.equalsIgnoreCase(COMPONENT_ELEMENT)) {
+                // Found a COMPONENT_ELEMENT
+                component.addChildLayoutElement(createLayoutComponent(component, childNode));
+            } else if (name.equalsIgnoreCase(FACET_ELEMENT)) {
+                // Found a FACET_ELEMENT
+                component.addChildLayoutElement(createLayoutFacet(component, childNode));
+            } else if (name.equalsIgnoreCase(OPTION_ELEMENT)) {
+                // Found a OPTION_ELEMENT
+                addOption(component, childNode);
+            } else if (name.equalsIgnoreCase(EVENT_ELEMENT)) {
+                // Found a EVENT_ELEMENT
+                // Get the event type
+                name = getAttributes(childNode).get(TYPE_ATTRIBUTE);
+
+                // Set the Handlers for the given event type (name)
+                List<Handler> handlers = component.getHandlers(name);
+                component.setHandlers(name, getHandlers(childNode, handlers));
+            } else if (name.equalsIgnoreCase(EDIT_ELEMENT)) {
+                // Found an EDIT_ELEMENT
+                component.addChildLayoutElement(createEditLayoutComponent(component, childNode));
+            } else if (name.equalsIgnoreCase(MARKUP_ELEMENT)) {
+                // Found an MARKUP_ELEMENT
+                component.addChildLayoutElement(createLayoutMarkup(component, childNode));
+            } else if (name.equalsIgnoreCase(STATIC_TEXT_ELEMENT)) {
+                // Found a STATIC_TEXT_ELEMENT
+                component.addChildLayoutElement(createLayoutStaticText(component, childNode));
+            } else if (name.equalsIgnoreCase(ATTRIBUTE_ELEMENT)) {
+                // Found a ATTRIBUTE_ELEMENT (actually in this case it will
+                // just add an "option" to the LayoutComponent), technically
+                // this case should only happen for LayoutMarkup components...
+                // this mess is caused by trying to support 2 .dtd's w/ 1 .dtd
+                // file... perhaps it's time to split.
+                createLayoutAttribute(component, childNode);
+            } else {
+                throw new RuntimeException("Unknown Element Found: '" + childNode.getNodeName() + "' under '<" + COMPONENT_ELEMENT + " id=\""
+                        + component.getUnevaluatedId() + "\"...'.");
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This adds a special {@link LayoutComponent} to the <code>UIComponent</code> tree that serves as a marker indicating
+     * that it is OK to edit this block of code. Editors can take advantage of this to know what is safe to edit. The type
+     * will be "markup" the id will be prefixed by {@link #EDITABLE} and an "option" named {@link #EDITABLE}, value ==
+     * <code>true</code> will be added.
+     * </p>
+     *
+     * @param node The {@link #COMPONENT_ELEMENT} node to extract information from when creating the <em>Edit</em>
+     * {@link LayoutComponent}.
+     */
+    private LayoutElement createEditLayoutComponent(LayoutElement parent, Node node) {
+        // First Add a popupMenu around this component... use it as the parent
+        parent = createEditPopupMenuLayoutComponent(parent, node);
+
+        // Pull off attributes...
+        Map<String, String> attributes = getAttributes(node);
+        String id = attributes.get(ID_ATTRIBUTE);
+
+        // Create the LayoutComponent
+        ComponentType type = ensureEditAreaType(parent);
+        LayoutComponent component = new LayoutComponent(parent, EDITABLE + id, type);
+        parent.addChildLayoutElement(component);
+
+        // Configure it...
+        component.setNested(LayoutElementUtil.isNestedLayoutComponent(component));
+        component.addOption(EDITABLE, Boolean.TRUE); // Flag
+
+        // Add children... (different for component LayoutElements)
+        addChildLayoutComponentChildren(component, node);
+
+        return parent;
+    }
+
+    /**
+     * <p>
+     * This method creates a PopupMenu component w/ the Editor commands.
+     * </p>
+     */
+    private LayoutElement createEditPopupMenuLayoutComponent(LayoutElement parent, Node node) {
+        // Pull off attributes...
+        Map<String, String> attributes = getAttributes(node);
+        String id = attributes.get(ID_ATTRIBUTE);
+
+        // Create the LayoutComponent
+        ComponentType type = ensurePopupMenuType(parent);
+        LayoutComponent popupMenu = new LayoutComponent(parent, EDIT_MENU + id, type);
+
+        // Configure it...
+        popupMenu.setNested(LayoutElementUtil.isNestedLayoutComponent(popupMenu));
+
+        // Could add "menu" facet here, however, I decided to do it in the xml
+
+        // Return the result
+        return popupMenu;
+    }
+
+    /**
+     * <p>
+     * This method ensures that a "popupMenu" {@link ComponentType} has been defined so that it can be used implicitly.
+     * </p>
+     */
+    private ComponentType ensurePopupMenuType(LayoutElement elt) {
+        // See if it is defined
+        LayoutDefinition ld = elt.getLayoutDefinition();
+        ComponentType type = null;
+        try {
+            type = getComponentType(elt, POPUP_MENU_TYPE);
+        } catch (IllegalArgumentException ex) {
+            // Nope, define it...
+            type = new ComponentType(POPUP_MENU_TYPE, POPUP_MENU_TYPE_CLASS);
+            ld.addComponentType(type);
+        }
+
+        // Return the type
+        return type;
+    }
+
+    /**
+     * <p>
+     * This method ensures that a "editArea" {@link ComponentType} has been defined so that it can be used implicitly.
+     * </p>
+     */
+    private ComponentType ensureEditAreaType(LayoutElement elt) {
+        // See if it is defined
+        LayoutDefinition ld = elt.getLayoutDefinition();
+        ComponentType type = null;
+        try {
+            type = getComponentType(elt, EDIT_AREA_TYPE);
+        } catch (IllegalArgumentException ex) {
+            // Nope, define it...
+            type = new ComponentType(EDIT_AREA_TYPE, EDIT_AREA_TYPE_CLASS);
+            ld.addComponentType(type);
+        }
+
+        // Return the type
+        return type;
+    }
+
+    /**
+     * <p>
+     * This method ensures that a "markup" {@link ComponentType} has been defined so that it can be used implicitly.
+     * </p>
+     */
+    private ComponentType ensureMarkupType(LayoutElement elt) {
+        // See if it is defined
+        LayoutDefinition ld = elt.getLayoutDefinition();
+        ComponentType type = null;
+        try {
+            type = getComponentType(elt, MARKUP_ELEMENT);
+        } catch (IllegalArgumentException ex) {
+            // Nope, define it...
+            type = new ComponentType(MARKUP_ELEMENT, MARKUP_FACTORY_CLASS);
+            ld.addComponentType(type);
+        }
+
+        // Return the type
+        return type;
+    }
+
+    /**
+     * <p>
+     * This method adds an option to the given {@link LayoutComponent} based on the information in the given
+     * {@link #OPTION_ELEMENT} <code>Node</code>.
+     * </p>
+     *
+     * @param component The {@link LayoutComponent}.
+     * @param node The {@link #OPTION_ELEMENT} <code>Node</code>.
+     */
+    private void addOption(LayoutComponent component, Node node) {
+        // Pull off the attributes
+        Map<String, String> attributes = getAttributes(node);
+
+        // Get the name
+        String name = attributes.get(NAME_ATTRIBUTE);
+        if (name == null || name.trim().equals("")) {
+            throw new RuntimeException("'" + NAME_ATTRIBUTE + "' attribute not found on '" + OPTION_ELEMENT + "' Element!");
+        }
+        name = name.trim();
+
+        // Get the value
+        Object value = getValueFromNode(node, attributes);
+
+        // Add the option to the component (value may be null)
+        component.addOption(name, value);
+    }
+
+    /**
+     * <p>
+     * This method reads obtains the {@link #VALUE_ATTRIBUTE} from the given node, or from the child {@link #LIST_ELEMENT}
+     * element. If neither are provided, <code>(null)</code> is returned. The attribute takes precedence over the child
+     * {@link #LIST_ELEMENT} element.
+     * </p>
+     *
+     * @param node <code>Node</code> containing the value attribute or {@link #LIST_ELEMENT}
+     * @param attributes <code>Map</code> of attributes which may contain {@link #VALUE_ATTRIBUTE}
+     *
+     * @return The value (as a <code>String</code> or <code>List</code>), or <code>(null)</code> if not specified.
+     */
+    private Object getValueFromNode(Node node, Map<String, String> attributes) {
+        Object value = attributes.get(VALUE_ATTRIBUTE);
+        if (value == null) {
+            // The value attribute may be null if multiple values are supplied.
+            // Walk children (we only care about LIST_ELEMENT)
+            List<String> list = new ArrayList();
+            Iterator<Node> it = getChildElements(node, LIST_ELEMENT).iterator();
+            while (it.hasNext()) {
+                // Add a value to the List
+                list.add(getAttributes(it.next()).get(VALUE_ATTRIBUTE));
+            }
+            if (list.size() > 0) {
+                // Only use the list if it has values
+                value = list;
+            }
+        }
+        return value;
+    }
+
+    /**
+     *
+     * @param node The {@link #STATIC_TEXT_ELEMENT} node to extract information from when creating the
+     * {@link LayoutStaticText}.
+     */
+    private LayoutElement createLayoutStaticText(LayoutElement parent, Node node) {
+        // Create new LayoutComponent
+        LayoutStaticText text = new LayoutStaticText(parent, "", getTextNodesAsString(node));
+
+        // Add all the attributes from the static text as options
+//    component.addOptions(getAttributes(node));
+
+        // Add escape... FIXME
+
+        // Return the LayoutStaticText
+        return text;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Utility Methods
+    //////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This method returns a <code>List</code> of all child <code>Element</code>s below the given <code>Node</code>.
+     * </p>
+     *
+     * @param node The <code>Node</code> to pull child elements from.
+     *
+     * @return <code>List</code> of child <code>Element</code>s found below the given <code>Node</code>.
+     */
+    public List<Node> getChildElements(Node node) {
+        return getChildElements(node, null);
+    }
+
+    /**
+     * <p>
+     * This method returns a List of all child Elements below the given Node matching the given name. If name equals null,
+     * all Elements below this node will be returned.
+     * </p>
+     *
+     * @param node The node to pull child elements from.
+     * @param name The name of the Elements to return.
+     *
+     * @return List of child elements found below the given node matching the name (if provided).
+     */
+    public List<Node> getChildElements(Node node, String name) {
+        // Get the child nodes
+        NodeList nodes = node.getChildNodes();
+        if (nodes == null) {
+            // No children, just return an empty List
+            return new ArrayList<>(0);
+        }
+
+        // Create a new List to store the child Elements
+        List<Node> list = new ArrayList<>();
+
+        // Add all the child Elements to the List
+        Node childNode = null;
+        for (int idx = 0; idx < nodes.getLength(); idx++) {
+            childNode = nodes.item(idx);
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                // Skip TEXT_NODE and other Node types
+                continue;
+            }
+
+            // Add to the list if name is null, or it matches the node name
+            if (name == null || childNode.getNodeName().equalsIgnoreCase(name)) {
+                list.add(childNode);
+            }
+        }
+
+        // Return the list of Elements
+        return list;
+    }
+
+    /**
+     * <p>
+     * This method returns the <code>String</code> representation of all the <code>Node.TEXT_NODE</code> nodes that are
+     * children of the given <code>Node</code>.
+     *
+     * @param node The <code>Node</code> to pull child <code>Element</code>s from.
+     *
+     * @return The <code>String</code> representation of all the <code>Node.TEXT_NODE</code> type nodes under the given
+     * <code>Node</code>.
+     */
+    public String getTextNodesAsString(Node node) {
+        // Get the child nodes
+        NodeList nodes = node.getChildNodes();
+        if (nodes == null) {
+            // No children, return null
+            return null;
+        }
+
+        // Create a StringBuffer
+        StringBuffer buf = new StringBuffer("");
+
+        // Add all the child Element values to the StringBuffer
+        Node childNode = null;
+        for (int idx = 0; idx < nodes.getLength(); idx++) {
+            childNode = nodes.item(idx);
+            if (childNode.getNodeType() != Node.TEXT_NODE && childNode.getNodeType() != Node.CDATA_SECTION_NODE) {
+                // Skip all other Node types
+                continue;
+            }
+            buf.append(childNode.getNodeValue());
+        }
+
+        // Return the String
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method returns a <code>Map</code> of all attributes for the given <code>Node</code>. Each attribute name will be
+     * stored in the <code>Map</code> in lower case so case can be ignored.
+     * </p>
+     *
+     * @param node The node to pull attributes from.
+     *
+     * @return <code>Map</code> of attributes found on the given <code>Node</code>.
+     */
+    public Map<String, String> getAttributes(Node node) {
+        // Get the attributes
+        NamedNodeMap attributes = node.getAttributes();
+        if (attributes == null || attributes.getLength() == 0) {
+            // No attributes, just return an empty Map
+            return new HashMap<>(0);
+        }
+
+        // Create a Map to contain the attributes
+        Map<String, String> map = new HashMap<>();
+
+        // Add all the attributes to the Map
+        Node attNode = null;
+        for (int idx = 0; idx < attributes.getLength(); idx++) {
+            attNode = attributes.item(idx);
+            map.put(attNode.getNodeName().toLowerCase(), attNode.getNodeValue());
+        }
+
+        // Return the map
+        return map;
+    }
+
+    /**
+     * <p>
+     * This utility method returns the requested {@link ComponentType}. If it is not found, it throws an
+     * <code>IllegalArgumentException</code>.
+     * </p>
+     *
+     * @param elt A {@link LayoutElement} whose root is a {@link LayoutDefinition}.
+     * @param type The <code>String</code> type to lookup.
+     *
+     * @return The {@link ComponentType}.
+     */
+    public ComponentType getComponentType(LayoutElement elt, String type) {
+        // Find the ComponentType
+        ComponentType compType = elt.getLayoutDefinition().getComponentType(type);
+        if (compType == null) {
+            // Check global component types (defined via @annotations). This
+            // is now the preferred way to define types, however, locally
+            // defined types should have precedence
+            compType = LayoutDefinitionManager.getGlobalComponentType(null, type);
+            if (compType == null) {
+                throw new IllegalArgumentException("ComponentType '" + type + "' not defined!");
+            }
+        }
+        return compType;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // Constants
+    //////////////////////////////////////////////////////////////////////
+
+    public static final String ATTRIBUTE_ELEMENT = "attribute";
+    public static final String COMPONENT_ELEMENT = "component";
+    public static final String COMPONENT_TYPE_ELEMENT = "componenttype";
+    public static final String EDIT_ELEMENT = "edit";
+    public static final String EVENT_ELEMENT = "event";
+    public static final String FACET_ELEMENT = "facet";
+    public static final String FOREACH_ELEMENT = "foreach";
+    public static final String HANDLER_ELEMENT = "handler";
+    public static final String HANDLERS_ELEMENT = "handlers";
+    public static final String HANDLER_DEFINITION_ELEMENT = "handlerdefinition";
+    public static final String IF_ELEMENT = "if";
+    public static final String INPUT_DEF_ELEMENT = "inputdef";
+    public static final String INPUT_ELEMENT = "input";
+    public static final String LAYOUT_DEFINITION_ELEMENT = "layoutdefinition";
+    public static final String LAYOUT_ELEMENT = "layout";
+    public static final String LIST_ELEMENT = "list";
+    public static final String MARKUP_ELEMENT = "markup";
+    public static final String OPTION_ELEMENT = "option";
+    public static final String OUTPUT_DEF_ELEMENT = "outputdef";
+    public static final String OUTPUT_MAPPING_ELEMENT = "outputmapping";
+    public static final String STATIC_TEXT_ELEMENT = "statictext";
+    public static final String TYPES_ELEMENT = "types";
+    public static final String RESOURCES_ELEMENT = "resources";
+    public static final String RESOURCE_ELEMENT = "resource";
+    public static final String WHILE_ELEMENT = "while";
+
+    public static final String CLASS_NAME_ATTRIBUTE = "classname";
+    public static final String CONDITION_ATTRIBUTE = "condition";
+    public static final String DEFAULT_ATTRIBUTE = "default";
+    public static final String DESCRIPTION_ATTRIBUTE = "description";
+    public static final String EXTRA_INFO_ATTRIBUTE = "extrainfo";
+    public static final String FACTORY_CLASS_ATTRIBUTE = "factoryclass";
+    public static final String ID_ATTRIBUTE = "id";
+    public static final String KEY_ATTRIBUTE = "key";
+    public static final String LIST_ATTRIBUTE = "list";
+    public static final String METHOD_NAME_ATTRIBUTE = "methodname";
+    public static final String NAME_ATTRIBUTE = "name";
+    public static final String OUTPUT_NAME_ATTRIBUTE = "outputname";
+    public static final String OVERWRITE_ATTRIBUTE = "overwrite";
+    public static final String PROPERTY_ATTRIBUTE = "property";
+    public static final String RENDERED_ATTRIBUTE = "rendered";
+    public static final String REQUIRED_ATTRIBUTE = "required";
+    public static final String TAG_ATTRIBUTE = "tag";
+    public static final String TARGET_KEY_ATTRIBUTE = "targetkey";
+    public static final String TARGET_TYPE_ATTRIBUTE = "targettype";
+    public static final String TYPE_ATTRIBUTE = "type";
+    public static final String VALUE_ATTRIBUTE = "value";
+
+    public static final String AUTO_RENDERED = "auto";
+    public static final String EDITABLE = "editableContent";
+    public static final String EDIT_MENU = "editMenu";
+
+    public static final String EDIT_AREA_TYPE = "editArea";
+    public static final String POPUP_MENU_TYPE = "popupMenu";
+    public static final String EDIT_AREA_TYPE_CLASS = "com.sun.jsftemplating.component.factory.basic.EditAreaFactory";
+    public static final String MARKUP_FACTORY_CLASS = "com.sun.jsftemplating.component.factory.basic.MarkupFactory";
+    public static final String POPUP_MENU_TYPE_CLASS = "com.sun.jsftemplating.component.factory.basic.PopupMenuFactory";
+
+    /**
+     * This is used to set the "value" option for static text fields.
+     */
+//    public static final String VALUE_OPTION    =   "value";
+
+    private URL _url = null;
+    private EntityResolver _entityResolver = null;
+    private ErrorHandler _errorHandler = null;
+    private String _baseURI = null;
+
+    private Map<String, HandlerDefinition> _handlerDefs = new HashMap<>();
+    private int _markupCount = 1;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/renderer/TemplateRenderer.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/renderer/TemplateRenderer.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.renderer;
+
+import com.sun.jsftemplating.component.TemplateComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.Resource;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.Renderer;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * <p>
+ * This renderer is a generic "template-based" renderer. It uses a <code>LayoutElement</code> tree as its template and
+ * walks this tree. This renderer will actually delegate the encode functionality to the {@link LayoutDefinition}
+ * object, which is the top of the <code>LayoutElement</code> in the tree.
+ * </p>
+ *
+ * <p>
+ * This renderer also has the feature of registering {@link Resource} objects to the Request scope prior to rendering
+ * its output. This allows {@link Resource} objects such as ResourceBundles to be added to the Request scope for easy
+ * access.
+ * </p>
+ *
+ * @see LayoutDefinition
+ * @see com.sun.jsftemplating.layout.descriptors.LayoutElement
+ * @see Resource
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class TemplateRenderer extends Renderer {
+
+    /**
+     * <p>
+     * This method returns true. This method indicates that this <code>Renderer</code> will assume resposibilty for
+     * rendering its own children.
+     * </p>
+     *
+     * @return true
+     *
+     * @see #encodeChildren(FacesContext, UIComponent)
+     */
+    @Override
+    public boolean getRendersChildren() {
+        return true;
+    }
+
+    /**
+     * <p>
+     * This method initializes the Resources so they will be available for children. It then calls encodeBegin on the
+     * superclass.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param component The UIComponent, should be a {@link TemplateComponent}
+     */
+    @Override
+    public void encodeBegin(FacesContext context, UIComponent component) throws IOException {
+        // Make sure we have a TemplateComponent
+        if (!(component instanceof TemplateComponent)) {
+            throw new IllegalArgumentException("TemplateRenderer requires that its UIComponent be an " + "instance of TemplateComponent!");
+        }
+        TemplateComponent tempComp = (TemplateComponent) component;
+        LayoutDefinition def = tempComp.getLayoutDefinition(context);
+
+        // First ensure that our Resources are available
+        Iterator<Resource> it = def.getResources().iterator();
+        Resource resource = null;
+        while (it.hasNext()) {
+            resource = it.next();
+            // Just calling getResource() puts it in the Request scope
+            resource.getFactory().getResource(context, resource);
+        }
+
+        // Call the super class
+        super.encodeBegin(context, component);
+    }
+
+    /**
+     * <p>
+     * This method prevents the super class's default functionality of rendering the child UIComponents. This
+     * <code>Renderer</code> implementation requires that the children be explicitly rendered. This method does nothing.
+     * </p>
+     *
+     * @param context The <code>FacesContext</code>
+     * @param component The <code>UIComponent</code>
+     */
+    @Override
+    public void encodeChildren(FacesContext context, UIComponent component) {
+        // Do nothing...
+    }
+
+    /**
+     * <p>
+     * This method performs the rendering for the TemplateRenderer. It expects that component be an instanceof
+     * {@link TemplateComponent}. It obtains the {@link LayoutDefinition} from the {@link TemplateComponent}, initializes
+     * the {@link Resource} objects defined by the {@link LayoutDefinition} (if any), and finally delegates the encoding to
+     * the {@link LayoutDefinition#encode(FacesContext, UIComponent)} method of the {@link LayoutDefinition}.
+     * </p>
+     *
+     * @param context The FacesContext object.
+     * @param component The {@link TemplateComponent}.
+     */
+    @Override
+    public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
+        // Sanity Check...
+        if (!component.isRendered()) {
+            return;
+        }
+
+        // Get the LayoutDefinition and begin rendering
+        TemplateComponent tempComp = (TemplateComponent) component;
+        LayoutDefinition def = tempComp.getLayoutDefinition(context);
+
+        // The following "encode" method does all the rendering
+        def.encode(context, (UIComponent) tempComp);
+    }
+
+    /**
+     * <p>
+     * Decode any new state of the specified UIComponent from the request contained in the specified FacesContext, and store
+     * that state on the UIComponent.
+     * </p>
+     *
+     * <p>
+     * During decoding, events may be queued for later processing (by event listeners that have registered an interest), by
+     * calling <code>queueEvent()</code> on the associated UIComponent.
+     * </p>
+     *
+     * <p>
+     * This implementation of this method invokes the super class and then any handlers that have been registered to process
+     * decode functionality. The execution of these handlers is delegated to the LayoutDefinition.
+     * </p>
+     *
+     * @param context FacesContext for the request we are processing
+     * @param component UIComponent to be decoded.
+     *
+     * @exception NullPointerException if <code>context</code> or <code>component</code> is <code>null</code>
+     */
+    @Override
+    public void decode(FacesContext context, UIComponent component) {
+        // Call the super first
+        super.decode(context, component);
+
+        // Call any decode handlers
+        TemplateComponent tempComp = (TemplateComponent) component;
+        LayoutDefinition def = tempComp.getLayoutDefinition(context);
+        def.decode(context, component);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/renderer/package.html
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/renderer/package.html
@@ -1,0 +1,58 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<body>
+    <p>    This package provides a strategy for rendering complex components.  A
+    complex component is any component that consists of multiple
+    sub-components.  The {@link com.sun.jsftemplating.renderer.TemplateRenderer}
+    is the actual Renderer class, the other files in this package provide
+    support for creating and holding the LayoutDefinition information.
+    While {@link com.sun.jsftemplating.renderer.TemplateRenderer} could also
+    render a simple component, the flexibility and extensibility
+    capabilities are probably overkill for small components.</p>
+
+    <p>    The {@link com.sun.jsftemplating.renderer.TemplateRenderer}
+    is driven off a "template".  The template is actually a tree data
+    structure consisting of
+    "{@link com.sun.jsftemplating.layout.descriptors.LayoutElement}"
+    objects.  This structure is walked in order to render the component.
+    This data structure may be populated programatically, however, a
+    {@link com.sun.jsftemplating.layout.LayoutDefinitionManager}
+    is the recommended way to obtain the structure.  A
+    {@link com.sun.jsftemplating.layout.LayoutDefinitionManager}
+    is responsible for locating a
+    {@link com.sun.jsftemplating.layout.descriptors.LayoutDefinition} for a
+    particular component (such as a table component).  How this is done is
+    left to implementations of
+    {@link com.sun.jsftemplating.layout.LayoutDefinitionManager}.  One
+    implementation currently exists which populates the
+    {@link com.sun.jsftemplating.layout.descriptors.LayoutElement}
+    tree from an XML file:
+    {@link com.sun.jsftemplating.layout.xml.XMLLayoutDefinitionManager}.</p>
+
+    <p>    Different types of
+    {@link com.sun.jsftemplating.layout.descriptors.LayoutElement} objects are
+    used to effect the output.
+    {@link com.sun.jsftemplating.layout.descriptors.LayoutElement}
+    are delegated the encode responsibilty so that they may determine
+    whether and how their child components are encoded.  See the
+    {@link com.sun.jsftemplating.layout.descriptors.LayoutElement}
+    documentation and the implementing classes of
+    {@link com.sun.jsftemplating.layout.descriptors.LayoutElement}
+    for more information.</p>
+</body>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/resource/ResourceBundleFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/resource/ResourceBundleFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.resource;
+
+import com.sun.jsftemplating.layout.descriptors.Resource;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.Map;
+
+/**
+ * <p>
+ * This factory class provides a means to instantiate a java.util.ResouceBundle. It implements the
+ * {@link ResourceFactory} which the {@link com.sun.jsftemplating.renderer.TemplateRenderer} knows how to use to create
+ * arbitrary {@link Resource} objects. This factory utilizes the ResourceBundleManager for efficiency.
+ * </p>
+ *
+ * @see ResourceFactory
+ * @see Resource
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ResourceBundleFactory implements ResourceFactory {
+
+    /**
+     * <p>
+     * This is the factory method responsible for obtaining a ResourceBundle. This method uses the ResourceBundleManager to
+     * manage instances of ResourceBundles per key/locale.
+     * </p>
+     *
+     * <p>
+     * It should be noted that this method does not do anything if there is already a request attribute with the given id.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param descriptor The Resource descriptor that is associated with the requested Resource.
+     *
+     * @return The newly created Resource
+     */
+    @Override
+    public Object getResource(FacesContext context, Resource descriptor) {
+        // Get the id from the descriptor, this is the id that should be used
+        // to store it in the RequestScope
+        String id = descriptor.getId();
+        Map<String, Object> map = context.getExternalContext().getRequestMap();
+        if (map.containsKey(id)) {
+            // It is already set
+            return map.get(id);
+        }
+
+        // Obtain the ResourceBundle
+        Object resource = ResourceBundleManager.getInstance(context).getBundle(descriptor.getExtraInfo(), Util.getLocale(context));
+
+        // The id does not exist in the request scope yet.
+        map.put(id, resource);
+
+        return resource;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/resource/ResourceBundleManager.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/resource/ResourceBundleManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.resource;
+
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * <p>
+ * This class caches <code>ResourceBundle</code> objects per locale.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ResourceBundleManager {
+
+    /**
+     * <p>
+     * Use {@link #getInstance()} to obtain an instance.
+     * </p>
+     */
+    protected ResourceBundleManager() {
+    }
+
+    /**
+     * <p>
+     * Use this method to get the instance of this class.
+     * </p>
+     *
+     * @deprecated Use ResourceBundleManager#getInstance(FacesContext).
+     */
+    @Deprecated
+    public static ResourceBundleManager getInstance() {
+        return getInstance(null);
+    }
+
+    /**
+     * <p>
+     * Use this method to get the instance of this class.
+     * </p>
+     */
+    public static ResourceBundleManager getInstance(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        ResourceBundleManager mgr = null;
+        if (ctx != null) {
+            // Look in application scope for it...
+            mgr = (ResourceBundleManager) ctx.getExternalContext().getApplicationMap().get(RB_MGR);
+        }
+        if (mgr == null) {
+            // 1st time... create / initialize it
+            mgr = new ResourceBundleManager();
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(RB_MGR, mgr);
+            }
+        }
+
+        // Return the map...
+        return mgr;
+    }
+
+    /**
+     * <p>
+     * This method checks the cache for the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param baseName Name of the bundle.
+     * @param locale The <code>Locale</code>.
+     *
+     * @return The requested <code>ResourceBundle</code> in the most appropriate <code>Locale</code>.
+     */
+    protected ResourceBundle getCachedBundle(String baseName, Locale locale) {
+        return _cache.get(getCacheKey(baseName, locale));
+    }
+
+    /**
+     * <p>
+     * This method generates a unique key for setting / getting <code>ResourceBundle</code>s from the cache. It is important
+     * to have different keys per locale (obviously).
+     * </p>
+     */
+    protected String getCacheKey(String baseName, Locale locale) {
+        return baseName + "__" + locale.toString();
+    }
+
+    /**
+     * <p>
+     * This method adds a <code>ResourceBundle</code> to the cache.
+     * </p>
+     */
+    protected void addCachedBundle(String baseName, Locale locale, ResourceBundle bundle) {
+        // Copy the old Map to prevent changing a Map while someone is
+        // accessing it.
+        Map<String, ResourceBundle> map = new HashMap<>(_cache);
+
+        // Add the new bundle
+        map.put(getCacheKey(baseName, locale), bundle);
+
+        // Set this new Map as the shared cache Map
+        _cache = map;
+    }
+
+    /**
+     * <p>
+     * This method obtains the requested <code>ResourceBundle</code> as specified by the given <code>basename</code> and
+     * <code>locale</code>.
+     * </p>
+     *
+     * @param baseName The base name for the <code>ResourceBundle</code>.
+     * @param locale The desired <code>Locale</code>.
+     */
+    public ResourceBundle getBundle(String baseName, Locale locale) {
+        ResourceBundle bundle = getCachedBundle(baseName, locale);
+        if (bundle == null) {
+            try {
+                bundle = ResourceBundle.getBundle(baseName, locale, Util.getClassLoader(baseName));
+            } catch (MissingResourceException ex) {
+                // Use System.out.println b/c we don't want infinite loop and
+                // we're too lazy to do more...
+                System.out.println("Can't find bundle: " + baseName);
+                ex.printStackTrace();
+            }
+            if (bundle != null) {
+                addCachedBundle(baseName, locale, bundle);
+            }
+        }
+        return bundle;
+    }
+
+    /**
+     * <p>
+     * This method obtains the requested <code>ResourceBundle</code> as
+     * specified by the given basename, locale, and classloader.</p>
+     *
+     * @param baseName The base name for the <code>ResourceBundle</code>.
+     * @param locale The desired <code>Locale</code>.
+     * @param loader The <code>ClassLoader</code> that should be used.
+     */
+    public ResourceBundle getBundle(String baseName, Locale locale, ClassLoader loader) {
+        ResourceBundle bundle = getCachedBundle(baseName, locale);
+        if (bundle == null) {
+            bundle = ResourceBundle.getBundle(baseName, locale, loader);
+            if (bundle != null) {
+                addCachedBundle(baseName, locale, bundle);
+            }
+        }
+
+        return bundle;
+    }
+
+    /**
+     * <p>
+     * Application scope key which stores the <code>ResourceBundleManager</code> instance for this application.
+     * </p>
+     */
+    private static final String RB_MGR = "__jsft_ResourceBundleMgr";
+
+    /**
+     * <p>
+     * The cache of <code>ResourceBundle</code>s.
+     * </p>
+     */
+    private Map<String, ResourceBundle> _cache = new HashMap<>();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/resource/ResourceFactory.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/resource/ResourceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.resource;
+
+import com.sun.jsftemplating.layout.descriptors.Resource;
+
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This file defines the ResourceFactory interface. Resources are added to the Request scope so that they may be
+ * accessed easily using JSF EL value-binding, or by other convient means.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface ResourceFactory {
+
+    /**
+     * <p>
+     * This is the method responsible for getting the resource using the given {@link Resource} descriptor.
+     * </p>
+     *
+     * @param context The FacesContext
+     * @param descriptor The Resource descriptor that is associated with the requested Resource.
+     *
+     * @return The newly created (or found) resource.
+     */
+    Object getResource(FacesContext context, Resource descriptor);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/CachedURLConnection.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/CachedURLConnection.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * <p>
+ * This class enables a URL connection to a cached object of type <code>&lt;T&gt;</code>. It is required that a
+ * <code>WeakReference</code> to this object by used, allowing GC to occur if no other Strong references are present.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class CachedURLConnection<T> extends URLConnection {
+
+    /**
+     * <p>
+     * This constructor requires the <code>WeakReference&lt;T&gt;</code> containing the object to be supplied, in addition
+     * to the URL.
+     * </p>
+     */
+    public CachedURLConnection(URL url, WeakReference<T> weakRef) {
+        super(url);
+        if (weakRef == null || weakRef.get() == null) {
+            throw new IllegalArgumentException("The weakRef is required in " + "order to create a CachedURLConnection!");
+        }
+        this.weakRef = weakRef;
+    }
+
+    /**
+     * <p>
+     * This method is overriden to provide access to an InputStream based on the <code>T</code> object.
+     * </p>
+     */
+    @Override
+    public InputStream getInputStream() throws IOException {
+        try {
+            // If the value is (null) a NPE will be thrown here... only
+            // should occur if the object has been GC'd.
+            byte bytes[] = null;
+            T obj = weakRef.get();
+            if (obj instanceof byte[]) {
+                bytes = (byte[]) obj;
+            } else {
+                bytes = obj.toString().getBytes();
+            }
+            return new ByteArrayInputStream(bytes);
+        } catch (NullPointerException ex) {
+            throw new IOException("Cached object was null!");
+        }
+    }
+
+    /**
+     * <p>
+     * This method is required to be overriden, however, no "connection" is needed, so this method does nothing.
+     * </p>
+     */
+    @Override
+    public void connect() throws IOException {
+        // Do nothing.
+    }
+
+    private WeakReference<T> weakRef = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/CachedURLStreamHandler.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/CachedURLStreamHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+/**
+ * <p>
+ * This class enables a <code>URLConnection</code> to be returned when <code>openConnection(URL)</code> is called which
+ * is capable of reading from a <code>T</code> object.
+ * </p>
+ */
+public class CachedURLStreamHandler<T> extends URLStreamHandler {
+
+    /**
+     * <p>
+     * This constructor stores the given <code>T</code> object, which will be used by the {@link CachedURLConnection} which
+     * is created when openConnection is called. It stores this as a <em>WeakReference</em>, so it will be garbage collected
+     * if no other "strong" references refer to it!
+     * </p>
+     */
+    public CachedURLStreamHandler(T obj) {
+        this.weakRef = new WeakReference<>(obj);
+    }
+
+    /**
+     * <p>
+     * This method creates a new {@link CachedURLConnection} associated with the <code>T</code> object given when the
+     * constructor was called.
+     * </p>
+     */
+    @Override
+    protected URLConnection openConnection(URL url) throws IOException {
+        return new CachedURLConnection<>(url, weakRef);
+    }
+
+    private WeakReference<T> weakRef = null;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/ClasspathEntityResolver.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/ClasspathEntityResolver.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.ext.EntityResolver2;
+
+/**
+ * <p>
+ * This <code>EntityResolver</code> looks for files that are included as <code>SYSTEM</code> entities in the java
+ * class-path. If the file is not found in the class path the resolver returns null, allowing default mechanism to
+ * search for the file on the file system.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class ClasspathEntityResolver implements EntityResolver2 {
+
+    /**
+     * <p>
+     * This method implements the old-style resolveEntity method. This is not recommended as it does not provide the baseURI
+     * and may fail when it shouldn't.
+     * </p>
+     */
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) {
+        return resolveEntity("", publicId, "", systemId);
+    }
+
+    /**
+     * <p>
+     * This method returns null.
+     * </p>
+     */
+    @Override
+    public InputSource getExternalSubset(String name, String baseURI) {
+        return null;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId) {
+        if (systemId != null) {
+            if (baseURI != null) {
+                if (systemId.startsWith(baseURI)) {
+                    systemId = systemId.substring(baseURI.length());
+                }
+            }
+            int idx = systemId.indexOf(':');
+            if (idx != -1) {
+                // remove "file:/", "jndi:/", etc
+                systemId = systemId.substring(idx + 1);
+            }
+
+            // Remove any extra leading /'s
+            while (systemId.startsWith("/")) {
+                // String of leading '/'
+                systemId = systemId.substring(1);
+            }
+
+            // We should first check to see if it is in the context root,
+            // avoid using Servlet API's so this code can work outside a
+            // Servlet container.
+            InputStream stream = null;
+            URL url = null;
+            if (FACES_CONTEXT != null) {
+                try {
+                    // The following will work w/ ServletContext/PortletContext
+                    // Get the FacesContext...
+                    Method meth = FACES_CONTEXT.getMethod("getCurrentInstance", (Class[]) null);
+                    Object ctx = meth.invoke((Object) null, (Object[]) null);
+
+                    if (ctx != null) {
+                        // Get the ExternalContext...
+                        meth = ctx.getClass().getMethod("getExternalContext", (Class[]) null);
+                        ctx = meth.invoke(ctx, (Object[]) null);
+
+                        // Get actual underlying external context...
+                        meth = ctx.getClass().getMethod("getContext", (Class[]) null);
+                        ctx = meth.invoke(ctx, (Object[]) null);
+
+                        // Get the resource using the ServletContext/PortletContext
+                        meth = ctx.getClass().getMethod("getResource", STRING_ARG);
+                        // The path must start w/ a '/'
+                        url = (URL) meth.invoke(ctx, "/" + systemId);
+                        if (url != null) {
+                            stream = url.openStream();
+                        }
+                    }
+                } catch (NoSuchMethodException ex) {
+                    throw new RuntimeException(ex);
+                } catch (IllegalAccessException ex) {
+                    throw new RuntimeException(ex);
+                } catch (InvocationTargetException ex) {
+                    throw new RuntimeException(ex);
+                } catch (IOException ex) {
+                    // Ignore... we will check other places
+                }
+            }
+
+            // First check to see if we can load this via a file:/// path,
+            // even though this may work via the default... depending on how
+            // the uri is constructed, it may not be able to locate it
+            // correctly this way. We will give higher priority to
+            // file:/// than finding it in the ClassPath.
+            if (stream == null) {
+                try {
+                    stream = new URL(baseURI + "/" + systemId).openStream();
+                } catch (IOException ex) {
+                    // Ignore... we will check the ClassPath
+                }
+
+                if (stream == null) {
+                    // Ok, we tried... now check the Classpath...
+                    // Get the ClassLoader
+                    ClassLoader loader = Util.getClassLoader(systemId);
+
+                    // Attempt to find the resource via the ClassPath
+                    stream = loader.getResourceAsStream(systemId);
+                    if (stream == null) {
+                        // Try adding a '/'
+                        stream = loader.getResourceAsStream("/" + systemId);
+                        if (stream == null) {
+                            // Try in the META-INF directory
+                            stream = loader.getResourceAsStream("META-INF/" + systemId);
+                        }
+                    }
+                }
+            }
+
+            if (stream != null) {
+                // Found, return an InputSource to the resource
+                return new InputSource(stream);
+            }
+            if (LogUtil.configEnabled(LOGGER_NAME)) {
+                LogUtil.config(LOGGER_NAME, "Unable to resolve entity." + "\n\tsystemId: '" + systemId + "'\n\tbaseURI: '" + baseURI
+                        + "'\n\tpublicId: '" + publicId + "'\n\tname: '" + name + "'");
+            }
+        }
+
+        // use the default behaviour
+        return null;
+    }
+
+    public static final String LOGGER_NAME = "javax.enterpise.system.tools.admin.guiframework";
+
+    private static final Class[] STRING_ARG = new Class[] { String.class };
+    private static final Class FACES_CONTEXT = Util.noExceptionLoadClass("jakarta.faces.context.FacesContext");
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/FileUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/FileUtil.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionException;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * <p>
+ * This class is for general purpose utility methods.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class FileUtil {
+
+    /**
+     * <p>
+     * This method calculates the system path to the given filename that is relative to the docroot. It takes the
+     * <code>ServletContext</code> or <code>PortletContext</code> (which is why this method takes an <code>Object</code> for
+     * this parameter) and the relative path to find. It then invokes the <code>getRealPath(String)</code> method of the
+     * <code>ServletContext</code> / <code>PortletContext</code> and returns the result. This method uses reflection.
+     * </p>
+     */
+    public static String getRealPath(Object ctx, String relativePath) {
+        String path = null;
+
+        // The following should work w/ a ServletContext or PortletContext
+        Method method = null;
+        try {
+            method = ctx.getClass().getMethod("getRealPath", REALPATH_ARGS);
+        } catch (NoSuchMethodException ex) {
+            throw new RuntimeException(ex);
+        }
+        try {
+            path = (String) method.invoke(ctx, relativePath);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        } catch (InvocationTargetException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        // Return Result
+        return path;
+    }
+
+    /**
+     * <p>
+     * This method checks for the <code>relPath</code> in the docroot of the application. This should work in both Portlet
+     * and Servlet environments. If <code>FacesContext</code> is null, null will be returned.
+     * </p>
+     */
+    public static URL getResource(String relPath) {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        if (facesContext == null) {
+            return null;
+        }
+        Object ctx = facesContext.getExternalContext().getContext();
+        URL url = null;
+
+        // The following should work w/ a ServletContext or PortletContext
+        Method method = null;
+        try {
+            method = ctx.getClass().getMethod("getResource", GET_RES_ARGS);
+        } catch (NoSuchMethodException ex) {
+            throw new LayoutDefinitionException("Unable to find " + "'getResource' method in this environment!", ex);
+        }
+        try {
+            url = (URL) method.invoke(ctx, "/" + relPath);
+        } catch (IllegalAccessException ex) {
+            throw new LayoutDefinitionException(ex);
+        } catch (InvocationTargetException ex) {
+            throw new LayoutDefinitionException(ex);
+        }
+
+        return url;
+    }
+
+    /**
+     * <p>
+     * This method searches for the given relative path filename. It first looks relative the context root of the
+     * application, it then looks in the classpath, including relative to the <code>META-INF</code> folder. If found a
+     * <code>URL</code> to the file will be returned.
+     * </p>
+     *
+     * @param path The Path.
+     *
+     * @param defSuff The suffix to use if the file specified in path is not found, it is sometimes useful to translate the
+     * path using a default suffix.
+     */
+    public static URL searchForFile(String path, String defSuff) throws IOException {
+        // Remove leading '/' characters if needed
+        boolean absolutePath = false;
+        String newPath = path;
+        while (newPath.startsWith("/")) {
+            newPath = newPath.substring(1);
+            absolutePath = true;
+        }
+
+        // Check to see if we have already found this before (on this request)
+        URL url = null;
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        Map<String, URL> filesFound = getFilesFoundMap(ctx);
+        if (filesFound != null) {
+            url = filesFound.get(newPath);
+            if (url != null) {
+                // We've already figured this out, abort before we start
+                return url;
+            }
+        }
+
+        // Next check relative newPath (i.e. determine the directory w/i the app
+        // they are in and prepend it to the newPath)
+        if (!absolutePath) {
+            // Check for URL syntax... at this point it will look like a relative
+            // path.
+            //
+            // NOTE: While this should not be exposed from the browser, it is
+            // valid for server-side code to request page fragments via URLs.
+            // If this is the case, "newPath" will be in the form:
+            // <protocol>://... We'll simply detect by checking for "://".
+            if (newPath.contains("://")) {
+                // Looks like a URL...
+                try {
+                    // Read the contents
+                    byte[] content = readFromURL(new URL(newPath));
+
+                    // Use request scope in order to persist it appropriately...
+                    // Not retrievied, prevents GC from happenning early
+                    if (ctx != null) {
+                        ctx.getExternalContext().getRequestMap().put("__gf." + newPath, content);
+                    }
+
+                    // Use special URL which will buffer the contents
+                    url = new URL(null, newPath, new CachedURLStreamHandler<>(content));
+
+                    // Cache the URL...
+                    if (filesFound != null) {
+                        // Cache what we found -- each LDM calls this method, help them...
+                        filesFound.put(newPath, url);
+                    }
+
+                    // We need to end early b/c this is a special case...
+                    return url;
+                } catch (MalformedURLException ex) {
+                    // This is probably bad, but we'll ignore it and see if
+                    // it can be found via a relative path.
+                } catch (IOException ex) {
+                    // Rethrow it b/c this error probably should be shown.
+                    throw ex;
+                }
+            }
+
+            String absPath = getAbsolutePath(ctx, newPath);
+            url = searchForFile(absPath, defSuff);
+
+            // We're done, don't search anymore even if not found
+            return url;
+        }
+
+        // Check for file in docroot.
+        url = getResource(newPath);
+        if (url == null) {
+            // Check the classpath for the file
+            ClassLoader loader = Util.getClassLoader(path);
+            url = loader.getResource(newPath);
+            if (url == null) {
+                // Check w/ a leading '/'
+                url = loader.getResource("/" + newPath);
+                if (url == null) {
+                    // Check in "META-INF/"
+                    url = loader.getResource("META-INF/" + newPath);
+                    if (url == null && defSuff != null) {
+                        // Check to see if the extension is not .jsf, if
+                        // not then try finding w/ the extension of .jsf
+                        // This allows developers to write .jsf files and
+                        // share them even if the FacesServlet is mapped
+                        // differently
+                        int idx = path.lastIndexOf('.');
+                        if (idx != -1) {
+                            String ext = path.substring(idx);
+                            if (!ext.equalsIgnoreCase(defSuff)) {
+                                return searchForFile(path.substring(0, idx) + defSuff, null);
+                            }
+                        } else {
+                            return searchForFile(path + defSuff, null);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (url != null && filesFound != null) {
+            // Cache what we found -- each LDM calls this method, help them...
+            filesFound.put(newPath, url);
+        }
+
+        // Return a url to the file (hopefully)...
+        return url;
+    }
+
+    /**
+     * <p>
+     * This method converts a path relative to the current viewId into an absolute path from the context-root. It does this
+     * by prepending the current viewId to it. It is expected that relPath does not contain a leading '/'.
+     * </p>
+     *
+     * @param ctx The <code>FacesContext</code>.
+     * @param relPath The relative path to convert.
+     *
+     * @return The absolute path (relative to the context-root).
+     */
+    public static String getAbsolutePath(FacesContext ctx, String relPath) {
+        // Sanity check
+        String absPath = null;
+        if (ctx != null) {
+            // Make sure we have a ViewRoot
+            UIViewRoot viewRoot = ctx.getViewRoot();
+            if (viewRoot != null) {
+                // Get the viewId
+                String viewId = viewRoot.getViewId();
+                if (viewId == null) {
+                    viewId = "/";
+                } else if (!viewId.startsWith("/")) {
+                    // Ensure our viewId starts with a '/'
+                    viewId = "/" + viewId;
+                }
+                int slash = viewId.lastIndexOf('/');
+
+                // This will give our our base directory...
+                absPath = viewId.substring(0, ++slash);
+
+                // Append on the relative path
+                absPath += relPath;
+            }
+        }
+        return absPath == null ? "/" + relPath : absPath;
+    }
+
+    /**
+     * <p>
+     * This method looks for "/./" or "/../" elements in an absolute path and removes them. If a "/./" is found, it simply
+     * removes it. If a "/../" is found, it removes it and the preceeding path element. This method also removes duplate '/'
+     * characters (i.e. "//" becomes "/").
+     * </p>
+     */
+    public static String cleanUpPath(String absPath) {
+        // First lets remove any "/./" elements
+        int idx;
+        while ((idx = absPath.indexOf("/./")) != -1) {
+            absPath = absPath.substring(0, idx) + absPath.substring(idx + 2);
+        }
+
+        // Next remove any "/../" elements
+        while ((idx = absPath.indexOf("/../")) != -1) {
+            int prevElement = 0;
+            if (idx > 0) {
+                // Find previous element
+                prevElement = absPath.lastIndexOf('/', idx - 1);
+                if (prevElement == -1) {
+                    prevElement = 0;
+                }
+            }
+            absPath = absPath.substring(0, prevElement) + absPath.substring(idx + 3);
+        }
+
+        // Remove "//"
+        while ((idx = absPath.indexOf("//")) != -1) {
+            absPath = absPath.substring(0, idx) + absPath.substring(idx + 1);
+        }
+
+        // Return the fixed-up path
+        return absPath;
+    }
+
+    /**
+     * <p>
+     * This method looks for resources in jar files without using the ClassLoader. It accepts directories in which it should
+     * scan for jar files.
+     * </p>
+     *
+     * @param facesContext The <code>FacesContext</code>.
+     * @param resourcePath The resource name to search in all jar files.
+     * @param searchPaths The array of paths to search for jar files.
+     */
+    public static List<Tuple> getJarResources(FacesContext facesContext, String resourcePath, String... searchPaths) throws IOException {
+        if (searchPaths == null) {
+            // Use default jar search path...
+            searchPaths = DEFAULT_SEARCH_PATH;
+        }
+        List<Tuple> entries = new ArrayList<>();
+        ExternalContext ec = facesContext.getExternalContext();
+        for (String searchPath : searchPaths) {
+            Set<String> paths = ec.getResourcePaths(searchPath);
+            for (String path : paths) {
+                if ("jar".equalsIgnoreCase(path.substring(path.length() - 3))) {
+// FIXME: Can this be a URL?
+                    JarFile jarFile = new JarFile(new File(ec.getResource(path).getFile()));
+                    JarEntry jarEntry = jarFile.getJarEntry(resourcePath);
+                    if (jarEntry != null) {
+                        entries.add(new Tuple(jarFile, jarEntry));
+                    }
+                }
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * <p>
+     * This method read content from a <code>URL</code> and returns the result as a <code>byte[]</code>.
+     * </p>
+     */
+    public static byte[] readFromURL(URL url) throws IOException {
+        byte buffer[] = new byte[10000];
+        byte result[] = new byte[0];
+
+        // try {
+        int count = 0;
+        int offset = 0;
+        InputStream in = url.openStream();
+
+        // Attempt to read up to 10K bytes.
+        count = in.read(buffer);
+        while (count != -1) {
+            // Make room for new content...
+            // result = Arrays.copyOf(result, offset + count); Java 6 only...
+            // When I can depend on Java 6... replace the following 3 lines
+            // with the line above.
+            byte oldResult[] = result;
+            result = new byte[offset + count];
+            System.arraycopy(oldResult, 0, result, 0, offset);
+
+            // Copy in new content...
+            System.arraycopy(buffer, 0, result, offset, count);
+
+            // Increment the offset
+            offset += count;
+
+            // Attempt to read up to 10K more bytes...
+            count = in.read(buffer);
+        }
+        // } catch (IOException ex) {
+        // throw new RuntimException("Error while trying to read from URL: " + url);
+        // }
+        return result;
+    }
+
+    /**
+     * <p>
+     * This method provides access to a Map containing the URLs of files that have been found already on this particular
+     * request. This is done to speed up the task of locating the appropriate URL.
+     * </p>
+     *
+     * <p>
+     * The <code>Map</code> returned is keyed by the viewId (or String representation of the URL) for the file in question.
+     * If the given <code>FacesContext</code> is <code>null</code>, <code>null</code> will be returned from this method.
+     * </p>
+     */
+    private static Map<String, URL> getFilesFoundMap(FacesContext ctx) {
+        Map<String, URL> filesFound = null;
+        // Only do this caching if we're in Faces...
+        if (ctx != null) {
+            filesFound = (Map<String, URL>) ctx.getExternalContext().getRequestMap().get(FILES_FOUND);
+            if (filesFound == null) {
+                // Not yet created, create it...
+                filesFound = new HashMap<>(8);
+                ctx.getExternalContext().getRequestMap().put(FILES_FOUND, filesFound);
+            }
+        }
+        return filesFound;
+    }
+
+    private static final String FILES_FOUND = "_filesFoundThisRequest";
+    private static final Class[] REALPATH_ARGS = new Class[] { String.class };
+    private static final Class[] GET_RES_ARGS = new Class[] { String.class };
+    private static final String[] DEFAULT_SEARCH_PATH = new String[] { "/WEB-INF/lib/" };
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/HandlerUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/HandlerUtil.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContextImpl;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.ArrayList;
+import java.util.EventObject;
+import java.util.List;
+
+/**
+ * <p>
+ * This class is for {@link Handler} utility methods.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class HandlerUtil {
+
+    /**
+     * <p>
+     * This method invokes the {@link Handler} identified by the given id.
+     * </p>
+     *
+     * @param handlerId The id of the globally defined {@link Handler}.
+     * @param elt The {@link LayoutElement} to associate with the {@link Handler}, it does not need to reference the
+     * {@link Handler}.
+     * @param args <code>Object[]</code> that represent the arguments to pass into the {@link Handler}.
+     *
+     * @return The value returned from the {@link Handler} if any.
+     */
+    public static Object dispatchHandler(String handlerId, LayoutElement elt, Object... args) {
+        // Get the Handler
+        HandlerDefinition def = elt.getLayoutDefinition().getHandlerDefinition(handlerId);
+        if (def == null) {
+            def = LayoutDefinitionManager.getGlobalHandlerDefinition(handlerId);
+        }
+        if (def == null) {
+            throw new IllegalArgumentException("Unable to locate handler definition for '" + handlerId + "'!");
+        }
+        Handler handler = new Handler(def);
+        if (args != null) {
+            // Basic check to make sure we have valid arguments
+            int size = args.length;
+            if (size % 2 == 1) {
+                throw new IllegalArgumentException("Arguments to " + "dispatchHandler must be paired: name1, value1, "
+                        + "name2, value2.  An odd number was received which " + "is invalid.");
+            }
+
+            // Set all the input values
+            String name = null;
+            Object value = null;
+            for (int count = 0; count < size; count += 2) {
+                name = (String) args[count];
+                value = args[count + 1];
+                handler.setInputValue(name, value);
+            }
+        }
+
+        // Put it in a List
+        List<Handler> handlers = new ArrayList<>();
+        handlers.add(handler);
+
+        // Create a HandlerContext...
+        HandlerContext handlerCtx = new HandlerContextImpl(FacesContext.getCurrentInstance(), elt, new EventObject(elt), "none");
+
+        return elt.dispatchHandlers(handlerCtx, handlers);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/IncludeInputStream.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/IncludeInputStream.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * <p>
+ * This <code>InputStream</code> looks for lines beginning with "#include '<em>filename</em>'" where filename is the
+ * name of a file to include. It replaces the "#include" line with contents of the specified file. Any other line
+ * beginning with '#' is illegal.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class IncludeInputStream extends FilterInputStream {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public IncludeInputStream(InputStream input) {
+        super(input);
+    }
+
+    /**
+     * <p>
+     * This overriden method implements the include feature.
+     * </p>
+     *
+     * @return The next character.
+     */
+    @Override
+    public int read() throws IOException {
+        int intChar = -1;
+        if (redirStream != null) {
+            // We are already redirecting, delegate
+            intChar = redirStream.read();
+            if (intChar != -1) {
+                return intChar;
+            }
+
+            // Found end of redirect file, stop delegating
+            redirStream = null;
+        }
+
+        // Read next character
+        intChar = super.read();
+        char ch = (char) intChar;
+
+        // If we were at the end of the line, check for new line w/ #
+        if (eol) {
+            // Check to see if we have a '#'
+            if (ch == '#') {
+                intChar = startInclude();
+            } else {
+                eol = false;
+            }
+        }
+
+        // Flag EOL if we're at the end of a line
+        if (ch == 0x0A || ch == 0x0D) {
+            eol = true;
+        }
+
+        return intChar;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return 0;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public int read(byte[] bytes, int off, int len) throws IOException {
+        if (bytes == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || off > bytes.length || len < 0 || off + len > bytes.length || off + len < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int c = read();
+        if (c == -1) {
+            return -1;
+        }
+        bytes[off] = (byte) c;
+
+        int i = 1;
+        try {
+            for (; i < len; i++) {
+                c = read();
+                if (c == -1) {
+                    break;
+                }
+                if (bytes != null) {
+                    bytes[off + i] = (byte) c;
+                }
+            }
+        } catch (IOException ee) {
+            ee.printStackTrace();
+        }
+        return i;
+    }
+
+    /**
+     *
+     */
+    private int startInclude() throws IOException {
+        // Mark this spot in case #include doesn't match
+        mark(MARK_LIMIT);
+
+        // We have a line beginning w/ '#', verify we have "#include"
+        int ch;
+        for (int count = 0; count < INCLUDE_LEN; count++) {
+            // look for include
+            ch = super.read();
+            if (Character.toLowerCase((char) ch) != INCLUDE.charAt(count)) {
+                reset(); // Restore stream position
+                return '#';
+            }
+        }
+
+        // Skip whitespace...
+        ch = super.read();
+        while (ch == ' ' || ch == '\t') {
+            ch = super.read();
+        }
+
+        // Skip '"' or '\''
+        if (ch == '"' || ch == '\'') {
+            ch = super.read();
+        }
+
+        // Read the file name
+        StringBuffer buf = new StringBuffer("");
+        while (ch != '"' && ch != '\'' && ch != 0x0A && ch != 0x0D && ch != -1) {
+            buf.append((char) ch);
+            ch = super.read();
+        }
+
+        // Skip ending '"' or '\'', if any
+        if (ch == '"' || ch == '\'') {
+            ch = super.read();
+        }
+
+        // Get the file name...
+        String filename = buf.toString();
+
+        // Look for the file
+        URL url = FileUtil.searchForFile(filename, null);
+        if (url != null) {
+            redirStream = new IncludeInputStream(new BufferedInputStream(url.openStream()));
+        } else {
+            // Throw a FnF exception...
+            throw new FileNotFoundException(filename);
+        }
+
+        // Read the first character from the file to return
+        return redirStream.read();
+    }
+
+    /**
+     * <p>
+     * Simple test case (requires a test file).
+     * </p>
+     */
+    public static void main(String[] args) {
+        try {
+            IncludeInputStream stream = new IncludeInputStream(new FileInputStream(args[0]));
+            int ch = '\n';
+            while (ch != -1) {
+                System.out.print((char) ch);
+                ch = stream.read();
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private boolean eol = true;
+    private IncludeInputStream redirStream = null;
+
+    private static final String INCLUDE = "include";
+    private static final int INCLUDE_LEN = INCLUDE.length();
+
+    private static final int MARK_LIMIT = 128;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/LayoutElementUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/LayoutElementUtil.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+import com.sun.jsftemplating.layout.descriptors.LayoutFacet;
+
+import jakarta.faces.context.FacesContext;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * <p>
+ * This class is a utility class for misc {@link LayoutElement} related tasks.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LayoutElementUtil {
+
+    /**
+     * <p>
+     * This method determines if the given {@link LayoutElement} is inside a {@link LayoutComponent}. It will look at all
+     * the parents, if any of them are {@link LayoutComponent} instances, this method will return <code>true</code>.
+     * </p>
+     *
+     * @param elt The {@link LayoutElement} to check.
+     *
+     * @return true If a {@link LayoutComponent} exists as an ancestor.
+     */
+    public static boolean isNestedLayoutComponent(LayoutElement elt) {
+        return getParentLayoutComponent(elt) != null;
+    }
+
+    /**
+     * <p>
+     * This method returns the nearest {@link LayoutComponent} that contains the given {@link LayoutElement}, null if none.
+     * </p>
+     *
+     * @param elt The {@link LayoutElement} to start with.
+     *
+     * @return The containing {@link LayoutComponent} if one exists.
+     */
+    public static LayoutComponent getParentLayoutComponent(LayoutElement elt) {
+        elt = elt.getParent();
+        while (elt != null) {
+            if (elt instanceof LayoutComponent) {
+                return (LayoutComponent) elt;
+            }
+            elt = elt.getParent();
+        }
+        return null;
+    }
+
+    /**
+     * <p>
+     * This method returns true if any of the parent {@link LayoutElement}s are {@link LayoutComponent}s. If a
+     * {@link LayoutFacet} is encountered first, false is automatically returned. This method is specific to processing
+     * needed for creating a {@link LayoutComponent}. Do not use this for general cases when you need to find if a
+     * {@link LayoutElement} is embedded within a {@link LayoutComponent} (which should ignore {@link LayoutFacet}
+     * elements).
+     * </p>
+     *
+     * @param elt The {@link LayoutElement} to check.
+     *
+     * @return true if it has a {@link LayoutComponent} ancestor.
+     */
+    public static boolean isLayoutComponentChild(LayoutElement elt) {
+        elt = elt.getParent();
+        while (elt != null) {
+            if (elt instanceof LayoutComponent) {
+                // Make sure we are in a LayoutComponent and not an "if",
+                // "while", or something like that
+                if (elt.getClass().getName().equals(LayoutComponent.CLASS_NAME)) {
+                    // This is a real LayoutComponent, return true
+                    return true;
+                }
+
+                // This isn't a LC, however, we need to count it as such if
+                // there is any LC parent (even if we encounter a LayoutFacet
+                // first)
+                return isNestedLayoutComponent(elt);
+            } else if (elt instanceof LayoutFacet) {
+                // Don't consider it a child if it is a facet
+                return false;
+            }
+            elt = elt.getParent();
+        }
+
+        // Not found
+        return false;
+    }
+
+    /**
+     * <p>
+     * This method produces a generated ID. It optionally uses the given base as a prefix to the generated ID
+     * ({@link #DEFAULT_ID_BASE} is used otherwise). Do not depend on this implementation, it may change in the future.
+     * </p>
+     *
+     * <p>
+     * Since this implementation increments the number each call, it may not produce reproducible results. You should pass
+     * in your own number to use, see {@link #getGeneratedId(String, int)}. JSFT makes an effort to cause generated ids to
+     * be reproducible accross requests, but it is not guarenteed (particularly in highly dynamic pages in development
+     * mode).
+     * </p>
+     */
+    public static String getGeneratedId(String base) {
+        return getGeneratedId(base, incHighestId(_highId));
+    }
+
+    /**
+     * <p>
+     * This method produces a generated ID. It optionally uses the given base as a prefix to the generated ID
+     * ({@link #DEFAULT_ID_BASE} is used otherwise). This implementation will generate an id that contains the given number.
+     * Do not depend result of this this implementation, it may change in the future.
+     * </p>
+     *
+     * <p>
+     * This method replaces illegal characters (all non alpha characters) with an '_'.
+     * </p>
+     *
+     * @param base Prefix to use in the id.
+     * @param num Number to use in the id.
+     */
+    public static String getGeneratedId(String base, int num) {
+        if (base == null) {
+            base = DEFAULT_ID_BASE;
+        } else {
+            base = base.trim();
+            if (base.equals("")) {
+                base = DEFAULT_ID_BASE;
+            } else {
+                StringBuffer buf = new StringBuffer();
+                int lowch;
+                for (int ch : base.toCharArray()) {
+                    lowch = ch | 0x20;
+                    if (lowch >= 'a' && lowch <= 'z') {
+                        buf.append((char) ch);
+                    } else {
+                        buf.append('_');
+                    }
+                }
+                base = buf.toString();
+            }
+        }
+        return base + num;
+    }
+
+    /**
+     * <p>
+     * This method returns the next id that has not been used.
+     * </p>
+     */
+    public static int getStartingIdNumber(FacesContext ctx, String key) {
+        if (ctx == null) {
+            // Make sure we have the FacesContext...
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, Integer> startMap = null;
+        if (ctx != null) {
+            // Check Application Scope for the Map...
+            startMap = (Map<String, Integer>) ctx.getExternalContext().getApplicationMap().get(ID_IDX_MAP);
+        }
+        if (startMap == null) {
+            // Not found, 1st time... create / initialize it
+            startMap = new ConcurrentHashMap<>(50, 0.75f, 3);
+            if (ctx != null) {
+                // Save for later
+                ctx.getExternalContext().getApplicationMap().put(ID_IDX_MAP, startMap);
+            }
+        }
+
+        // Now look for the desired start key...
+        Integer start = startMap.get(key);
+        if (start == null) {
+            // Save for later
+// FIXME: Why do I need _highId?  Isn't key+0 good enough?
+            start = incHighestId(_highId);
+            startMap.put(key, start);
+        }
+
+        // Return the answer...
+        return start;
+    }
+
+    /**
+     * <p>
+     * This method ensures the highest id is higher than the given int.
+     * </p>
+     */
+    public static synchronized int incHighestId(int num) {
+        if (num >= _highId) {
+            _highId = num + 1;
+        }
+        return _highId;
+    }
+
+    /**
+     * <p>
+     * This method checks to see if the given <code>component</code> is sitting inside a facet or not. If it is, it will use
+     * the facet name for its id so that it will be found correctly. However, if the facet tag exists outside a component,
+     * then it is not a facet -- its a place holder for a facet. In this case it will not use the id of the place holder.
+     * </p>
+     */
+    public static void checkForFacetChild(LayoutElement parent, LayoutComponent component) {
+        // Figure out if this should be stored as a facet, if so under what id
+        if (!LayoutElementUtil.isLayoutComponentChild(component)) {
+            // Need to add this so that it has the correct facet name
+            // Check to see if this LayoutComponent is inside a LayoutFacet
+            String id = component.getUnevaluatedId();
+            while (parent != null) {
+                if (parent instanceof LayoutFacet) {
+                    // Inside a LayoutFacet, use its id... only if this facet
+                    // is a child of a LayoutComponent (otherwise, it is a
+                    // layout facet used for layout, not for defining a facet
+                    // of a UIComponent)
+                    if (LayoutElementUtil.isLayoutComponentChild(parent)) {
+                        id = parent.getUnevaluatedId();
+                    }
+                    break;
+                }
+                parent = parent.getParent();
+            }
+
+            // Set the facet name
+            component.addOption(LayoutComponent.FACET_NAME, id);
+        }
+    }
+
+    /**
+     * <p>
+     * This method recurses through the {@link LayoutElement} tree to generate a String representation of its structure.
+     * </p>
+     */
+    public static void dumpTree(LayoutElement elt, StringBuffer buf, String indent) {
+        // First add the current LayoutElement
+        String compInfo = "";
+        if (elt instanceof LayoutComponent) {
+            LayoutComponent comp = (LayoutComponent) elt;
+            compInfo = " nested=" + comp.isNested();
+        } else if (elt instanceof LayoutFacet) {
+            compInfo = " isRendered=" + ((LayoutFacet) elt).isRendered();
+        }
+        buf.append(indent + elt.getUnevaluatedId() + " (" + elt.getClass().getName() + ")" + compInfo + "\n");
+
+        // Children...
+        Iterator<LayoutElement> it = elt.getChildLayoutElements().iterator();
+        if (it.hasNext()) {
+            while (it.hasNext()) {
+                dumpTree(it.next(), buf, indent + "    ");
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Application scope key for the id index <code>Map</code>.
+     * </p>
+     */
+    private static final String ID_IDX_MAP = "__jsft_ID_Index_Map";
+
+    // May need to make this application-scoped...
+    private static int _highId = 0;
+
+    public static final String DEFAULT_ID_BASE = "id";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/LogUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/LogUtil.java
@@ -1,0 +1,1056 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>
+ * This class provides helper methods for logging messages. It uses standard J2SE logging. However, using these API's is
+ * abstracts this away from our code in case we want to go back to Apache commons logging or some other logging API in
+ * the future.
+ * </p>
+ *
+ * <p>
+ * The logging levels follow the J2SE log level names, they are as follows:
+ * </p>
+ *
+ * <ul>
+ * <li>FINEST -- Highly detailed tracing message</li>
+ * <li>FINER -- Fairly detailed tracing message</li>
+ * <li>FINE -- Coarse tracing message</li>
+ * <li>CONFIG -- Static configuration messages</li>
+ * <li>INFO -- Informational messages (logged by default)</li>
+ * <li>WARNING -- Potentially problematic messages</li>
+ * <li>SEVERE -- Serious failure messages</li>
+ * </ul>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class LogUtil {
+
+    ////////////////////////////////////////////////////////////
+    // FINEST LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finestEnabled() {
+        return getLogger().isLoggable(Level.FINEST);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finestEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.FINEST);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finest(String msgId, Object... params) {
+        getLogger().log(Level.FINEST, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finest(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.FINEST, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finest(String msg) {
+        finest(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finest(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.FINEST, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finest(String msg, Throwable ex) {
+        getLogger().log(Level.FINEST, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finest(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.FINEST, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // FINER LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finerEnabled() {
+        return getLogger().isLoggable(Level.FINER);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean finerEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.FINER);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finer(String msgId, Object... params) {
+        getLogger().log(Level.FINER, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void finer(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.FINER, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finer(String msg) {
+        finer(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void finer(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.FINER, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finer(String msg, Throwable ex) {
+        getLogger().log(Level.FINER, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void finer(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.FINER, DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msg, ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // FINE LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean fineEnabled() {
+        return getLogger().isLoggable(Level.FINE);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean fineEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.FINE);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void fine(String msgId, Object... params) {
+        getLogger().log(Level.FINE, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void fine(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.FINE, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void fine(String msg) {
+        fine(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void fine(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.FINE, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void fine(String msg, Throwable ex) {
+        getLogger().log(Level.FINE, getMessage(msg, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void fine(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.FINE, getMessage(msg, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // CONFIG LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean configEnabled() {
+        return getLogger().isLoggable(Level.CONFIG);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean configEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.CONFIG);
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void config(String msgId, Object... params) {
+        getLogger().log(Level.CONFIG, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void config(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.CONFIG, getMessage(msgId, params, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg.
+     * </p>
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void config(String msg) {
+        config(DEFAULT_LOGGER, msg);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized or non-localized message. This method will first attempt to find
+     * <code>msg</code> in the properties file, if not found it will print the given msg. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message (or <code>ResourceBundle</code> key).
+     */
+    public static void config(Object loggerId, String msg) {
+        getLogger(loggerId).log(Level.CONFIG, getMessage(msg, false));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message.
+     * </p>
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void config(String msg, Throwable ex) {
+        getLogger().log(Level.CONFIG, getMessage(msg, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msg The message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     */
+    public static void config(Object loggerId, String msg, Throwable ex) {
+        getLogger(loggerId).log(Level.CONFIG, getMessage(msg, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // INFO LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean infoEnabled() {
+        return getLogger().isLoggable(Level.INFO);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean infoEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.INFO);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The default Logger will be used.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(String msgId) {
+        getLogger().log(Level.INFO, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(Object loggerId, String msgId) {
+        getLogger(loggerId).log(Level.INFO, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(String msgId, Object... params) {
+        getLogger().log(Level.INFO, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.INFO, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(String msgId, Throwable ex) {
+        getLogger().log(Level.INFO, getMessage(msgId, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void info(Object loggerId, String msgId, Throwable ex) {
+        getLogger(loggerId).log(Level.INFO, getMessage(msgId, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // WARNING LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean warningEnabled() {
+        return getLogger().isLoggable(Level.WARNING);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean warningEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.WARNING);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The default Logger will be used.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(String msgId) {
+        getLogger().log(Level.WARNING, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(Object loggerId, String msgId) {
+        getLogger(loggerId).log(Level.WARNING, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(String msgId, Object... params) {
+        getLogger().log(Level.WARNING, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.WARNING, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(String msgId, Throwable ex) {
+        getLogger().log(Level.WARNING, getMessage(msgId, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void warning(Object loggerId, String msgId, Throwable ex) {
+        getLogger(loggerId).log(Level.WARNING, getMessage(msgId, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // SEVERE LOGGING METHODS
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the default logger.
+     * </p>
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean severeEnabled() {
+        return getLogger().isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * <p>
+     * Method to check if this log level is enabled for the given logger.
+     * </p>
+     *
+     * @param loggerId The logger to check. This may be specified as a String or Class Object.
+     *
+     * @return true if the log level is enabled, false otherwise.
+     */
+    public static boolean severeEnabled(Object loggerId) {
+        return getLogger(loggerId).isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The default Logger will be used.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(String msgId) {
+        getLogger().log(Level.SEVERE, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a simple localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(Object loggerId, String msgId) {
+        getLogger(loggerId).log(Level.SEVERE, getMessage(msgId, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key and zero or more substitution parameters. It will use the default
+     * Logger.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(String msgId, Object... params) {
+        getLogger().log(Level.SEVERE, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method supporting a localized message key, zero or more substitution parameters, and the ability to specify
+     * the Logger.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param params Value(s) to substitute into the message.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(Object loggerId, String msgId, Object... params) {
+        getLogger(loggerId).log(Level.SEVERE, getMessage(msgId, params, true));
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message.
+     * </p>
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(String msgId, Throwable ex) {
+        getLogger().log(Level.SEVERE, getMessage(msgId, false), ex);
+    }
+
+    /**
+     * <p>
+     * Logging method to log a <code>Throwable</code> with a localized message. The specified Logger will be used.
+     * </p>
+     *
+     * @param loggerId The logger to use. This may be specified as a String or Class Object.
+     *
+     * @param msgId The <code>ResourceBundle</code> key used to lookup the message.
+     *
+     * @param ex The <code>Throwable</code> to log.
+     *
+     * @see LogUtil#BUNDLE_NAME
+     */
+    public static void severe(Object loggerId, String msgId, Throwable ex) {
+        getLogger(loggerId).log(Level.SEVERE, getMessage(msgId, false), ex);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Misc methods
+    ////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * This method provides direct access to the default Logger. It is private because the internals of what type of logger
+     * is being used should not be exposed outside this class.
+     * </p>
+     */
+    private static Logger getLogger() {
+        return DEFAULT_LOGGER;
+    }
+
+    /**
+     * <p>
+     * This method provides direct access to the Logger. It is private because the internals of what type of logger is being
+     * used should not be exposed outside this class.
+     * </p>
+     *
+     * <p>
+     * This method will return the default logger (if INFO), or delegate to {@link #getLogger(String)} or
+     * {@link #getLogger(Class)}.
+     * </p>
+     *
+     * @param key The logger to use as specified by the Object.
+     */
+    private static Logger getLogger(Object key) {
+        // If null, use default
+        if (key == null) {
+            return getLogger();
+        }
+
+        // If string, use it as logger name
+        if (key instanceof String) {
+            return getLogger((String) key);
+        }
+
+        // If Log, return it
+        if (key instanceof Logger) {
+            return (Logger) key;
+        }
+
+        // If class, use it
+        if (key instanceof Class) {
+            return getLogger((Class) key);
+        }
+
+        // else, use the class name
+        return getLogger(key.getClass());
+    }
+
+    /**
+     * <p>
+     * This method provides direct access to the Logger. It is private because the internals of what type of logger is being
+     * used should not be exposed outside this class.
+     * </p>
+     *
+     * @param key The logger to use as specified by the String.
+     */
+    private static Logger getLogger(String key) {
+        if (key.trim().length() == 0) {
+            return DEFAULT_LOGGER;
+        }
+        return Logger.getLogger(key);
+    }
+
+    /**
+     * <p>
+     * This method provides direct access to the Logger. It is private because the internals of what type of logger is being
+     * used should not be exposed outside this class.
+     * </p>
+     *
+     * @param key The logger to use as specified by the Class.
+     */
+    private static Logger getLogger(Class key) {
+        if (key == null) {
+            return DEFAULT_LOGGER;
+        }
+        return Logger.getLogger(key.getName());
+    }
+
+    /**
+     * <p>
+     * This method gets the appropriate message to display. It will attempt to resolve it from the
+     * <code>ResourceBundle</code>. If not found and it will either use the message id as the key, or it will return an
+     * error message depending on whether <code>strict</code> is true or false.
+     * </p>
+     *
+     * @param msgId The message key
+     * @param strict True if key not found should be an error
+     *
+     * @return The message to write to the log file.
+     */
+    private static String getMessage(String msgId, boolean strict) {
+        return getMessage(msgId, new Object[0], strict);
+    }
+
+    /**
+     * <p>
+     * This method gets the appropriate message to display. It will attempt to resolve it from the
+     * <code>ResourceBundle</code>. If not found and it will either use the message id as the key, or it will return an
+     * error message depending on whether <code>strict</code> is true or false.
+     * </p>
+     *
+     * @param msgId The message key
+     * @param params The parameters
+     * @param strict True if key not found should be an error
+     *
+     * @return The message to write to the log file.
+     */
+    private static String getMessage(String msgId, Object[] params, boolean strict) {
+        String result = MessageUtil.getInstance().getMessage(BUNDLE_NAME, msgId, params);
+        if (result == null || result.equals(msgId)) {
+            // We didn't find the key...
+            if (strict) {
+                // A key is required, return an error message
+                if (msgId != null && msgId.equals(KEY_NOT_FOUND_KEY)) {
+                    // This is here to prevent and infinite loop
+                    result = KEY_NOT_FOUND_KEY + LOG_KEY_MESSAGE_SEPARATOR + "'" + params[0] + "' not found in ResourceBundle: '"
+                            + BUNDLE_NAME + "'";
+                } else {
+                    result = getMessage(KEY_NOT_FOUND_KEY, new Object[] { msgId }, strict);
+                }
+            } else {
+                // Use the msgId as the message, use the default key
+                result = DEFAULT_LOG_KEY + LOG_KEY_MESSAGE_SEPARATOR + msgId;
+            }
+        } else {
+            // We found the key, construct the log format...
+            result = msgId + LOG_KEY_MESSAGE_SEPARATOR + result;
+        }
+
+        // Return the formatted result
+        return result;
+    }
+
+    /**
+     * <p>
+     * This is the bundle name for the <code>ResourceBundle</code> that contains all the message strings.
+     * </p>
+     */
+    public static final String BUNDLE_NAME = "com.sun.jsftemplating.resource.LogMessages";
+
+    /**
+     * <p>
+     * This is the default log key.
+     * </p>
+     */
+    public static final String DEFAULT_LOG_KEY = "JSFT0001";
+
+    /**
+     * <p>
+     * This is the default logger name.
+     * </p>
+     */
+    public static final String DEFAULT_LOGGER_NAME = "com.sun.jsftemplating";
+
+    /**
+     * <p>
+     * This key is used when the requested key is not found to inform the developer they forgot to add a key.
+     * </p>
+     */
+    public static final String KEY_NOT_FOUND_KEY = "JSFT0002";
+
+    /**
+     * <p>
+     * The default Logger.
+     * </p>
+     */
+    private static final Logger DEFAULT_LOGGER = getLogger(DEFAULT_LOGGER_NAME);
+
+    /**
+     * <p>
+     * This is the separator between the the log key and log message.
+     * </p>
+     */
+    private static final String LOG_KEY_MESSAGE_SEPARATOR = ": ";
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/MessageUtil.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/MessageUtil.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import com.sun.jsftemplating.resource.ResourceBundleManager;
+
+import jakarta.faces.context.FacesContext;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+/**
+ * <p>
+ * This class gets ResourceBundle messages and formats them.
+ * </p>
+ *
+ * @author Ken Paulsen
+ */
+public class MessageUtil extends Object {
+
+    /**
+     * <p>
+     * This class should not be instantiated directly.
+     * </p>
+     */
+    private MessageUtil() {
+    }
+
+    /**
+     * <p>
+     * Use this to get an instance of this class.
+     * </p>
+     */
+    public static MessageUtil getInstance() {
+        return _instance;
+    }
+
+    /**
+     * <p>
+     * This method returns a formatted String from the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param baseName The <code>ResourceBundle</code> name.
+     * @param key The <code>ResourceBundle</code> key.
+     */
+    public String getMessage(String baseName, String key) {
+        return getMessage(baseName, key, null);
+    }
+
+    /**
+     * <p>
+     * This method returns a formatted String from the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param baseName The <code>ResourceBundle</code> name.
+     * @param key The <code>ResourceBundle</code> key.
+     * @param args The substitution values (may be null).
+     */
+    public String getMessage(String baseName, String key, Object args[]) {
+        return getMessage(null, baseName, key, args);
+    }
+
+    /**
+     * <p>
+     * This method returns a formatted String from the requested <code>ResourceBundle</code>.
+     * </p>
+     *
+     * @param locale The desired <code>Locale</code> (may be null).
+     * @param baseName The <code>ResourceBundle</code> name.
+     * @param key The <code>ResourceBundle</code> key.
+     * @param args The substitution values (may be null).
+     */
+    public String getMessage(Locale locale, String baseName, String key, Object args[]) {
+        if (key == null) {
+            return null;
+        }
+        if (baseName == null) {
+            throw new RuntimeException("'baseName' is null for key '" + key + "'!");
+        }
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (locale == null) {
+            locale = Util.getLocale(ctx);
+        }
+
+        // Get the ResourceBundle
+        ResourceBundle bundle = ResourceBundleManager.getInstance(ctx).getBundle(baseName, locale);
+        if (bundle == null) {
+            // FIXME: Log a warning
+            return key;
+        }
+
+        String message = null;
+        try {
+            message = bundle.getString(key);
+        } catch (MissingResourceException ex) {
+            // Key not found!
+            // FIXME: Log a warning
+        }
+        if (message == null) {
+            // No message found?
+            return key;
+        }
+
+        return getFormattedMessage(message, args);
+    }
+
+    /**
+     * Format message using given arguments.
+     *
+     * @param message The string used as a pattern for inserting arguments.
+     * @param args The arguments to be inserted into the string.
+     */
+    public static String getFormattedMessage(String message, Object args[]) {
+        // Sanity Check
+        if (message == null || args == null || args.length == 0) {
+            return message;
+        }
+
+        String result = null;
+
+        MessageFormat mf = new MessageFormat(message);
+        result = mf.format(args);
+
+        return result != null ? result : message;
+    }
+
+    /**
+     * <p>
+     * Singleton. This one is OK to share across VMs (no state).
+     * </p>
+     */
+    private static final MessageUtil _instance = new MessageUtil();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/SimplePatternMatcher.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/SimplePatternMatcher.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * <p>
+ * This class provides the implementation of a simple PatternMatcher and a static utility-method to create an array of
+ * SimplePatternMatchers from a comma separated String.
+ * </p>
+ *
+ * @author Imre O&szlig;wald (ioss@emx.jevelopers.com)
+ */
+
+public class SimplePatternMatcher {
+
+    private Pattern regexPattern = null;
+
+    private String pattern;
+
+    private String prepared;
+
+    private Mode mode;
+
+    private enum Mode {
+        SIMPLEREGEX, PREFIX, SUFFIX, EXACT
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final Collection<SimplePatternMatcher> EMPTY_PATTERN_COLLECTION = Collections.EMPTY_LIST;
+
+    /**
+     * Constructor.
+     *
+     * @param pattern a single pattern against which this instance should match.
+     * @throws PatternSyntaxException if the pattern could not be compiled.
+     */
+    public SimplePatternMatcher(final String pattern) {
+
+        this.pattern = pattern.trim();
+        if (this.pattern.length() > 0) {
+            if (!pattern.contains("?")) {
+                if (pattern.lastIndexOf('*') == 0) {
+                    this.mode = Mode.SUFFIX;
+                    this.prepared = pattern.substring(1);
+                } else if (pattern.indexOf('*') == pattern.length() - 1) {
+                    this.mode = Mode.PREFIX;
+                    this.prepared = pattern.substring(0, pattern.length() - 1);
+                } else if (pattern.indexOf('*') == -1) {
+                    this.mode = Mode.EXACT;
+                }
+            }
+            if (this.mode == null) {
+                this.mode = Mode.SIMPLEREGEX;
+
+                final String regex = SimplePatternMatcher.regexify(pattern);
+                // TODO: catch the possible PatternSyntaxException and provide a
+                // "non-regex" Exception and message
+                this.regexPattern = Pattern.compile(regex);
+            }
+        }
+    }
+
+    /**
+     * splits a delimiter separated <code>String</code> into a <code>Collection</code> of
+     * <code>SimplePatternMatcher</code>s. If the provided String is <code>null</code> or empty, an empty Collection is
+     * returned. If after splitting the provided <code>String</code> a part is <em>empty</em> the part will be ignored. ( So
+     * ";;;;;;" will result in an empty Collection being returned. )
+     *
+     * @param multiplePatterns the String to split
+     * @param delimiter the delimiter to split the multiplePatterns at.
+     * @return Collection of SimplePatternMatchers
+     */
+    public static Collection<SimplePatternMatcher> parseMultiPatternString(final String multiplePatterns, final String delimiter) {
+        if (multiplePatterns == null || multiplePatterns.trim().length() == 0) {
+            return EMPTY_PATTERN_COLLECTION;
+        }
+        final String[] patterns = multiplePatterns.split(delimiter);
+        final List<SimplePatternMatcher> result = new ArrayList<>();
+        for (String pattern : patterns) {
+            pattern = pattern.trim();
+            if (pattern.length() == 0) {
+                continue;
+            }
+            final SimplePatternMatcher matcher = new SimplePatternMatcher(pattern);
+            result.add(matcher);
+        }
+        return result;
+    }
+
+    /**
+     * <p>
+     * tests if the provided input matches this pattern. If the input is <code>null</code> this method will return
+     * <code>false</code>
+     * </p>
+     *
+     * @param input the String to match against.
+     * @return true if the input matches this pattern, false otherwise.
+     */
+    public boolean matches(final String input) {
+        if (input == null) {
+            return false;
+        }
+        if (this.pattern.length() == 0) {
+            return true;
+        }
+        switch (this.mode) {
+        case PREFIX:
+            return this.prepared.length() == 0 || input.startsWith(this.prepared);
+        case SUFFIX:
+            return input.endsWith(this.prepared);
+        case EXACT:
+            return input.equals(this.pattern);
+        case SIMPLEREGEX:
+            return this.regexPattern.matcher(input).matches();
+        default:
+            // should not happen
+            throw new IllegalStateException("Unknown Mode: " + this.mode);
+        }
+    }
+
+    /**
+     * Default Constructor.
+     */
+    protected SimplePatternMatcher() {
+    }
+
+    /**
+     * translates a 'simple' pattern String into a regular expression.
+     *
+     * @param pattern the 'simple' pattern to translate
+     * @return the translation
+     */
+    public static String regexify(final CharSequence pattern) {
+        if (pattern == null) {
+            throw new NullPointerException("Pattern may not be null");
+        }
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0, len = pattern.length(); i < len; i++) {
+            final char c = pattern.charAt(i);
+            switch (c) {
+            case '.':
+                sb.append("\\.");
+                break;
+            case '*':
+                sb.append("(.*)");
+                break;
+            case '?':
+                sb.append('.');
+                break;
+            default:
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "SimplePatternMatcher: " + this.pattern + " in mode " + this.mode;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/Tuple.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/Tuple.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ * @author Jason CTR Lee
+ */
+public class Tuple {
+    private List<Object> elements = new ArrayList<>();
+
+    public Tuple(Object... elements) {
+        for (Object element : elements) {
+            this.elements.add(element);
+        }
+    }
+
+    public Object getElement(int index) {
+        return elements.get(index);
+    }
+
+    public List<Object> getElements() {
+        return Collections.unmodifiableList(elements);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/TypeConversion.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/TypeConversion.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+/**
+ * <p>
+ * An object that can convert a value to a different type.
+ * </p>
+ *
+ * @author Todd Fast, todd.fast@sun.com
+ * @author Mike Frisino, michael.frisino@sun.com
+ */
+public interface TypeConversion {
+
+    /**
+     * <p>
+     * Converts the provided value to the type represented by the implementor if this interface.
+     * </p>
+     */
+    Object convertValue(Object value);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/TypeConverter.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/TypeConverter.java
@@ -1,0 +1,1061 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import jakarta.faces.context.FacesContext;
+
+import java.math.BigDecimal;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Provides an efficient and robust mechanism for converting an object to a different type. For example, one can convert
+ * a <code>String</code> to an <code>Integer</code> using the <code>TypeConverter</code> like this:
+ *
+ * <pre>
+ * Integer i = (Integer) TypeConverter.asType(Integer.class, "123");
+ * </pre>
+ *
+ * or using the shortcut method:
+ *
+ * <pre>
+ * int i = TypeConverter.asInt("123");
+ * </pre>
+ *
+ * The <code>TypeConverter</code> comes ready to convert all the primitive types, plus a few more like
+ * <code>java.sql.Date</code> and <code>
+ * java.math.BigDecimal</code>.
+ * <p>
+ *
+ * The conversion process has been optimized so that it is now a constant time operation (aside from the conversion
+ * itself, which may vary). Because of this optimization, it is possible to register classes that implement the new
+ * <code>TypeConversion</code> interface for conversion to a custom type. For example, this means that you can define a
+ * class to convert arbitrary objects to type <code>Foo</code>, and register it for use throughout the VM:
+ *
+ * <pre>
+ *    TypeConversion fooConversion = new FooTypeConversion();
+ *    TypeConverter.registerTypeConversion(Foo.class, fooConversion);
+ *    ...
+ *    Bar bar = new Bar();
+ *    Foo foo = (Foo) TypeConverter.asType(Foo.class, bar);
+ *    ...
+ *    String s = "bar";
+ *    Foo foo = (Foo) TypeConverter.asType(Foo.class, s);
+ * </pre>
+ *
+ * The TypeConverter allows specification of an arbitrary <i>type key</i> in the <code>registerTypeConversion()</code>
+ * and <code>asType()</code> methods, so one can simultaneously register a conversion object under a <code>
+ * Class</code> object, a class name, and a logical type name. For example, the following are valid ways of converting a
+ * string to an <code>int</code> using <code>TypeConverter</code>:
+ *
+ * <pre>
+ * Integer i = (Integer) TypeConverter.asType(Integer.class, "123");
+ * Integer i = (Integer) TypeConverter.asType("java.lang.Integer", "123");
+ * Integer i = (Integer) TypeConverter.asType(TypeConverter.TYPE_INT, "123");
+ * Integer i = (Integer) TypeConverter.asType(TypeConverter.TYPE_INTEGER, "123");
+ * Integer i = (Integer) TypeConverter.asType("int", "123");
+ * Integer i = (Integer) TypeConverter.asType("integer", "123");
+ * int i = TypeConverter.asInt("123");
+ * </pre>
+ *
+ * Default type conversions have been registered under the following keys:
+ *
+ * <pre>
+ *    Classes:
+ *        java.lang.Object
+ *        java.lang.String
+ *        java.lang.Integer
+ *        java.lang.Integer.TYPE (int)
+ *        java.lang.Double
+ *        java.lang.Double.TYPE (double)
+ *        java.lang.Boolean
+ *        java.lang.Boolean.TYPE (boolean)
+ *        java.lang.Long
+ *        java.lang.Long.TYPE (long)
+ *        java.lang.Float
+ *        java.lang.Float.TYPE (float)
+ *        java.lang.Short
+ *        java.lang.Short.TYPE (short)
+ *        java.lang.Byte
+ *        java.lang.Byte.TYPE (byte)
+ *        java.lang.Character
+ *        java.lang.Character.TYPE (char)
+ *        java.math.BigDecimal
+ *        java.sql.Date
+ *        java.sql.Time
+ *        java.sql.Timestamp
+ *              java.util.Locale
+ *
+ *    Class name strings:
+ *        "java.lang.Object"
+ *        "java.lang.String"
+ *        "java.lang.Integer"
+ *        "java.lang.Double"
+ *        "java.lang.Boolean"
+ *        "java.lang.Long"
+ *        "java.lang.Float"
+ *        "java.lang.Short"
+ *        "java.lang.Byte"
+ *        "java.lang.Character"
+ *        "java.math.BigDecimal"
+ *        "java.sql.Date"
+ *        "java.sql.Time"
+ *        "java.sql.Timestamp"
+ *              "java.util.Locale"
+ *
+ *    Logical type name string constants:
+ *        TypeConverter.TYPE_UNKNOWN ("null")
+ *        TypeConverter.TYPE_OBJECT ("object")
+ *        TypeConverter.TYPE_STRING ("string")
+ *        TypeConverter.TYPE_INT ("int")
+ *        TypeConverter.TYPE_INTEGER ("integer")
+ *        TypeConverter.TYPE_DOUBLE ("double")
+ *        TypeConverter.TYPE_BOOLEAN ("boolean")
+ *        TypeConverter.TYPE_LONG ("long")
+ *        TypeConverter.TYPE_FLOAT ("float")
+ *        TypeConverter.TYPE_SHORT ("short")
+ *        TypeConverter.TYPE_BYTE ("byte")
+ *        TypeConverter.TYPE_CHAR ("char")
+ *        TypeConverter.TYPE_CHARACTER ("character")
+ *        TypeConverter.TYPE_BIG_DECIMAL ("bigdecimal")
+ *        TypeConverter.TYPE_SQL_DATE ("sqldate")
+ *        TypeConverter.TYPE_DATE ("date")
+ *        TypeConverter.TYPE_SQL_TIME ("sqltime")
+ *        TypeConverter.TYPE_SQL_TIMESTAMP ("sqltimestamp")
+ *              TypeConverter.TYPE_LOCALE ("locale")
+ * </pre>
+ *
+ * The <code>TypeConverter</code> treats type keys of type <code>Class</code> slightly differently than other keys. If
+ * the provided value is already of the type specified by the type key class, it is returned without a conversion taking
+ * place. For example, a value of type <code>MySub</code> that extends the class <code>MySuper</code> would not be
+ * converted in the following situation because it is already of the necessary type:
+ *
+ * <pre>
+ * MySub o = (MySub) TypeConverter.asType(MySuper.class, mySub);
+ * </pre>
+ *
+ * Be warned that although the type conversion infrastructure in this class is desgned to add only minimal overhead to
+ * the conversion process, conversion of an object to another type is a potentially expensive operation and should be
+ * used with discretion.
+ *
+ * @see TypeConversion
+ * @author Todd Fast, todd.fast@sun.com
+ * @author Mike Frisino, michael.frisino@sun.com
+ * @author Ken Paulsen, ken.paulsen@sun.com (stripped down)
+ * @author Jason Lee, jason@steeplesoft.com
+ */
+public class TypeConverter extends Object {
+
+    /**
+     * <p>
+     * Cannot instantiate.
+     * </p>
+     */
+    private TypeConverter() {
+        super();
+    }
+
+    /**
+     * <p>
+     * Returns the <code>Map</code> of {@link TypeConversion} objects registered for this application. The keys for the
+     * values in this <code>Map</code> may be arbitrary objects, the values are of type {@link TypeConversion}. The
+     * <code>Map</code> will be a <code>ConcurrentHashMap</code>.
+     * </p>
+     */
+    public static Map<Object, TypeConversion> getTypeConversions(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<Object, TypeConversion> conversions = null;
+        if (ctx != null) {
+            conversions = (Map<Object, TypeConversion>) ctx.getExternalContext().getApplicationMap().get(CONVERSIONS);
+        }
+        if (conversions == null) {
+            // 1st time... initialize it
+            conversions = new ConcurrentHashMap<>(80, 0.75f, 1);
+
+            // Add type conversions by class
+            conversions.put(Object.class, OBJECT_TYPE_CONVERSION);
+            conversions.put(String.class, STRING_TYPE_CONVERSION);
+            conversions.put(Integer.class, INTEGER_TYPE_CONVERSION);
+            conversions.put(Integer.TYPE, INTEGER_TYPE_CONVERSION);
+            conversions.put(Double.class, DOUBLE_TYPE_CONVERSION);
+            conversions.put(Double.TYPE, DOUBLE_TYPE_CONVERSION);
+            conversions.put(Boolean.class, BOOLEAN_TYPE_CONVERSION);
+            conversions.put(Boolean.TYPE, BOOLEAN_TYPE_CONVERSION);
+            conversions.put(Long.class, LONG_TYPE_CONVERSION);
+            conversions.put(Long.TYPE, LONG_TYPE_CONVERSION);
+            conversions.put(Float.class, FLOAT_TYPE_CONVERSION);
+            conversions.put(Float.TYPE, FLOAT_TYPE_CONVERSION);
+            conversions.put(Short.class, SHORT_TYPE_CONVERSION);
+            conversions.put(Short.TYPE, SHORT_TYPE_CONVERSION);
+            conversions.put(BigDecimal.class, BIG_DECIMAL_TYPE_CONVERSION);
+            conversions.put(Byte.class, BYTE_TYPE_CONVERSION);
+            conversions.put(Byte.TYPE, BYTE_TYPE_CONVERSION);
+            conversions.put(Character.class, CHARACTER_TYPE_CONVERSION);
+            conversions.put(Character.TYPE, CHARACTER_TYPE_CONVERSION);
+            conversions.put(java.util.Date.class, DATE_TYPE_CONVERSION);
+            conversions.put(java.sql.Date.class, SQL_DATE_TYPE_CONVERSION);
+            conversions.put(java.sql.Time.class, SQL_TIME_TYPE_CONVERSION);
+            conversions.put(java.sql.Timestamp.class, SQL_TIMESTAMP_TYPE_CONVERSION);
+            conversions.put(java.util.Locale.class, LOCALE_TYPE_CONVERSION);
+
+            // Add type conversions by class name
+            conversions.put(Object.class.getName(), OBJECT_TYPE_CONVERSION);
+            conversions.put(String.class.getName(), STRING_TYPE_CONVERSION);
+            conversions.put(Integer.class.getName(), INTEGER_TYPE_CONVERSION);
+            conversions.put(Double.class.getName(), DOUBLE_TYPE_CONVERSION);
+            conversions.put(Boolean.class.getName(), BOOLEAN_TYPE_CONVERSION);
+            conversions.put(Long.class.getName(), LONG_TYPE_CONVERSION);
+            conversions.put(Float.class.getName(), FLOAT_TYPE_CONVERSION);
+            conversions.put(Short.class.getName(), SHORT_TYPE_CONVERSION);
+            conversions.put(BigDecimal.class.getName(), BIG_DECIMAL_TYPE_CONVERSION);
+            conversions.put(Byte.class.getName(), BYTE_TYPE_CONVERSION);
+            conversions.put(Character.class.getName(), CHARACTER_TYPE_CONVERSION);
+            conversions.put(java.util.Date.class.getName(), DATE_TYPE_CONVERSION);
+            conversions.put(java.sql.Date.class.getName(), SQL_DATE_TYPE_CONVERSION);
+            conversions.put(java.sql.Time.class.getName(), SQL_TIME_TYPE_CONVERSION);
+            conversions.put(java.sql.Timestamp.class.getName(), SQL_TIMESTAMP_TYPE_CONVERSION);
+            conversions.put(java.util.Locale.class.getName(), LOCALE_TYPE_CONVERSION);
+
+            // Add type conversions by name
+            conversions.put(TYPE_UNKNOWN, UNKNOWN_TYPE_CONVERSION);
+            conversions.put(TYPE_OBJECT, OBJECT_TYPE_CONVERSION);
+            conversions.put(TYPE_STRING, STRING_TYPE_CONVERSION);
+            conversions.put(TYPE_INT, INTEGER_TYPE_CONVERSION);
+            conversions.put(TYPE_INTEGER, INTEGER_TYPE_CONVERSION);
+            conversions.put(TYPE_DOUBLE, DOUBLE_TYPE_CONVERSION);
+            conversions.put(TYPE_BOOLEAN, BOOLEAN_TYPE_CONVERSION);
+            conversions.put(TYPE_LONG, LONG_TYPE_CONVERSION);
+            conversions.put(TYPE_FLOAT, FLOAT_TYPE_CONVERSION);
+            conversions.put(TYPE_SHORT, SHORT_TYPE_CONVERSION);
+            conversions.put(TYPE_BIG_DECIMAL, BIG_DECIMAL_TYPE_CONVERSION);
+            conversions.put(TYPE_BYTE, BYTE_TYPE_CONVERSION);
+            conversions.put(TYPE_CHAR, CHARACTER_TYPE_CONVERSION);
+            conversions.put(TYPE_CHARACTER, CHARACTER_TYPE_CONVERSION);
+            conversions.put(TYPE_DATE, DATE_TYPE_CONVERSION);
+            conversions.put(TYPE_SQL_DATE, SQL_DATE_TYPE_CONVERSION);
+            conversions.put(TYPE_SQL_TIME, SQL_TIME_TYPE_CONVERSION);
+            conversions.put(TYPE_SQL_TIMESTAMP, SQL_TIMESTAMP_TYPE_CONVERSION);
+            conversions.put(TYPE_LOCALE, LOCALE_TYPE_CONVERSION);
+
+            if (ctx != null) {
+                // Save it for next time...
+                ctx.getExternalContext().getApplicationMap().put(CONVERSIONS, conversions);
+            }
+        }
+
+        // Return all the type conversions...
+        return conversions;
+    }
+
+    /**
+     * Register a type conversion object under the specified key. This method can be used by developers to register custom
+     * type conversion objects.
+     */
+    public static void registerTypeConversion(FacesContext ctx, Object key, TypeConversion conversion) {
+        getTypeConversions(ctx).put(key, conversion);
+    }
+
+    /**
+     * <p>
+     * Convert an object to the type specified by the provided type key. A type conversion object must have been previously
+     * registered under the provided key in order for the conversion to succeed (with one exception, see below).
+     * </p>
+     *
+     * <p>
+     * Note, this method treats type keys of type <code>Class</code> differently than other type keys. That is, this method
+     * will check if the provided value is the same as or a subclass of the specified class. If it is, this method returns
+     * the value object immediately without attempting to convert its type. One exception to this rule is if the provided
+     * type key is <code>Object.class</code>, in which case the conversion is attempted anyway. The reason for this
+     * deviation is that this key may have special meaning based on the type of the provided value. For example, if the
+     * provided value is a byte array, the <code>ObjectTypeConversion</code> class assumes it is a serialized object and
+     * attempts to deserialize it. Because all objects, including arrays, are of type <code>Object</code>, this conversion
+     * would never be attempted without this special handling. (Note that the default conversion for type key <code>
+     *        Object.class</code> is to simply return the original object.)
+     * </p>
+     *
+     * @param typeKey The key under which the desired type conversion object has been previously registered. Most commonly,
+     * this key should be a <code>Class</code> object, a class name string, or a logical type string represented by the
+     * various <code>TYPE_*</code> constants defined in this class.
+     *
+     * @param value The value to convert to the specified target type
+     *
+     * @return The converted value object, or <code>null</code> if the original value is <code>null</code>
+     */
+    public static Object asType(Object typeKey, Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        /*
+         * System.out.println("COERCE_TYPE: Coercing ("+value+ ")\n\tfrom "+value.getClass().getName()+
+         * "\n\tto   "+typeKey+"\n");
+         */
+
+        if (typeKey == null) {
+            return value;
+        }
+
+        // Check if the provided value is already of the target type
+        if (typeKey instanceof Class && (Class) typeKey != Object.class) {
+            if (((Class) typeKey).isInstance(value)) {
+                return value;
+            }
+        }
+
+        // Find the type conversion object
+        TypeConversion conversion = getTypeConversions(null).get(typeKey);
+
+        // Convert the value
+        if (conversion != null) {
+            return conversion.convertValue(value);
+        } else {
+            throw new IllegalArgumentException(
+                    "Could not find type conversion for " + "type \"" + typeKey + "\" (value = \"" + value + "\")");
+        }
+    }
+
+    /**
+     *
+     */
+    public static byte asByte(Object value) {
+        return asByte(value, (byte) 0);
+    }
+
+    /**
+     *
+     */
+    public static byte asByte(Object value, byte defaultValue) {
+        value = asType(Byte.class, value);
+        if (value != null) {
+            return ((Byte) value).byteValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static short asShort(Object value) {
+        return asShort(value, (short) 0);
+    }
+
+    /**
+     *
+     */
+    public static short asShort(Object value, short defaultValue) {
+        value = asType(Short.class, value);
+        if (value != null) {
+            return ((Short) value).shortValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static int asInt(Object value) {
+        return asInt(value, 0);
+    }
+
+    /**
+     *
+     */
+    public static int asInt(Object value, int defaultValue) {
+        value = asType(Integer.class, value);
+        if (value != null) {
+            return ((Integer) value).intValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static long asLong(Object value) {
+        return asLong(value, 0L);
+    }
+
+    /**
+     *
+     */
+    public static long asLong(Object value, long defaultValue) {
+        value = asType(Long.class, value);
+        if (value != null) {
+            return ((Long) value).longValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static float asFloat(Object value) {
+        return asFloat(value, 0F);
+    }
+
+    /**
+     *
+     */
+    public static float asFloat(Object value, float defaultValue) {
+        value = asType(Float.class, value);
+        if (value != null) {
+            return ((Float) value).floatValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static double asDouble(Object value) {
+        return asDouble(value, 0D);
+    }
+
+    /**
+     *
+     */
+    public static double asDouble(Object value, double defaultValue) {
+        value = asType(Double.class, value);
+        if (value != null) {
+            return ((Double) value).doubleValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static char asChar(Object value) {
+        return asChar(value, (char) 0);
+    }
+
+    /**
+     *
+     */
+    public static char asChar(Object value, char defaultValue) {
+        value = asType(Character.class, value);
+        if (value != null) {
+            return ((Character) value).charValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static boolean asBoolean(Object value) {
+        return asBoolean(value, false);
+    }
+
+    /**
+     *
+     */
+    public static boolean asBoolean(Object value, boolean defaultValue) {
+        value = asType(Boolean.class, value);
+        if (value != null) {
+            return ((Boolean) value).booleanValue();
+        }
+        return defaultValue;
+    }
+
+    /**
+     *
+     */
+    public static String asString(Object value) {
+        return (String) asType(String.class, value);
+    }
+
+    /**
+     *
+     */
+    public static String asString(Object value, String defaultValue) {
+        value = asType(String.class, value);
+        if (value != null) {
+            return (String) value;
+        }
+        return defaultValue;
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    // Inner classes
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     *
+     */
+    public static class UnknownTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class StringTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (value.getClass().isArray()) {
+                // This is a byte array; we can convert it to a string
+                if (value.getClass().getComponentType() == Byte.TYPE) {
+                    value = new String((byte[]) value, UTF8);
+                } else if (value.getClass().getComponentType() == Character.TYPE) {
+                    value = new String((char[]) value);
+                }
+            } else if (!(value instanceof String)) {
+                value = value.toString();
+            }
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class IntegerTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Integer)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Integer(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class DoubleTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Double)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Double(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class BooleanTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Boolean)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = Boolean.valueOf(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class LongTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Long)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Long(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class FloatTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Float)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Float(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class ShortTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Short)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Short(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class BigDecimalTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof BigDecimal)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new BigDecimal(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class ByteTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Byte)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Byte(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class CharacterTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof Character)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new Character(v.charAt(0));
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class SqlDateTypeConversion implements TypeConversion {
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof java.sql.Date)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    // Value must be in the "yyyy-mm-dd" format
+                    value = java.sql.Date.valueOf(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class DateTypeConversion implements TypeConversion {
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof java.util.Date)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    value = new java.util.Date(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class SqlTimeTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof java.sql.Time)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    // Value must be in the "hh:mm:ss" format
+                    value = java.sql.Time.valueOf(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class SqlTimestampTypeConversion implements TypeConversion {
+
+        /**
+         *
+         */
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+
+            if (!(value instanceof java.sql.Timestamp)) {
+                String v = value.toString();
+                if (v.trim().length() == 0) {
+                    value = null;
+                } else {
+                    // Value must be in the "yyyy-mm-dd hh:mm:ss.fffffffff"
+                    // format
+                    value = java.sql.Timestamp.valueOf(v);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class ObjectTypeConversion implements TypeConversion {
+        @Override
+        public Object convertValue(Object value) {
+            /*
+             * if (value==null) { return null; }
+             *
+             * // TODO: Decide if this is important functionality. For now just return the Object that is passed in. if
+             * (value.getClass().isArray()) { // This is a byte array; we can convert it to an object if
+             * (value.getClass().getComponentType() == Byte.TYPE) { ByteArrayInputStream bis = new
+             * ByteArrayInputStream((byte[])value); ApplicationObjectInputStream ois = null; try { ois = new
+             * ApplicationObjectInputStream(bis); value = ois.readObject(); } catch (Exception e) { throw new
+             * WrapperRuntimeException( "Could not deserialize object",e); } finally { try { if (ois != null) { ois.close(); } if
+             * (bis != null) { bis.close(); } } catch (IOException e) { // Ignore } } } else { // value is OK as is } }
+             */
+
+            return value;
+        }
+    }
+
+    /**
+     *
+     */
+    public static class LocaleTypeConversion implements TypeConversion {
+        @Override
+        public Object convertValue(Object value) {
+            if (value == null) {
+                return null;
+            }
+            if (!(value instanceof java.util.Locale)) {
+                String language = value.toString();
+                String country = null;
+                String locale = value.toString();
+                int index = locale.indexOf("_");
+                if (index > -1) {
+                    language = locale.substring(0, index);
+                    country = locale.substring(index + 1);
+                    value = new java.util.Locale(language, country);
+                } else {
+                    value = new java.util.Locale(language);
+                }
+            }
+
+            return value;
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+    // Test classes
+    /////////////////////////////////////////////////////////////////////////
+
+    /*
+     * private static class TestSuperclass extends Object { }
+     *
+     * private static class Test extends TestSuperclass { public static void main(String[] args) { if
+     * (!(TypeConverter.asString(new Integer(12)) instanceof String)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Integer.class, "12") instanceof Integer)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Long.class, "12") instanceof Long)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Float.class, "12.0") instanceof Float)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Double.class, "12.0") instanceof Double)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Short.class, "12") instanceof Short)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(BigDecimal.class, "12") instanceof BigDecimal)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Boolean.class, "true") instanceof Boolean)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Byte.class, "12") instanceof Byte)) { throw new Error(); }
+     *
+     * if (!(TypeConverter.asType(Character.class, "1") instanceof Character)) { throw new Error(); }
+     *
+     * System.out.println("Test passed."); } }
+     */
+
+    /////////////////////////////////////////////////////////////////////////
+    // Class variables
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * <p>
+     * Application scope key for storing {@link TypeConversion}s for this application.
+     * </p>
+     */
+    private static final String CONVERSIONS = "__jsft_TypeConversions";
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
+    /** Logical type name "null" */
+    public static final String TYPE_UNKNOWN = "null";
+
+    /** Logical type name "object" */
+    public static final String TYPE_OBJECT = "object";
+
+    /** Logical type name "string" */
+    public static final String TYPE_STRING = "string";
+
+    /** Logical type name "int" */
+    public static final String TYPE_INT = "int";
+
+    /** Logical type name "integer" */
+    public static final String TYPE_INTEGER = "integer";
+
+    /** Logical type name "long" */
+    public static final String TYPE_LONG = "long";
+
+    /** Logical type name "float" */
+    public static final String TYPE_FLOAT = "float";
+
+    /** Logical type name "double" */
+    public static final String TYPE_DOUBLE = "double";
+
+    /** Logical type name "short" */
+    public static final String TYPE_SHORT = "short";
+
+    /** Logical type name "boolean" */
+    public static final String TYPE_BOOLEAN = "boolean";
+
+    /** Logical type name "byte" */
+    public static final String TYPE_BYTE = "byte";
+
+    /** Logical type name "char" */
+    public static final String TYPE_CHAR = "char";
+
+    /** Logical type name "character" */
+    public static final String TYPE_CHARACTER = "character";
+
+    /** Logical type name "bigdecimal" */
+    public static final String TYPE_BIG_DECIMAL = "bigdecimal";
+
+    /** Logical type name "sqldate" */
+    public static final String TYPE_SQL_DATE = "sqldate";
+
+    /** Logical type name "date java.util.Date" */
+    public static final String TYPE_DATE = "date";
+
+    /** Logical type name "sqltime" */
+    public static final String TYPE_SQL_TIME = "sqltime";
+
+    /** Logial type name = "locale" */
+    public static final String TYPE_LOCALE = "locale";
+
+    /** Logical type name "sqltimestamp" */
+    public static final String TYPE_SQL_TIMESTAMP = "sqltimestamp";
+
+    public static final TypeConversion UNKNOWN_TYPE_CONVERSION = new UnknownTypeConversion();
+    public static final TypeConversion OBJECT_TYPE_CONVERSION = new ObjectTypeConversion();
+    public static final TypeConversion STRING_TYPE_CONVERSION = new StringTypeConversion();
+    public static final TypeConversion INTEGER_TYPE_CONVERSION = new IntegerTypeConversion();
+    public static final TypeConversion DOUBLE_TYPE_CONVERSION = new DoubleTypeConversion();
+    public static final TypeConversion BOOLEAN_TYPE_CONVERSION = new BooleanTypeConversion();
+    public static final TypeConversion LONG_TYPE_CONVERSION = new LongTypeConversion();
+    public static final TypeConversion FLOAT_TYPE_CONVERSION = new FloatTypeConversion();
+    public static final TypeConversion SHORT_TYPE_CONVERSION = new ShortTypeConversion();
+    public static final TypeConversion BIG_DECIMAL_TYPE_CONVERSION = new BigDecimalTypeConversion();
+    public static final TypeConversion BYTE_TYPE_CONVERSION = new ByteTypeConversion();
+    public static final TypeConversion CHARACTER_TYPE_CONVERSION = new CharacterTypeConversion();
+    public static final TypeConversion DATE_TYPE_CONVERSION = new DateTypeConversion();
+    public static final TypeConversion SQL_DATE_TYPE_CONVERSION = new SqlDateTypeConversion();
+    public static final TypeConversion SQL_TIME_TYPE_CONVERSION = new SqlTimeTypeConversion();
+    public static final TypeConversion SQL_TIMESTAMP_TYPE_CONVERSION = new SqlTimestampTypeConversion();
+    public static final TypeConversion LOCALE_TYPE_CONVERSION = new LocaleTypeConversion();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/UIComponentTypeConversion.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/UIComponentTypeConversion.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+
+/**
+ * <p>
+ * This {@link TypeConversion} makes an attempt to convert a String clientId to a UIComponent.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class UIComponentTypeConversion implements TypeConversion {
+
+    /**
+     *
+     */
+    @Override
+    public Object convertValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (!(value instanceof UIComponent)) {
+            String strVal = value.toString();
+            if (strVal.trim().length() == 0) {
+                value = null;
+            } else {
+                // Treat String as clientId
+                FacesContext ctx = FacesContext.getCurrentInstance();
+                if (!strVal.startsWith(":")) {
+                    strVal = ":" + strVal;
+                }
+                value = ctx.getViewRoot().findComponent(strVal);
+            }
+        }
+
+        return value;
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/Util.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/Util.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * <p>
+ * This class is for general purpose utility methods.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class Util {
+
+    /**
+     * <p>
+     * This method returns the ContextClassLoader unless it is null, in which case it returns the ClassLoader that loaded
+     * "obj". Unless it is null, in which it will return the system ClassLoader.
+     * </p>
+     *
+     * @param obj May be null, if non-null when the Context ClassLoader is null, then the Classloader used to load this
+     * Object will be returned.
+     */
+    public static ClassLoader getClassLoader(Object obj) {
+        // Get the ClassLoader
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            if (obj != null) {
+                loader = obj.getClass().getClassLoader();
+            }
+        }
+
+        // Wrap with custom ClassLoader if specified
+        loader = getCustomClassLoader(loader);
+
+        return loader;
+    }
+// NOTE: Maybe in addition to getClassLoader, we should have Iterator<ClassLoader> getClassLoaders() for cases where we want to attempt multiple ClassLoaders
+
+    /**
+     * <p>
+     * Method to get the custom <code>ClassLoader</code> if one exists. If one does not exist, it will return the
+     * <code>ClassLoader</code> that is passed in. If (null) is passed in for the parent <code>ClassLoader</code>, it will
+     * get the <b>System</b> <code>ClassLoader</code>, not the context <code>ClassLoader</code> or any other one.
+     * </p>
+     */
+    private static ClassLoader getCustomClassLoader(ClassLoader parent) {
+        // Figure out the parent ClassLoader
+        parent = parent == null ? ClassLoader.getSystemClassLoader() : parent;
+
+        // Check to see if we've calculated the ClassLoader for this parent
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        Map<ClassLoader, ClassLoader> classLoaderCache = getClassLoaderCache(ctx);
+        ClassLoader loader = classLoaderCache.get(parent);
+        if (loader != null) {
+            return loader;
+        }
+        loader = parent;
+
+        // Look to see if a custom ClassLoader was specified via an initParam
+        String clsName = null;
+        if (ctx != null) {
+            clsName = ctx.getExternalContext().getInitParameterMap().get(CUSTOM_CLASS_LOADER);
+        }
+        if (clsName != null) {
+            if (clsName.equals(loader.getClass().getName())) {
+                // It has already been wrapped
+                return loader;
+            }
+            try {
+                // Intantiate the custom classloader w/ "loader" as its parent
+                Class cls = Class.forName(clsName, true, parent);
+                loader = (ClassLoader) cls.getConstructor(ClassLoader.class).newInstance(parent);
+
+                // Set custom classloader as the context-classloader... This
+                // didn't work, JSF blew up... revisit this if necessary
+//        Thread.currentThread().setContextClassLoader(loader);
+            } catch (ClassNotFoundException ex) {
+                throw new IllegalArgumentException("Unable to load class (" + clsName + ").  Make sure your context-param is "
+                        + "specified correctly and that your custom ClassLoader " + "is included in your application.", ex);
+            } catch (NoSuchMethodException ex) {
+                throw new IllegalArgumentException("Unable to load class (" + clsName + ").  You must have a constructor that "
+                        + "allows the parent ClassLoader to be provided on your " + "custom ClassLoader.", ex);
+            } catch (InstantiationException ex) {
+                throw new RuntimeException("Unable to instantiate class (" + clsName + ")!", ex);
+            } catch (IllegalAccessException ex) {
+                throw new RuntimeException("Unable to access class (" + clsName + ")!", ex);
+            } catch (java.lang.reflect.InvocationTargetException ex) {
+                throw new RuntimeException("Unable to instantiate class (" + clsName + ")!", ex);
+            }
+        }
+
+        // Cache for next time
+        classLoaderCache.put(parent, loader);
+
+        // Return the ClassLoader (may be the same one passed in)
+        return loader;
+    }
+
+    /**
+     * <p>
+     * Provides access to the application-scoped Map which stores custom ClassLoaders which may wrap a parent ClassLoader in
+     * this application.
+     * </p>
+     */
+    private static Map<ClassLoader, ClassLoader> getClassLoaderCache(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<ClassLoader, ClassLoader> map = null;
+        if (ctx != null) {
+            map = (Map<ClassLoader, ClassLoader>) ctx.getExternalContext().getApplicationMap().get(CLASSLOADER_CACHE);
+        }
+        if (map == null) {
+            // 1st time... initialize it
+            map = new HashMap<>(4);
+            if (ctx != null) {
+                ctx.getExternalContext().getApplicationMap().put(CLASSLOADER_CACHE, map);
+            }
+        }
+
+        // Return the map...
+        return map;
+    }
+
+    /**
+     * <p>
+     * This method will attempt to load a Class from the context ClassLoader. If it fails, it will try from the ClassLoader
+     * used to load the given object. If that's null, or fails, it will try using the System ClassLoader.
+     * </p>
+     *
+     * @param className The full name of the class to load.
+     * @param obj An optional Object used to help find the ClassLoader to use.
+     */
+    public static Class loadClass(String className, Object obj) throws ClassNotFoundException {
+        // Get the context ClassLoader
+        ClassLoader loader = getClassLoader(obj);
+        Class cls = null;
+        if (loader != null) {
+            try {
+                cls = Class.forName(className, false, loader);
+            } catch (ClassNotFoundException ex) {
+                // Ignore
+                if (LogUtil.finestEnabled()) {
+                    LogUtil.finest("Unable to find class (" + className + ") using the context ClassLoader: '" + loader
+                            + "'.  I will keep looking.", ex);
+                }
+            }
+        }
+        if (cls == null) {
+            // Still haven't found it... look for it somewhere else.
+            if (obj != null) {
+                loader = obj.getClass().getClassLoader();
+                if (loader != null) {
+                    try {
+                        cls = Class.forName(className, false, loader);
+                    } catch (ClassNotFoundException ex) {
+                        // Ignore
+                        if (LogUtil.finestEnabled()) {
+                            LogUtil.finest("Unable to find class (" + className + ") using ClassLoader: '" + loader
+                                    + "'.  I will try the System ClassLoader.", ex);
+                        }
+                    }
+                }
+            }
+            if (cls == null) {
+                // Still haven't found it, use System ClassLoader
+                loader = ClassLoader.getSystemClassLoader();
+
+                // Allow this one to throw the Exception if not found
+                cls = Class.forName(className, false, loader);
+            }
+        }
+
+        // Return the Class
+        return cls;
+    }
+
+    /**
+     * <p>
+     * Method which returns the Class for the given class name, or null if any exception occurs. No exceptions are thrown.
+     * </p>
+     */
+    public static Class noExceptionLoadClass(String name) {
+        Class cls = null;
+        try {
+            cls = Util.loadClass(name, null);
+        } catch (Exception ex) {
+            // Ignore...
+        }
+        return cls;
+    }
+
+    /**
+     * <p>
+     * This method attempts load the requested Class. If obj is a String, it will use this value as the fully qualified
+     * class name. If it is a Class, it will return it. If it is anything else, it will return the Class for the given
+     * Object.
+     * </p>
+     *
+     * @param obj The Object describing the requested Class
+     */
+    public static Class getClass(Object obj) throws ClassNotFoundException {
+        if (obj == null || obj instanceof Class) {
+            return (Class) obj;
+        }
+        Class cls = null;
+        if (obj instanceof String) {
+            cls = loadClass((String) obj, obj);
+        } else {
+            cls = obj.getClass();
+        }
+        return cls;
+    }
+
+    /**
+     * <p>
+     * This method locates the requested <code>Method</code> on the given <code>Class</code>, with the given
+     * <code>params</code>. This method does not throw any exceptions. Instead it will return <code>null</code> if unable to
+     * locate the method.
+     * </p>
+     */
+    public static Method getMethod(Class cls, String name, Class... prms) {
+        Method method = null;
+        try {
+            method = cls.getMethod(name, prms);
+        } catch (NoSuchMethodException ex) {
+            // Do nothing, we're eating the exception
+        } catch (SecurityException ex) {
+            // Do nothing, we're eating the exception
+        }
+        return method;
+    }
+
+    /**
+     * <p>
+     * This method converts the given Map into a Properties Map (if it is already one, then it simply returns the given
+     * Map).
+     * </p>
+     */
+    public static Properties mapToProperties(Map map) {
+        if (map == null || map instanceof Properties) {
+            return (Properties) map;
+        }
+
+        // Create Properties and add all the values
+        Properties props = new Properties();
+        props.putAll(map);
+
+        // Return the result
+        return props;
+    }
+
+    /**
+     * <p>
+     * Help obtain the current <code>Locale</code>.
+     * </p>
+     */
+    public static Locale getLocale(FacesContext context) {
+        Locale locale = null;
+        if (context != null) {
+            // Attempt to obtain the locale from the UIViewRoot
+            UIViewRoot root = context.getViewRoot();
+            if (root != null) {
+                locale = root.getLocale();
+            }
+        }
+
+        // Return the locale; if not found, return the system default Locale
+        return locale == null ? Locale.getDefault() : locale;
+    }
+
+    /**
+     * <p>
+     * This method escapes text so that HTML tags and escape characters can be shown in an HTML page without seeming to be
+     * parsed.
+     * </p>
+     */
+    public static String htmlEscape(String str) {
+        if (str == null) {
+            return null;
+        }
+        StringBuffer buf = new StringBuffer("");
+        for (char ch : str.toCharArray()) {
+            switch (ch) {
+            case '&':
+                buf.append("&amp;");
+                break;
+            case '<':
+                buf.append("&lt;");
+                break;
+            case '>':
+                buf.append("&gt;");
+                break;
+            default:
+                buf.append(ch);
+                break;
+            }
+        }
+        return buf.toString();
+    }
+
+    /**
+     * <p>
+     * This method strips leading delimeter.
+     * </p>
+     *
+     */
+    protected static String stripLeadingDelimeter(String str, char ch) {
+        if (str == null || str.equals("")) {
+            return str;
+        }
+        int j = 0;
+        char[] strArr = str.toCharArray();
+        for (int i = 0; i < strArr.length; i++) {
+            j = i;
+            if (strArr[i] != ch) {
+                break;
+            }
+        }
+        return str.substring(j);
+
+    }
+
+    /**
+     * Closes an InputStream if it is non-null, throwing away any Exception that may occur
+     *
+     * @param is
+     */
+    public static void closeStream(InputStream is) {
+        if (is != null) {
+            try {
+                is.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Application scope attribute name for storing custom <code>ClassLoaders</code>.
+     * </p>
+     */
+    private static final String CLASSLOADER_CACHE = "__jsft_ClassLoaders";
+
+    /**
+     * <p>
+     * This is the context-param that specifies the JSFTemplating custom <code>ClassLoader</code> to use.
+     * </p>
+     */
+    public static final String CUSTOM_CLASS_LOADER = "com.sun.jsftemplating.CLASSLOADER";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/BaseContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/BaseContext.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * <p>
+ * This class provides a base implemention of {@link Context} to implement code that is likely to be needed by most
+ * {@link Context} implementations.
+ * </p>
+ */
+public abstract class BaseContext implements Context {
+
+    /**
+     * Constructor.
+     */
+    protected BaseContext() {
+    }
+
+    /**
+     * <p>
+     * This method may be used to manage arbitrary information between the code invoking the {@link FileStreamer} and the
+     * <code>ContentSource</code>. This method retrieves an attribute.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    @Override
+    public Object getAttribute(String name) {
+        if (name == null) {
+            return null;
+        }
+
+        // Return the value (if any)
+        return _att.get(name);
+    }
+
+    /**
+     * <p>
+     * This provides access to all attributes in this Context.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    @Override
+    public Set<String> getAttributeKeys() {
+        return _att.keySet();
+    }
+
+    /**
+     * <p>
+     * This method may be used to manage arbitrary information between the code invoking the {@link FileStreamer} and the
+     * <code>ContentSource</code>. This method sets an attribute.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    @Override
+    public void setAttribute(String name, Object value) {
+        if (name != null) {
+            _att.put(name, value);
+        }
+    }
+
+    /**
+     * <p>
+     * This method may be used to manage arbitrary information between the coding invoking the {@link FileStreamer} and the
+     * <code>ContentSource</code>. This method removes an attribute.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    @Override
+    public void removeAttribute(String name) {
+        _att.remove(name);
+    }
+
+    /**
+     * <p>
+     * Application scope key for allowed paths.
+     * </p>
+     */
+    protected static final String ALLOWED_PATHS_KEY = "__jsft_AllowPath";
+
+    /**
+     * <p>
+     * Application scope key for denied paths.
+     * </p>
+     */
+    protected static final String DENIED_PATHS_KEY = "__jsft_DenyPath";
+
+    private Map<String, Object> _att = new HashMap<>();
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ContentSource.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ContentSource.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * <p>
+ * Implement this interface to provide an Object that is capable of providing data to <code>FileStreamer</code>.
+ * <code>ContentSource</code> implementations must be thread safe. The <code>FileStreamer</code> will reuse the same
+ * instance when 2 requests are made to the same ContentSource type. Instance variables, therefore, should not be used;
+ * you may use the context to store local information.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public interface ContentSource {
+
+    /**
+     * <p>
+     * This method should return a unique string used to identify this <code>ContentSource</code>. This string must be
+     * specified in order to select the appropriate <code>ContentSource</code> when using the <code>FileStreamer</code>.
+     * </p>
+     */
+    String getId();
+
+    /**
+     * <p>
+     * This method is responsible for generating the content and returning an InputStream to that content. It is also
+     * responsible for setting any attribute values in the {@link Context}, such as {@link Context#EXTENSION} or
+     * {@link Context#CONTENT_TYPE}.
+     * </p>
+     */
+    InputStream getInputStream(Context ctx) throws IOException;
+
+    /**
+     * <p>
+     * This method returns the path of the resource that was requested.
+     * </p>
+     */
+    String getResourcePath(Context ctx);
+
+    /**
+     * <p>
+     * This method may be used to clean up any temporary resources. It will be invoked after the <code>InputStream</code>
+     * has been completely read.
+     * </p>
+     */
+    void cleanUp(Context ctx);
+
+    /**
+     * <p>
+     * This method is responsible for returning the last modified date of the content, or -1 if not applicable. This
+     * information will be used for caching.
+     * </p>
+     */
+    long getLastModified(Context context);
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/Context.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/Context.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Set;
+
+/**
+ * <p>
+ * This interface provides API's to encapsulate environment specific objects so that the FileStreamer class is not
+ * specific to a specific environment (like a Servlet environment).
+ * </p>
+ */
+public interface Context {
+
+    /**
+     * <p>
+     * Accessor to get the {@link FileStreamer} instance.
+     * </p>
+     */
+    FileStreamer getFileStreamer();
+
+    /**
+     * <p>
+     * This method locates the appropriate {@link ContentSource} for this <code>Context</code>.
+     * </p>
+     */
+    ContentSource getContentSource();
+
+    /**
+     * <p>
+     * This method allows the Context to restrict access to resources. It returns <code>true</code> if the user is allowed
+     * to view the resource. It returns <code>false</code> if the user should not be allowed access to the resource.
+     * </p>
+     */
+    boolean hasPermission(ContentSource src);
+
+    /**
+     * <p>
+     * This method is responsible for setting the response header information.
+     * </p>
+     */
+    void writeHeader(ContentSource source) throws IOException;
+
+    /**
+     * <p>
+     * This method is responsible for sending an error.
+     * </p>
+     */
+    void sendError(int code, String msg) throws IOException;
+
+    /**
+     * <p>
+     * This method is responsible for returning an <code>OutputStream</code> suitable for writing content.
+     * </p>
+     */
+    OutputStream getOutputStream() throws IOException;
+
+    /**
+     * <p>
+     * This method may be used to manage arbitrary information between the code invoking the {@link FileStreamer} and the
+     * <code>ContentSource</code>. This method retrieves an attribute.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    Object getAttribute(String name);
+
+    /**
+     * <p>
+     * This provides access to all attributes in this Context.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    Set<String> getAttributeKeys();
+
+    /**
+     * <p>
+     * This method may be used to manage arbitrary information between the code invoking the {@link FileStreamer} and the
+     * <code>ContentSource</code>. This method sets an attribute.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    void setAttribute(String name, Object value);
+
+    /**
+     * <p>
+     * This method may be used to manage arbitrary information between the coding invoking the {@link FileStreamer} and the
+     * <code>ContentSource</code>. This method removes an attribute.
+     * </p>
+     *
+     * <p>
+     * See individual {@link ContentSource} implementations for more details on supported / required attributes.
+     * </p>
+     */
+    void removeAttribute(String name);
+
+    /**
+     * <p>
+     * This is the number of milliseconds into the future until the content should expire. This constant is currently set at
+     * about 7 years.
+     * </p>
+     */
+    long EXPIRY_TIME = 1000 * 60 * 60 * 24 * 365 * 7;
+
+    /**
+     * <p>
+     * This is the {@link Context} attribute name used to specify the filename extension of the content. It is the
+     * responsibility of the {@link ContentSource} to set this value. The value should represent the filename extension of
+     * the content if it were saved to a filesystem.
+     * </p>
+     */
+    String EXTENSION = "extension";
+
+    /**
+     * <p>
+     * The Content-type ("ContentType"). This is the {@link Context} attribute used to specify an explicit "Content-type".
+     * It may be set by the {@link ContentSource}. If not specified, the {@link #EXTENSION} will typically be used (if
+     * possible). If that fails, the {@link FileStreamer#getDefaultMimeType} is used.
+     * </p>
+     */
+    String CONTENT_TYPE = "ContentType";
+
+    /**
+     * <p>
+     * The value for the "Content-Disposition" ("disposition"). This is the {@link Context} attribute used to specify the
+     * content disposition. The content disposition tells the browser how to handle the content. The two standard values for
+     * this are:
+     * </p>
+     *
+     * <ul>
+     * <li>inline</li>
+     * <li>attachment</li>
+     * </ul>
+     *
+     * <p>
+     * See RFC 2183 for more information. This value may be set by the {@link ContentSource}. If not specified, nothing will
+     * be set. This value may be used in conjunction with the {@link #CONTENT_FILENAME} attribute, or the entire content
+     * disposition may be specified with this attribute.
+     * </p>
+     */
+    String CONTENT_DISPOSITION = "disposition";
+
+    /**
+     * <p>
+     * The value for the "Content-Disposition" ("filename"). This is the {@link Context} attribute used to specify an
+     * explicit "filename". It may be set by the {@link ContentSource}. If not specified, nothing will be set. If
+     * {@link #CONTENT_DISPOSITION} is also set, this method will append the file name. If not set, it will set the
+     * contentDisposition to "attachment".
+     * </p>
+     */
+    String CONTENT_FILENAME = "filename";
+
+    /**
+     * <p>
+     * This is the path of the requested file ("filename"). It is the responsibility of the {@link Context} implementation
+     * to provide this information as an attribute.
+     * </p>
+     */
+    String FILE_PATH = "filePath";
+
+    /**
+     * <p>
+     * This is the parameter that may be provided to identify the {@link ContentSource} implementation to be used. This
+     * value must match the value returned by the <code>ContentSource</code> implementation's <code>getId()</code> method.
+     * It is typical for {@link Context} implementations to allow this to be specified by a <code>HttpServletRequest</code>
+     * parameter.
+     * </p>
+     */
+    String CONTENT_SOURCE_ID = "contentSourceId";
+
+    /**
+     * <p>
+     * This String ("ContentSources") is the name of the <code>Servlet</code> init parameter or context param (depending on
+     * environment implementation) that should be used to register all available {@link ContentSource} implementations. This
+     * should be a list of full classnames of the {@link ContentSource}s.
+     * </p>
+     */
+    String CONTENT_SOURCES = "ContentSources";
+
+    /**
+     * <p>
+     * This String ("com.sun.jsftemplating.FS_ALLOW_PATHS") is the name of the <code>Servlet</code> init parameter or
+     * context param (depending on environment implementation) that should be used to register all valid paths for resources
+     * to be streamed by {@link FileStreamer}. This should be specified as a comma (or semi-colon) separated list of path
+     * prefixes. Paths are relative to the context root of the application. Any path starting with one of the paths in this
+     * list may be served using FileStreamer (provided it is not explicitly excluded via {@link #DENY_PATHS}). Leading "/"
+     * characters maybe specified, but will be removed when doing a comparison. A value of "/" will provide access to the
+     * entire application, which is the default value if not specified.
+     * </p>
+     */
+    String ALLOW_PATHS = "com.sun.jsftemplating.FS_ALLOW_PATHS";
+
+    /**
+     * <p>
+     * This String ("com.sun.jsftemplating.FS_DENY_PATHS") is the name of the <code>Servlet</code> init parameter or context
+     * param (depending on environment implementation) that should be used to register all valid paths for resources to be
+     * streamed by {@link FileStreamer}. This should be specified as a comma (or semi-colon) separated list of path
+     * prefixes. Paths are relative to the context root of the application. Any path starting with one of the paths in this
+     * list may <b>NOT</b> be served using FileStreamer. Leading '/' characters maybe specified, but will be removed when
+     * doing a comparison. In addition to supporting prefix patterns, any path starting with an asterisk (<code>*</code>)
+     * character will be interpreted as a suffix pattern. Any path ending with the characters following the asterisk will
+     * match and will <b>NOT</b> be served. The default value is:
+     * </p>
+     * <p>
+     * <code>META-INF/,WEB-INF/</code>"
+     * </p>
+     */
+    String DENY_PATHS = "com.sun.jsftemplating.FS_DENY_PATHS";
+
+    /**
+     * <p>
+     * This is the id of the default {@link ContentSource}. This is set to the id of the {@link ResourceContentSource}.
+     * </p>
+     */
+    String DEFAULT_CONTENT_SOURCE_ID = ResourceContentSource.ID;
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/FacesStreamerContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/FacesStreamerContext.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * <p>
+ * This class encapsulates servlet specific objects so that the {@link FileStreamer} class is not servlet-specific.
+ * </p>
+ *
+ * <p>
+ * This implementation will look for the following attributes ({@link BaseContext#setAttribute(String, Object)}):
+ * </p>
+ *
+ * <ul>
+ * <li>{@link Context#CONTENT_TYPE} -- The "Content-type:" of the response.</li>
+ * <li>{@link Context#CONTENT_DISPOSITION} -- Disposition of the streamed content.</li>
+ * <li>{@link Context#CONTENT_FILENAME} -- Filename of the streamed content.</li>
+ * <li>{@link Context#EXTENSION} -- The file extension of the response.</li>
+ * </ul>
+ */
+public class FacesStreamerContext extends BaseContext {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public FacesStreamerContext(FacesContext ctx) {
+        setFacesContext(ctx);
+        init();
+    }
+
+    /**
+     * <p>
+     * This method initializes {@link FileStreamer} {@link ContentSource}s. It looks for the {@link Context#CONTENT_SOURCES}
+     * context parameter (JSF doesn't provide a way to get to the ServletConfig init parameters, as of JSF 1.2).
+     * </p>
+     */
+    protected synchronized void init() {
+        FacesContext ctx = getFacesContext();
+        if (ctx == null) {
+            // Should not happen in a normal env...
+            return;
+        }
+        ExternalContext extCtx = ctx.getExternalContext();
+        boolean initDone = extCtx.getApplicationMap().containsKey(INIT_DONE);
+        if (initDone) {
+            return;
+        }
+
+        // Register ContentSources
+        String sources = extCtx.getInitParameter(CONTENT_SOURCES);
+        FileStreamer fs = getFileStreamer();
+        if (sources != null && sources.trim().length() != 0) {
+            StringTokenizer tokens = new StringTokenizer(sources, " \t\n\r\f,;:");
+            while (tokens.hasMoreTokens()) {
+                fs.registerContentSource(tokens.nextToken());
+            }
+        }
+
+        // Set Valid path parameters...
+        String path, end;
+        String allow = extCtx.getInitParameter(ALLOW_PATHS);
+        List<String> paths = new ArrayList<>();
+        if (allow != null) {
+            StringTokenizer tok = new StringTokenizer(allow, ",:;");
+            while (tok.hasMoreTokens()) {
+                path = tok.nextToken();
+                end = path.endsWith("/") ? "/" : "";
+                paths.add(ResourceContentSource.normalize(path) + end);
+            }
+        } else {
+            paths.add("");
+        }
+        setAllowedPaths(extCtx, paths);
+
+        // Set invalid paths...
+        String deny = extCtx.getInitParameter(DENY_PATHS);
+        paths = new ArrayList<>();
+        if (deny != null) {
+            StringTokenizer tok = new StringTokenizer(deny, ",:;");
+            while (tok.hasMoreTokens()) {
+                path = tok.nextToken();
+                end = path.endsWith("/") ? "/" : "";
+                paths.add(ResourceContentSource.normalize(path) + end);
+            }
+        } else {
+            paths.add("WEB-INF/");
+            paths.add("META-INF/");
+        }
+        setDeniedPaths(extCtx, paths);
+
+        if (ctx != null) {
+            // Mark initialization as complete
+            extCtx.getApplicationMap().put(INIT_DONE, true);
+        }
+    }
+
+    /**
+     * <p>
+     * Accessor to get the {@link FileStreamer} instance.
+     * </p>
+     */
+    @Override
+    public FileStreamer getFileStreamer() {
+        return FileStreamer.getFileStreamer(getFacesContext());
+    }
+
+    /**
+     * <p>
+     * This method locates the appropriate {@link ContentSource} for this {@link Context}. It uses the
+     * <code>FacesContext</code>'s <code>ExternalContext</code> to look for a <b>request parameter</b> named
+     * {@link Context#CONTENT_SOURCE_ID}. This value is used as the key when looking up registered {@link ContentSource}
+     * implementations.
+     * </p>
+     */
+    @Override
+    public ContentSource getContentSource() {
+        ContentSource src = (ContentSource) getAttribute("_contentSource");
+        if (src != null) {
+            return src;
+        }
+
+        // Get the ContentSource id
+        FacesContext ctx = getFacesContext();
+        String id = ctx.getExternalContext().getRequestParameterMap().get(Context.CONTENT_SOURCE_ID);
+        if (id == null) {
+            // Use the default ContentSource
+            id = Context.DEFAULT_CONTENT_SOURCE_ID;
+        }
+
+        // Get the ContentSource
+        src = getFileStreamer().getContentSource(id);
+        if (src == null) {
+            throw new RuntimeException("The ContentSource with id '" + id + "' is not registered!");
+        }
+
+        // Return the ContentSource
+        setAttribute("_contentSource", src);
+        return src;
+    }
+
+    /**
+     * <p>
+     * This method allows the Context to restrict access to resources. It returns <code>true</code> if the user is allowed
+     * to view the resource. It returns <code>false</code> if the user should not be allowed access to the resource.
+     * </p>
+     */
+    @Override
+    public boolean hasPermission(ContentSource src) {
+        String filename = src.getResourcePath(this);
+        ExternalContext extCtx = getFacesContext().getExternalContext();
+        boolean ok = false;
+
+        // Ensure it is in our list of OK paths...
+        List<String> paths = getAllowedPaths(extCtx);
+        for (String path : paths) {
+            if (filename.startsWith(path)) {
+                ok = true;
+                break;
+            }
+        }
+
+        // ...and ensure it is not in our blacklisted paths...
+        if (ok) {
+            // Only check if ok so far...
+            paths = getDeniedPaths(extCtx);
+            for (String path : paths) {
+                if ((path.startsWith("*") && filename.endsWith(path.substring(1))) || filename.startsWith(path)) {
+                    // Matched suffix pattern
+                    ok = false;
+                    break;
+                }
+            }
+        }
+
+        return ok;
+    }
+
+    /**
+     * <p>
+     * This methods sets the allowed paths for resources. Paths may be further restricted using the {@link #setDeniedPaths}
+     * method.
+     * </p>
+     */
+    public List<String> getAllowedPaths(ExternalContext extCtx) {
+        return (List<String>) extCtx.getApplicationMap().get(ALLOWED_PATHS_KEY);
+    }
+
+    /**
+     * <p>
+     * This methods sets the allowed paths for resources. Paths may be further restricted using the {@link #setDeniedPaths}
+     * method.
+     * </p>
+     */
+    public void setAllowedPaths(ExternalContext ctx, List<String> paths) {
+        ctx.getApplicationMap().put(ALLOWED_PATHS_KEY, paths);
+    }
+
+    /**
+     * <p>
+     * This methods sets the list of paths in which resources should not be served.
+     * </p>
+     */
+    public void setDeniedPaths(ExternalContext ctx, List<String> paths) {
+        ctx.getApplicationMap().put(DENIED_PATHS_KEY, paths);
+    }
+
+    /**
+     * <p>
+     * This methods sets the list of paths for resources.
+     * </p>
+     */
+    public List<String> getDeniedPaths(ExternalContext extCtx) {
+        return (List<String>) extCtx.getApplicationMap().get(DENIED_PATHS_KEY);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the response header information.
+     * </p>
+     */
+    @Override
+    public void writeHeader(ContentSource source) {
+// FIXME: Portlet
+        ServletResponse resp = (ServletResponse) getFacesContext().getExternalContext().getResponse();
+
+        // Set the "Last-Modified" Header
+        // First check context
+        long longTime = source.getLastModified(this);
+        if (longTime != -1) {
+            HttpServletResponse httpResponse = (HttpServletResponse) resp;
+            httpResponse.setDateHeader("Last-Modified", longTime);
+            httpResponse.setDateHeader("Expires", new java.util.Date().getTime() + Context.EXPIRY_TIME);
+        }
+
+        // First check CONTENT_TYPE
+        String contentType = (String) getAttribute(CONTENT_TYPE);
+        if (contentType == null) {
+            // Not found yet, check EXTENSION
+            String ext = (String) getAttribute(EXTENSION);
+            if (ext != null) {
+                contentType = FileStreamer.getMimeType(ext);
+            }
+            if (contentType == null) {
+                // Default Content-type is: application/octet-stream
+                contentType = FileStreamer.getDefaultMimeType();
+            }
+        }
+        ((HttpServletResponse) resp).setHeader("Content-type", contentType);
+
+        // Check disposition/filename to associate a name with the stream
+        String disposition = (String) getAttribute(CONTENT_DISPOSITION);
+        String filename = (String) getAttribute(CONTENT_FILENAME);
+        if (disposition == null) {
+            // No disposition set, see if we have a filename
+            if (filename != null) {
+                ((HttpServletResponse) resp).setHeader("Content-Disposition", DEFAULT_DISPOSITION + ";filename=\"" + filename + "\"");
+            }
+        } else {
+            // Disposition set, see if we also have a filename
+            if (filename != null) {
+                disposition += ";filename=\"" + filename + "\"";
+            }
+            ((HttpServletResponse) resp).setHeader("Content-Disposition", disposition);
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for sending an error.
+     * </p>
+     */
+    @Override
+    public void sendError(int code, String msg) throws IOException {
+// FIXME: JSF 2.0 now provides: externalContext.responseSendError(int, String)
+// FIXME: Portal
+        HttpServletResponse resp = (HttpServletResponse) getFacesContext().getExternalContext().getResponse();
+        if (msg == null) {
+            resp.sendError(code);
+        } else {
+            resp.sendError(code, msg);
+        }
+    }
+
+    /**
+     * <p>
+     * This method is returns the <code>ServletOutputStream</code>.
+     * </p>
+     */
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return getFacesContext().getExternalContext().getResponseOutputStream();
+    }
+
+    /**
+     * <p>
+     * This returns the <code>FacesContext</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>getAttribute({@link #FACES_CONTEXT})</code>
+     * </p>
+     */
+    public FacesContext getFacesContext() {
+        return (FacesContext) getAttribute(FACES_CONTEXT);
+    }
+
+    /**
+     * <p>
+     * This sets the <code>FacesContext</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>setAttribute({@link #FACES_CONTEXT}, ctx)</code>
+     * </p>
+     */
+    protected void setFacesContext(FacesContext ctx) {
+        setAttribute(FACES_CONTEXT, ctx);
+    }
+
+    /**
+     * <p>
+     * Flag indicating initialization for this class has been completed.
+     * </p>
+     */
+    private static final String INIT_DONE = "__jsft_StreamContextInitialized";
+
+    /**
+     * <p>
+     * The attribute value to access the <code>FacesContext</code>. See {@link #getFacesContext()}.
+     * </p>
+     */
+    public static final String FACES_CONTEXT = "facesContext";
+
+    /**
+     * <p>
+     * The default Content-Disposition. It is only used when a filename is provided, but a disposition is not. The default
+     * is "attachment". This will normally cause a browser to prompt the user to save the file. This is the default since
+     * setting a filename implies that the user may want to save this file. You must explicitly set the disposition for
+     * "inline" behavior with a filename.
+     * </p>
+     */
+    public static final String DEFAULT_DISPOSITION = "attachment";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/FileStreamer.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/FileStreamer.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import com.sun.jsftemplating.util.FileUtil;
+import com.sun.jsftemplating.util.LogUtil;
+import com.sun.jsftemplating.util.Tuple;
+import com.sun.jsftemplating.util.Util;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.servlet.ServletContext;
+
+import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>
+ * This class provides the ability to retrieve information from an abritrary source. It provides the ability to set the
+ * Content-type of the file if the request is http-based. If the Content-type is not explicitly specified, it will
+ * attempt to guess based on the extension (if possible). It requires the {@link ContentSource} for the data to be
+ * retrieved to be defined by calling {@link #registerContentSource(String)}.
+ * </p>
+ *
+ * @author Ken Paulsen (ken.paulsen@sun.com)
+ */
+public class FileStreamer {
+    public static final String CONTENT_SOURCES = "contentSources";
+
+    /**
+     * <p>
+     * Only instantiate via factory method. This method has JSF-specific features.
+     * </p>
+     */
+    private FileStreamer(FacesContext ctx) {
+        try {
+            List<Tuple> entries = FileUtil.getJarResources(ctx, "/META-INF/jsftemplating/fileStreamer.properties");
+            for (Tuple tuple : entries) {
+                Properties props = new Properties();
+                JarFile jarFile = (JarFile) tuple.getElement(0);
+                InputStream is = jarFile.getInputStream((JarEntry) tuple.getElement(1));
+                props.load(is);
+                is.close();
+                jarFile.close();
+                processFileStreamerProperties(props);
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(FileStreamer.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    /**
+     * <p>
+     * This private constructor should only be used when in a non-JSF environment.
+     * </p>
+     */
+    private FileStreamer() {
+        super();
+    }
+
+    /**
+     * <p>
+     * Use this method to obtain the instance of this class.
+     * </p>
+     */
+    public static FileStreamer getFileStreamer(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        FileStreamer streamer = null;
+        if (ctx != null) {
+            streamer = (FileStreamer) ctx.getExternalContext().getApplicationMap().get(STREAMER_INST);
+            if (streamer == null) {
+                // 1st time... initialize it
+                streamer = new FileStreamer(ctx);
+                ctx.getExternalContext().getApplicationMap().put(STREAMER_INST, streamer);
+            }
+        } else {
+            // No FacesConfig... just return a new instance.
+            streamer = new FileStreamer();
+        }
+        return streamer;
+    }
+
+    /**
+     * <p>
+     * This method should be used if you are NOT using JSF, but instead a plain <code>Servlet</code> environment.
+     * </p>
+     */
+    public static FileStreamer getFileStreamer(ServletContext ctx) {
+        FileStreamer streamer = null;
+        if (ctx != null) {
+            streamer = (FileStreamer) ctx.getAttribute(STREAMER_INST + "srvlt");
+            if (streamer == null) {
+                // 1st time... initialize it
+                streamer = new FileStreamer();
+                ctx.setAttribute(STREAMER_INST + "srvlt", streamer);
+            }
+        } else {
+            // No ServletConfig... just return a new instance.
+            streamer = new FileStreamer();
+        }
+        return streamer;
+    }
+
+    /**
+     * <p>
+     * This method registers the given <code>className</code> as a {@link ContentSource}. This method will attempt to
+     * resolve and instantiate the given <code>className</code>. If it is unable to do so, it will throw an
+     * <code>IllegalArgumentException</code>.
+     * </p>
+     *
+     * @param className The full classname of the {@link ContentSource} implementation.
+     */
+    public void registerContentSource(String className) {
+        // Sanity Check
+        if (className == null || className.trim().equals("")) {
+            return;
+        }
+
+        Class cls = null;
+        try {
+            cls = Util.loadClass(className, className);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex);
+        }
+        registerContentSource(cls);
+    }
+
+    /**
+     * <p>
+     * This method registers the given <code>Class</code> as a {@link ContentSource}. This method will attempt to
+     * instantiate the given <code>Class</code> (<code>cls</code>). If it is unable to do so, it will throw an
+     * <code>IllegalArgumentException</code>.
+     * </p>
+     *
+     * @param cls The <code>Class</code> for the {@link ContentSource} implementation.
+     */
+    public void registerContentSource(Class cls) {
+        // Create a new instance
+        ContentSource source = null;
+        try {
+            source = (ContentSource) cls.newInstance();
+        } catch (Exception ex) {
+            throw new IllegalArgumentException(ex);
+        }
+        registerContentSource(source);
+    }
+
+    /**
+     * <p>
+     * This method registers the given {@link ContentSource}.
+     * </p>
+     *
+     * @param source The {@link ContentSource} implementation to register.
+     */
+    public void registerContentSource(ContentSource source) {
+        // Add the new instance to the registered ContentSources
+        getContentSources(null).put(source.getId(), source);
+    }
+
+    /**
+     * <p>
+     * This method provides access to the application's registered {@link ContentSource}s.
+     * </p>
+     */
+    private Map<String, ContentSource> getContentSources(FacesContext ctx) {
+        if (ctx == null) {
+            ctx = FacesContext.getCurrentInstance();
+        }
+        Map<String, ContentSource> sources = null;
+        if (ctx != null) {
+            sources = (Map<String, ContentSource>) ctx.getExternalContext().getApplicationMap().get(FS_CONTENT_SOURCES);
+        }
+        if (sources == null) {
+            // 1st time... initialize it
+            sources = new HashMap<>();
+            sources.put(ResourceContentSource.ID, new ResourceContentSource());
+            if (ctx != null) {
+                // Save in application scope for next time...
+                ctx.getExternalContext().getApplicationMap().put(FS_CONTENT_SOURCES, sources);
+            }
+        }
+
+        // Return the map...
+        return sources;
+    }
+
+    /**
+     * <p>
+     * This method looks up a ContentSource given its id. The {@link ContentSource} must be previously registered.
+     * </p>
+     */
+    public ContentSource getContentSource(String id) {
+        return getContentSources(null).get(id);
+    }
+
+    /**
+     * <p>
+     * This method is the main method for this class. It drives the process, which includes obtaining the appropriate
+     * {@link ContentSource}, and copying the output of the {@link ContentSource} to the {@link Context}'s
+     * <code>OutputStream</code>, and telling the {@link ContentSource} to {@link ContentSource#cleanUp(Context)}.
+     * </p>
+     *
+     * @param ctx The {@link Context} in which to execute this method.
+     */
+    public void streamContent(Context ctx) throws IOException {
+        // Get the ContentSource
+        ContentSource source = ctx.getContentSource();
+
+        // Write Content
+        if (ctx.hasPermission(source)) {
+            writeContent(source, ctx);
+        } else {
+            ctx.sendError(404, "File Not Found");
+        }
+
+        // Clean Up
+        source.cleanUp(ctx);
+    }
+
+    protected void processFileStreamerProperties(Properties props) {
+        String contentSourcesProp = (String) props.get(CONTENT_SOURCES);
+        if (contentSourcesProp != null && contentSourcesProp.length() > 0) {
+            String[] contentSources = contentSourcesProp.split(",");
+            for (String cs : contentSources) {
+                cs = cs.trim(); // In case it's a comma-and-space-delimited list :)
+                LogUtil.config("Registering ContentSource " + cs);
+                this.registerContentSource(cs);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for copying the data from the given <code>InputStream</code> to the
+     * <code>OutputStream</code>. The <code>InputStream</code> comes from the {@link ContentSource}. The
+     * <code>OutputStream</code> is obtained from the {@link Context}.
+     * </p>
+     */
+    protected void writeContent(ContentSource source, Context context) throws IOException {
+        // Get the InputStream
+        InputStream in = source.getInputStream(context);
+
+        // Get the OutputStream
+        if (in == null) {
+// FIXME: Provide generic "response complete" flag & check this before throwing an exception...
+            throw new FileNotFoundException();
+//        String jspPage = (String) context.getAttribute("JSP_PAGE_SERVED");
+//        if (jspPage != null && (jspPage.equals("false"))) {
+//        try {
+            // Mainly to take care of javahelp2, bcz javahelp2 code needs an Exception to be thrown for FileNotFound.
+            // We may have to localize this message.
+//            ((HttpServletResponse)resp).sendError(404, "File Not Found");
+//        } catch (IOException ex) {
+            // squelch it, just return.
+//        }
+//        }
+
+            // nothing to write, already done
+//        return;
+        }
+
+        OutputStream out = context.getOutputStream();
+
+        // Get the InputStream
+        InputStream stream = new BufferedInputStream(in);
+
+        // Write the header
+        context.writeHeader(source);
+
+        // Copy the data to the ServletOutputStream
+        byte[] buf = new byte[512]; // Set our buffer at 512 bytes
+
+        int read = stream.read(buf, 0, 512);
+        while (read != -1) {
+            // Write data from the OutputStream to the InputStream
+            out.write(buf, 0, read);
+
+            // Read more...
+            read = stream.read(buf, 0, 512);
+        }
+
+        // Close the Stream
+        stream.close();
+    }
+
+    /**
+     * <p>
+     * This method attempts to return the mime type for the given <code>extension</code>. If the type is not found,
+     * <code>null</code> will be returned.
+     * </p>
+     */
+    public static String getMimeType(String extension) {
+        String mimeType = null;
+        extension = extension.toLowerCase();
+        Object context = FacesContext.getCurrentInstance().getExternalContext().getContext();
+        if (context instanceof ServletContext) {
+            mimeType = ((ServletContext) context).getMimeType(extension);
+        }
+
+        if (mimeType == null) {
+            mimeType = mimeTypes.get(extension);
+        }
+        return mimeType;
+    }
+
+    /**
+     * <p>
+     * Get the default mime type {@link #DEFAULT_CONTENT_TYPE}.
+     * </p>
+     */
+    public static String getDefaultMimeType() {
+        return DEFAULT_CONTENT_TYPE;
+    }
+
+    /**
+     * <p>
+     * Application scope key for an instance of this class.
+     * </p>
+     */
+    private static final String STREAMER_INST = "__jsft_FileStreamer";
+
+    /**
+     * <p>
+     * Application scope key for <code>FileStreamer</code> {@link ContentSource}s.
+     * </p>
+     */
+    private static final String FS_CONTENT_SOURCES = "__jsft_FS_Sources";
+
+    /**
+     * HashMap to hold mimetypes by extension.
+     */
+    private static Map<String, String> mimeTypes = new HashMap<>(120);
+    static {
+        mimeTypes.put("aif", "audio/x-aiff");
+        mimeTypes.put("aifc", "audio/x-aiff");
+        mimeTypes.put("aiff", "audio/x-aiff");
+        mimeTypes.put("asc", "text/plain");
+        mimeTypes.put("asf", "application/x-ms-asf");
+        mimeTypes.put("asx", "application/x-ms-asf");
+        mimeTypes.put("au", "audio/basic");
+        mimeTypes.put("avi", "video/x-msvideo");
+        mimeTypes.put("bin", "application/octet-stream");
+        mimeTypes.put("bmp", "image/bmp");
+        mimeTypes.put("bwf", "audio/wav");
+        mimeTypes.put("bz2", "application/x-bzip2");
+        mimeTypes.put("c", "text/plain");
+        mimeTypes.put("cc", "text/plain");
+        mimeTypes.put("cdda", "audio/x-aiff");
+        mimeTypes.put("class", "application/octet-stream");
+        mimeTypes.put("com", "application/octet-stream");
+        mimeTypes.put("cpp", "text/plain");
+        mimeTypes.put("cpr", "image/cpr");
+        mimeTypes.put("css", "text/css");
+        mimeTypes.put("doc", "application/msword");
+        mimeTypes.put("dot", "application/msword");
+        mimeTypes.put("dtd", "text/xml");
+        mimeTypes.put("ear", "application/zip");
+        mimeTypes.put("exe", "application/octet-stream");
+        mimeTypes.put("flc", "video/flc");
+        mimeTypes.put("fm", "application/x-maker");
+        mimeTypes.put("frame", "application/x-maker");
+        mimeTypes.put("frm", "application/x-maker");
+        mimeTypes.put("h", "text/plain");
+        mimeTypes.put("hh", "text/plain");
+        mimeTypes.put("hpp", "text/plain");
+        mimeTypes.put("hqx", "application/mac-binhex40");
+        mimeTypes.put("htm", "text/html");
+        mimeTypes.put("html", "text/html");
+        mimeTypes.put("gif", "image/gif");
+        mimeTypes.put("gz", "application/x-gunzip");
+        mimeTypes.put("ico", "image/x-icon");
+        mimeTypes.put("iso", "application/octet-stream");
+        mimeTypes.put("jar", "application/zip");
+        mimeTypes.put("java", "text/plain");
+        mimeTypes.put("jnlp", "application/x-java-jnlp-file");
+        mimeTypes.put("jpeg", "image/jpeg");
+        mimeTypes.put("jpe", "image/jpeg");
+        mimeTypes.put("jpg", "image/jpeg");
+        mimeTypes.put("js", "application/javascript");
+        mimeTypes.put("jsf", "text/plain");
+        mimeTypes.put("m3u", "audio/x-mpegurl");
+        mimeTypes.put("maker", "application/x-maker");
+        mimeTypes.put("mid", "audio/midi");
+        mimeTypes.put("midi", "audio/midi");
+        mimeTypes.put("mim", "application/mime");
+        mimeTypes.put("mime", "application/mime");
+        mimeTypes.put("mov", "video/quicktime");
+        mimeTypes.put("mp2", "audio/mpeg");
+        mimeTypes.put("mp3", "audio/mpeg");
+        mimeTypes.put("mp4", "video/mpeg4");
+        mimeTypes.put("mpa", "video/mpeg");
+        mimeTypes.put("mpe", "video/mpeg");
+        mimeTypes.put("mpeg", "video/mpeg");
+        mimeTypes.put("mpg", "video/mpeg");
+        mimeTypes.put("mpga", "audio/mpeg");
+        mimeTypes.put("mpm", "video/mpeg");
+        mimeTypes.put("mpv", "video/mpeg");
+        mimeTypes.put("pdf", "application/pdf");
+        mimeTypes.put("pic", "image/x-pict");
+        mimeTypes.put("pict", "image/x-pict");
+        mimeTypes.put("pct", "image/x-pict");
+        mimeTypes.put("pl", "application/x-perl");
+        mimeTypes.put("png", "image/png");
+        mimeTypes.put("pnm", "image/x-portable-anymap");
+        mimeTypes.put("pbm", "image/x-portable-bitmap");
+        mimeTypes.put("ppm", "image/x-portable-pixmap");
+        mimeTypes.put("ps", "application/postscript");
+        mimeTypes.put("ppt", "application/vnd.ms-powerpoint");
+        mimeTypes.put("qt", "video/quicktime");
+        mimeTypes.put("ra", "application/vnd.rn-realaudio");
+        mimeTypes.put("rar", "application/zip");
+        mimeTypes.put("rf", "application/vnd.rn-realflash");
+        mimeTypes.put("ra", "audio/vnd.rn-realaudio");
+        mimeTypes.put("ram", "audio/x-pn-realaudio");
+        mimeTypes.put("rm", "application/vnd.rn-realmedia");
+        mimeTypes.put("rmm", "audio/x-pn-realaudio");
+        mimeTypes.put("rsml", "application/vnd.rn-rsml");
+        mimeTypes.put("rtf", "text/rtf");
+        mimeTypes.put("rv", "video/vnd.rn-realvideo");
+        mimeTypes.put("spl", "application/futuresplash");
+        mimeTypes.put("snd", "audio/basic");
+        mimeTypes.put("ssm", "application/smil");
+        mimeTypes.put("swf", "application/x-shockwave-flash");
+        mimeTypes.put("tar", "application/x-tar");
+        mimeTypes.put("tgz", "application/x-gtar");
+        mimeTypes.put("tif", "image/tiff");
+        mimeTypes.put("tiff", "image/tiff");
+        mimeTypes.put("txt", "text/plain");
+        mimeTypes.put("ulw", "audio/basic");
+        mimeTypes.put("war", "application/zip");
+        mimeTypes.put("wav", "audio/x-wav");
+        mimeTypes.put("wax", "application/x-ms-wax");
+        mimeTypes.put("wm", "application/x-ms-wm");
+        mimeTypes.put("wma", "application/x-ms-wma");
+        mimeTypes.put("wml", "text/wml");
+        mimeTypes.put("wmw", "application/x-ms-wmw");
+        mimeTypes.put("wrd", "application/msword");
+        mimeTypes.put("wvx", "application/x-ms-wvx");
+        mimeTypes.put("xbm", "image/x-xbitmap");
+        mimeTypes.put("xpm", "image/image/x-xpixmap");
+        mimeTypes.put("xml", "text/xml");
+        mimeTypes.put("xsl", "text/xml");
+        mimeTypes.put("xls", "application/vnd.ms-excel");
+        mimeTypes.put("zip", "application/zip");
+        mimeTypes.put("z", "application/x-compress");
+        mimeTypes.put("Z", "application/x-compress");
+    }
+
+    /**
+     * <p>
+     * The Default Content-type ("application/octet-stream").
+     * </p>
+     */
+    public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/FileStreamerPhaseListener.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/FileStreamerPhaseListener.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import com.sun.jsftemplating.annotation.Handler;
+import com.sun.jsftemplating.annotation.HandlerInput;
+import com.sun.jsftemplating.annotation.HandlerOutput;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.faces.FacesException;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.event.PhaseEvent;
+import jakarta.faces.event.PhaseId;
+import jakarta.faces.event.PhaseListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * <p>
+ * <code>FileStreamerPhaseListener</code> provides a <code>PhaseListener</code> to wrap JSFTemplating's
+ * {@link FileStreamer} utility, a utility method to construct a <code>FileStreamPhaseListener</code>-compatible URL,
+ * and an event {@link Handler} to expose the utility method to the PDL.
+ * </p>
+ *
+ * @author Jason CTR Lee
+ */
+public class FileStreamerPhaseListener implements PhaseListener {
+
+    private static final long serialVersionUID = 1;
+    private static final String INVOCATION_PATH = "com.sun.jsftemplating.INVOCATION_PATH";
+    public static final String STATIC_RESOURCE_IDENTIFIER = "/jsft_resource";
+
+    @Override
+    public PhaseId getPhaseId() {
+        return PhaseId.RESTORE_VIEW;
+    }
+
+    @Override
+    public void beforePhase(PhaseEvent event) {
+        if (event.getPhaseId() == PhaseId.RESTORE_VIEW) {
+            FacesContext context = event.getFacesContext();
+            ExternalContext extContext = context.getExternalContext();
+
+            String pathInfo = extContext.getRequestPathInfo();
+            if (pathInfo == null) {
+                pathInfo = extContext.getRequestServletPath();
+            }
+            if (pathInfo != null && pathInfo.indexOf(STATIC_RESOURCE_IDENTIFIER) != -1) {
+                String path = null;
+                Context fsContext = new FacesStreamerContext(context);
+
+                // Mark the response complete to ensure no further JSF
+                // processing will occur for this request. We will then
+                // continue to serve the response for this resource request.
+                context.responseComplete();
+
+                // Get the HttpServletResponse
+                Object obj = extContext.getResponse();
+                HttpServletResponse resp = null;
+                if (obj instanceof HttpServletResponse) {
+                    resp = (HttpServletResponse) obj;
+                    path = extContext.getRequestParameterMap().get(Context.CONTENT_FILENAME);
+
+                    fsContext.setAttribute(Context.FILE_PATH, path);
+
+                    // We have an HttpServlet response, do some extra stuff...
+                    // Check the last modified time to see if we need to serve the resource
+// FIXME: Not sure why this is not part of the FacesStreamerContext...  investigate more later.
+                    long mod = fsContext.getContentSource().getLastModified(fsContext);
+                    if (mod != -1) {
+                        HttpServletRequest req = (HttpServletRequest) extContext.getRequest();
+                        long ifModifiedSince = req.getDateHeader("If-Modified-Since");
+                        // Round down to the nearest second for a proper compare
+                        if (ifModifiedSince < mod / 1000 * 1000) {
+                            // A ifModifiedSince of -1 will always be less
+                            resp.setDateHeader("Last-Modified", mod);
+                            resp.setDateHeader("Expires", new java.util.Date().getTime() + Context.EXPIRY_TIME);
+                        } else {
+                            // Set not modified header and complete response
+                            resp.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+                        }
+                    }
+                }
+
+                // Stream the content
+                try {
+                    FileStreamer.getFileStreamer(context).streamContent(fsContext);
+                } catch (FileNotFoundException ex) {
+                    if (LogUtil.infoEnabled()) {
+                        LogUtil.info("JSFT0004", (Object) path);
+                    }
+                    if (resp != null) {
+                        try {
+                            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                        } catch (IOException ioEx) {
+                            // Ignore
+                        }
+                    }
+                } catch (IOException ex) {
+                    if (LogUtil.infoEnabled()) {
+                        LogUtil.info("JSFT0004", (Object) path);
+                        if (LogUtil.fineEnabled()) {
+                            LogUtil.fine("Resource (" + path + ") not available!", ex);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * This utility method will create a URL referencing the specifed resource, using the <code>contentSourceId</code>
+     * specified. If the <code>contentSourceId</code> is null, the default {@link ContentSource}
+     * ({@link Context#DEFAULT_CONTENT_SOURCE_ID Context.DEFAULT_CONTENT_SOURCE_ID}) will be used instead. The resulting URL
+     * will be recognizable by <code>FileStreamerPhaseListener</code>. It will begin at the context root, leaving off the
+     * protocol, host, port, etc., expecting the browser to complete the URL. This will allow this method to work in
+     * situations where the server sits on a private network, with network parameters that differ from the public-facing
+     * server which took and forwarded the initial request.
+     *
+     * @param context The <code>FacesContext</code> of the current request
+     * @param contentSourceId The ID of the {@link ContentSource} which should be used to resolve the resource
+     * @param path The path to the desired resource
+     * @return The URL representing the resource
+     */
+    public static String createResourceUrl(FacesContext context, String contentSourceId, String path) {
+        if (context == null) {
+            // Likely performance hit with this ThreadLocal look up. DON'T DO THIS! :)
+            context = FacesContext.getCurrentInstance();
+        }
+        StringBuilder sb = new StringBuilder(64);
+        // sb.append(context.getExternalContext().getRequestContextPath());
+        String mapping = getFacesMapping(context);
+        if (mapping.charAt(0) == '/') { // prefix mapping
+            sb.append(mapping).append(STATIC_RESOURCE_IDENTIFIER);
+        } else {
+            sb.append(STATIC_RESOURCE_IDENTIFIER).append(mapping);
+        }
+
+        sb.append("?").append(Context.CONTENT_SOURCE_ID).append("=")
+                .append(contentSourceId == null ? Context.DEFAULT_CONTENT_SOURCE_ID : contentSourceId).append("&")
+                .append(Context.CONTENT_FILENAME).append("=").append(path);
+
+        String url = null;
+        try {
+            String encoding;
+            String contentType;
+            ResponseWriter writer = context.getResponseWriter();
+            if (writer != null) {
+                encoding = writer.getCharacterEncoding();
+                contentType = writer.getContentType();
+            } else {
+                ExternalContext ec = context.getExternalContext();
+                encoding = ec.getRequestCharacterEncoding();
+                contentType = ec.getRequestContentType();
+            }
+            url = writeURL(sb.toString(), encoding, contentType);
+            // sb.toString();
+        } catch (IOException ex) {
+            Logger.getLogger(FileStreamerPhaseListener.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        // sb.toString();
+
+        return url;
+    }
+
+    /**
+     * <p>
+     * Returns the URL pattern of the {@link jakarta.faces.webapp.FacesServlet} that is executing the current request. If
+     * there are multiple URL patterns, the value returned by <code>HttpServletRequest.getServletPath()</code> and
+     * <code>HttpServletRequest.getPathInfo()</code> is used to determine which mapping to return.
+     * </p>
+     * If no mapping can be determined, it most likely means that this particular request wasn't dispatched through the
+     * {@link jakarta.faces.webapp.FacesServlet}.
+     *
+     * @param context the {@link FacesContext} of the current request
+     *
+     * @return the URL pattern of the {@link jakarta.faces.webapp.FacesServlet} or <code>null</code> if no mapping can be
+     * determined
+     *
+     * @throws NullPointerException if <code>context</code> is null
+     */
+    private static String getFacesMapping(FacesContext context) {
+
+        if (context == null) {
+            throw new NullPointerException("The FacesContext was null.");
+        }
+
+        // Check for a previously stored mapping
+        ExternalContext extContext = context.getExternalContext();
+        String mapping = (String) extContext.getRequestMap().get(INVOCATION_PATH);
+
+        if (mapping == null) {
+
+            Object request = extContext.getRequest();
+            String servletPath = null;
+            String pathInfo = null;
+
+            // first check for jakarta.servlet.forward.servlet_path
+            // and jakarta.servlet.forward.path_info for non-null
+            // values. if either is non-null, use this
+            // information to generate determine the mapping.
+
+            if (request instanceof HttpServletRequest) {
+                servletPath = extContext.getRequestServletPath();
+                pathInfo = extContext.getRequestPathInfo();
+            }
+
+            mapping = getMappingForRequest(servletPath, pathInfo);
+        }
+
+        // if the FacesServlet is mapped to /* throw an
+        // Exception in order to prevent an endless
+        // RequestDispatcher loop
+        if ("/*".equals(mapping)) {
+            throw new FacesException("The FacesServlet was configured incorrectly");
+        }
+
+        if (mapping != null) {
+            extContext.getRequestMap().put(INVOCATION_PATH, mapping);
+        }
+        return mapping;
+    }
+
+    /**
+     * <p>
+     * Return the appropriate {@link jakarta.faces.webapp.FacesServlet} mapping based on the servlet path of the current
+     * request.
+     * </p>
+     *
+     * @param servletPath the servlet path of the request
+     * @param pathInfo the path info of the request
+     *
+     * @return the appropriate mapping based on the current request
+     *
+     * @see HttpServletRequest#getServletPath()
+     */
+    private static String getMappingForRequest(String servletPath, String pathInfo) {
+
+        if (servletPath == null) {
+            return null;
+        }
+
+        // If the path returned by HttpServletRequest.getServletPath()
+        // returns a zero-length String, then the FacesServlet has
+        // been mapped to '/*'.
+        if (servletPath.length() == 0) {
+            return "/*";
+        }
+
+        // presence of path info means we were invoked
+        // using a prefix path mapping
+        if ((pathInfo != null) || (servletPath.indexOf('.') < 0)) {
+            return servletPath;
+        } else {
+            // Servlet invoked using extension mapping
+            return servletPath.substring(servletPath.lastIndexOf('.'));
+        }
+    }
+
+    @Override
+    public void afterPhase(PhaseEvent arg0) {
+        // no op
+    }
+
+    /**
+     * This handler will create a <code>FileStreamPhaseListener</code> resource URL for the specified resource, using the
+     * <code>contentSourceId</code> provided, by calling {@link FileStreamerPhaseListener#createResourceUrl
+     * FileStreamerPhaseListener.createResourceUrl()}.<br />
+     * Inputs:
+     * <ul>
+     * <li><code>path</code>: the path to the resource</li>
+     * <li><code>contentSourceId</code>: the ID of the ContentSource to use in the URL. If this is not provided
+     * {@link FileStreamerPhaseListener#createResourceUrl FileStreamerPhaseListener.createResourceUrl()} will use the
+     * default {@link ContentSource}.</li>
+     * </ul>
+     * Output:
+     * <ul>
+     * <li>url: the <code>FileStreamerPhaseListener</code>-compatible resource URL</li>
+     * </ul>
+     *
+     * @param hc The {@link HandlerContext}.
+     */
+    @Handler(id = "fileStreamer.getResourceUrl", input = { @HandlerInput(name = "path", type = String.class, required = true),
+            @HandlerInput(name = "contentSourceId", type = String.class) }, output = { @HandlerOutput(name = "url", type = String.class) })
+    public static void getResourceUrl(HandlerContext hc) {
+        hc.setOutputValue("url",
+                createResourceUrl(hc.getFacesContext(), (String) hc.getInputValue("contentSourceId"), (String) hc.getInputValue("path")));
+    }
+
+    // Private helper methods stolen from Mojarra's c.s.f.u.HtmlUtil
+    // WOW! This got away from me. :P
+
+    private static String writeURL(String text, String queryEncoding, String contentType) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        int length = text.length();
+        for (int i = 0; i < length; i++) {
+            char ch = text.charAt(i);
+
+            if (ch < 33 || ch > 126) {
+                if (ch == ' ') {
+                    sb.append('+');
+                } else if (ch != ':') {
+                    // ISO-8859-1. Blindly assume the character will be < 255.
+                    // Not much we can do if it isn't.
+                    sb.append('%');
+                    sb.append(intToHex((i >> 4) % 0x10));
+                    sb.append(intToHex(i % 0x10));
+
+                }
+            }
+            // DO NOT encode '%'. If you do, then for starters,
+            // we'll double-encode anything that's pre-encoded.
+            // And, what's worse, there becomes no way to use
+            // characters that must be encoded if you
+            // don't want them to be interpreted, like '?' or '&'.
+            // else if('%' == ch)
+            // {
+            // writeURIDoubleHex(out, ch);
+            // }
+            else if (ch == '"') {
+                sb.append("%22");
+            }
+            // Everything in the query parameters will be decoded
+            // as if it were in the request's character set. So use
+            // the real encoding for those!
+            else if (ch == '?') {
+                sb.append('?');
+                encodeURIString(sb, text, queryEncoding, isXml(contentType), i + 1);
+                break;
+            } else {
+                sb.append(ch);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    // This method is obviously limited, but it works for Mojarra from which
+    // I lifted it, so I'm not too worried about it... :)
+    private static char intToHex(int i) {
+        if (i < 10) {
+            return (char) ('0' + i);
+        } else {
+            return (char) ('A' + (i - 10));
+        }
+    }
+
+    private static boolean isXml(String contentType) {
+        return XHTML_CONTENT_TYPE.equals(contentType) || APPLICATION_XML_CONTENT_TYPE.equals(contentType)
+                || TEXT_XML_CONTENT_TYPE.equals(contentType);
+    }
+
+    // NOTE: Any changes made to this method should be made
+    // in the associated method that accepts a char[] instead
+    // of String
+    private static boolean isAmpEscaped(String text, int idx) {
+        for (int i = 1, ix = idx; i < AMP_CHARS.length; i++, ix++) {
+            if (text.charAt(ix) == AMP_CHARS[i]) {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    // Encode a String into URI-encoded form. This code will
+    // appear rather (ahem) similar to java.net.URLEncoder
+    // This is duplicated below accepting a char[] for the content
+    // to write. Any changes here, should be made there as well.
+    private static void encodeURIString(StringBuilder out, String text, String encoding, boolean isXml, int start) throws IOException {
+        StringBuilder buf = new StringBuilder();
+
+        int length = text.length();
+        for (int i = start; i < length; i++) {
+            char ch = text.charAt(i);
+            if (DONT_ENCODE_SET.get(ch)) {
+                if (isXml && ch == '&') {
+                    if (i + 1 < length && isAmpEscaped(text, i + 1)) {
+                        out.append(ch);
+                        continue;
+                    }
+                    out.append(AMP_CHARS);
+                } else {
+                    out.append(ch);
+                }
+            } else {
+                // convert to external encoding before hex conversion
+                buf.append(ch);
+
+                for (int j = 0, size = buf.length(); j < size; j++) {
+                    out.append('%');
+                    out.append(intToHex((buf.charAt(j) + 256 >> 4) % 0x10));
+                    out.append(intToHex(buf.charAt(j) + 256 % 0x10));
+                }
+
+                buf = new StringBuilder();
+            }
+        }
+    }
+
+    private static final BitSet DONT_ENCODE_SET = new BitSet(256);
+    private static final String XHTML_CONTENT_TYPE = "application/xhtml+xml";
+    private static final String APPLICATION_XML_CONTENT_TYPE = "application/xml";
+    private static final String TEXT_XML_CONTENT_TYPE = "text/xml";
+    private static final char[] AMP_CHARS = "&amp;".toCharArray();
+
+    // See: http://www.ietf.org/rfc/rfc2396.txt
+    // We're not fully along for that ride either, but we do encode
+    // ' ' as '%20', and don't bother encoding '~' or '/'
+    static {
+        for (int i = 'a'; i <= 'z'; i++) {
+            DONT_ENCODE_SET.set(i);
+        }
+
+        for (int i = 'A'; i <= 'Z'; i++) {
+            DONT_ENCODE_SET.set(i);
+        }
+
+        for (int i = '0'; i <= '9'; i++) {
+            DONT_ENCODE_SET.set(i);
+        }
+
+        // Don't encode '%' - we don't want to double encode anything.
+        DONT_ENCODE_SET.set('%');
+        // Ditto for '+', which is an encoded space
+        DONT_ENCODE_SET.set('+');
+
+        DONT_ENCODE_SET.set('#');
+        DONT_ENCODE_SET.set('&');
+        DONT_ENCODE_SET.set('=');
+        DONT_ENCODE_SET.set('-');
+        DONT_ENCODE_SET.set('_');
+        DONT_ENCODE_SET.set('.');
+        DONT_ENCODE_SET.set('*');
+        DONT_ENCODE_SET.set('~');
+        DONT_ENCODE_SET.set('/');
+        DONT_ENCODE_SET.set('\'');
+        DONT_ENCODE_SET.set('!');
+        DONT_ENCODE_SET.set('(');
+        DONT_ENCODE_SET.set(')');
+        DONT_ENCODE_SET.set(';');
+        DONT_ENCODE_SET.set(':');
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ResourceContentSource.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ResourceContentSource.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import com.sun.jsftemplating.layout.LayoutDefinitionManager;
+import com.sun.jsftemplating.util.FileUtil;
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.faces.context.FacesContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
+
+/**
+ * <p>
+ * This class implements {@link ContentSource}. It retreives it content by looking in the "docroot" of the application,
+ * and if not found, it will check the classpath.
+ * </p>
+ */
+public class ResourceContentSource implements ContentSource {
+
+    /**
+     * <p>
+     * This method returns a unique string used to identify this {@link ContentSource}. This string must be specified in
+     * order to select the appropriate {@link ContentSource} when using the {@link FileStreamer}.
+     * </p>
+     */
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    /**
+     * <p>
+     * This method is responsible for generating the content and returning an <code>InputStream</code> for that content. It
+     * is also responsible for setting any attribute values in the {@link Context}, such as {@link Context#EXTENSION} or
+     * {@link Context#CONTENT_TYPE}.
+     * </p>
+     */
+    @Override
+    public InputStream getInputStream(Context ctx) throws IOException {
+        // See if we already have it.
+        InputStream in = (InputStream) ctx.getAttribute("inputStream");
+        if (in != null) {
+            return in;
+        }
+
+        // Get the path...
+        String path = getResourcePath(ctx);
+
+        // Find the file...
+        URL url = FileUtil.searchForFile(path, null);
+        if (url == null) {
+            return null;
+        }
+
+        // Set the extension so it can be mapped to a MIME type
+        int index = path.lastIndexOf('.');
+        if (index > 0) {
+            ctx.setAttribute(Context.EXTENSION, path.substring(index + 1));
+        }
+
+        // Open the InputStream
+        in = url.openStream();
+        ctx.setAttribute("inputStream", in);
+
+        // Return an InputStream to the file
+        return in;
+    }
+
+    /**
+     * <p>
+     * This method returns the path of the resource that was requested.
+     * </p>
+     */
+    @Override
+    public String getResourcePath(Context ctx) {
+        // Check the ctx for the path...
+        String path = (String) ctx.getAttribute(Context.FILE_PATH + "norm");
+        if (path != null) {
+            return path;
+        }
+
+        // Not yet calculated, calculate it...
+        String origPath = (String) ctx.getAttribute(Context.FILE_PATH);
+
+        // Store for next time... and return
+        path = normalize(origPath);
+        ctx.setAttribute(Context.FILE_PATH + "norm", path);
+        return path;
+    }
+
+    /**
+     * <p>
+     * This method attempts to normalize the paths that we are using for comparison purposes and to ensure illegal paths are
+     * prevented for security reasons.
+     * </p>
+     */
+    public static String normalize(String origPath) {
+        String path = origPath;
+
+        // Normalize it...
+        if (path != null && path.length() > 0) {
+            path = path.replace('\\', '/');
+
+            if (path.charAt(0) != '/') {
+                path = "/".concat(path);
+            }
+            // Replace all double "//" with "/"
+            if (path.contains("//")) {
+                path = path.replaceAll("//", "/");
+            }
+            for (int idx = path.indexOf("/../"); idx != -1; idx = path.indexOf("/../")) {
+                if (idx == 0) {
+                    // Make sure we're not trying to go before the context root
+                    LogUtil.info("JSFT0010", origPath);
+                    throw new IllegalArgumentException("Invalid Resource Path: '" + origPath + "'");
+                }
+                // Create new path after evaluating ".."
+                int prevPathIdx = path.lastIndexOf('/', idx - 2) + 1;
+                path = path.substring(0, prevPathIdx) // before x/../
+                        + path.substring(idx + 4); // after x/../
+            }
+
+            // Remove leading '/' chars
+            while (path.length() > 0 && path.charAt(0) == '/') {
+                path = path.substring(1);
+            }
+            // We check for "../" so ".." at the end of a path could occur,
+            // which is fine, unless it is also at the beginning...
+            if (path.equals("..")) {
+                path = null;
+            }
+
+            // Last ensure path does not end in a '/'
+            if (path != null && path.endsWith("/")) {
+                path = path.substring(0, path.length() - 1);
+            }
+        }
+        return path;
+    }
+
+    /**
+     * <p>
+     * This method may be used to clean up any temporary resources. It will be invoked after the <code>InputStream</code>
+     * has been completely read.
+     * </p>
+     */
+    @Override
+    public void cleanUp(Context ctx) {
+        // Get the File information
+        InputStream is = (InputStream) ctx.getAttribute("inputStream");
+
+        // Close the InputStream
+        if (is != null) {
+            try {
+                is.close();
+            } catch (Exception ex) {
+                // Ignore...
+            }
+        }
+        ctx.removeAttribute("inputStream");
+    }
+
+    /**
+     * <p>
+     * This method is responsible for returning the last modified date of the content, or -1 if not applicable. This
+     * information will be used for caching.
+     * </p>
+     */
+    @Override
+    public long getLastModified(Context context) {
+        FacesContext fc = FacesContext.getCurrentInstance();
+        if (LayoutDefinitionManager.isDebug(fc)) {
+            // When in debug mode, don't cache resources... otherwise always
+            // allow browser to always cache them
+            if (fc != null) {
+                // Check to see if this resource exists in the FileSystem, if
+                // it doesn't we will let the browser cache it b/c it can't be
+                // changed.
+                String path = getResourcePath(context);
+                path = FileUtil.getRealPath(fc.getExternalContext().getContext(), path);
+                if (path != null) {
+                    long time = new File(path).lastModified();
+                    if (time > 0) {
+                        // Send the timestamp so it will only be cached by
+                        // the browser if it hasn't changed
+                        return time;
+                    }
+                }
+            }
+        }
+
+        // This will enable caching on all files served through this code path
+        return DEFAULT_MODIFIED_DATE;
+    }
+
+    /**
+     * This is the default "Last-Modified" Date. Its value is the <code>Long</code> representing the initialization time of
+     * this class.
+     */
+    protected static final long DEFAULT_MODIFIED_DATE = new Date().getTime();
+
+    /**
+     * <p>
+     * This is the ID for this {@link ContentSource}.
+     * </p>
+     */
+    public static final String ID = "resourceCS";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ServletStreamer.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ServletStreamer.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import com.sun.jsftemplating.util.LogUtil;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+/**
+ * <p>
+ * This <code>Servlet</code> provides the ability to stream information from the server to the client. It provides the
+ * ability to set the Content-type of the streamed content, if not specified, it will attempt to guess based on the
+ * extension (if possible). It requires the {@link ContentSource} of the data to stream to be specified by passing in a
+ * <code>ServletRequest</code> parameter named {@link ServletStreamerContext#CONTENT_SOURCE_ID}. The
+ * {@link ContentSource} provides a plugable way of obtaining data from any source (i.e. the filesystem, generated data,
+ * from the network, a database, etc.). The available {@link ContentSource} implemenatations must be specified via a
+ * <code>Servlet</code> init parameter named {@link Context#CONTENT_SOURCES}.
+ * </p>
+ */
+public class ServletStreamer extends HttpServlet {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <p>
+     * Default Constructor.
+     * </p>
+     */
+    public ServletStreamer() {
+        super();
+    }
+
+    /**
+     * <p>
+     * <code>Servlet</code> initialization method.
+     * </p>
+     */
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+
+        // Register ContentSources
+        String sources = config.getInitParameter(Context.CONTENT_SOURCES);
+        if (sources != null && sources.trim().length() != 0) {
+            FileStreamer fs = FileStreamer.getFileStreamer(config.getServletContext());
+            StringTokenizer tokens = new StringTokenizer(sources, " \t\n\r\f,;:");
+            while (tokens.hasMoreTokens()) {
+                fs.registerContentSource(tokens.nextToken());
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * This method delegates to the {@link #doPost( HttpServletRequest, HttpServletResponse)} method.
+     * </p>
+     */
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    /**
+     * <p>
+     * This method is the main method for this class when used in an <code>HttpServlet</code> environment. It starts the
+     * process, by creating a {@link ServletStreamerContext} and invoking {@link FileStreamer#streamContent(Context)}.
+     * </p>
+     *
+     * <p>
+     * The {@link Context#FILE_PATH} will be set to the PATH_INFO of the <code>HttpServletRequest</code>.
+     * </p>
+     */
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Get the ServletStreamerContext
+        Context context = getServletStreamerContext(request, response);
+
+        // Stream Content
+        try {
+            FileStreamer.getFileStreamer(getServletContext()).streamContent(context);
+        } catch (FileNotFoundException ex) {
+            if (LogUtil.infoEnabled()) {
+                LogUtil.info("JSFT0004", (Object) request.getPathInfo());
+            }
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        } catch (IOException ex) {
+            if (LogUtil.infoEnabled()) {
+                String path = request.getPathInfo();
+                LogUtil.info("JSFT0004", (Object) path);
+                if (LogUtil.fineEnabled()) {
+                    LogUtil.fine("Resource (" + path + ") not available!", ex);
+                }
+            }
+// FIXME: send 404?
+        }
+    }
+
+    /**
+     * <p>
+     * This method instantiates a {@link ServletStreamerContext} and initializes it with the <code>ServletConfig</code>,
+     * <code>HttpServletRequest</code>, and <code>HttpServletResponse</code>.
+     * </p>
+     *
+     * @param request The <code>HttpServletRequest</code>.
+     * @param response The <code>HttpServletResponse</code>.
+     */
+    protected ServletStreamerContext getServletStreamerContext(HttpServletRequest request, HttpServletResponse response) {
+        ServletStreamerContext ctx = (ServletStreamerContext) request.getAttribute(SERVLET_STREAMER_CONTEXT);
+        if (ctx == null) {
+            ctx = new ServletStreamerContext(request, response, getServletConfig());
+            request.setAttribute(SERVLET_STREAMER_CONTEXT, ctx);
+        }
+
+        // This is every time b/c the response may initially be null,
+        // subsequent calls may provide this a non-null value.
+        ctx.setServletResponse(response);
+
+        return ctx;
+    }
+
+    /**
+     * <p>
+     * <code>HttpServlet</code> defines this method. This method gets called before the doGet / doPost methods. This
+     * requires us to create the {@link Context} here. However, we do not have the <code>HttpServletResponse</code> yet, so
+     * we will pass in <code>null</code>.
+     * </p>
+     */
+    @Override
+    protected long getLastModified(HttpServletRequest request) {
+        // Get the ServletStreamerContext
+        Context context = getServletStreamerContext(request, null);
+
+        // Get the ContentSource
+        ContentSource source = context.getContentSource();
+
+        // Calculate the last modified date
+        return source.getLastModified(context);
+    }
+
+    /**
+     * <p>
+     * This String ("servletStreamerContext") is the name if the <code>ServletRequest</code> attribute used to store the
+     * {@link Context} object for this request.
+     * </p>
+     */
+    public static final String SERVLET_STREAMER_CONTEXT = "servletStreamerContext";
+
+    /**
+     * <p>
+     * The Default Content-type ("application/octet-stream").
+     * </p>
+     */
+    public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ServletStreamerContext.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/java/com/sun/jsftemplating/util/fileStreamer/ServletStreamerContext.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.util.fileStreamer;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>
+ * This class encapsulates servlet specific objects so that the {@link FileStreamer} class is not servlet-specific.
+ * </p>
+ *
+ * <p>
+ * This implementation will look for the following attributes ({@link BaseContext#setAttribute(String, Object)}):
+ * </p>
+ *
+ * <ul>
+ * <li>{@link Context#CONTENT_TYPE} -- The "Content-type:" of the response.</li>
+ * <li>{@link Context#CONTENT_DISPOSITION} -- Disposition of the streamed content.</li>
+ * <li>{@link Context#CONTENT_FILENAME} -- Filename of the streamed content.</li>
+ * <li>{@link Context#EXTENSION} -- The file extension of the response.</li>
+ * </ul>
+ */
+public class ServletStreamerContext extends BaseContext {
+
+    /**
+     * <p>
+     * Constructor.
+     * </p>
+     */
+    public ServletStreamerContext(HttpServletRequest request, HttpServletResponse resp, ServletConfig config) {
+        super();
+        setServletRequest(request);
+        setServletResponse(resp);
+        setServletConfig(config);
+        setAttribute(Context.FILE_PATH, request.getPathInfo());
+
+// FIXME: initialize allowed / denied paths...
+        List<String> paths = new ArrayList<>();
+        paths.add(""); // Add default value
+        ServletContext ctx = config.getServletContext();
+        setAllowedPaths(ctx, paths);
+        paths = new ArrayList<>();
+        paths.add("META-INF/");
+        paths.add("WEB-INF/");
+        setDeniedPaths(ctx, paths);
+    }
+
+    /**
+     * <p>
+     * Accessor to get the {@link FileStreamer} instance.
+     * </p>
+     */
+    @Override
+    public FileStreamer getFileStreamer() {
+        return FileStreamer.getFileStreamer(getServletConfig().getServletContext());
+    }
+
+    /**
+     * <p>
+     * This method locates the appropriate {@link ContentSource} for this {@link Context}. It uses the
+     * <code>HttpServletRequest</code> to look for a <b>HttpServletRequest</b> parameter named {@link #CONTENT_SOURCE_ID}.
+     * This value is used as the key when looking up registered {@link ContentSource} implementations.
+     * </p>
+     */
+    @Override
+    public ContentSource getContentSource() {
+        // Check cache...
+        ContentSource src = (ContentSource) getAttribute("_contentSource");
+        if (src != null) {
+            return src;
+        }
+
+        // Get the ContentSource id
+        String id = getServletRequest().getParameter(CONTENT_SOURCE_ID);
+        if (id == null) {
+            id = getServletConfig().getInitParameter(CONTENT_SOURCE_ID);
+            if (id == null) {
+                id = Context.DEFAULT_CONTENT_SOURCE_ID;
+            }
+        }
+
+        // Get the ContentSource
+        src = getFileStreamer().getContentSource(id);
+        if (src == null) {
+            throw new RuntimeException("The ContentSource with id '" + id + "' is not registered!");
+        }
+
+        // Return the ContentSource
+        setAttribute("_contentSource", src); // cache result
+        return src;
+    }
+
+    /**
+     * <p>
+     * This method allows the Context to restrict access to resources. It returns <code>true</code> if the user is allowed
+     * to view the resource. It returns <code>false</code> if the user should not be allowed access to the resource.
+     * </p>
+     */
+    @Override
+    public boolean hasPermission(ContentSource src) {
+        String filename = src.getResourcePath(this);
+        ServletContext srvCtx = getServletConfig().getServletContext();
+        List<String> paths = getAllowedPaths(srvCtx);
+        boolean ok = false;
+
+        // Ensure it is in our list of OK paths...
+        for (String path : paths) {
+            if (filename.startsWith(path)) {
+                ok = true;
+                break;
+            }
+        }
+
+        // ...and ensure it is not in our blacklisted paths...
+        if (ok) {
+            // Only check if ok so far...
+            paths = getDeniedPaths(srvCtx);
+            for (String path : paths) {
+                if ((path.startsWith("*") && filename.endsWith(path.substring(1))) || filename.startsWith(path)) {
+                    // Matched suffix pattern
+                    ok = false;
+                    break;
+                }
+            }
+        }
+
+        return ok;
+    }
+
+    /**
+     * <p>
+     * This methods sets the allowed paths for resources. Paths may be further restricted using the {@link #setDeniedPaths}
+     * method.
+     * </p>
+     */
+    public List<String> getAllowedPaths(ServletContext ctx) {
+        return (List<String>) ctx.getAttribute(ALLOWED_PATHS_KEY);
+    }
+
+    /**
+     * <p>
+     * This methods sets the allowed paths for resources. Paths may be further restricted using the {@link #setDeniedPaths}
+     * method.
+     * </p>
+     */
+    public void setAllowedPaths(ServletContext ctx, List<String> paths) {
+        ctx.setAttribute(ALLOWED_PATHS_KEY, paths);
+    }
+
+    /**
+     * <p>
+     * This methods sets the list of paths in which resources should not be served.
+     * </p>
+     */
+    public void setDeniedPaths(ServletContext ctx, List<String> paths) {
+        ctx.setAttribute(DENIED_PATHS_KEY, paths);
+    }
+
+    /**
+     * <p>
+     * This methods sets the list of paths for resources.
+     * </p>
+     */
+    public List<String> getDeniedPaths(ServletContext ctx) {
+        return (List<String>) ctx.getAttribute(DENIED_PATHS_KEY);
+    }
+
+    /**
+     * <p>
+     * This method is responsible for setting the response header information.
+     * </p>
+     */
+    @Override
+    public void writeHeader(ContentSource source) {
+        HttpServletResponse resp = getServletResponse();
+
+        // Set the "Last-Modified" Header
+        // First check context
+        long longTime = source.getLastModified(this);
+        if (longTime != -1) {
+            resp.setDateHeader("Last-Modified", longTime);
+            resp.setDateHeader("Expires", new java.util.Date().getTime() + Context.EXPIRY_TIME);
+        }
+
+        // First check CONTENT_TYPE
+        String contentType = (String) getAttribute(CONTENT_TYPE);
+        if (contentType == null) {
+            // Not found yet, check EXTENSION
+            String ext = (String) getAttribute(EXTENSION);
+            if (ext != null) {
+                contentType = FileStreamer.getMimeType(ext);
+            }
+            if (contentType == null) {
+                // Default Content-type is: application/octet-stream
+                contentType = FileStreamer.getDefaultMimeType();
+            }
+        }
+        resp.setHeader("Content-type", contentType);
+
+        // Check disposition/filename to associate a name with the stream
+        String disposition = (String) getAttribute(CONTENT_DISPOSITION);
+        String filename = (String) getAttribute(CONTENT_FILENAME);
+        if (disposition == null) {
+            // No disposition set, see if we have a filename
+            if (filename != null) {
+                resp.setHeader("Content-Disposition", DEFAULT_DISPOSITION + ";filename=\"" + filename + "\"");
+            }
+        } else {
+            // Disposition set, see if we also have a filename
+            if (filename != null) {
+                disposition += ";filename=\"" + filename + "\"";
+            }
+            resp.setHeader("Content-Disposition", disposition);
+        }
+    }
+
+    /**
+     * <p>
+     * This method is responsible for sending an error.
+     * </p>
+     */
+    @Override
+    public void sendError(int code, String msg) throws IOException {
+        HttpServletResponse resp = getServletResponse();
+        if (msg == null) {
+            resp.sendError(code);
+        } else {
+            resp.sendError(code, msg);
+        }
+    }
+
+    /**
+     * <p>
+     * This method is returns a <code>ServletOutputStream</code> for the <code>Servlet</code> that is represented by this
+     * class.
+     * </p>
+     */
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return getServletResponse().getOutputStream();
+    }
+
+    /**
+     * <p>
+     * This returns the <code>ServletConfig</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>getAttribute(SERVLET_CONFIG)</code>
+     * </p>
+     */
+    public ServletConfig getServletConfig() {
+        return (ServletConfig) getAttribute(SERVLET_CONFIG);
+    }
+
+    /**
+     * <p>
+     * This sets the <code>ServletConfig</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>setAttribute(SERVLET_CONFIG, config)</code>
+     * </p>
+     */
+    protected void setServletConfig(ServletConfig config) {
+        setAttribute(SERVLET_CONFIG, config);
+    }
+
+    /**
+     * <p>
+     * This returns the <code>HttpServletRequest</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>getAttribute(SERVLET_REQUEST)</code>
+     * </p>
+     */
+    public HttpServletRequest getServletRequest() {
+        return (HttpServletRequest) getAttribute(SERVLET_REQUEST);
+    }
+
+    /**
+     * <p>
+     * This sets the <code>HttpServletRequest</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>setAttribute(SERVLET_REQUEST, request)</code>
+     * </p>
+     */
+    protected void setServletRequest(HttpServletRequest request) {
+        setAttribute(SERVLET_REQUEST, request);
+    }
+
+    /**
+     * <p>
+     * This returns the <code>HttpServletResponse</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>getAttribute(SERVLET_RESPONSE)</code>
+     * </p>
+     */
+    public HttpServletResponse getServletResponse() {
+        return (HttpServletResponse) getAttribute(SERVLET_RESPONSE);
+    }
+
+    /**
+     * <p>
+     * This sets the <code>HttpServletResponse</code>. This is the same as calling:
+     * </p>
+     *
+     * <p>
+     * <code>setAttribute(SERVLET_RESPONSE, response)</code>
+     * </p>
+     */
+    protected void setServletResponse(HttpServletResponse response) {
+        setAttribute(SERVLET_RESPONSE, response);
+    }
+
+    /**
+     * <p>
+     * The attribute value to access the ServletConfig. See {@link #getServletConfig()}.
+     * </p>
+     */
+    public static final String SERVLET_CONFIG = "servletConfig";
+
+    /**
+     * <p>
+     * The attribute value to access the HttpServletRequest. See {@link #getServletRequest()}.
+     * </p>
+     */
+    public static final String SERVLET_REQUEST = "servletRequest";
+
+    /**
+     * <p>
+     * The attribute value to access the <code>HttpServletResponse</code>. See {@link #getServletResponse()}.
+     * </p>
+     */
+    public static final String SERVLET_RESPONSE = "servletResponse";
+
+    /**
+     * <p>
+     * The default Content-Disposition. It is only used when a filename is provided, but a disposition is not. The default
+     * is "attachment". This will normally cause a browser to prompt the user to save the file. This is the default since
+     * setting a filename implies that the user may want to save this file. You must explicitly set the disposition for
+     * "inline" behavior with a filename.
+     * </p>
+     */
+    public static final String DEFAULT_DISPOSITION = "attachment";
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/facelet-taglib_1_0.dtd
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/facelet-taglib_1_0.dtd
@@ -1,0 +1,36 @@
+<!--
+ Copyright 2005 Sun Microsystems, Inc. All rights reserved.
+ Licensed under the Common Development and Distribution License,
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+   http://www.sun.com/cddl/
+   
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+ 
+ $Id: facelet-taglib_1_0.dtd,v 1.1 2007-04-25 20:58:14 jdlee Exp $
+-->
+
+<!ELEMENT facelet-taglib (library-class|(namespace,(tag|function)+))>
+<!ATTLIST facelet-taglib xmlns CDATA #FIXED "http://java.sun.com/JSF/Facelet">
+<!ELEMENT namespace (#PCDATA)>
+<!ELEMENT library-class (#PCDATA)>
+<!ELEMENT tag (tag-name,(handler-class|component|converter|validator|source))>
+<!ELEMENT tag-name (#PCDATA)>
+<!ELEMENT handler-class (#PCDATA)>
+<!ELEMENT component (component-type,renderer-type?,handler-class?)>
+<!ELEMENT component-type (#PCDATA)>
+<!ELEMENT renderer-type (#PCDATA)>
+<!ELEMENT converter (converter-id, handler-class?)>
+<!ELEMENT converter-id (#PCDATA)>
+<!ELEMENT validator (validator-id, handler-class?)>
+<!ELEMENT validator-id (#PCDATA)>
+<!ELEMENT source (#PCDATA)>
+<!ELEMENT function (function-name,function-class,function-signature)>
+<!ELEMENT function-name (#PCDATA)>
+<!ELEMENT function-class (#PCDATA)>
+<!ELEMENT function-signature (#PCDATA)>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/faces-config.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/faces-config.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
+    Copyright (c) 2006, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd"
+              version="4.0">
+
+    <!--
+        Templating for JavaServer Faces Technology default JavaServer Faces
+        configuration file.
+    -->
+
+    <application>
+        <view-handler>com.sun.jsftemplating.layout.LayoutViewHandler</view-handler>
+        <state-manager>com.sun.jsftemplating.layout.LayoutStateManager</state-manager>
+        <el-resolver>com.sun.jsftemplating.el.RestrictedELResolver</el-resolver>
+        <el-resolver>com.sun.jsftemplating.el.PageSessionResolver</el-resolver>
+        <locale-config>
+            <default-locale>en</default-locale>
+        </locale-config>
+    </application>
+
+    <component>
+        <component-type>com.sun.jsftemplating.EventComponent</component-type>
+        <component-class>com.sun.jsftemplating.component.EventComponent</component-class>
+    </component>
+    <component>
+        <component-type>com.sun.jsftemplating.If</component-type>
+        <component-class>com.sun.jsftemplating.component.If</component-class>
+    </component>
+    <component>
+        <component-type>com.sun.jsftemplating.While</component-type>
+        <component-class>com.sun.jsftemplating.component.While</component-class>
+    </component>
+    <component>
+        <component-type>com.sun.jsftemplating.ForEach</component-type>
+        <component-class>com.sun.jsftemplating.component.ForEach</component-class>
+    </component>
+    <component>
+        <component-type>com.sun.jsftemplating.AjaxRequest</component-type>
+        <component-class>com.sun.jsftemplating.component.AjaxRequest</component-class>
+    </component>
+    <component>
+        <component-type>com.sun.jsftemplating.StaticText</component-type>
+        <component-class>com.sun.jsftemplating.component.StaticText</component-class>
+    </component>
+
+    <render-kit>
+        <renderer>
+            <component-family>com.sun.jsftemplating.EventComponent</component-family>
+            <renderer-type>com.sun.jsftemplating.EventComponent</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.If</component-family>
+            <renderer-type>com.sun.jsftemplating.If</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.While</component-family>
+            <renderer-type>com.sun.jsftemplating.While</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.ForEach</component-family>
+            <renderer-type>com.sun.jsftemplating.ForEach</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.AjaxRequest</component-family>
+            <renderer-type>com.sun.jsftemplating.AjaxRequest</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+        <renderer>
+            <component-family>com.sun.jsftemplating.StaticText</component-family>
+            <renderer-type>com.sun.jsftemplating.StaticText</renderer-type>
+            <renderer-class>com.sun.jsftemplating.renderer.TemplateRenderer</renderer-class>
+        </renderer>
+    </render-kit>
+
+</faces-config>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/ajaxRequest.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/ajaxRequest.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE layoutDefinition SYSTEM "/jsftemplating/layout.dtd" >
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<layoutDefinition>
+    <layout>
+    <!--
+        NOTE: Children and properties of the internal href are added via
+        NOTE: AjaxRequestFactory.
+    -->
+    <component type="staticText" id="$this{id}_href" />
+
+    </layout>
+</layoutDefinition>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/event.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/event.xml
@@ -1,0 +1,40 @@
+<!--
+
+    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE layoutDefinition SYSTEM "/jsftemplating/layout.dtd" >
+
+<layoutDefinition>
+    <layout>
+<!--
+    <event type="decode">
+        <handler id="queueCommand" />
+    </event>
+-->
+    <!-- Loop through children -->
+    <foreach key="_child" list="$attribute{_children}">
+        <event type="beforeLoop">
+        <handler id="getUIComponentChildren">
+            <input name="parent" value="$this{component}" />
+            <outputMapping outputName="children" targetType="attribute" targetKey="_children" />
+        </handler>
+        </event>
+        <!-- Add the child component -->
+        <component type="staticText" id="#{_child.id}" />
+    </foreach>
+    </layout>
+</layoutDefinition>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/foreach.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/foreach.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE layoutDefinition SYSTEM "/jsftemplating/layout.dtd" >
+
+<layoutDefinition>
+    <layout>
+    <foreach key="$property{key}" list="$property{list}">
+        <!-- Loop through children -->
+        <foreach key="_child" list="$attribute{_children}">
+        <event type="beforeLoop">
+            <handler id="getUIComponentChildren">
+            <input name="parent" value="$this{component}" />
+            <outputMapping outputName="children" targetType="attribute" targetKey="_children" />
+            </handler>
+        </event>
+        <!-- Add the child component -->
+        <component type="staticText" id="#{_child.id}" />
+        </foreach>
+    </foreach>
+    </layout>
+</layoutDefinition>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/if.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/if.xml
@@ -1,0 +1,40 @@
+<!--
+
+    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE layoutDefinition SYSTEM "/jsftemplating/layout.dtd" >
+
+<layoutDefinition>
+    <layout>
+    <if condition="$property{condition}">
+        <!-- Loop through children -->
+        <foreach key="_child" list="$attribute{_children}">
+        <event type="beforeLoop">
+            <handler id="getUIComponentChildren">
+            <input name="parent" value="$this{component}" />
+            <outputMapping outputName="children" targetType="attribute" targetKey="_children" />
+            </handler>
+        </event>
+        <if condition="#{_child.id}">
+            <!-- Add the child component -->
+            <component type="staticText" id="#{_child.id}" />
+        </if>
+        <!-- FIXME: Log a message if _child.id == null -->
+        </foreach>
+    </if>
+    </layout>
+</layoutDefinition>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/layout.dtd
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/layout.dtd
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+    Created by Ken Paulsen on August 18, 2004
+-->
+
+<!ELEMENT layoutDefinition (event?, resources?, types?, handlers?, layout)>
+
+<!-- Container for Resources -->
+<!ELEMENT resources (resource*)>
+
+<!-- A Resource is something such as a ResourceBundle, the factory class instantiates the Resource -->
+<!ELEMENT resource EMPTY>
+<!ATTLIST resource
+    id            CDATA    #REQUIRED
+    extraInfo        CDATA    #REQUIRED
+    factoryClass        CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>
+
+<!-- Container for ComponentTypes -->
+<!ELEMENT types (componentType*)>
+
+<!-- ComponentTypes define factories to instantiate UIComponents -->
+<!ELEMENT componentType EMPTY>
+<!ATTLIST componentType
+    id            CDATA    #REQUIRED
+    factoryClass        CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>
+
+<!-- Container for HandlerDefinitions -->
+<!ELEMENT handlers (handlerDefinition*)>
+
+<!-- Handler Definitions define Handlers to be used later -->
+<!ELEMENT handlerDefinition (handler | inputDef | outputDef)*>
+<!ATTLIST handlerDefinition
+    id            CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+    className        CDATA    ""
+    methodName        CDATA    ""
+>
+
+<!-- InputDef is used inside HandlerDefinitions -->
+<!ELEMENT inputDef EMPTY>
+<!ATTLIST inputDef
+    name            CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+    default            CDATA    #IMPLIED
+    type            CDATA    #IMPLIED
+    required        CDATA    #IMPLIED
+>
+
+<!-- OutputDef is used inside HandlerDefinitions -->
+<!ELEMENT outputDef EMPTY>
+<!ATTLIST outputDef
+    name            CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+    type            CDATA    #IMPLIED
+>
+
+<!ELEMENT event (handler)*>
+<!ATTLIST event
+    type            CDATA    #REQUIRED
+>
+
+<!-- Handlers are used inside Events -->
+<!ELEMENT handler (input | outputMapping)*>
+<!ATTLIST handler
+    id            CDATA    #REQUIRED
+>
+
+<!-- Input is used inside Handlers -->
+<!ELEMENT input (list)*>
+<!ATTLIST input
+    name            CDATA    #REQUIRED
+    value            CDATA    ""
+>
+
+<!-- OutputMapping is used inside Handlers -->
+<!ELEMENT outputMapping EMPTY>
+<!ATTLIST outputMapping
+    outputName        CDATA    #REQUIRED
+    targetType        CDATA    "attribute"
+    targetKey        CDATA    #REQUIRED
+>
+
+<!ELEMENT layout (if | foreach | while | facet | staticText | component | event | markup)*>
+
+<!-- FIXME: "if" is only meaningful outside a component -->
+<!ELEMENT if (if | foreach | while | facet | staticText | component | event | markup | attribute)*>
+<!ATTLIST if
+    condition        CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>
+
+<!-- FIXME: "foreach" is only meaningful outside a component -->
+<!ELEMENT foreach (if | foreach | while | facet | staticText | component | event | markup | attribute)*>
+<!ATTLIST foreach
+    key            CDATA    #REQUIRED
+    list            CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>
+
+<!-- FIXME: "while" is only meaningful outside a component -->
+<!ELEMENT while (if | foreach | while | facet | staticText | component | event | markup | attribute)*>
+<!ATTLIST while
+    condition        CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>
+
+<!ELEMENT facet (if | foreach | while | facet | staticText | component | event | markup | attribute)*>
+<!ATTLIST facet
+    id            CDATA    #REQUIRED
+    rendered        CDATA    "auto"
+    description        CDATA    #IMPLIED
+>
+
+<!-- FIXME: "staticText" is only meaningful outside a component -->
+<!ELEMENT staticText (#PCDATA)>
+<!ATTLIST staticText
+    escape            CDATA    #IMPLIED
+>
+
+<!ELEMENT component (option | facet | staticText | event | edit | component | markup)*>
+<!ATTLIST component
+    type            CDATA    #REQUIRED
+    id            CDATA    #REQUIRED
+    overwrite        CDATA    "false"
+    description        CDATA    #IMPLIED
+>
+
+<!ELEMENT edit (option | facet | event | component | markup)*>
+<!ATTLIST edit
+    id            CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>
+
+<!-- FIXME: "markup" is only meaningful outside a component?? -->
+<!-- markup type can be "open", "close", or "both" -->
+<!ELEMENT markup (if | foreach | while | facet | staticText | edit | component | event | markup | attribute)*>
+<!ATTLIST markup
+    tag            CDATA    #REQUIRED
+    type            CDATA    "both"
+    description        CDATA    #IMPLIED
+>
+
+<!-- "attribute" is only meaningful inside markup -->
+<!ELEMENT attribute (event)*>
+<!ATTLIST attribute
+    name            CDATA    #REQUIRED
+    value            CDATA    #REQUIRED
+    property        CDATA    #IMPLIED
+    description        CDATA    #IMPLIED
+>
+
+<!-- "option" is meaningful to a component -->
+<!ELEMENT option (list*)>
+<!ATTLIST option
+    name            CDATA    #REQUIRED
+    value            CDATA    ""
+    description        CDATA    #IMPLIED
+>
+
+<!-- "list" is used inside an option -->
+<!ELEMENT list EMPTY>
+<!ATTLIST list
+    value            CDATA    #REQUIRED
+    description        CDATA    #IMPLIED
+>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/renderChildren.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/renderChildren.jsf
@@ -1,0 +1,22 @@
+<!--
+
+    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!foreach _child : $this{children}>        
+    <!-- Add the child component -->
+    <component id="#{_child.id}" />
+</foreach>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/staticText.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/staticText.xml
@@ -1,0 +1,21 @@
+<!--
+
+    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!beforeEncode
+    write(value="$property{value}");
+/>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/while.xml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/jsftemplating/while.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!DOCTYPE layoutDefinition SYSTEM "/jsftemplating/layout.dtd" >
+
+<layoutDefinition>
+    <layout>
+    <while condition="$property{condition}">
+        <!-- Loop through children -->
+        <foreach key="_child" list="$attribute{_children}">
+        <event type="beforeLoop">
+            <handler id="getUIComponentChildren">
+            <input name="parent" value="$this{component}" />
+            <outputMapping outputName="children" targetType="attribute" targetKey="_children" />
+            </handler>
+        </event>
+        <!-- Add the child component -->
+        <component type="staticText" id="#{_child.id}" />
+        </foreach>
+    </while>
+    </layout>
+</layoutDefinition>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml-lat1.ent
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml-lat1.ent
@@ -1,0 +1,196 @@
+<!-- Portions (C) International Organization for Standardization 1986
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+<!-- Character entity set. Typical invocation:
+    <!ENTITY % HTMLlat1 PUBLIC
+       "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+       "http://www.w3.org/TR/xhtml1/DTD/xhtml-lat1.ent">
+    %HTMLlat1;
+-->
+
+<!ENTITY nbsp   "&#160;"> <!-- no-break space = non-breaking space,
+                                  U+00A0 ISOnum -->
+<!ENTITY iexcl  "&#161;"> <!-- inverted exclamation mark, U+00A1 ISOnum -->
+<!ENTITY cent   "&#162;"> <!-- cent sign, U+00A2 ISOnum -->
+<!ENTITY pound  "&#163;"> <!-- pound sign, U+00A3 ISOnum -->
+<!ENTITY curren "&#164;"> <!-- currency sign, U+00A4 ISOnum -->
+<!ENTITY yen    "&#165;"> <!-- yen sign = yuan sign, U+00A5 ISOnum -->
+<!ENTITY brvbar "&#166;"> <!-- broken bar = broken vertical bar,
+                                  U+00A6 ISOnum -->
+<!ENTITY sect   "&#167;"> <!-- section sign, U+00A7 ISOnum -->
+<!ENTITY uml    "&#168;"> <!-- diaeresis = spacing diaeresis,
+                                  U+00A8 ISOdia -->
+<!ENTITY copy   "&#169;"> <!-- copyright sign, U+00A9 ISOnum -->
+<!ENTITY ordf   "&#170;"> <!-- feminine ordinal indicator, U+00AA ISOnum -->
+<!ENTITY laquo  "&#171;"> <!-- left-pointing double angle quotation mark
+                                  = left pointing guillemet, U+00AB ISOnum -->
+<!ENTITY not    "&#172;"> <!-- not sign = angled dash,
+                                  U+00AC ISOnum -->
+<!ENTITY shy    "&#173;"> <!-- soft hyphen = discretionary hyphen,
+                                  U+00AD ISOnum -->
+<!ENTITY reg    "&#174;"> <!-- registered sign = registered trade mark sign,
+                                  U+00AE ISOnum -->
+<!ENTITY macr   "&#175;"> <!-- macron = spacing macron = overline
+                                  = APL overbar, U+00AF ISOdia -->
+<!ENTITY deg    "&#176;"> <!-- degree sign, U+00B0 ISOnum -->
+<!ENTITY plusmn "&#177;"> <!-- plus-minus sign = plus-or-minus sign,
+                                  U+00B1 ISOnum -->
+<!ENTITY sup2   "&#178;"> <!-- superscript two = superscript digit two
+                                  = squared, U+00B2 ISOnum -->
+<!ENTITY sup3   "&#179;"> <!-- superscript three = superscript digit three
+                                  = cubed, U+00B3 ISOnum -->
+<!ENTITY acute  "&#180;"> <!-- acute accent = spacing acute,
+                                  U+00B4 ISOdia -->
+<!ENTITY micro  "&#181;"> <!-- micro sign, U+00B5 ISOnum -->
+<!ENTITY para   "&#182;"> <!-- pilcrow sign = paragraph sign,
+                                  U+00B6 ISOnum -->
+<!ENTITY middot "&#183;"> <!-- middle dot = Georgian comma
+                                  = Greek middle dot, U+00B7 ISOnum -->
+<!ENTITY cedil  "&#184;"> <!-- cedilla = spacing cedilla, U+00B8 ISOdia -->
+<!ENTITY sup1   "&#185;"> <!-- superscript one = superscript digit one,
+                                  U+00B9 ISOnum -->
+<!ENTITY ordm   "&#186;"> <!-- masculine ordinal indicator,
+                                  U+00BA ISOnum -->
+<!ENTITY raquo  "&#187;"> <!-- right-pointing double angle quotation mark
+                                  = right pointing guillemet, U+00BB ISOnum -->
+<!ENTITY frac14 "&#188;"> <!-- vulgar fraction one quarter
+                                  = fraction one quarter, U+00BC ISOnum -->
+<!ENTITY frac12 "&#189;"> <!-- vulgar fraction one half
+                                  = fraction one half, U+00BD ISOnum -->
+<!ENTITY frac34 "&#190;"> <!-- vulgar fraction three quarters
+                                  = fraction three quarters, U+00BE ISOnum -->
+<!ENTITY iquest "&#191;"> <!-- inverted question mark
+                                  = turned question mark, U+00BF ISOnum -->
+<!ENTITY Agrave "&#192;"> <!-- latin capital letter A with grave
+                                  = latin capital letter A grave,
+                                  U+00C0 ISOlat1 -->
+<!ENTITY Aacute "&#193;"> <!-- latin capital letter A with acute,
+                                  U+00C1 ISOlat1 -->
+<!ENTITY Acirc  "&#194;"> <!-- latin capital letter A with circumflex,
+                                  U+00C2 ISOlat1 -->
+<!ENTITY Atilde "&#195;"> <!-- latin capital letter A with tilde,
+                                  U+00C3 ISOlat1 -->
+<!ENTITY Auml   "&#196;"> <!-- latin capital letter A with diaeresis,
+                                  U+00C4 ISOlat1 -->
+<!ENTITY Aring  "&#197;"> <!-- latin capital letter A with ring above
+                                  = latin capital letter A ring,
+                                  U+00C5 ISOlat1 -->
+<!ENTITY AElig  "&#198;"> <!-- latin capital letter AE
+                                  = latin capital ligature AE,
+                                  U+00C6 ISOlat1 -->
+<!ENTITY Ccedil "&#199;"> <!-- latin capital letter C with cedilla,
+                                  U+00C7 ISOlat1 -->
+<!ENTITY Egrave "&#200;"> <!-- latin capital letter E with grave,
+                                  U+00C8 ISOlat1 -->
+<!ENTITY Eacute "&#201;"> <!-- latin capital letter E with acute,
+                                  U+00C9 ISOlat1 -->
+<!ENTITY Ecirc  "&#202;"> <!-- latin capital letter E with circumflex,
+                                  U+00CA ISOlat1 -->
+<!ENTITY Euml   "&#203;"> <!-- latin capital letter E with diaeresis,
+                                  U+00CB ISOlat1 -->
+<!ENTITY Igrave "&#204;"> <!-- latin capital letter I with grave,
+                                  U+00CC ISOlat1 -->
+<!ENTITY Iacute "&#205;"> <!-- latin capital letter I with acute,
+                                  U+00CD ISOlat1 -->
+<!ENTITY Icirc  "&#206;"> <!-- latin capital letter I with circumflex,
+                                  U+00CE ISOlat1 -->
+<!ENTITY Iuml   "&#207;"> <!-- latin capital letter I with diaeresis,
+                                  U+00CF ISOlat1 -->
+<!ENTITY ETH    "&#208;"> <!-- latin capital letter ETH, U+00D0 ISOlat1 -->
+<!ENTITY Ntilde "&#209;"> <!-- latin capital letter N with tilde,
+                                  U+00D1 ISOlat1 -->
+<!ENTITY Ograve "&#210;"> <!-- latin capital letter O with grave,
+                                  U+00D2 ISOlat1 -->
+<!ENTITY Oacute "&#211;"> <!-- latin capital letter O with acute,
+                                  U+00D3 ISOlat1 -->
+<!ENTITY Ocirc  "&#212;"> <!-- latin capital letter O with circumflex,
+                                  U+00D4 ISOlat1 -->
+<!ENTITY Otilde "&#213;"> <!-- latin capital letter O with tilde,
+                                  U+00D5 ISOlat1 -->
+<!ENTITY Ouml   "&#214;"> <!-- latin capital letter O with diaeresis,
+                                  U+00D6 ISOlat1 -->
+<!ENTITY times  "&#215;"> <!-- multiplication sign, U+00D7 ISOnum -->
+<!ENTITY Oslash "&#216;"> <!-- latin capital letter O with stroke
+                                  = latin capital letter O slash,
+                                  U+00D8 ISOlat1 -->
+<!ENTITY Ugrave "&#217;"> <!-- latin capital letter U with grave,
+                                  U+00D9 ISOlat1 -->
+<!ENTITY Uacute "&#218;"> <!-- latin capital letter U with acute,
+                                  U+00DA ISOlat1 -->
+<!ENTITY Ucirc  "&#219;"> <!-- latin capital letter U with circumflex,
+                                  U+00DB ISOlat1 -->
+<!ENTITY Uuml   "&#220;"> <!-- latin capital letter U with diaeresis,
+                                  U+00DC ISOlat1 -->
+<!ENTITY Yacute "&#221;"> <!-- latin capital letter Y with acute,
+                                  U+00DD ISOlat1 -->
+<!ENTITY THORN  "&#222;"> <!-- latin capital letter THORN,
+                                  U+00DE ISOlat1 -->
+<!ENTITY szlig  "&#223;"> <!-- latin small letter sharp s = ess-zed,
+                                  U+00DF ISOlat1 -->
+<!ENTITY agrave "&#224;"> <!-- latin small letter a with grave
+                                  = latin small letter a grave,
+                                  U+00E0 ISOlat1 -->
+<!ENTITY aacute "&#225;"> <!-- latin small letter a with acute,
+                                  U+00E1 ISOlat1 -->
+<!ENTITY acirc  "&#226;"> <!-- latin small letter a with circumflex,
+                                  U+00E2 ISOlat1 -->
+<!ENTITY atilde "&#227;"> <!-- latin small letter a with tilde,
+                                  U+00E3 ISOlat1 -->
+<!ENTITY auml   "&#228;"> <!-- latin small letter a with diaeresis,
+                                  U+00E4 ISOlat1 -->
+<!ENTITY aring  "&#229;"> <!-- latin small letter a with ring above
+                                  = latin small letter a ring,
+                                  U+00E5 ISOlat1 -->
+<!ENTITY aelig  "&#230;"> <!-- latin small letter ae
+                                  = latin small ligature ae, U+00E6 ISOlat1 -->
+<!ENTITY ccedil "&#231;"> <!-- latin small letter c with cedilla,
+                                  U+00E7 ISOlat1 -->
+<!ENTITY egrave "&#232;"> <!-- latin small letter e with grave,
+                                  U+00E8 ISOlat1 -->
+<!ENTITY eacute "&#233;"> <!-- latin small letter e with acute,
+                                  U+00E9 ISOlat1 -->
+<!ENTITY ecirc  "&#234;"> <!-- latin small letter e with circumflex,
+                                  U+00EA ISOlat1 -->
+<!ENTITY euml   "&#235;"> <!-- latin small letter e with diaeresis,
+                                  U+00EB ISOlat1 -->
+<!ENTITY igrave "&#236;"> <!-- latin small letter i with grave,
+                                  U+00EC ISOlat1 -->
+<!ENTITY iacute "&#237;"> <!-- latin small letter i with acute,
+                                  U+00ED ISOlat1 -->
+<!ENTITY icirc  "&#238;"> <!-- latin small letter i with circumflex,
+                                  U+00EE ISOlat1 -->
+<!ENTITY iuml   "&#239;"> <!-- latin small letter i with diaeresis,
+                                  U+00EF ISOlat1 -->
+<!ENTITY eth    "&#240;"> <!-- latin small letter eth, U+00F0 ISOlat1 -->
+<!ENTITY ntilde "&#241;"> <!-- latin small letter n with tilde,
+                                  U+00F1 ISOlat1 -->
+<!ENTITY ograve "&#242;"> <!-- latin small letter o with grave,
+                                  U+00F2 ISOlat1 -->
+<!ENTITY oacute "&#243;"> <!-- latin small letter o with acute,
+                                  U+00F3 ISOlat1 -->
+<!ENTITY ocirc  "&#244;"> <!-- latin small letter o with circumflex,
+                                  U+00F4 ISOlat1 -->
+<!ENTITY otilde "&#245;"> <!-- latin small letter o with tilde,
+                                  U+00F5 ISOlat1 -->
+<!ENTITY ouml   "&#246;"> <!-- latin small letter o with diaeresis,
+                                  U+00F6 ISOlat1 -->
+<!ENTITY divide "&#247;"> <!-- division sign, U+00F7 ISOnum -->
+<!ENTITY oslash "&#248;"> <!-- latin small letter o with stroke,
+                                  = latin small letter o slash,
+                                  U+00F8 ISOlat1 -->
+<!ENTITY ugrave "&#249;"> <!-- latin small letter u with grave,
+                                  U+00F9 ISOlat1 -->
+<!ENTITY uacute "&#250;"> <!-- latin small letter u with acute,
+                                  U+00FA ISOlat1 -->
+<!ENTITY ucirc  "&#251;"> <!-- latin small letter u with circumflex,
+                                  U+00FB ISOlat1 -->
+<!ENTITY uuml   "&#252;"> <!-- latin small letter u with diaeresis,
+                                  U+00FC ISOlat1 -->
+<!ENTITY yacute "&#253;"> <!-- latin small letter y with acute,
+                                  U+00FD ISOlat1 -->
+<!ENTITY thorn  "&#254;"> <!-- latin small letter thorn,
+                                  U+00FE ISOlat1 -->
+<!ENTITY yuml   "&#255;"> <!-- latin small letter y with diaeresis,
+                                  U+00FF ISOlat1 -->

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml-special.ent
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml-special.ent
@@ -1,0 +1,80 @@
+<!-- Special characters for XHTML -->
+
+<!-- Character entity set. Typical invocation:
+     <!ENTITY % HTMLspecial PUBLIC
+        "-//W3C//ENTITIES Special for XHTML//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml-special.ent">
+     %HTMLspecial;
+-->
+
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!-- Relevant ISO entity set is given unless names are newly introduced.
+     New names (i.e., not in ISO 8879 list) do not clash with any
+     existing ISO 8879 entity names. ISO 10646 character numbers
+     are given for each character, in hex. values are decimal
+     conversions of the ISO 10646 values and refer to the document
+     character set. Names are Unicode names. 
+-->
+
+<!-- C0 Controls and Basic Latin -->
+<!ENTITY quot    "&#34;"> <!--  quotation mark, U+0022 ISOnum -->
+<!ENTITY amp     "&#38;#38;"> <!--  ampersand, U+0026 ISOnum -->
+<!ENTITY lt      "&#38;#60;"> <!--  less-than sign, U+003C ISOnum -->
+<!ENTITY gt      "&#62;"> <!--  greater-than sign, U+003E ISOnum -->
+<!ENTITY apos     "&#39;"> <!--  apostrophe = APL quote, U+0027 ISOnum -->
+
+<!-- Latin Extended-A -->
+<!ENTITY OElig   "&#338;"> <!--  latin capital ligature OE,
+                                    U+0152 ISOlat2 -->
+<!ENTITY oelig   "&#339;"> <!--  latin small ligature oe, U+0153 ISOlat2 -->
+<!-- ligature is a misnomer, this is a separate character in some languages -->
+<!ENTITY Scaron  "&#352;"> <!--  latin capital letter S with caron,
+                                    U+0160 ISOlat2 -->
+<!ENTITY scaron  "&#353;"> <!--  latin small letter s with caron,
+                                    U+0161 ISOlat2 -->
+<!ENTITY Yuml    "&#376;"> <!--  latin capital letter Y with diaeresis,
+                                    U+0178 ISOlat2 -->
+
+<!-- Spacing Modifier Letters -->
+<!ENTITY circ    "&#710;"> <!--  modifier letter circumflex accent,
+                                    U+02C6 ISOpub -->
+<!ENTITY tilde   "&#732;"> <!--  small tilde, U+02DC ISOdia -->
+
+<!-- General Punctuation -->
+<!ENTITY ensp    "&#8194;"> <!-- en space, U+2002 ISOpub -->
+<!ENTITY emsp    "&#8195;"> <!-- em space, U+2003 ISOpub -->
+<!ENTITY thinsp  "&#8201;"> <!-- thin space, U+2009 ISOpub -->
+<!ENTITY zwnj    "&#8204;"> <!-- zero width non-joiner,
+                                    U+200C NEW RFC 2070 -->
+<!ENTITY zwj     "&#8205;"> <!-- zero width joiner, U+200D NEW RFC 2070 -->
+<!ENTITY lrm     "&#8206;"> <!-- left-to-right mark, U+200E NEW RFC 2070 -->
+<!ENTITY rlm     "&#8207;"> <!-- right-to-left mark, U+200F NEW RFC 2070 -->
+<!ENTITY ndash   "&#8211;"> <!-- en dash, U+2013 ISOpub -->
+<!ENTITY mdash   "&#8212;"> <!-- em dash, U+2014 ISOpub -->
+<!ENTITY lsquo   "&#8216;"> <!-- left single quotation mark,
+                                    U+2018 ISOnum -->
+<!ENTITY rsquo   "&#8217;"> <!-- right single quotation mark,
+                                    U+2019 ISOnum -->
+<!ENTITY sbquo   "&#8218;"> <!-- single low-9 quotation mark, U+201A NEW -->
+<!ENTITY ldquo   "&#8220;"> <!-- left double quotation mark,
+                                    U+201C ISOnum -->
+<!ENTITY rdquo   "&#8221;"> <!-- right double quotation mark,
+                                    U+201D ISOnum -->
+<!ENTITY bdquo   "&#8222;"> <!-- double low-9 quotation mark, U+201E NEW -->
+<!ENTITY dagger  "&#8224;"> <!-- dagger, U+2020 ISOpub -->
+<!ENTITY Dagger  "&#8225;"> <!-- double dagger, U+2021 ISOpub -->
+<!ENTITY permil  "&#8240;"> <!-- per mille sign, U+2030 ISOtech -->
+<!ENTITY lsaquo  "&#8249;"> <!-- single left-pointing angle quotation mark,
+                                    U+2039 ISO proposed -->
+<!-- lsaquo is proposed but not yet ISO standardized -->
+<!ENTITY rsaquo  "&#8250;"> <!-- single right-pointing angle quotation mark,
+                                    U+203A ISO proposed -->
+<!-- rsaquo is proposed but not yet ISO standardized -->
+
+<!-- Currency Symbols -->
+<!ENTITY euro   "&#8364;"> <!--  euro sign, U+20AC NEW -->

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml-symbol.ent
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml-symbol.ent
@@ -1,0 +1,237 @@
+<!-- Mathematical, Greek and Symbolic characters for XHTML -->
+
+<!-- Character entity set. Typical invocation:
+     <!ENTITY % HTMLsymbol PUBLIC
+        "-//W3C//ENTITIES Symbols for XHTML//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml-symbol.ent">
+     %HTMLsymbol;
+-->
+
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+<!-- Relevant ISO entity set is given unless names are newly introduced.
+     New names (i.e., not in ISO 8879 list) do not clash with any
+     existing ISO 8879 entity names. ISO 10646 character numbers
+     are given for each character, in hex. values are decimal
+     conversions of the ISO 10646 values and refer to the document
+     character set. Names are Unicode names. 
+-->
+
+<!-- Latin Extended-B -->
+<!ENTITY fnof     "&#402;"> <!-- latin small letter f with hook = function
+                                    = florin, U+0192 ISOtech -->
+
+<!-- Greek -->
+<!ENTITY Alpha    "&#913;"> <!-- greek capital letter alpha, U+0391 -->
+<!ENTITY Beta     "&#914;"> <!-- greek capital letter beta, U+0392 -->
+<!ENTITY Gamma    "&#915;"> <!-- greek capital letter gamma,
+                                    U+0393 ISOgrk3 -->
+<!ENTITY Delta    "&#916;"> <!-- greek capital letter delta,
+                                    U+0394 ISOgrk3 -->
+<!ENTITY Epsilon  "&#917;"> <!-- greek capital letter epsilon, U+0395 -->
+<!ENTITY Zeta     "&#918;"> <!-- greek capital letter zeta, U+0396 -->
+<!ENTITY Eta      "&#919;"> <!-- greek capital letter eta, U+0397 -->
+<!ENTITY Theta    "&#920;"> <!-- greek capital letter theta,
+                                    U+0398 ISOgrk3 -->
+<!ENTITY Iota     "&#921;"> <!-- greek capital letter iota, U+0399 -->
+<!ENTITY Kappa    "&#922;"> <!-- greek capital letter kappa, U+039A -->
+<!ENTITY Lambda   "&#923;"> <!-- greek capital letter lamda,
+                                    U+039B ISOgrk3 -->
+<!ENTITY Mu       "&#924;"> <!-- greek capital letter mu, U+039C -->
+<!ENTITY Nu       "&#925;"> <!-- greek capital letter nu, U+039D -->
+<!ENTITY Xi       "&#926;"> <!-- greek capital letter xi, U+039E ISOgrk3 -->
+<!ENTITY Omicron  "&#927;"> <!-- greek capital letter omicron, U+039F -->
+<!ENTITY Pi       "&#928;"> <!-- greek capital letter pi, U+03A0 ISOgrk3 -->
+<!ENTITY Rho      "&#929;"> <!-- greek capital letter rho, U+03A1 -->
+<!-- there is no Sigmaf, and no U+03A2 character either -->
+<!ENTITY Sigma    "&#931;"> <!-- greek capital letter sigma,
+                                    U+03A3 ISOgrk3 -->
+<!ENTITY Tau      "&#932;"> <!-- greek capital letter tau, U+03A4 -->
+<!ENTITY Upsilon  "&#933;"> <!-- greek capital letter upsilon,
+                                    U+03A5 ISOgrk3 -->
+<!ENTITY Phi      "&#934;"> <!-- greek capital letter phi,
+                                    U+03A6 ISOgrk3 -->
+<!ENTITY Chi      "&#935;"> <!-- greek capital letter chi, U+03A7 -->
+<!ENTITY Psi      "&#936;"> <!-- greek capital letter psi,
+                                    U+03A8 ISOgrk3 -->
+<!ENTITY Omega    "&#937;"> <!-- greek capital letter omega,
+                                    U+03A9 ISOgrk3 -->
+
+<!ENTITY alpha    "&#945;"> <!-- greek small letter alpha,
+                                    U+03B1 ISOgrk3 -->
+<!ENTITY beta     "&#946;"> <!-- greek small letter beta, U+03B2 ISOgrk3 -->
+<!ENTITY gamma    "&#947;"> <!-- greek small letter gamma,
+                                    U+03B3 ISOgrk3 -->
+<!ENTITY delta    "&#948;"> <!-- greek small letter delta,
+                                    U+03B4 ISOgrk3 -->
+<!ENTITY epsilon  "&#949;"> <!-- greek small letter epsilon,
+                                    U+03B5 ISOgrk3 -->
+<!ENTITY zeta     "&#950;"> <!-- greek small letter zeta, U+03B6 ISOgrk3 -->
+<!ENTITY eta      "&#951;"> <!-- greek small letter eta, U+03B7 ISOgrk3 -->
+<!ENTITY theta    "&#952;"> <!-- greek small letter theta,
+                                    U+03B8 ISOgrk3 -->
+<!ENTITY iota     "&#953;"> <!-- greek small letter iota, U+03B9 ISOgrk3 -->
+<!ENTITY kappa    "&#954;"> <!-- greek small letter kappa,
+                                    U+03BA ISOgrk3 -->
+<!ENTITY lambda   "&#955;"> <!-- greek small letter lamda,
+                                    U+03BB ISOgrk3 -->
+<!ENTITY mu       "&#956;"> <!-- greek small letter mu, U+03BC ISOgrk3 -->
+<!ENTITY nu       "&#957;"> <!-- greek small letter nu, U+03BD ISOgrk3 -->
+<!ENTITY xi       "&#958;"> <!-- greek small letter xi, U+03BE ISOgrk3 -->
+<!ENTITY omicron  "&#959;"> <!-- greek small letter omicron, U+03BF NEW -->
+<!ENTITY pi       "&#960;"> <!-- greek small letter pi, U+03C0 ISOgrk3 -->
+<!ENTITY rho      "&#961;"> <!-- greek small letter rho, U+03C1 ISOgrk3 -->
+<!ENTITY sigmaf   "&#962;"> <!-- greek small letter final sigma,
+                                    U+03C2 ISOgrk3 -->
+<!ENTITY sigma    "&#963;"> <!-- greek small letter sigma,
+                                    U+03C3 ISOgrk3 -->
+<!ENTITY tau      "&#964;"> <!-- greek small letter tau, U+03C4 ISOgrk3 -->
+<!ENTITY upsilon  "&#965;"> <!-- greek small letter upsilon,
+                                    U+03C5 ISOgrk3 -->
+<!ENTITY phi      "&#966;"> <!-- greek small letter phi, U+03C6 ISOgrk3 -->
+<!ENTITY chi      "&#967;"> <!-- greek small letter chi, U+03C7 ISOgrk3 -->
+<!ENTITY psi      "&#968;"> <!-- greek small letter psi, U+03C8 ISOgrk3 -->
+<!ENTITY omega    "&#969;"> <!-- greek small letter omega,
+                                    U+03C9 ISOgrk3 -->
+<!ENTITY thetasym "&#977;"> <!-- greek theta symbol,
+                                    U+03D1 NEW -->
+<!ENTITY upsih    "&#978;"> <!-- greek upsilon with hook symbol,
+                                    U+03D2 NEW -->
+<!ENTITY piv      "&#982;"> <!-- greek pi symbol, U+03D6 ISOgrk3 -->
+
+<!-- General Punctuation -->
+<!ENTITY bull     "&#8226;"> <!-- bullet = black small circle,
+                                     U+2022 ISOpub  -->
+<!-- bullet is NOT the same as bullet operator, U+2219 -->
+<!ENTITY hellip   "&#8230;"> <!-- horizontal ellipsis = three dot leader,
+                                     U+2026 ISOpub  -->
+<!ENTITY prime    "&#8242;"> <!-- prime = minutes = feet, U+2032 ISOtech -->
+<!ENTITY Prime    "&#8243;"> <!-- double prime = seconds = inches,
+                                     U+2033 ISOtech -->
+<!ENTITY oline    "&#8254;"> <!-- overline = spacing overscore,
+                                     U+203E NEW -->
+<!ENTITY frasl    "&#8260;"> <!-- fraction slash, U+2044 NEW -->
+
+<!-- Letterlike Symbols -->
+<!ENTITY weierp   "&#8472;"> <!-- script capital P = power set
+                                     = Weierstrass p, U+2118 ISOamso -->
+<!ENTITY image    "&#8465;"> <!-- black-letter capital I = imaginary part,
+                                     U+2111 ISOamso -->
+<!ENTITY real     "&#8476;"> <!-- black-letter capital R = real part symbol,
+                                     U+211C ISOamso -->
+<!ENTITY trade    "&#8482;"> <!-- trade mark sign, U+2122 ISOnum -->
+<!ENTITY alefsym  "&#8501;"> <!-- alef symbol = first transfinite cardinal,
+                                     U+2135 NEW -->
+<!-- alef symbol is NOT the same as hebrew letter alef,
+     U+05D0 although the same glyph could be used to depict both characters -->
+
+<!-- Arrows -->
+<!ENTITY larr     "&#8592;"> <!-- leftwards arrow, U+2190 ISOnum -->
+<!ENTITY uarr     "&#8593;"> <!-- upwards arrow, U+2191 ISOnum-->
+<!ENTITY rarr     "&#8594;"> <!-- rightwards arrow, U+2192 ISOnum -->
+<!ENTITY darr     "&#8595;"> <!-- downwards arrow, U+2193 ISOnum -->
+<!ENTITY harr     "&#8596;"> <!-- left right arrow, U+2194 ISOamsa -->
+<!ENTITY crarr    "&#8629;"> <!-- downwards arrow with corner leftwards
+                                     = carriage return, U+21B5 NEW -->
+<!ENTITY lArr     "&#8656;"> <!-- leftwards double arrow, U+21D0 ISOtech -->
+<!-- Unicode does not say that lArr is the same as the 'is implied by' arrow
+    but also does not have any other character for that function. So lArr can
+    be used for 'is implied by' as ISOtech suggests -->
+<!ENTITY uArr     "&#8657;"> <!-- upwards double arrow, U+21D1 ISOamsa -->
+<!ENTITY rArr     "&#8658;"> <!-- rightwards double arrow,
+                                     U+21D2 ISOtech -->
+<!-- Unicode does not say this is the 'implies' character but does not have 
+     another character with this function so rArr can be used for 'implies'
+     as ISOtech suggests -->
+<!ENTITY dArr     "&#8659;"> <!-- downwards double arrow, U+21D3 ISOamsa -->
+<!ENTITY hArr     "&#8660;"> <!-- left right double arrow,
+                                     U+21D4 ISOamsa -->
+
+<!-- Mathematical Operators -->
+<!ENTITY forall   "&#8704;"> <!-- for all, U+2200 ISOtech -->
+<!ENTITY part     "&#8706;"> <!-- partial differential, U+2202 ISOtech  -->
+<!ENTITY exist    "&#8707;"> <!-- there exists, U+2203 ISOtech -->
+<!ENTITY empty    "&#8709;"> <!-- empty set = null set, U+2205 ISOamso -->
+<!ENTITY nabla    "&#8711;"> <!-- nabla = backward difference,
+                                     U+2207 ISOtech -->
+<!ENTITY isin     "&#8712;"> <!-- element of, U+2208 ISOtech -->
+<!ENTITY notin    "&#8713;"> <!-- not an element of, U+2209 ISOtech -->
+<!ENTITY ni       "&#8715;"> <!-- contains as member, U+220B ISOtech -->
+<!ENTITY prod     "&#8719;"> <!-- n-ary product = product sign,
+                                     U+220F ISOamsb -->
+<!-- prod is NOT the same character as U+03A0 'greek capital letter pi' though
+     the same glyph might be used for both -->
+<!ENTITY sum      "&#8721;"> <!-- n-ary summation, U+2211 ISOamsb -->
+<!-- sum is NOT the same character as U+03A3 'greek capital letter sigma'
+     though the same glyph might be used for both -->
+<!ENTITY minus    "&#8722;"> <!-- minus sign, U+2212 ISOtech -->
+<!ENTITY lowast   "&#8727;"> <!-- asterisk operator, U+2217 ISOtech -->
+<!ENTITY radic    "&#8730;"> <!-- square root = radical sign,
+                                     U+221A ISOtech -->
+<!ENTITY prop     "&#8733;"> <!-- proportional to, U+221D ISOtech -->
+<!ENTITY infin    "&#8734;"> <!-- infinity, U+221E ISOtech -->
+<!ENTITY ang      "&#8736;"> <!-- angle, U+2220 ISOamso -->
+<!ENTITY and      "&#8743;"> <!-- logical and = wedge, U+2227 ISOtech -->
+<!ENTITY or       "&#8744;"> <!-- logical or = vee, U+2228 ISOtech -->
+<!ENTITY cap      "&#8745;"> <!-- intersection = cap, U+2229 ISOtech -->
+<!ENTITY cup      "&#8746;"> <!-- union = cup, U+222A ISOtech -->
+<!ENTITY int      "&#8747;"> <!-- integral, U+222B ISOtech -->
+<!ENTITY there4   "&#8756;"> <!-- therefore, U+2234 ISOtech -->
+<!ENTITY sim      "&#8764;"> <!-- tilde operator = varies with = similar to,
+                                     U+223C ISOtech -->
+<!-- tilde operator is NOT the same character as the tilde, U+007E,
+     although the same glyph might be used to represent both  -->
+<!ENTITY cong     "&#8773;"> <!-- approximately equal to, U+2245 ISOtech -->
+<!ENTITY asymp    "&#8776;"> <!-- almost equal to = asymptotic to,
+                                     U+2248 ISOamsr -->
+<!ENTITY ne       "&#8800;"> <!-- not equal to, U+2260 ISOtech -->
+<!ENTITY equiv    "&#8801;"> <!-- identical to, U+2261 ISOtech -->
+<!ENTITY le       "&#8804;"> <!-- less-than or equal to, U+2264 ISOtech -->
+<!ENTITY ge       "&#8805;"> <!-- greater-than or equal to,
+                                     U+2265 ISOtech -->
+<!ENTITY sub      "&#8834;"> <!-- subset of, U+2282 ISOtech -->
+<!ENTITY sup      "&#8835;"> <!-- superset of, U+2283 ISOtech -->
+<!ENTITY nsub     "&#8836;"> <!-- not a subset of, U+2284 ISOamsn -->
+<!ENTITY sube     "&#8838;"> <!-- subset of or equal to, U+2286 ISOtech -->
+<!ENTITY supe     "&#8839;"> <!-- superset of or equal to,
+                                     U+2287 ISOtech -->
+<!ENTITY oplus    "&#8853;"> <!-- circled plus = direct sum,
+                                     U+2295 ISOamsb -->
+<!ENTITY otimes   "&#8855;"> <!-- circled times = vector product,
+                                     U+2297 ISOamsb -->
+<!ENTITY perp     "&#8869;"> <!-- up tack = orthogonal to = perpendicular,
+                                     U+22A5 ISOtech -->
+<!ENTITY sdot     "&#8901;"> <!-- dot operator, U+22C5 ISOamsb -->
+<!-- dot operator is NOT the same character as U+00B7 middle dot -->
+
+<!-- Miscellaneous Technical -->
+<!ENTITY lceil    "&#8968;"> <!-- left ceiling = APL upstile,
+                                     U+2308 ISOamsc  -->
+<!ENTITY rceil    "&#8969;"> <!-- right ceiling, U+2309 ISOamsc  -->
+<!ENTITY lfloor   "&#8970;"> <!-- left floor = APL downstile,
+                                     U+230A ISOamsc  -->
+<!ENTITY rfloor   "&#8971;"> <!-- right floor, U+230B ISOamsc  -->
+<!ENTITY lang     "&#9001;"> <!-- left-pointing angle bracket = bra,
+                                     U+2329 ISOtech -->
+<!-- lang is NOT the same character as U+003C 'less than sign' 
+     or U+2039 'single left-pointing angle quotation mark' -->
+<!ENTITY rang     "&#9002;"> <!-- right-pointing angle bracket = ket,
+                                     U+232A ISOtech -->
+<!-- rang is NOT the same character as U+003E 'greater than sign' 
+     or U+203A 'single right-pointing angle quotation mark' -->
+
+<!-- Geometric Shapes -->
+<!ENTITY loz      "&#9674;"> <!-- lozenge, U+25CA ISOpub -->
+
+<!-- Miscellaneous Symbols -->
+<!ENTITY spades   "&#9824;"> <!-- black spade suit, U+2660 ISOpub -->
+<!-- black here seems to mean filled as opposed to hollow -->
+<!ENTITY clubs    "&#9827;"> <!-- black club suit = shamrock,
+                                     U+2663 ISOpub -->
+<!ENTITY hearts   "&#9829;"> <!-- black heart suit = valentine,
+                                     U+2665 ISOpub -->
+<!ENTITY diams    "&#9830;"> <!-- black diamond suit, U+2666 ISOpub -->

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml1-transitional.dtd
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/META-INF/xhtml1-transitional.dtd
@@ -1,0 +1,1201 @@
+<!--
+   Extensible HTML version 1.0 Transitional DTD
+
+   This is the same as HTML 4 Transitional except for
+   changes due to the differences between XML and SGML.
+
+   Namespace = http://www.w3.org/1999/xhtml
+
+   For further information, see: http://www.w3.org/TR/xhtml1
+
+   Copyright (c) 1998-2002 W3C (MIT, INRIA, Keio),
+   All Rights Reserved. 
+
+   This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+
+   PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+   SYSTEM "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+
+   $Revision: 1.1 $
+   $Date: 2007-04-25 20:58:14 $
+
+-->
+
+<!--================ Character mnemonic entities =========================-->
+
+<!ENTITY % HTMLlat1 PUBLIC
+   "-//W3C//ENTITIES Latin 1 for XHTML//EN"
+   "xhtml-lat1.ent">
+%HTMLlat1;
+
+<!ENTITY % HTMLsymbol PUBLIC
+   "-//W3C//ENTITIES Symbols for XHTML//EN"
+   "xhtml-symbol.ent">
+%HTMLsymbol;
+
+<!ENTITY % HTMLspecial PUBLIC
+   "-//W3C//ENTITIES Special for XHTML//EN"
+   "xhtml-special.ent">
+%HTMLspecial;
+
+<!--================== Imported Names ====================================-->
+
+<!ENTITY % ContentType "CDATA">
+    <!-- media type, as per [RFC2045] -->
+
+<!ENTITY % ContentTypes "CDATA">
+    <!-- comma-separated list of media types, as per [RFC2045] -->
+
+<!ENTITY % Charset "CDATA">
+    <!-- a character encoding, as per [RFC2045] -->
+
+<!ENTITY % Charsets "CDATA">
+    <!-- a space separated list of character encodings, as per [RFC2045] -->
+
+<!ENTITY % LanguageCode "NMTOKEN">
+    <!-- a language code, as per [RFC3066] -->
+
+<!ENTITY % Character "CDATA">
+    <!-- a single character, as per section 2.2 of [XML] -->
+
+<!ENTITY % Number "CDATA">
+    <!-- one or more digits -->
+
+<!ENTITY % LinkTypes "CDATA">
+    <!-- space-separated list of link types -->
+
+<!ENTITY % MediaDesc "CDATA">
+    <!-- single or comma-separated list of media descriptors -->
+
+<!ENTITY % URI "CDATA">
+    <!-- a Uniform Resource Identifier, see [RFC2396] -->
+
+<!ENTITY % UriList "CDATA">
+    <!-- a space separated list of Uniform Resource Identifiers -->
+
+<!ENTITY % Datetime "CDATA">
+    <!-- date and time information. ISO date format -->
+
+<!ENTITY % Script "CDATA">
+    <!-- script expression -->
+
+<!ENTITY % StyleSheet "CDATA">
+    <!-- style sheet data -->
+
+<!ENTITY % Text "CDATA">
+    <!-- used for titles etc. -->
+
+<!ENTITY % FrameTarget "NMTOKEN">
+    <!-- render in this frame -->
+
+<!ENTITY % Length "CDATA">
+    <!-- nn for pixels or nn% for percentage length -->
+
+<!ENTITY % MultiLength "CDATA">
+    <!-- pixel, percentage, or relative -->
+
+<!ENTITY % Pixels "CDATA">
+    <!-- integer representing length in pixels -->
+
+<!-- these are used for image maps -->
+
+<!ENTITY % Shape "(rect|circle|poly|default)">
+
+<!ENTITY % Coords "CDATA">
+    <!-- comma separated list of lengths -->
+
+<!-- used for object, applet, img, input and iframe -->
+<!ENTITY % ImgAlign "(top|middle|bottom|left|right)">
+
+<!-- a color using sRGB: #RRGGBB as Hex values -->
+<!ENTITY % Color "CDATA">
+
+<!-- There are also 16 widely known color names with their sRGB values:
+
+    Black  = #000000    Green  = #008000
+    Silver = #C0C0C0    Lime   = #00FF00
+    Gray   = #808080    Olive  = #808000
+    White  = #FFFFFF    Yellow = #FFFF00
+    Maroon = #800000    Navy   = #000080
+    Red    = #FF0000    Blue   = #0000FF
+    Purple = #800080    Teal   = #008080
+    Fuchsia= #FF00FF    Aqua   = #00FFFF
+-->
+
+<!--=================== Generic Attributes ===============================-->
+
+<!-- core attributes common to most elements
+  id       document-wide unique id
+  class    space separated list of classes
+  style    associated style info
+  title    advisory title/amplification
+-->
+<!ENTITY % coreattrs
+ "id          ID             #IMPLIED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED"
+  >
+
+<!-- internationalization attributes
+  lang        language code (backwards compatible)
+  xml:lang    language code (as per XML 1.0 spec)
+  dir         direction for weak/neutral text
+-->
+<!ENTITY % i18n
+ "lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #IMPLIED"
+  >
+
+<!-- attributes for common UI events
+  onclick     a pointer button was clicked
+  ondblclick  a pointer button was double clicked
+  onmousedown a pointer button was pressed down
+  onmouseup   a pointer button was released
+  onmousemove a pointer was moved onto the element
+  onmouseout  a pointer was moved away from the element
+  onkeypress  a key was pressed and released
+  onkeydown   a key was pressed down
+  onkeyup     a key was released
+-->
+<!ENTITY % events
+ "onclick     %Script;       #IMPLIED
+  ondblclick  %Script;       #IMPLIED
+  onmousedown %Script;       #IMPLIED
+  onmouseup   %Script;       #IMPLIED
+  onmouseover %Script;       #IMPLIED
+  onmousemove %Script;       #IMPLIED
+  onmouseout  %Script;       #IMPLIED
+  onkeypress  %Script;       #IMPLIED
+  onkeydown   %Script;       #IMPLIED
+  onkeyup     %Script;       #IMPLIED"
+  >
+
+<!-- attributes for elements that can get the focus
+  accesskey   accessibility key character
+  tabindex    position in tabbing order
+  onfocus     the element got the focus
+  onblur      the element lost the focus
+-->
+<!ENTITY % focus
+ "accesskey   %Character;    #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED"
+  >
+
+<!ENTITY % attrs "%coreattrs; %i18n; %events;">
+
+<!-- text alignment for p, div, h1-h6. The default is
+     align="left" for ltr headings, "right" for rtl -->
+
+<!ENTITY % TextAlign "align (left|center|right|justify) #IMPLIED">
+
+<!--=================== Text Elements ====================================-->
+
+<!ENTITY % special.extra
+   "object | applet | img | map | iframe">
+    
+<!ENTITY % special.basic
+    "br | span | bdo">
+
+<!ENTITY % special
+   "%special.basic; | %special.extra;">
+
+<!ENTITY % fontstyle.extra "big | small | font | basefont">
+
+<!ENTITY % fontstyle.basic "tt | i | b | u
+                      | s | strike ">
+
+<!ENTITY % fontstyle "%fontstyle.basic; | %fontstyle.extra;">
+
+<!ENTITY % phrase.extra "sub | sup">
+<!ENTITY % phrase.basic "em | strong | dfn | code | q |
+                   samp | kbd | var | cite | abbr | acronym">
+
+<!ENTITY % phrase "%phrase.basic; | %phrase.extra;">
+
+<!ENTITY % inline.forms "input | select | textarea | label | button">
+
+<!-- these can occur at block or inline level -->
+<!ENTITY % misc.inline "ins | del | script">
+
+<!-- these can only occur at block level -->
+<!ENTITY % misc "noscript | %misc.inline;">
+
+<!ENTITY % inline "a | %special; | %fontstyle; | %phrase; | %inline.forms;">
+
+<!-- %Inline; covers inline or "text-level" elements -->
+<!ENTITY % Inline "(#PCDATA | %inline; | %misc.inline;)*">
+
+<!--================== Block level elements ==============================-->
+
+<!ENTITY % heading "h1|h2|h3|h4|h5|h6">
+<!ENTITY % lists "ul | ol | dl | menu | dir">
+<!ENTITY % blocktext "pre | hr | blockquote | address | center | noframes">
+
+<!ENTITY % block
+    "p | %heading; | div | %lists; | %blocktext; | isindex |fieldset | table">
+
+<!-- %Flow; mixes block and inline and is used for list items etc. -->
+<!ENTITY % Flow "(#PCDATA | %block; | form | %inline; | %misc;)*">
+
+<!--================== Content models for exclusions =====================-->
+
+<!-- a elements use %Inline; excluding a -->
+
+<!ENTITY % a.content
+   "(#PCDATA | %special; | %fontstyle; | %phrase; | %inline.forms; | %misc.inline;)*">
+
+<!-- pre uses %Inline excluding img, object, applet, big, small,
+     font, or basefont -->
+
+<!ENTITY % pre.content
+   "(#PCDATA | a | %special.basic; | %fontstyle.basic; | %phrase.basic; |
+       %inline.forms; | %misc.inline;)*">
+
+<!-- form uses %Flow; excluding form -->
+
+<!ENTITY % form.content "(#PCDATA | %block; | %inline; | %misc;)*">
+
+<!-- button uses %Flow; but excludes a, form, form controls, iframe -->
+
+<!ENTITY % button.content
+   "(#PCDATA | p | %heading; | div | %lists; | %blocktext; |
+      table | br | span | bdo | object | applet | img | map |
+      %fontstyle; | %phrase; | %misc;)*">
+
+<!--================ Document Structure ==================================-->
+
+<!-- the namespace URI designates the document profile -->
+
+<!ELEMENT html (head, body)>
+<!ATTLIST html
+  %i18n;
+  id          ID             #IMPLIED
+  xmlns       %URI;          #FIXED 'http://www.w3.org/1999/xhtml'
+  >
+
+<!--================ Document Head =======================================-->
+
+<!ENTITY % head.misc "(script|style|meta|link|object|isindex)*">
+
+<!-- content model is %head.misc; combined with a single
+     title and an optional base element in any order -->
+
+<!ELEMENT head (%head.misc;,
+     ((title, %head.misc;, (base, %head.misc;)?) |
+      (base, %head.misc;, (title, %head.misc;))))>
+
+<!ATTLIST head
+  %i18n;
+  id          ID             #IMPLIED
+  profile     %URI;          #IMPLIED
+  >
+
+<!-- The title element is not considered part of the flow of text.
+       It should be displayed, for example as the page header or
+       window title. Exactly one title is required per document.
+    -->
+<!ELEMENT title (#PCDATA)>
+<!ATTLIST title 
+  %i18n;
+  id          ID             #IMPLIED
+  >
+
+<!-- document base URI -->
+
+<!ELEMENT base EMPTY>
+<!ATTLIST base
+  id          ID             #IMPLIED
+  href        %URI;          #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!-- generic metainformation -->
+<!ELEMENT meta EMPTY>
+<!ATTLIST meta
+  %i18n;
+  id          ID             #IMPLIED
+  http-equiv  CDATA          #IMPLIED
+  name        CDATA          #IMPLIED
+  content     CDATA          #REQUIRED
+  scheme      CDATA          #IMPLIED
+  >
+
+<!--
+  Relationship values can be used in principle:
+
+   a) for document specific toolbars/menus when used
+      with the link element in document head e.g.
+        start, contents, previous, next, index, end, help
+   b) to link to a separate style sheet (rel="stylesheet")
+   c) to make a link to a script (rel="script")
+   d) by stylesheets to control how collections of
+      html nodes are rendered into printed documents
+   e) to make a link to a printable version of this document
+      e.g. a PostScript or PDF version (rel="alternate" media="print")
+-->
+
+<!ELEMENT link EMPTY>
+<!ATTLIST link
+  %attrs;
+  charset     %Charset;      #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  type        %ContentType;  #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  media       %MediaDesc;    #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!-- style info, which may include CDATA sections -->
+<!ELEMENT style (#PCDATA)>
+<!ATTLIST style
+  %i18n;
+  id          ID             #IMPLIED
+  type        %ContentType;  #REQUIRED
+  media       %MediaDesc;    #IMPLIED
+  title       %Text;         #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- script statements, which may include CDATA sections -->
+<!ELEMENT script (#PCDATA)>
+<!ATTLIST script
+  id          ID             #IMPLIED
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #REQUIRED
+  language    CDATA          #IMPLIED
+  src         %URI;          #IMPLIED
+  defer       (defer)        #IMPLIED
+  xml:space   (preserve)     #FIXED 'preserve'
+  >
+
+<!-- alternate content container for non script-based rendering -->
+
+<!ELEMENT noscript %Flow;>
+<!ATTLIST noscript
+  %attrs;
+  >
+
+<!--======================= Frames =======================================-->
+
+<!-- inline subwindow -->
+
+<!ELEMENT iframe %Flow;>
+<!ATTLIST iframe
+  %coreattrs;
+  longdesc    %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  src         %URI;          #IMPLIED
+  frameborder (1|0)          "1"
+  marginwidth %Pixels;       #IMPLIED
+  marginheight %Pixels;      #IMPLIED
+  scrolling   (yes|no|auto)  "auto"
+  align       %ImgAlign;     #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  >
+
+<!-- alternate content container for non frame-based rendering -->
+
+<!ELEMENT noframes %Flow;>
+<!ATTLIST noframes
+  %attrs;
+  >
+
+<!--=================== Document Body ====================================-->
+
+<!ELEMENT body %Flow;>
+<!ATTLIST body
+  %attrs;
+  onload      %Script;       #IMPLIED
+  onunload    %Script;       #IMPLIED
+  background  %URI;          #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  text        %Color;        #IMPLIED
+  link        %Color;        #IMPLIED
+  vlink       %Color;        #IMPLIED
+  alink       %Color;        #IMPLIED
+  >
+
+<!ELEMENT div %Flow;>  <!-- generic language/style container -->
+<!ATTLIST div
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Paragraphs =======================================-->
+
+<!ELEMENT p %Inline;>
+<!ATTLIST p
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Headings =========================================-->
+
+<!--
+  There are six levels of headings from h1 (the most important)
+  to h6 (the least important).
+-->
+
+<!ELEMENT h1  %Inline;>
+<!ATTLIST h1
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h2 %Inline;>
+<!ATTLIST h2
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h3 %Inline;>
+<!ATTLIST h3
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h4 %Inline;>
+<!ATTLIST h4
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h5 %Inline;>
+<!ATTLIST h5
+  %attrs;
+  %TextAlign;
+  >
+
+<!ELEMENT h6 %Inline;>
+<!ATTLIST h6
+  %attrs;
+  %TextAlign;
+  >
+
+<!--=================== Lists ============================================-->
+
+<!-- Unordered list bullet styles -->
+
+<!ENTITY % ULStyle "(disc|square|circle)">
+
+<!-- Unordered list -->
+
+<!ELEMENT ul (li)+>
+<!ATTLIST ul
+  %attrs;
+  type        %ULStyle;     #IMPLIED
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- Ordered list numbering style
+
+    1   arabic numbers      1, 2, 3, ...
+    a   lower alpha         a, b, c, ...
+    A   upper alpha         A, B, C, ...
+    i   lower roman         i, ii, iii, ...
+    I   upper roman         I, II, III, ...
+
+    The style is applied to the sequence number which by default
+    is reset to 1 for the first list item in an ordered list.
+-->
+<!ENTITY % OLStyle "CDATA">
+
+<!-- Ordered (numbered) list -->
+
+<!ELEMENT ol (li)+>
+<!ATTLIST ol
+  %attrs;
+  type        %OLStyle;      #IMPLIED
+  compact     (compact)      #IMPLIED
+  start       %Number;       #IMPLIED
+  >
+
+<!-- single column list (DEPRECATED) --> 
+<!ELEMENT menu (li)+>
+<!ATTLIST menu
+  %attrs;
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- multiple column list (DEPRECATED) --> 
+<!ELEMENT dir (li)+>
+<!ATTLIST dir
+  %attrs;
+  compact     (compact)     #IMPLIED
+  >
+
+<!-- LIStyle is constrained to: "(%ULStyle;|%OLStyle;)" -->
+<!ENTITY % LIStyle "CDATA">
+
+<!-- list item -->
+
+<!ELEMENT li %Flow;>
+<!ATTLIST li
+  %attrs;
+  type        %LIStyle;      #IMPLIED
+  value       %Number;       #IMPLIED
+  >
+
+<!-- definition lists - dt for term, dd for its definition -->
+
+<!ELEMENT dl (dt|dd)+>
+<!ATTLIST dl
+  %attrs;
+  compact     (compact)      #IMPLIED
+  >
+
+<!ELEMENT dt %Inline;>
+<!ATTLIST dt
+  %attrs;
+  >
+
+<!ELEMENT dd %Flow;>
+<!ATTLIST dd
+  %attrs;
+  >
+
+<!--=================== Address ==========================================-->
+
+<!-- information on author -->
+
+<!ELEMENT address (#PCDATA | %inline; | %misc.inline; | p)*>
+<!ATTLIST address
+  %attrs;
+  >
+
+<!--=================== Horizontal Rule ==================================-->
+
+<!ELEMENT hr EMPTY>
+<!ATTLIST hr
+  %attrs;
+  align       (left|center|right) #IMPLIED
+  noshade     (noshade)      #IMPLIED
+  size        %Pixels;       #IMPLIED
+  width       %Length;       #IMPLIED
+  >
+
+<!--=================== Preformatted Text ================================-->
+
+<!-- content is %Inline; excluding 
+        "img|object|applet|big|small|sub|sup|font|basefont" -->
+
+<!ELEMENT pre %pre.content;>
+<!ATTLIST pre
+  %attrs;
+  width       %Number;      #IMPLIED
+  xml:space   (preserve)    #FIXED 'preserve'
+  >
+
+<!--=================== Block-like Quotes ================================-->
+
+<!ELEMENT blockquote %Flow;>
+<!ATTLIST blockquote
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!--=================== Text alignment ===================================-->
+
+<!-- center content -->
+<!ELEMENT center %Flow;>
+<!ATTLIST center
+  %attrs;
+  >
+
+<!--=================== Inserted/Deleted Text ============================-->
+
+<!--
+  ins/del are allowed in block and inline content, but its
+  inappropriate to include block content within an ins element
+  occurring in inline content.
+-->
+<!ELEMENT ins %Flow;>
+<!ATTLIST ins
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!ELEMENT del %Flow;>
+<!ATTLIST del
+  %attrs;
+  cite        %URI;          #IMPLIED
+  datetime    %Datetime;     #IMPLIED
+  >
+
+<!--================== The Anchor Element ================================-->
+
+<!-- content is %Inline; except that anchors shouldn't be nested -->
+
+<!ELEMENT a %a.content;>
+<!ATTLIST a
+  %attrs;
+  %focus;
+  charset     %Charset;      #IMPLIED
+  type        %ContentType;  #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  href        %URI;          #IMPLIED
+  hreflang    %LanguageCode; #IMPLIED
+  rel         %LinkTypes;    #IMPLIED
+  rev         %LinkTypes;    #IMPLIED
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--===================== Inline Elements ================================-->
+
+<!ELEMENT span %Inline;> <!-- generic language/style container -->
+<!ATTLIST span
+  %attrs;
+  >
+
+<!ELEMENT bdo %Inline;>  <!-- I18N BiDi over-ride -->
+<!ATTLIST bdo
+  %coreattrs;
+  %events;
+  lang        %LanguageCode; #IMPLIED
+  xml:lang    %LanguageCode; #IMPLIED
+  dir         (ltr|rtl)      #REQUIRED
+  >
+
+<!ELEMENT br EMPTY>   <!-- forced line break -->
+<!ATTLIST br
+  %coreattrs;
+  clear       (left|all|right|none) "none"
+  >
+
+<!ELEMENT em %Inline;>   <!-- emphasis -->
+<!ATTLIST em %attrs;>
+
+<!ELEMENT strong %Inline;>   <!-- strong emphasis -->
+<!ATTLIST strong %attrs;>
+
+<!ELEMENT dfn %Inline;>   <!-- definitional -->
+<!ATTLIST dfn %attrs;>
+
+<!ELEMENT code %Inline;>   <!-- program code -->
+<!ATTLIST code %attrs;>
+
+<!ELEMENT samp %Inline;>   <!-- sample -->
+<!ATTLIST samp %attrs;>
+
+<!ELEMENT kbd %Inline;>  <!-- something user would type -->
+<!ATTLIST kbd %attrs;>
+
+<!ELEMENT var %Inline;>   <!-- variable -->
+<!ATTLIST var %attrs;>
+
+<!ELEMENT cite %Inline;>   <!-- citation -->
+<!ATTLIST cite %attrs;>
+
+<!ELEMENT abbr %Inline;>   <!-- abbreviation -->
+<!ATTLIST abbr %attrs;>
+
+<!ELEMENT acronym %Inline;>   <!-- acronym -->
+<!ATTLIST acronym %attrs;>
+
+<!ELEMENT q %Inline;>   <!-- inlined quote -->
+<!ATTLIST q
+  %attrs;
+  cite        %URI;          #IMPLIED
+  >
+
+<!ELEMENT sub %Inline;> <!-- subscript -->
+<!ATTLIST sub %attrs;>
+
+<!ELEMENT sup %Inline;> <!-- superscript -->
+<!ATTLIST sup %attrs;>
+
+<!ELEMENT tt %Inline;>   <!-- fixed pitch font -->
+<!ATTLIST tt %attrs;>
+
+<!ELEMENT i %Inline;>   <!-- italic font -->
+<!ATTLIST i %attrs;>
+
+<!ELEMENT b %Inline;>   <!-- bold font -->
+<!ATTLIST b %attrs;>
+
+<!ELEMENT big %Inline;>   <!-- bigger font -->
+<!ATTLIST big %attrs;>
+
+<!ELEMENT small %Inline;>   <!-- smaller font -->
+<!ATTLIST small %attrs;>
+
+<!ELEMENT u %Inline;>   <!-- underline -->
+<!ATTLIST u %attrs;>
+
+<!ELEMENT s %Inline;>   <!-- strike-through -->
+<!ATTLIST s %attrs;>
+
+<!ELEMENT strike %Inline;>   <!-- strike-through -->
+<!ATTLIST strike %attrs;>
+
+<!ELEMENT basefont EMPTY>  <!-- base font size -->
+<!ATTLIST basefont
+  id          ID             #IMPLIED
+  size        CDATA          #REQUIRED
+  color       %Color;        #IMPLIED
+  face        CDATA          #IMPLIED
+  >
+
+<!ELEMENT font %Inline;> <!-- local change to font -->
+<!ATTLIST font
+  %coreattrs;
+  %i18n;
+  size        CDATA          #IMPLIED
+  color       %Color;        #IMPLIED
+  face        CDATA          #IMPLIED
+  >
+
+<!--==================== Object ======================================-->
+<!--
+  object is used to embed objects as part of HTML pages.
+  param elements should precede other content. Parameters
+  can also be expressed as attribute/value pairs on the
+  object element itself when brevity is desired.
+-->
+
+<!ELEMENT object (#PCDATA | param | %block; | form | %inline; | %misc;)*>
+<!ATTLIST object
+  %attrs;
+  declare     (declare)      #IMPLIED
+  classid     %URI;          #IMPLIED
+  codebase    %URI;          #IMPLIED
+  data        %URI;          #IMPLIED
+  type        %ContentType;  #IMPLIED
+  codetype    %ContentType;  #IMPLIED
+  archive     %UriList;      #IMPLIED
+  standby     %Text;         #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  border      %Pixels;       #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!--
+  param is used to supply a named property value.
+  In XML it would seem natural to follow RDF and support an
+  abbreviated syntax where the param elements are replaced
+  by attribute value pairs on the object start tag.
+-->
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+  id          ID             #IMPLIED
+  name        CDATA          #REQUIRED
+  value       CDATA          #IMPLIED
+  valuetype   (data|ref|object) "data"
+  type        %ContentType;  #IMPLIED
+  >
+
+<!--=================== Java applet ==================================-->
+<!--
+  One of code or object attributes must be present.
+  Place param elements before other content.
+-->
+<!ELEMENT applet (#PCDATA | param | %block; | form | %inline; | %misc;)*>
+<!ATTLIST applet
+  %coreattrs;
+  codebase    %URI;          #IMPLIED
+  archive     CDATA          #IMPLIED
+  code        CDATA          #IMPLIED
+  object      CDATA          #IMPLIED
+  alt         %Text;         #IMPLIED
+  name        NMTOKEN        #IMPLIED
+  width       %Length;       #REQUIRED
+  height      %Length;       #REQUIRED
+  align       %ImgAlign;     #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!--=================== Images ===========================================-->
+
+<!--
+   To avoid accessibility problems for people who aren't
+   able to see the image, you should provide a text
+   description using the alt and longdesc attributes.
+   In addition, avoid the use of server-side image maps.
+-->
+
+<!ELEMENT img EMPTY>
+<!ATTLIST img
+  %attrs;
+  src         %URI;          #REQUIRED
+  alt         %Text;         #REQUIRED
+  name        NMTOKEN        #IMPLIED
+  longdesc    %URI;          #IMPLIED
+  height      %Length;       #IMPLIED
+  width       %Length;       #IMPLIED
+  usemap      %URI;          #IMPLIED
+  ismap       (ismap)        #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  border      %Length;       #IMPLIED
+  hspace      %Pixels;       #IMPLIED
+  vspace      %Pixels;       #IMPLIED
+  >
+
+<!-- usemap points to a map element which may be in this document
+  or an external document, although the latter is not widely supported -->
+
+<!--================== Client-side image maps ============================-->
+
+<!-- These can be placed in the same document or grouped in a
+     separate document although this isn't yet widely supported -->
+
+<!ELEMENT map ((%block; | form | %misc;)+ | area+)>
+<!ATTLIST map
+  %i18n;
+  %events;
+  id          ID             #REQUIRED
+  class       CDATA          #IMPLIED
+  style       %StyleSheet;   #IMPLIED
+  title       %Text;         #IMPLIED
+  name        CDATA          #IMPLIED
+  >
+
+<!ELEMENT area EMPTY>
+<!ATTLIST area
+  %attrs;
+  %focus;
+  shape       %Shape;        "rect"
+  coords      %Coords;       #IMPLIED
+  href        %URI;          #IMPLIED
+  nohref      (nohref)       #IMPLIED
+  alt         %Text;         #REQUIRED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--================ Forms ===============================================-->
+
+<!ELEMENT form %form.content;>   <!-- forms shouldn't be nested -->
+
+<!ATTLIST form
+  %attrs;
+  action      %URI;          #REQUIRED
+  method      (get|post)     "get"
+  name        NMTOKEN        #IMPLIED
+  enctype     %ContentType;  "application/x-www-form-urlencoded"
+  onsubmit    %Script;       #IMPLIED
+  onreset     %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  accept-charset %Charsets;  #IMPLIED
+  target      %FrameTarget;  #IMPLIED
+  >
+
+<!--
+  Each label must not contain more than ONE field
+  Label elements shouldn't be nested.
+-->
+<!ELEMENT label %Inline;>
+<!ATTLIST label
+  %attrs;
+  for         IDREF          #IMPLIED
+  accesskey   %Character;    #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  >
+
+<!ENTITY % InputType
+  "(text | password | checkbox |
+    radio | submit | reset |
+    file | hidden | image | button)"
+   >
+
+<!-- the name attribute is required for all but submit & reset -->
+
+<!ELEMENT input EMPTY>     <!-- form control -->
+<!ATTLIST input
+  %attrs;
+  %focus;
+  type        %InputType;    "text"
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  checked     (checked)      #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  size        CDATA          #IMPLIED
+  maxlength   %Number;       #IMPLIED
+  src         %URI;          #IMPLIED
+  alt         CDATA          #IMPLIED
+  usemap      %URI;          #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  accept      %ContentTypes; #IMPLIED
+  align       %ImgAlign;     #IMPLIED
+  >
+
+<!ELEMENT select (optgroup|option)+>  <!-- option selector -->
+<!ATTLIST select
+  %attrs;
+  name        CDATA          #IMPLIED
+  size        %Number;       #IMPLIED
+  multiple    (multiple)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  tabindex    %Number;       #IMPLIED
+  onfocus     %Script;       #IMPLIED
+  onblur      %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!ELEMENT optgroup (option)+>   <!-- option group -->
+<!ATTLIST optgroup
+  %attrs;
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #REQUIRED
+  >
+
+<!ELEMENT option (#PCDATA)>     <!-- selectable choice -->
+<!ATTLIST option
+  %attrs;
+  selected    (selected)     #IMPLIED
+  disabled    (disabled)     #IMPLIED
+  label       %Text;         #IMPLIED
+  value       CDATA          #IMPLIED
+  >
+
+<!ELEMENT textarea (#PCDATA)>     <!-- multi-line text field -->
+<!ATTLIST textarea
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  rows        %Number;       #REQUIRED
+  cols        %Number;       #REQUIRED
+  disabled    (disabled)     #IMPLIED
+  readonly    (readonly)     #IMPLIED
+  onselect    %Script;       #IMPLIED
+  onchange    %Script;       #IMPLIED
+  >
+
+<!--
+  The fieldset element is used to group form fields.
+  Only one legend element should occur in the content
+  and if present should only be preceded by whitespace.
+-->
+<!ELEMENT fieldset (#PCDATA | legend | %block; | form | %inline; | %misc;)*>
+<!ATTLIST fieldset
+  %attrs;
+  >
+
+<!ENTITY % LAlign "(top|bottom|left|right)">
+
+<!ELEMENT legend %Inline;>     <!-- fieldset label -->
+<!ATTLIST legend
+  %attrs;
+  accesskey   %Character;    #IMPLIED
+  align       %LAlign;       #IMPLIED
+  >
+
+<!--
+ Content is %Flow; excluding a, form, form controls, iframe
+--> 
+<!ELEMENT button %button.content;>  <!-- push button -->
+<!ATTLIST button
+  %attrs;
+  %focus;
+  name        CDATA          #IMPLIED
+  value       CDATA          #IMPLIED
+  type        (button|submit|reset) "submit"
+  disabled    (disabled)     #IMPLIED
+  >
+
+<!-- single-line text input control (DEPRECATED) -->
+<!ELEMENT isindex EMPTY>
+<!ATTLIST isindex
+  %coreattrs;
+  %i18n;
+  prompt      %Text;         #IMPLIED
+  >
+
+<!--======================= Tables =======================================-->
+
+<!-- Derived from IETF HTML table standard, see [RFC1942] -->
+
+<!--
+ The border attribute sets the thickness of the frame around the
+ table. The default units are screen pixels.
+
+ The frame attribute specifies which parts of the frame around
+ the table should be rendered. The values are not the same as
+ CALS to avoid a name clash with the valign attribute.
+-->
+<!ENTITY % TFrame "(void|above|below|hsides|lhs|rhs|vsides|box|border)">
+
+<!--
+ The rules attribute defines which rules to draw between cells:
+
+ If rules is absent then assume:
+     "none" if border is absent or border="0" otherwise "all"
+-->
+
+<!ENTITY % TRules "(none | groups | rows | cols | all)">
+  
+<!-- horizontal placement of table relative to document -->
+<!ENTITY % TAlign "(left|center|right)">
+
+<!-- horizontal alignment attributes for cell contents
+
+  char        alignment char, e.g. char=':'
+  charoff     offset for alignment char
+-->
+<!ENTITY % cellhalign
+  "align      (left|center|right|justify|char) #IMPLIED
+   char       %Character;    #IMPLIED
+   charoff    %Length;       #IMPLIED"
+  >
+
+<!-- vertical alignment attributes for cell contents -->
+<!ENTITY % cellvalign
+  "valign     (top|middle|bottom|baseline) #IMPLIED"
+  >
+
+<!ELEMENT table
+     (caption?, (col*|colgroup*), thead?, tfoot?, (tbody+|tr+))>
+<!ELEMENT caption  %Inline;>
+<!ELEMENT thead    (tr)+>
+<!ELEMENT tfoot    (tr)+>
+<!ELEMENT tbody    (tr)+>
+<!ELEMENT colgroup (col)*>
+<!ELEMENT col      EMPTY>
+<!ELEMENT tr       (th|td)+>
+<!ELEMENT th       %Flow;>
+<!ELEMENT td       %Flow;>
+
+<!ATTLIST table
+  %attrs;
+  summary     %Text;         #IMPLIED
+  width       %Length;       #IMPLIED
+  border      %Pixels;       #IMPLIED
+  frame       %TFrame;       #IMPLIED
+  rules       %TRules;       #IMPLIED
+  cellspacing %Length;       #IMPLIED
+  cellpadding %Length;       #IMPLIED
+  align       %TAlign;       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  >
+
+<!ENTITY % CAlign "(top|bottom|left|right)">
+
+<!ATTLIST caption
+  %attrs;
+  align       %CAlign;       #IMPLIED
+  >
+
+<!--
+colgroup groups a set of col elements. It allows you to group
+several semantically related columns together.
+-->
+<!ATTLIST colgroup
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+ col elements define the alignment properties for cells in
+ one or more columns.
+
+ The width attribute specifies the width of the columns, e.g.
+
+     width=64        width in screen pixels
+     width=0.5*      relative width of 0.5
+
+ The span attribute causes the attributes of one
+ col element to apply to more than one column.
+-->
+<!ATTLIST col
+  %attrs;
+  span        %Number;       "1"
+  width       %MultiLength;  #IMPLIED
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!--
+    Use thead to duplicate headers when breaking table
+    across page boundaries, or for static headers when
+    tbody sections are rendered in scrolling panel.
+
+    Use tfoot to duplicate footers when breaking table
+    across page boundaries, or for static footers when
+    tbody sections are rendered in scrolling panel.
+
+    Use multiple tbody sections when rules are needed
+    between groups of table rows.
+-->
+<!ATTLIST thead
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tfoot
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tbody
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  >
+
+<!ATTLIST tr
+  %attrs;
+  %cellhalign;
+  %cellvalign;
+  bgcolor     %Color;        #IMPLIED
+  >
+
+<!-- Scope is simpler than headers attribute for common tables -->
+<!ENTITY % Scope "(row|col|rowgroup|colgroup)">
+
+<!-- th is for headers, td for data and for cells acting as both -->
+
+<!ATTLIST th
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  nowrap      (nowrap)       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  width       %Length;       #IMPLIED
+  height      %Length;       #IMPLIED
+  >
+
+<!ATTLIST td
+  %attrs;
+  abbr        %Text;         #IMPLIED
+  axis        CDATA          #IMPLIED
+  headers     IDREFS         #IMPLIED
+  scope       %Scope;        #IMPLIED
+  rowspan     %Number;       "1"
+  colspan     %Number;       "1"
+  %cellhalign;
+  %cellvalign;
+  nowrap      (nowrap)       #IMPLIED
+  bgcolor     %Color;        #IMPLIED
+  width       %Length;       #IMPLIED
+  height      %Length;       #IMPLIED
+  >
+

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/com/sun/jsftemplating/resource/LogMessages.properties
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/com/sun/jsftemplating/resource/LogMessages.properties
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+# This file contains localized log messages.  Each log message should be
+# accompanied by a comment above the message and follow the following format:
+#
+#        JSFT####=<message>
+#
+
+# The following key is reserved.  It is not used for localization, but is
+# referenced in log messages that do not provide a key.  Messages without a
+# key should limited to CONFIG through FINEST messages, all other log messages
+# should provide a key and be localized.
+JSFT0001=This messages does not need to be localized: {0}
+
+# This key is used when another key is not found... if you see this error, you
+# should fix the key that is missing.
+JSFT0002=The following Message ID was not found in the the com.sun.enterprise.tools.resource.LogMessages: {0}
+
+# This key reports that the VariableResolver was unable to find a key.
+JSFT0003=VariableResolver was unable to find key ({0}) in ResourceBundle ({1}).
+
+# This key reports that the requested resource is not available
+JSFT0004=The requested resource ({0}) is not available.
+
+# This shows a message when the .jsf file is not found.
+JSFT0005=The requested JSFTemplating page ({0}) was not found.  Ignore this message if this request is handled by a .jsp file or some other technology.
+
+#
+JSFT0006=WARNING: Failed to set property ({0}) with (null) value.  This occured on the component named ({1}) of type ({2}).
+
+# Message to help diagnose EL evaluation problems
+JSFT0007=WARNING: Failed to evaluate EL expression ({0}).
+
+# Message for sun:tableRowGroup to indicate that data is null
+JSFT0008=WARNING: TableRowGroupFactory expected a List<List<Object>>, but received a List<(null)>.  The (null) will be interpretted as a List<Object> with length 0.
+
+# Message for f:validator when it does not resolve to a Validator.
+JSFT0009=WARNING: Validator on component ({0}) did not resolve to a jakarta.faces.validator.Validator!
+
+# Message for invalid resource
+JSFT0010=WARNING: Resource ({0}) is not valid!
+
+# Message for duplicate component id's
+JSFT0011=WARNING: The clientId ({0}) appears more than once!  Make sure you have not included it multiple times within the same NamingContainer.

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/info.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/info.jsf
@@ -1,0 +1,66 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!initPage
+    isDebug(value=>$attribute{isDebug});
+/>
+<f:verbatim>
+<html>
+   <head>
+    <title>Templating for JavaServer&trade; Faces Info</title>
+    <style type="text/css">
+.title h2 {text-align: center;}
+.title p {text-align: center;}
+.info .title {background-color: #333388; color: #CCCCCC; font-family: Arial,sans-serif; font-size: 14pt; font-weight: bold; margin-top: 40px; padding: 15px; white-space: nowrap;}
+.info pre {border: 2px solid #333388; padding: 15px;}
+h2 {color: #333388; font-family: Arial,sans-serif; font-size: 16pt; font-weight: bold; padding: 15px;}
+    </style>
+   </head>
+   <body bgcolor="#FFFFFF">
+   <div class="title">
+ <h2> Powered by Templating for JavaServer&trade; Faces Technology! </h2>
+ <p> Visit <a href="https://jsftemplating.dev.java.net">https://jsftemplating.dev.java.net</a>
+     to learn more about JSFTemplating.</p>
+    </div>
+</f:verbatim>
+<!if #{isDebug}>
+    <event>
+    <!beforeEncode
+        getGlobalHandlerInformation(info=>$attribute{handlers});
+        getGlobalComponentTypeInformation(info=>$attribute{compTypes});
+    />
+    </event>
+<f:verbatim>
+    <div class="info" id="handlers">
+        <div class="title">
+        Handlers:
+        </div>
+        <pre>$attribute{handlers}</pre>
+    </div>
+    <div class="info" id="types">
+        <div class="title">
+        ComponentTypes:
+        </div>
+        <pre>$attribute{compTypes}</pre>
+    </div>
+</f:verbatim>
+</!if>
+<f:verbatim>
+   </body>
+</html>
+</f:verbatim>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/jsftemplating.css
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/main/resources/jsftemplating.css
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+.lfEditArea .lfEditor {display:inline; border:1px dotted #B66;}
+.lfEditAreaOFF .lfEditor {display:inline;}
+.lfEditAreaOFF .lfEditor .editMenu {display:none;}
+.lfEditorContent {}
+
+/* Popup Menu Styles */
+.popupArea .lfEditArea {background-color:#FFCCCC;}
+.popupMenu {position:absolute; text-align:left; z-index:1000; background-color:#FFF; font-family:Arial,Helvetica,sans-serif; font-size:10pt; width:200px; visibility:hidden; border:2px outset #68D; padding:2px 2px 2px 2px;}
+.popupMenuTitle {font-family:Arial,Helvetica,sans-serif; text-align:center; font-weight:bold; background-color: #BBB; margin-bottom: 5px;}
+/* .popupMenuItems {padding-left:15px; padding-right:10px;} */

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/ContextMocker.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/ContextMocker.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating;
+
+import jakarta.faces.application.Application;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.ExternalContext;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.context.ResponseStream;
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.lifecycle.Lifecycle;
+import jakarta.faces.render.RenderKit;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.mockito.Mockito;
+
+/**
+ * Provide a dummy FacesContext for unit tests to pass.
+ *
+ * @author Romain Grecourt
+ */
+public class ContextMocker extends FacesContext {
+  public ExternalContext _extCtx = new ExternalContextMocker();
+  public UIViewRoot _viewRoot = Mockito.mock(UIViewRoot.class);
+
+  public ContextMocker() {
+  }
+
+  static ContextMocker _ctx = new ContextMocker();
+  public static void init(){
+    setCurrentInstance(_ctx);
+  }
+
+  @Override
+  public Lifecycle getLifecycle() {
+    return Mockito.mock(Lifecycle.class);
+  }
+
+  @Override
+  public ExternalContext getExternalContext() {
+    return _extCtx;
+  }
+
+  @Override
+  public Application getApplication() {
+    return Mockito.mock(Application.class);
+  }
+
+  @Override
+  public Iterator<String> getClientIdsWithMessages() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public FacesMessage.Severity getMaximumSeverity() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public Iterator<FacesMessage> getMessages() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public Iterator<FacesMessage> getMessages(String clientId) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public RenderKit getRenderKit() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public boolean getRenderResponse() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public boolean getResponseComplete() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public ResponseStream getResponseStream() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void setResponseStream(ResponseStream responseStream) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public ResponseWriter getResponseWriter() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void setResponseWriter(ResponseWriter responseWriter) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public UIViewRoot getViewRoot() {
+    return _viewRoot;
+  }
+
+  @Override
+  public void setViewRoot(UIViewRoot root) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void addMessage(String clientId, FacesMessage message) {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void release() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void renderResponse() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  @Override
+  public void responseComplete() {
+    throw new UnsupportedOperationException("Not supported.");
+  }
+
+  public static class ExternalContextMocker extends ExternalContext {
+
+    public ExternalContextMocker() {
+    }
+
+    public Map<String,Object> _appMap = new HashMap<>();
+    public Map _initParamMap = new HashMap();
+    public Map<String, Object> _requestMap = new HashMap<>();
+
+    @Override
+    public Map<String, Object> getApplicationMap() {
+      return _appMap;
+    }
+    @Override
+    public void dispatch(String path) throws IOException {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String encodeActionURL(String url) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String encodeNamespace(String name) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String encodeResourceURL(String url) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String getAuthType() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Object getContext() {
+      return this;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+      return (String) _initParamMap.get(name);
+    }
+
+    @Override
+    public Map getInitParameterMap() {
+      return _initParamMap;
+    }
+
+    @Override
+    public String getRemoteUser() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Object getRequest() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String getRequestContextPath() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Map<String, Object> getRequestCookieMap() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Map<String, String> getRequestHeaderMap() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Map<String, String[]> getRequestHeaderValuesMap() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Locale getRequestLocale() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Iterator<Locale> getRequestLocales() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Map<String, Object> getRequestMap() {
+      return _requestMap;
+    }
+
+    @Override
+    public Map<String, String> getRequestParameterMap() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Iterator<String> getRequestParameterNames() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Map<String, String[]> getRequestParameterValuesMap() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String getRequestPathInfo() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String getRequestServletPath() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public URL getResource(String path) {
+      return this.getClass().getClassLoader().getResource(path);
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String path) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Set<String> getResourcePaths(String path) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Object getResponse() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Object getSession(boolean create) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Map<String, Object> getSessionMap() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void log(String message) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void log(String message, Throwable exception) {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void redirect(String url) throws IOException {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public String encodeWebsocketURL(String string) {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void release() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+  }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/handlers/UtilHandlerTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/handlers/UtilHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 Payara Services Ltd.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.jsftemplating.handlers;
+
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContext;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerContextImpl;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.IODescriptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author jonathan coustick
+ */
+public class UtilHandlerTest {
+
+    @Test
+    public void mapPutNullTest() {
+        HandlerContext context = new HandlerContextImpl(null, null, null, null);
+        HandlerDefinition mapPutDefinition = new HandlerDefinition("mapPut");
+        mapPutDefinition.setHandlerMethod(UtilHandlers.class.getCanonicalName(), "mapPut");
+        IODescriptor mapDescriptor = new IODescriptor("map", Map.class.getCanonicalName());
+        Map<String, IODescriptor> inputsMap = new HashMap<>();
+        inputsMap.put("map", mapDescriptor);
+        mapPutDefinition.setInputDefs(inputsMap);
+
+        Handler mapPutHandler = new Handler(mapPutDefinition);
+        mapPutHandler.setInputValue("map", null);
+
+        context.setHandler(mapPutHandler);
+        try {
+            UtilHandlers.mapPut(context);
+            Assert.fail("mapPut failed to throw exception");
+        } catch(HandlerException ex) {
+            //expected result
+        }
+    }
+
+
+
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/LayoutDefinitionManagerTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/LayoutDefinitionManagerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout;
+
+import com.sun.jsftemplating.ContextMocker;
+import com.sun.jsftemplating.component.factory.basic.StaticTextFactory;
+import com.sun.jsftemplating.layout.descriptors.ComponentType;
+import com.sun.jsftemplating.layout.descriptors.handler.HandlerDefinition;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *  <p>    Tests for the {@link LayoutDefinitionManager}.</p>
+ */
+public class LayoutDefinitionManagerTest {
+  @Before
+  public void init(){
+    ContextMocker.init();
+  }
+    /**
+     *    <p> Test to ensure we can read global {@link ComponentType}s.</p>
+     */
+  @Test
+    public void testReadGlobalComponentTypes() {
+    try {
+        ComponentType staticText = LayoutDefinitionManager.getGlobalComponentType(null,"staticText");
+        Assert.assertTrue("staticTextNull", staticText != null);
+        ComponentType event = LayoutDefinitionManager.getGlobalComponentType(null,"event");
+        Assert.assertTrue("eventNull", event != null);
+        Assert.assertTrue("eventNotEqualStaticText", staticText != event);
+        Assert.assertTrue("staticTextType", staticText.getFactory() instanceof StaticTextFactory);
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    public void testReadFaceletsTagLibXml() {
+    //assertNotNull(LayoutDefinitionManager.getGlobalComponentTypes().get("http://java.sun.com/jsf/extensions/dynafaces:scripts"));
+    }
+
+    /**
+     *    <p> Test to ensure we can read global {@link HandlerDefinition}s.</p>
+     */
+    @Test
+    public void testReadGlobalHandlers() {
+    try {
+        // Try to get a HandlerDefinition that doesn't exist
+        HandlerDefinition handler = LayoutDefinitionManager.getGlobalHandlerDefinition("nullHandler");
+        Assert.assertTrue("nullHandler", handler == null);
+
+        // Test the "println" handler
+        handler = LayoutDefinitionManager.getGlobalHandlerDefinition("println");
+        Assert.assertTrue("notNullHandler", handler != null);
+        // Test id
+        Assert.assertEquals("id", "println", handler.getId());
+        // Test 'value' input def.
+        Assert.assertTrue("valueParamNotNull", handler.getInputDef("value") != null);
+        Assert.assertEquals("valueParamName", "value", handler.getInputDef("value").getName());
+        Assert.assertEquals("valueParamType", String.class, handler.getInputDef("value").getType());
+        Assert.assertEquals("valueParamRequired", true, handler.getInputDef("value").isRequired());
+
+        // Test the "setUIComponentProperty" handler
+        handler = LayoutDefinitionManager.getGlobalHandlerDefinition("setUIComponentProperty");
+        Assert.assertTrue("notNullHandler2", handler != null);
+        // Test 'value' input def.
+        Assert.assertTrue("valueParamNotNull2", handler.getInputDef("value") != null);
+        Assert.assertEquals("valueParamName2", "value", handler.getInputDef("value").getName());
+        Assert.assertEquals("valueParamType2", Object.class, handler.getInputDef("value").getType());
+        Assert.assertEquals("valueParamRequired2", false, handler.getInputDef("value").isRequired());
+
+        // Test the "getUIComponentChildren" handler
+        handler = LayoutDefinitionManager.getGlobalHandlerDefinition("getUIComponentChildren");
+        Assert.assertTrue("notNullHandler3", handler != null);
+        // Test method name
+        Assert.assertEquals("methodName", "getChildren", handler.getHandlerMethod().getName());
+        // Test 'size' output def
+        Assert.assertTrue("sizeParamNotNull", handler.getOutputDef("size") != null);
+        Assert.assertEquals("sizeParamName", "size", handler.getOutputDef("size").getName());
+        Assert.assertEquals("sizeParamType", Integer.class, handler.getOutputDef("size").getType());
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/facelets/FaceletsLayoutDefinitionReaderTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/facelets/FaceletsLayoutDefinitionReaderTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.facelets;
+
+import com.sun.jsftemplating.ContextMocker;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * <p>
+ * Tests for the {@link FaceletsLayoutDefinitionReader}.
+ * </p>
+ *
+ */
+
+public class FaceletsLayoutDefinitionReaderTest {
+
+  private final ClassLoader cl = FaceletsLayoutDefinitionReaderTest.class.getClassLoader();
+
+  @Before
+  public void init(){
+    ContextMocker.init();
+  }
+
+    /**
+     *
+     * <p>
+     * Simple test to ensure we can read a facelets file.
+     * </p>
+     *
+     */
+    @Test
+    public void testRead1() {
+        try {
+            FaceletsLayoutDefinitionReader reader =
+                new FaceletsLayoutDefinitionReader("foo", cl.getResource("./simple.xhtml"));
+            LayoutDefinition ld = reader.read();
+            Assert.assertEquals("LayoutDefinition.unevaluatedId", "foo", ld
+                    .getUnevaluatedId());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    public void timeTest(String fileName, int iterations) {
+        try {
+        java.util.Date start = new java.util.Date();
+        for (int x=0; x<iterations; x++) {
+        FaceletsLayoutDefinitionReader reader =
+            new FaceletsLayoutDefinitionReader("foo", cl.getResource(fileName));
+        LayoutDefinition ld = reader.read();
+        }
+        java.util.Date end = new java.util.Date();
+System.out.println("Faclets performance " + fileName + " (" + iterations + "), lower is better: " + (end.getTime() - start.getTime()));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testSpeed() {
+    timeTest("./speed-s.xhtml", 1);
+//    timeTest(new URL("file:"),".speed-m.xhtml", 500);
+//    timeTest(new URL("file:"),".speed-l.xhtml", 500);
+//    timeTest(new URL("file:"),".speed-xl.xhtml", 500);
+    }
+
+    /**
+     *
+     * <p>
+     * This tests the accuracy of what was read.
+     * </p>
+     *
+     * public void testReadAccuracy() {
+     *
+     * try {
+     *
+     * FaceletsLayoutDefinitionReader reader =
+     *
+     * new FaceletsLayoutDefinitionReader("bar", new
+     * URL(new URL("file:"),".readTest1.jsf"));
+     *
+     * LayoutDefinition ld = reader.read();
+     *
+     * List<LayoutElement> children = ld.getChildLayoutElements();
+     *
+     * if (children.size() < 5) {
+     *
+     * throw new RuntimeException("Not enough children!");
+     *  }
+     *
+     * assertEquals("testReadAccuracy.id.y",
+     *
+     * "y", children.get(2).getUnevaluatedId());
+     *
+     * assertEquals("testReadAccuracy.value.abcd",
+     *
+     * "abcd", ((LayoutComponent) children.get(2)).getOption("value"));
+     *
+     *
+     *
+     * assertEquals("testReadAccuracy.id.hhh",
+     *
+     * "hhh", children.get(3).getUnevaluatedId());
+     *
+     * assertEquals("testReadAccuracy.text.some tree",
+     *
+     * "some tree",
+     *
+     * ((LayoutComponent) children.get(3)).getOption("text"));
+     *
+     * assertEquals("testReadAccuracy.hhh:treeNode1.id",
+     *
+     * "treeNode1",
+     *
+     * children.get(3).getChildLayoutElements().get(0).getUnevaluatedId());
+     *
+     * assertEquals("testReadAccuracy.hhh:treeNode1.text",
+     *
+     * "abc",
+     *
+     * ((LayoutComponent)
+     * children.get(3).getChildLayoutElements().get(0)).getOption("text"));
+     *
+     *
+     *
+     * assertEquals("testReadAccuracy.id.theform",
+     *
+     * "theform", children.get(4).getUnevaluatedId());
+     *
+     * assertEquals("testReadAccuracy.style1",
+     *
+     * "border: 1px solid red;",
+     *
+     * ((LayoutComponent) children.get(4)).getOption("style"));
+     *
+     *
+     *
+     * for (LayoutElement elt : children.get(4).getChildLayoutElements()) {
+     *
+     * System.out.println(elt.getUnevaluatedId());
+     *  }
+     *  } catch (Exception ex) {
+     *
+     * ex.printStackTrace();
+     *
+     * fail(ex.getMessage());
+     *  }
+     *  }
+     *
+     */
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/EventParserCommandTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/EventParserCommandTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.ContextMocker;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.handler.Handler;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ *  <p>    Tests for the {@link EventParserCommand}.</p>
+ */
+public class EventParserCommandTest {
+
+    @Before
+    public void init() {
+        ContextMocker.init();
+    }
+    /**
+     *    <p> Simple test to ensure we can read a template.</p>
+     * @throws Exception
+     */
+    @Test
+    public void testHandlerParsing() throws Exception {
+        // Create element to contain handlers...
+        LayoutDefinition elt = new LayoutDefinition("top");
+
+        // Setup the parser...
+        TemplateParser parser = new TemplateParser(new ByteArrayInputStream(HANDLERS1));
+        parser.open();  // Needed to initialize things.
+
+        // Setup the reader...
+        TemplateReader reader = new TemplateReader("foo", parser);
+        reader.pushTag("event"); // The tag will be popped at the end
+
+        // Read the handlers...
+        command.process(bpc, new ProcessingContextEnvironment(reader, elt, true), "beforeEncode");
+
+        // Clean up
+        parser.close();
+
+        // Test to see if things worked...
+        Assert.assertEquals("component.id", "top", elt.getUnevaluatedId());
+        List<Handler> handlers = elt.getHandlers("beforeEncode", null);
+        Assert.assertEquals("handler.size", 3, handlers.size());
+        Assert.assertEquals("handler.name1", "println", handlers.get(0).getHandlerDefinition().getId());
+        Assert.assertEquals("handler.name2", "setAttribute", handlers.get(1).getHandlerDefinition().getId());
+        Assert.assertEquals("handler.name3", "printStackTrace", handlers.get(2).getHandlerDefinition().getId());
+        Assert.assertEquals("handler.valueInput1", "This is a test!", handlers.get(0).getInputValue("value"));
+        Assert.assertEquals("handler.keyInput2", "foo", handlers.get(1).getInputValue("key"));
+        Assert.assertEquals("handler.valueInput2", "bar", handlers.get(1).getInputValue("value"));
+        Assert.assertEquals("handler.msgInput3", "test", handlers.get(2).getInputValue("msg"));
+        Assert.assertEquals("handler.stOutput3.name", "stackTrace", handlers.get(2).getOutputValue("stackTrace").getOutputName());
+        Assert.assertEquals("handler.stOutput3.type",
+        "com.sun.jsftemplating.layout.descriptors.handler.RequestAttributeOutputType",
+        handlers.get(2).getOutputValue("stackTrace").getOutputType().getClass().getName());
+        Assert.assertEquals("handler.stOutput3.mappedName", "st", handlers.get(2).getOutputValue("stackTrace").getOutputKey());
+    }
+
+    @Test
+    public void testHandlerParsing2() throws Exception {
+        // Create element to contain handlers...
+        LayoutDefinition elt = new LayoutDefinition("newTop");
+
+        // Setup the parser...
+        TemplateParser parser = new TemplateParser(new ByteArrayInputStream(HANDLERS2));
+        parser.open();  // Needed to initialize things.
+
+        // Setup the reader...
+        TemplateReader reader = new TemplateReader("foo", parser);
+        reader.pushTag("event"); // The tag will be popped at the end
+
+        // Read the handlers...
+        command.process(bpc, new ProcessingContextEnvironment(reader, elt, true), "beforeEncode");
+
+        // Clean up
+        parser.close();
+
+        // Test to see if things worked...
+        Assert.assertEquals("component.id", "newTop", elt.getUnevaluatedId());
+
+        List<Handler> handlers = elt.getHandlers("beforeEncode", null);
+        Assert.assertEquals("handler.size", 1, handlers.size());
+        Assert.assertEquals("handler.valueInput1", "test", handlers.get(0).getInputValue("value"));
+    }
+
+    private static final byte[] HANDLERS1   = (
+    "\nprintln(\"This is a test!\");\n"
+    + "setAttribute(key='foo' value='bar');"
+    + "printStackTrace('test', stackTrace=>$attribute{st});/>").getBytes();
+
+    private static final byte[] HANDLERS2   = "println('test');/>".getBytes();
+
+    /**
+     *    <p> This class should be re-usable and thread-safe.</p>
+     */
+    EventParserCommand command = new EventParserCommand();
+    BaseProcessingContext bpc = new BaseProcessingContext(); // Not used
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateParserTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateParserTest.java
@@ -241,6 +241,7 @@ public class TemplateParserTest {
     try {
         TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
         parser.open();
+
         // Read some lines
         parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
         parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
@@ -248,10 +249,15 @@ public class TemplateParserTest {
         parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
         parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
 
-        // Test readUntil.  On line before, read until openning comment.
-        Assert.assertEquals("testReadUntilStr", "    // This text should be commented out.  <tags> should not be parsed.\n    <!--", parser.readUntil("<!--", false));
-        Assert.assertEquals("testReadUntilStr2", "\n    This text should be commented out.  <tags> should not be parsed.\n    -->", parser.readUntil("-->", false));
-        Assert.assertEquals("testReadUntilStr3", "\n    /*\n     *    This text should be commented out.  <tags> should not be parsed.\n     */", parser.readUntil("*/", false));
+        // Test readUntil - normalize line endings for cross-platform compatibility
+        String result1 = parser.readUntil("<!--", false).replaceAll("\\r\\n", "\n");
+        Assert.assertEquals("testReadUntilStr", "    // This text should be commented out.  <tags> should not be parsed.\n    <!--", result1);
+
+        String result2 = parser.readUntil("-->", false).replaceAll("\\r\\n", "\n");
+        Assert.assertEquals("testReadUntilStr2", "\n    This text should be commented out.  <tags> should not be parsed.\n    -->", result2);
+
+        String result3 = parser.readUntil("*/", false).replaceAll("\\r\\n", "\n");
+        Assert.assertEquals("testReadUntilStr3", "\n    /*\n     *    This text should be commented out.  <tags> should not be parsed.\n     */", result3);
 
         parser.close();
     } catch (Exception ex) {

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateParserTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateParserTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ *  <p>    Tests for the "Template" parser.</p>
+ */
+public class TemplateParserTest {
+
+  private final ClassLoader cl = TemplateParserTest.class.getClassLoader();
+
+    @Test
+  public void testURL() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
+        Assert.assertEquals(cl.getResource("./TemplateFormat.jsf").toString(), parser.getURL().toString());
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testOpenClose() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
+        parser.open();
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testNextChar1() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
+        parser.open();
+        Assert.assertEquals("testNextChar1-1", '#', parser.nextChar());
+        Assert.assertEquals("testNextChar1-2", ' ', parser.nextChar());
+        Assert.assertEquals("testNextChar1-3", 'R', parser.nextChar());
+        Assert.assertEquals("testNextChar1-4", 'e', parser.nextChar());
+        Assert.assertEquals("testNextChar1-5", 'a', parser.nextChar());
+        Assert.assertEquals("testNextChar1-6", 'd', parser.nextChar());
+        Assert.assertEquals("testNextChar1-7", 'e', parser.nextChar());
+        Assert.assertEquals("testNextChar1-8", 'r', parser.nextChar());
+        Assert.assertEquals("testNextChar1-9", ' ', parser.nextChar());
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testUnread() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
+        parser.open();
+        Assert.assertEquals("testNextChar1-1", '#', parser.nextChar());
+        Assert.assertEquals("testNextChar1-2", ' ', parser.nextChar());
+        parser.unread(' ');
+        Assert.assertEquals("testNextChar1-3", ' ', parser.nextChar());
+        Assert.assertEquals("testNextChar1-4", 'R', parser.nextChar());
+        parser.unread('R');
+        Assert.assertEquals("testNextChar1-5", 'R', parser.nextChar());
+        parser.unread('X');
+        Assert.assertEquals("testNextChar1-6", 'X', parser.nextChar());
+        Assert.assertEquals("testNextChar1-7", 'e', parser.nextChar());
+        parser.unread('1');
+        parser.unread('2');
+        parser.unread('3');
+        Assert.assertEquals("testNextChar1-8", '3', (char) parser.nextChar());
+        Assert.assertEquals("testNextChar1-9", '2', (char) parser.nextChar());
+        Assert.assertEquals("testNextChar1-10", '1', (char) parser.nextChar());
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testNVP() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
+        parser.open();
+        // Read some lines
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+
+        // Move in to the NVP (actually 1 past just to see that that works)
+        parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar();
+        parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar();
+        parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar();
+        parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar();
+        parser.nextChar(); parser.nextChar(); parser.nextChar();
+
+        NameValuePair nvp = parser.getNVP(null);
+
+        Assert.assertEquals("testNVP1", "ile", nvp.getName());
+        Assert.assertEquals("testNVP2", "jsftemplating/js/jsftemplating.js", nvp.getValue());
+        Assert.assertEquals("testNVP3", null, nvp.getTarget());
+
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testNVP2() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("TemplateFormat.jsf"));
+        parser.open();
+
+        // Read 49 lines
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+
+        // Move to the output mapping on line 50
+        parser.readUntil('v', false);
+        parser.unread('v');
+
+        NameValuePair nvp = parser.getNVP(null);
+
+        Assert.assertEquals("testNVP1", "value", nvp.getName());
+        Assert.assertEquals("testNVP2", "val", nvp.getValue());
+        Assert.assertEquals("testNVP3", "attribute", nvp.getTarget());
+
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testReadLine() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("TemplateFormat.jsf"));
+        parser.open();
+        // Read some lines
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+
+        // Read some characters
+        parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar();
+        parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar(); parser.nextChar();
+
+        // Make sure we're at the right spot
+        Assert.assertEquals("testReadLine1", ' ', parser.nextChar());
+        Assert.assertEquals("testReadLine2", 'm', parser.nextChar());
+
+        // Make sure we can read the rest of the line
+        Assert.assertEquals("testReadLine3", "ulti line comment is hit, skip until end is found", parser.readLine());
+
+        // Read more lines
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+
+        // Make sure we're at the right spot
+        Assert.assertEquals("testReadLine4", "        <sun:script file=\"jsftemplating/js/jsftemplating.js\" />", parser.readLine());
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testReadToken() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("TemplateFormat.jsf"));
+        parser.open();
+        // Read some lines
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+
+        // Move to the Script Tag
+        parser.readUntil('<', false);
+
+        // Test readToken()
+        Assert.assertEquals("testReadToken", "sun:script", parser.readToken());
+
+        // Test skipWhiteSpace();
+        parser.skipWhiteSpace(TemplateParser.SIMPLE_WHITE_SPACE);
+
+        // Test NVP
+        NameValuePair nvp = parser.getNVP(null);
+
+        // NVP should be setup correctly
+        Assert.assertEquals("testNVP1", "file", nvp.getName());
+        Assert.assertEquals("testNVP2", "jsftemplating/js/jsftemplating.js", nvp.getValue());
+        Assert.assertEquals("testNVP3", null, nvp.getTarget());
+
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    /**
+     *    This test tests the String version of Read Until.
+     */
+    @Test
+    public void testReadUntilStr() {
+    try {
+        TemplateParser parser = new TemplateParser(cl.getResource("./TemplateFormat.jsf"));
+        parser.open();
+        // Read some lines
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+        parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine(); parser.readLine();
+
+        // Test readUntil.  On line before, read until openning comment.
+        Assert.assertEquals("testReadUntilStr", "    // This text should be commented out.  <tags> should not be parsed.\n    <!--", parser.readUntil("<!--", false));
+        Assert.assertEquals("testReadUntilStr2", "\n    This text should be commented out.  <tags> should not be parsed.\n    -->", parser.readUntil("-->", false));
+        Assert.assertEquals("testReadUntilStr3", "\n    /*\n     *    This text should be commented out.  <tags> should not be parsed.\n     */", parser.readUntil("*/", false));
+
+        parser.close();
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+/*
+    public void testAdd() {
+    assertTrue(5 == 6);
+    }
+
+    public void testEquals() {
+    assertEquals(12, 12);
+    assertEquals(12L, 12L);
+    assertEquals(new Long(12), new Long(12));
+
+    assertEquals("Size", 12, 13);
+    assertEquals("Capacity", 12.0, 11.99, 0.0);
+    }
+
+    public static void main (String[] args) {
+        junit.textui.TestRunner.run(suite());
+    }
+*/
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateReaderTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateReaderTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.ContextMocker;
+import com.sun.jsftemplating.layout.descriptors.LayoutComponent;
+import com.sun.jsftemplating.layout.descriptors.LayoutComposition;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+import com.sun.jsftemplating.layout.descriptors.LayoutElement;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *  <p>    Tests for the {@link TemplateReader}.</p>
+ */
+public class TemplateReaderTest {
+
+  private final ClassLoader cl = TemplateReaderTest.class.getClassLoader();
+
+  @Before
+  public void init(){
+    ContextMocker.init();
+  }
+
+    /**
+     *    <p> Simple test to ensure we can read a template.</p>
+     */
+    @Test
+    public void testRead1() {
+    try {
+        TemplateReader reader =
+        new TemplateReader("foo", cl.getResource("./TemplateFormat.jsf"));
+        LayoutDefinition ld = reader.read();
+//        assertEquals("LayoutDefinition.unevaluatedId", "id1", ld.getUnevaluatedId());
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    public void timeTest(String fileName, int iterations) {
+        try {
+        java.util.Date start = new java.util.Date();
+        for (int x=0; x<iterations; x++) {
+        TemplateReader reader =
+            new TemplateReader("foo", cl.getResource(fileName));
+        LayoutDefinition ld = reader.read();
+        }
+        java.util.Date end = new java.util.Date();
+System.out.println("Template performance " + fileName + " (" + iterations + "), lower is better: " + (end.getTime() - start.getTime()));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testSpeed() {
+    timeTest("./speed-s.jsf", 500);
+//    timeTest(new URL("file:"),".speed-m.jsf", 500);
+//    timeTest(new URL("file:"),".speed-l.jsf", 500);
+//    timeTest(new URL("file:"),".speed-xl.jsf", 500);
+    }
+
+    /**
+     *    <p> This test reads <code>TemplateFormat2.jsf</code>.  This
+     *        file contains a bunch of {@link LayoutComposition} tags to
+     *        ensure they are read correctly.</p>
+     */
+    @Test
+    public void testReadComposition() {
+    try {
+        // Start reading...
+        TemplateReader reader =
+        new TemplateReader("foo", cl.getResource("./TemplateFormat2.jsf"));
+        LayoutDefinition ld = reader.read();
+
+        // Find the body LayoutComponent
+        LayoutElement body = ld.findLayoutElement("page").getChildLayoutElement("html").
+            getChildLayoutElement("body");
+        Assert.assertEquals("testReadComposition.body",
+        "body", body.getUnevaluatedId());
+
+        // Find each composition component and check the results...
+        LayoutElement child = body.getChildLayoutElement("form");
+        Assert.assertEquals("testReadComposition.formId",
+        "form", child.getUnevaluatedId());
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    @Test
+    public void testDecorate() {
+    try {
+        // Start reading...
+        TemplateReader reader =
+        new TemplateReader("foo", cl.getResource("./TemplateFormat3.jsf"));
+        LayoutDefinition ld = reader.read();
+
+        // Find the body LayoutComponent
+        LayoutElement body = ld.getChildLayoutElement("page");
+        body = body.getChildLayoutElement("html").getChildLayoutElement("body");
+        Assert.assertEquals("testReadDecorate.body",
+        "body", body.getUnevaluatedId());
+
+        // Find each composition component and check the results...
+        List<LayoutElement> children = body.getChildLayoutElements();
+        String[] results = {
+            "single1", "single2", "single3",
+            "single4", "single5", "Template.jsf",
+            "\"single7\"", "single11", "single12",
+            "single13", null, null, "mult2"
+        };
+        int[] resultChildSizes = {
+            0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 1, 2
+        };
+        int idx = 0;
+        for (LayoutElement child : children) {
+        Assert.assertTrue("testReadDecorate.instanceof" + idx,
+            child instanceof LayoutComposition);
+        Assert.assertEquals("testReadDecorate.val" + idx,
+            results[idx], ((LayoutComposition) child).getTemplate());
+        Assert.assertEquals("testReadDecorate.childSize" + idx,
+            resultChildSizes[idx++],
+            child.getChildLayoutElements().size());
+        }
+        Assert.assertEquals("testReadDecorate.childrenSize",
+        13, children.size());
+        LayoutElement htmlElt = children.get(5).findLayoutElement("html");
+        Assert.assertEquals("testReadDecorate.decorate.page.size",
+        2,
+        (htmlElt == null) ? 0 : htmlElt.getChildLayoutElements().size());
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+
+    /**
+     *    <p> This tests the accuracy of what was read.</p>
+     */
+    @Test
+    public void testReadAccuracy() {
+    try {
+        TemplateReader reader =
+        new TemplateReader("bar", cl.getResource("./readTest1.jsf"));
+        LayoutDefinition ld = reader.read();
+        List<LayoutElement> children = ld.getChildLayoutElements();
+        if (children.size() < 5) {
+        throw new RuntimeException("Not enough children!");
+        }
+        Assert.assertEquals("testReadAccuracy.id.y",
+        "y", children.get(2).getUnevaluatedId());
+        Assert.assertEquals("testReadAccuracy.value.abcd",
+        "abcd", ((LayoutComponent) children.get(2)).getOption("value"));
+
+        Assert.assertEquals("testReadAccuracy.id.hhh",
+        "hhh", children.get(3).getUnevaluatedId());
+        Assert.assertEquals("testReadAccuracy.text.some tree",
+        "some tree",
+        ((LayoutComponent) children.get(3)).getOption("text"));
+        Assert.assertEquals("testReadAccuracy.hhh:treeNode1.id",
+        "treeNode1",
+        children.get(3).getChildLayoutElements().get(0).getUnevaluatedId());
+        Assert.assertEquals("testReadAccuracy.hhh:treeNode1.text",
+        "abc",
+        ((LayoutComponent) children.get(3).getChildLayoutElements().get(0)).getOption("text"));
+
+        Assert.assertEquals("testReadAccuracy.id.theform",
+        "theform", children.get(4).getUnevaluatedId());
+        Assert.assertEquals("testReadAccuracy.style1",
+        "border: 1px solid red;",
+        ((LayoutComponent) children.get(4)).getOption("style"));
+
+        for (LayoutElement elt : children.get(4).getChildLayoutElements()) {
+        System.out.println(elt.getUnevaluatedId());
+        }
+    } catch (Exception ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateWriterTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/layout/template/TemplateWriterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.jsftemplating.layout.template;
+
+import com.sun.jsftemplating.ContextMocker;
+import com.sun.jsftemplating.layout.descriptors.LayoutDefinition;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *  <p>    Tests for the {@link TemplateWriter}.</p>
+ */
+public class TemplateWriterTest {
+    /**
+     *    <p> </p>
+     */
+  private final ClassLoader cl = TemplateWriterTest.class.getClassLoader();
+
+  @Before
+  public void init(){
+    ContextMocker.init();
+  }
+
+    @Test
+    public void testWrite1() {
+    try {
+        // First read some data
+        TemplateReader reader =
+        new TemplateReader("foo", cl.getResource("./TemplateFormat.jsf"));
+        LayoutDefinition ld = reader.read();
+//        assertEquals("LayoutDefinition.unevaluatedId", "id2", ld.getUnevaluatedId());
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        TemplateWriter writer =
+        new TemplateWriter(stream);
+        writer.write(ld);
+// FIXME: Add some sort of check here
+//        System.err.println(stream.toString());
+    } catch (IOException ex) {
+        ex.printStackTrace();
+        Assert.fail(ex.getMessage());
+    }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/util/SimplePatternMatcherTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/util/SimplePatternMatcherTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *
+ */
+package com.sun.jsftemplating.util;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * TestCase for <code>SimplePatternMatcher</code>.
+ *
+ * @author Imre O&szlig;wald (io@emx.jevelopers.com)
+ *
+ */
+public class SimplePatternMatcherTest {
+
+    /**
+     * Test method for {@link com.sun.jsftemplating.util.SimplePatternMatcher#matches(java.lang.String)}.
+     */
+    @Test
+    public void testMatches() {
+        long start = System.nanoTime();
+
+        Exception e = null;
+
+        MatchTest fullPath = new MatchTest("/some/folder/view.id");
+        MatchTest all = new MatchTest("*");
+        MatchTest suffix = new MatchTest("*.jsft");
+        MatchTest prefix = new MatchTest("/some/*");
+        MatchTest oneStar = new MatchTest("/some/*/test.jsp");
+        MatchTest complex = new MatchTest("/*/config/*/page?.jsp");
+
+        long start2 = System.nanoTime();
+
+        try {
+            new MatchTest(null);
+        } catch (NullPointerException npe) {
+            e = npe;
+        }
+        Assert.assertNotNull(e);
+        e = null;
+
+        for (int i = 0; i < 100; i++) { // run common cases more often for
+            // timing
+            fullPath.setMatching("/some/folder/view.id");
+            fullPath.setNonMatching(null, "", "/test", "/some", "/some/folder/view.i", "/some/folder/view.id2");
+            fullPath.test();
+
+            all.setMatching("", "/", "/page.jsp", "/some/page.jsp");
+            all.setNonMatching((String) null);
+            all.test();
+
+            suffix.setMatching("/.jsft", "/a.jsft", "/folder/x.jsft");
+            suffix.setNonMatching(null, "", "/jsft", "somexjsft", "/some.jsp", "/someother.jsftx");
+            suffix.test();
+
+            prefix.setMatching("/some/", "/some/page", "/some/page.jsp", "/some/more/page.jsp");
+            prefix.setNonMatching(null, "", "/", "/some", "/somex/", "/somex/page.jsp");
+            prefix.test();
+        }
+
+        oneStar.setMatching("/some/thing/test.jsp", "/some/thing/more/test.jsp", "/some/even.more/test.jsp");
+        oneStar.setNonMatching(null, "/test.jsp", "/somelonger/test.jsp", "/some/more/test.jsft");
+        oneStar.test();
+
+        complex.setMatching("/f1/config/downloads/page1.jsp", "//config//page2.jsp", "/f2/config/one/two/three/pageA.jsp",
+                "/a/b/c/d/config/e/f/g/pageX.jsp");
+        complex.setNonMatching(null, "x/config//pageN.jsp", "/x/config/x/page12.jsp", "/f1/config/downloads/page1.jspx",
+                "/f1/nonconfig/downloads/pageA.jsp");
+        complex.test();
+        long end = System.nanoTime();
+        System.out.println("testMatches() took: " + ((end - start) / 1000) + " mics");
+        System.out.println("matching took: " + ((end - start2) / 1000) + " mics");
+    }
+
+    /**
+     * Test method for {@link com.sun.jsftemplating.util.SimplePatternMatcher#parseMultiPatternString(String, String)}.
+     */
+    @Test
+    public void testParseMultiPatter() {
+        String mpattern = null;
+        Collection<SimplePatternMatcher> result = null;
+
+        result = SimplePatternMatcher.parseMultiPatternString(mpattern, ";");
+        Assert.assertTrue("null pattern should return an empty collection", result.isEmpty());
+
+        mpattern = "";
+        result = SimplePatternMatcher.parseMultiPatternString(mpattern, ";");
+        Assert.assertTrue("empty pattern should return an empty collection", result.isEmpty());
+
+        mpattern = "   \n\t   ";
+        result = SimplePatternMatcher.parseMultiPatternString(mpattern, ";");
+        Assert.assertTrue("trimmed empty pattern should return an empty collection", result.isEmpty());
+
+        mpattern = ";   ;   ;   ;  ;;   ;";
+        result = SimplePatternMatcher.parseMultiPatternString(mpattern, ";");
+        Assert.assertTrue("multiple (trimmed) empty pattern should return an empty collection", result.isEmpty());
+
+        mpattern = "/faces/*;;*.jsf";
+        result = SimplePatternMatcher.parseMultiPatternString(mpattern, ";");
+        Assert.assertTrue("'" + mpattern + "' should return an collection of size==2", result.size() == 2);
+    }
+
+    /**
+     * Test method for {@link com.sun.jsftemplating.util.SimplePatternMatcher#regexify(java.lang.CharSequence)}.
+     */
+    @Test
+    public void testRegexify() {
+        long start = System.nanoTime();
+
+        String source = null;
+        String expected = null;
+        Exception e = null;
+        try {
+            SimplePatternMatcher.regexify(source);
+        } catch (NullPointerException npe) {
+            e = npe;
+        }
+        Assert.assertNotNull(e);
+        e = null;
+
+        source = "";
+        expected = source;
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+
+        source = "/something/without/any/special/chars";
+        expected = source;
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+
+        source = "testingOne.inTheViewId";
+        expected = "testingOne\\.inTheViewId";
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+
+        source = "/testing.points/in.the./view.id";
+        expected = "/testing\\.points/in\\.the\\./view\\.id";
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+
+        source = "testingOne*inTheViewId";
+        expected = "testingOne(.*)inTheViewId";
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+
+        source = "testing*Multiple*in*The*View*Id";
+        expected = "testing(.*)Multiple(.*)in(.*)The(.*)View(.*)Id";
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+
+        source = "testingQuestionMarks?";
+        expected = "testingQuestionMarks.";
+        Assert.assertEquals(SimplePatternMatcher.regexify(source), expected);
+        long end = System.nanoTime();
+        System.out.println("regexify() took: " + ((end - start) / 1000) + " mics");
+
+    }
+
+    private static final class MatchTest {
+        private SimplePatternMatcher matcher;
+        private String[] matching;
+        private String[] nonMatching;
+
+        MatchTest(String pattern) {
+            this.matcher = new SimplePatternMatcher(pattern);
+        }
+
+        void setMatching(String... strings) {
+            this.matching = strings;
+        }
+
+        void setNonMatching(String... strings) {
+            this.nonMatching = strings;
+        }
+
+        void test() {
+            for (String match : matching) {
+                Assert.assertTrue(match + " should match " + this.matcher, this.matcher.matches(match));
+            }
+            for (String dontMatch : nonMatching) {
+                Assert.assertFalse(dontMatch + " should not match " + this.matcher, this.matcher.matches(dontMatch));
+            }
+        }
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/util/fileStreamer/ResourceContentSourceTest.java
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/java/com/sun/jsftemplating/util/fileStreamer/ResourceContentSourceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ *
+ */
+package com.sun.jsftemplating.util.fileStreamer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * TestCase for <code>ResourceContentSource</code>.
+ */
+public class ResourceContentSourceTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void normalizeDoesNotAccessContextRootParent() {
+        final String testPath = "../bad/path";
+        ResourceContentSource.normalize(testPath);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void normalizeDoesNotAccessContextRootParentWithLeadingSlash() {
+        final String testPath = "/../bad/path";
+        ResourceContentSource.normalize(testPath);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void doesNotGoBackTooFar() {
+        final String testPath = "/path/../../../../too/many/backward";
+        ResourceContentSource.normalize(testPath);
+    }
+
+    @Test
+    public void removesExtraSlashesAndBackwardPaths() {
+        final String testPath = "//OK/path//with/extra/slashes/and/..//in/the/middle/";
+        final String result = ResourceContentSource.normalize(testPath);
+        Assert.assertEquals("Wrong result", "OK/path/with/extra/slashes/in/the/middle", result);
+    }
+}

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/Template.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/Template.jsf
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun:page id="page">
+    <sun:html id="html">
+    <sun:head id="head">
+        <sun:title id="title">The title</sun:title>
+    </sun:head>
+    <sun:body id="body">
+        <sun:form id="form">
+        <!insert name="header" />
+        <!insert name="body" />
+        <!insert name="repeat3times" />
+        <!insert name="repeat3times">
+            "3repeat default
+        </insert>
+        <!insert name="repeat3times" />
+        <!insert name="footer">
+            "<div class="footer">Default Footer</div>
+        </insert>
+        </sun:form>
+    </sun:body>
+    </sun:html>
+</sun:page>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/TemplateFormat.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/TemplateFormat.jsf
@@ -1,0 +1,62 @@
+# Reader requirements:
+#   - Single pass reading.
+#   - Read until one of the following is encountered:
+#    '<', '#', "//", "/*", "<!--", '"', ''', '\'
+#   - if a '\' is hit, ignore the next character (including newlines)
+#   - if a component is hit ('<'):
+#    - Create LayoutComponent
+#    - recurse on children if they exist
+#    - Continue populating LayoutComponent until /> or </component>
+#   - if a single line comment is hit, skip the rest of the line
+#   - if a multi line comment is hit, skip until end is found
+#   - if a ''' or '"' is found (perhaps " should escape, ' should not?)
+#    - convert rest of line to String (and possibly subsequent lines)
+#    - if during component-search mode, create a StaticText (or
+#        verbatim) UIComponent
+
+<sun:page>
+    <sun:html>
+    <sun:head>
+        <sun:title>The title</sun:title>
+        <sun:script file="jsftemplating/js/jsftemplating.js" />
+    </sun:head>
+    <sun:body>
+
+    # This text should be commented out.  <tags> should not be parsed.
+    // This text should be commented out.  <tags> should not be parsed.
+    <!--
+    This text should be commented out.  <tags> should not be parsed.
+    -->
+    /*
+     *    This text should be commented out.  <tags> should not be parsed.
+     */
+
+"        <br /><br /><p>
+"        <center>
+"            single or double quotes ("'" or "'") allow text or markup
+    "            to be written directly to the output. The rest of a single
+"            line will be written out.
+"         </center>
+"        </p>
+'
+    '    <p> The following uses an actionListener, beforeEncode, and a command event... </p>
+'
+        <sun:hyperlink actionListener="$methodBinding{#{lfCommand.invokeCommandHandlers}}">
+        "Hyperlink Text <b> there should be a &lt;b&gt; between "Text" and 'there'.
+        <!beforeEncode println(value="BEFORE ENCODE!") />
+        <!command 
+            // ';' are optional, "//" is for comments
+            setAttribute(key="something"  value="Yes!")
+            getAttribute(key="something"  value=>$attribute{val});
+            println(value="$attribute{val}")
+        />
+        <!if something />
+        <!while something />
+        <!foreach key:something />
+        </sun:hyperlink>
+        <!facet staticText>
+        "Facets may be added using "!facet " infront of the type
+        </!facet>
+    </sun:body>
+    </sun:html>
+</sun:page>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/TemplateFormat2.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/TemplateFormat2.jsf
@@ -1,0 +1,41 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun:page id="page">
+    <sun:html id="html">
+    <sun:head id="head">
+        <sun:title id="title">The title</sun:title>
+    </sun:head>
+    <sun:body id="body">
+
+        <!composition "Template.jsf">
+        "Default text
+        <!define name="header">
+            "<h2>Header</h2>
+        </define>
+        <!define name="body">
+            "<div>Body</div>
+        </define>
+        <!define name="repeat3times">
+            "Repeat Me!
+        </define>
+        </composition>
+        <sun:form id="notUsed" />
+    </sun:body>
+    </sun:html>
+</sun:page>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/TemplateFormat3.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/TemplateFormat3.jsf
@@ -1,0 +1,60 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun:page id="page">
+    <sun:html id="html">
+    <sun:head id="head">
+        <sun:title id="title">The title</sun:title>
+    </sun:head>
+    <sun:body id="body">
+
+        <!decorate 'single1' />
+        <!decorate "single2" />
+        <!decorate
+        "single3" />
+        <!decorate template="single4" />
+        <!decorate template='single5' />
+        <!decorate template:"Template.jsf" />
+        <!decorate template:'"single7"' />
+        <!decorate template = "single11" />
+        <!decorate template= 'single12' />
+        <!decorate template
+        :"single13" />
+        <!decorate
+        />
+        <!decorate
+        >
+        <staticText value="foo" />
+        </
+        decorate
+        >
+        <!decorate template:
+        'mult2'
+        >
+        <f:verbatim>
+            <br /><br /><p>
+            <center> Test </center>
+            </p>
+        </f:verbatim>
+
+        <sun:form>
+        </sun:form>
+        </decorate>
+    </sun:body>
+    </sun:html>
+</sun:page>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/readTest1.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/readTest1.jsf
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ *  This file is used to test the TemplateReader, it is not meant to serve
+ *  as a best-practice example
+ */
+'<br /> Hello <b>World</b>&copy;!
+"<br /> Hello <b>World</b>&copy;!
+<sun:staticText id="y" value="abcd" />
+<sun:tree id="hhh" text="some tree">
+    <sun:treeNode id="treeNode1" style="border: 1px solid blue;" text="abc">
+    </sun:treeNode>
+</sun:tree>
+<sun:form id="theform" style="border: 1px solid red;">
+<sun:markup id="mark" tag="div">
+    <sun:textField value="bc" id="foo" style="border: 2px dashed blue;" />
+    <sun:passwordField value="123" id="bar" style='border: 2px dotted green;' />
+</sun:markup>
+</sun:form>

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/simple.xhtml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/simple.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+    <body>
+    #{2+2}
+    <br />
+    <ui:composition template="simpleTemplate.xhtml">
+            This should be all there is!
+        </ui:composition>
+    #{2 + 2}
+    </body>
+</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/simpleTemplate.xhtml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/simpleTemplate.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+    <body>
+    #{3+3}
+    <br />
+    #{3 + 3}
+    </body>
+</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-l.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-l.jsf
@@ -1,0 +1,1448 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+"<html>
+"    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+"    </body>
+"</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-l.xhtml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-l.xhtml
@@ -1,0 +1,1449 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    </body>
+</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-m.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-m.jsf
@@ -1,0 +1,188 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+"<html>
+"    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+"    </body>
+"</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-m.xhtml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-m.xhtml
@@ -1,0 +1,189 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    </body>
+</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-s.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-s.jsf
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+"<html>
+"    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+"    </body>
+"</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-s.xhtml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-s.xhtml
@@ -1,0 +1,49 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    </body>
+</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-xl.jsf
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-xl.jsf
@@ -1,0 +1,14048 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+"<html>
+"    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <!beforeCreate
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        />
+        </h:inputText>
+        <h:panelGroup>
+"        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+"    </body>
+"</html>  

--- a/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-xl.xhtml
+++ b/appserver/admingui/vdl/jsftemplating/jsftemplating/src/test/resources/speed-xl.xhtml
@@ -1,0 +1,14049 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<!--
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+    Random Text Random Text Random Text Random Text Random Text Random Text Random Text
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+    <body>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    <h:form>
+        <h:inputText value="#{requestScope.foo}" />
+        <h:inputText value="#{requestScope.bar}">
+        <ui:event type="beforeCreate">
+            getUIComponentProperty(component="jkl" name="propName" value=>$attribute{output});
+        </ui:event>
+        </h:inputText>
+        <h:panelGroup>
+        <br />
+        #{2 + 2}
+        <h:inputText value="#{requestScope.jkl}" />
+        </h:panelGroup>
+        <h:inputText value="#{requestScope.lkj}" />
+    </h:form>
+    </body>
+</html>  

--- a/appserver/admingui/vdl/jsftemplating/pom.xml
+++ b/appserver/admingui/vdl/jsftemplating/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
+    Copyright (c) 2014, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.admingui</groupId>
+        <artifactId>vdl</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jsftemplating-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>JSFTemplating</name>
+    <description>JSFTemplating is to work with Jakarta Faces technology to make building pages and components easier. It is used to define the layout of an example component.</description>
+
+    <modules>
+        <module>jsft</module>
+        <module>jsftemplating</module>
+        <module>jsftemplating-dt</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.sun.woodstock.dependlibs</groupId>
+                <artifactId>dataprovider</artifactId>
+                <version>1.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.5.4</version>
+                    <configuration>
+                        <forkCount>0</forkCount>
+                        <systemPropertyVariables>
+                            <propertyName>com.sun.jsftemplating.DEBUG</propertyName>
+                            <buildDirectory>true</buildDirectory>
+                        </systemPropertyVariables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>oss-release</id>
+            <properties>
+                 <!-- It is recommended to hardcode the name as the plugin usually takes
+                     the last project proccessed in the reactor - that can be confusing
+                     when you list deployments on Maven Central website. -->
+                <release.projectName>GlassFish JSF Templates</release.projectName>
+                <release.autoPublish>false</release.autoPublish>
+                <release.waitUntil>published</release.waitUntil>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/appserver/admingui/vdl/pom.xml
+++ b/appserver/admingui/vdl/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.main.admingui</groupId>
+        <artifactId>admingui</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>vdl</artifactId>
+    <packaging>pom</packaging>
+
+    <name>AdminGui VDL</name>
+
+    <modules>
+        <module>jsftemplating</module>
+    </modules>
+</project>

--- a/appserver/admingui/war/pom.xml
+++ b/appserver/admingui/war/pom.xml
@@ -167,7 +167,7 @@
                                 jakarta.servlet.jsp-api,
                                 jakarta.el-api,
                                 org.glassfish.expressly,
-                                org.glassfish.jsftemplating,
+                                org.glassfish.main.admingui.jsftemplating,
                                 org.glassfish.main.admingui.dataprovider
                             </HK2-Import-Bundles>
                         </manifestEntries>

--- a/appserver/distributions/glassfish/src/main/patches/jackson-module-jakarta-xmlbind-annotations/META-INF/2.22.MF
+++ b/appserver/distributions/glassfish/src/main/patches/jackson-module-jakarta-xmlbind-annotations/META-INF/2.22.MF
@@ -1,0 +1,60 @@
+Manifest-Version: 1.0
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
+Bundle-SymbolicName: com.fasterxml.jackson.module.jackson-module-jakar
+ ta-xmlbind-annotations
+Implementation-Vendor-Id: com.fasterxml.jackson.module
+Specification-Title: Jackson module: Jakarta XML Bind Annotations (jak
+ arta.xml.bind)
+Bundle-DocURL: https://github.com/FasterXML/jackson-modules-base
+Import-Package: jakarta.activation;resolution:=optional;version="[2.0,
+ 3)",jakarta.xml.bind;version="[3.0,4.0.100)",jakarta.xml.bind.annotat
+ ion;version="[3.0,4.0.100)",jakarta.xml.bind.annotation.adapters;vers
+ ion="[3.0,4.0.100)",com.fasterxml.jackson.annotation;version="[2.22,3
+ )",com.fasterxml.jackson.core;version="[2.22,3)",com.fasterxml.jackso
+ n.core.util;version="[2.22,3)",com.fasterxml.jackson.databind;version
+ ="[2.22,3)",com.fasterxml.jackson.databind.cfg;version="[2.22,3)",com
+ .fasterxml.jackson.databind.deser.std;version="[2.22,3)",com.fasterxm
+ l.jackson.databind.introspect;version="[2.22,3)",com.fasterxml.jackso
+ n.databind.jsonFormatVisitors;version="[2.22,3)",com.fasterxml.jackso
+ n.databind.jsontype;version="[2.22,3)",com.fasterxml.jackson.databind
+ .jsontype.impl;version="[2.22,3)",com.fasterxml.jackson.databind.node
+ ;version="[2.22,3)",com.fasterxml.jackson.databind.ser.std;version="[
+ 2.22,3)",com.fasterxml.jackson.databind.type;version="[2.22,3)",com.f
+ asterxml.jackson.databind.util;version="[2.22,3)",com.fasterxml.jacks
+ on.module.jakarta.xmlbind.deser;version="[2.22,3)",com.fasterxml.jack
+ son.module.jakarta.xmlbind.ser;version="[2.22,3)"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Export-Package: com.fasterxml.jackson.module.jakarta.xmlbind;version="
+ 2.22.0";uses:="com.fasterxml.jackson.annotation,com.fasterxml.jackson
+ .core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.c
+ fg,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.da
+ tabind.jsontype,com.fasterxml.jackson.databind.type,com.fasterxml.jac
+ kson.databind.util,jakarta.xml.bind.annotation,jakarta.xml.bind.annot
+ ation.adapters",com.fasterxml.jackson.module.jakarta.xmlbind.deser;ve
+ rsion="2.22.0";uses:="com.fasterxml.jackson.core,com.fasterxml.jackso
+ n.databind,com.fasterxml.jackson.databind.deser.std,jakarta.activatio
+ n",com.fasterxml.jackson.module.jakarta.xmlbind.ser;version="2.22.0";
+ uses:="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.
+ fasterxml.jackson.databind.jsonFormatVisitors,com.fasterxml.jackson.d
+ atabind.ser.std,jakarta.activation"
+Bundle-Name: Jackson module: Jakarta XML Bind Annotations (jakarta.xml
+ .bind)
+Multi-Release: true
+Build-Jdk-Spec: 1.8
+Bundle-Description: Support for using Jakarta XML Bind (aka JAXB 3.0) 
+ annotations as an alternativeto "native" Jackson annotations, for con
+ figuring data-binding.
+Implementation-Title: Jackson module: Jakarta XML Bind Annotations (ja
+ karta.xml.bind)
+Implementation-Version: 2.22.0
+Bundle-ManifestVersion: 2
+Specification-Vendor: FasterXML
+Bundle-Vendor: FasterXML
+Tool: Bnd-6.3.1.202206071316
+Implementation-Vendor: FasterXML
+Bundle-Version: 2.22.0
+X-Compile-Target-JDK: 1.8
+X-Compile-Source-JDK: 1.8
+Created-By: Apache Maven Bundle Plugin 5.1.9
+Specification-Version: 2.22.0
+

--- a/appserver/distributions/glassfish/src/main/patches/jackson-module-jakarta-xmlbind-annotations/META-INF/MANIFEST.MF
+++ b/appserver/distributions/glassfish/src/main/patches/jackson-module-jakarta-xmlbind-annotations/META-INF/MANIFEST.MF
@@ -1,0 +1,60 @@
+Manifest-Version: 1.0
+Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt
+Bundle-SymbolicName: com.fasterxml.jackson.module.jackson-module-jakar
+ ta-xmlbind-annotations
+Implementation-Vendor-Id: com.fasterxml.jackson.module
+Specification-Title: Jackson module: Jakarta XML Bind Annotations (jak
+ arta.xml.bind)
+Bundle-DocURL: https://github.com/FasterXML/jackson-modules-base
+Import-Package: jakarta.activation;resolution:=optional;version="[2.0,
+ 3)",jakarta.xml.bind;version="[3.0,5.0.100)",jakarta.xml.bind.annotat
+ ion;version="[3.0,5.0.100)",jakarta.xml.bind.annotation.adapters;vers
+ ion="[3.0,5.0.100)",com.fasterxml.jackson.annotation;version="[2.22,3
+ )",com.fasterxml.jackson.core;version="[2.22,3)",com.fasterxml.jackso
+ n.core.util;version="[2.22,3)",com.fasterxml.jackson.databind;version
+ ="[2.22,3)",com.fasterxml.jackson.databind.cfg;version="[2.22,3)",com
+ .fasterxml.jackson.databind.deser.std;version="[2.22,3)",com.fasterxm
+ l.jackson.databind.introspect;version="[2.22,3)",com.fasterxml.jackso
+ n.databind.jsonFormatVisitors;version="[2.22,3)",com.fasterxml.jackso
+ n.databind.jsontype;version="[2.22,3)",com.fasterxml.jackson.databind
+ .jsontype.impl;version="[2.22,3)",com.fasterxml.jackson.databind.node
+ ;version="[2.22,3)",com.fasterxml.jackson.databind.ser.std;version="[
+ 2.22,3)",com.fasterxml.jackson.databind.type;version="[2.22,3)",com.f
+ asterxml.jackson.databind.util;version="[2.22,3)",com.fasterxml.jacks
+ on.module.jakarta.xmlbind.deser;version="[2.22,3)",com.fasterxml.jack
+ son.module.jakarta.xmlbind.ser;version="[2.22,3)"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Export-Package: com.fasterxml.jackson.module.jakarta.xmlbind;version="
+ 2.22.0";uses:="com.fasterxml.jackson.annotation,com.fasterxml.jackson
+ .core,com.fasterxml.jackson.databind,com.fasterxml.jackson.databind.c
+ fg,com.fasterxml.jackson.databind.introspect,com.fasterxml.jackson.da
+ tabind.jsontype,com.fasterxml.jackson.databind.type,com.fasterxml.jac
+ kson.databind.util,jakarta.xml.bind.annotation,jakarta.xml.bind.annot
+ ation.adapters",com.fasterxml.jackson.module.jakarta.xmlbind.deser;ve
+ rsion="2.22.0";uses:="com.fasterxml.jackson.core,com.fasterxml.jackso
+ n.databind,com.fasterxml.jackson.databind.deser.std,jakarta.activatio
+ n",com.fasterxml.jackson.module.jakarta.xmlbind.ser;version="2.22.0";
+ uses:="com.fasterxml.jackson.core,com.fasterxml.jackson.databind,com.
+ fasterxml.jackson.databind.jsonFormatVisitors,com.fasterxml.jackson.d
+ atabind.ser.std,jakarta.activation"
+Bundle-Name: Jackson module: Jakarta XML Bind Annotations (jakarta.xml
+ .bind)
+Multi-Release: true
+Build-Jdk-Spec: 1.8
+Bundle-Description: Support for using Jakarta XML Bind (aka JAXB 3.0) 
+ annotations as an alternativeto "native" Jackson annotations, for con
+ figuring data-binding.
+Implementation-Title: Jackson module: Jakarta XML Bind Annotations (ja
+ karta.xml.bind)
+Implementation-Version: 2.22.0
+Bundle-ManifestVersion: 2
+Specification-Vendor: FasterXML
+Bundle-Vendor: FasterXML
+Tool: Bnd-6.3.1.202206071316
+Implementation-Vendor: FasterXML
+Bundle-Version: 2.22.0
+X-Compile-Target-JDK: 1.8
+X-Compile-Source-JDK: 1.8
+Created-By: Apache Maven Bundle Plugin 5.1.9
+Specification-Version: 2.22.0
+

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1822,8 +1822,9 @@
 
         <!-- glassfish-gui -->
         <dependency>
-            <groupId>org.glassfish.jsftemplating</groupId>
+            <groupId>org.glassfish.main.admingui</groupId>
             <artifactId>jsftemplating</artifactId>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -82,7 +82,7 @@
         <microprofile.health-api.version>4.0.1</microprofile.health-api.version>
 
         <!-- MicroProfile JWT / JWT Authentication Mechanism for Jakarta Security -->
-        <microprofile-jwt-auth-api.version>2.1</microprofile-jwt-auth-api.version>
+        <microprofile-jwt-auth-api.version>2.2-RC1</microprofile-jwt-auth-api.version>
         <omnifaces-jwt-auth.version>4.0.0-M2</omnifaces-jwt-auth.version>
 
         <!-- MicroProfile REST Client -->
@@ -90,7 +90,6 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
 
         <!-- Admin console components -->
-        <jsftemplating.version>4.2.0</jsftemplating.version>
         <jsf-ext.version>0.2</jsf-ext.version>
         <woodstock.version>6.0.3</woodstock.version>
         <woodstock-dataprovider.version>1.0</woodstock-dataprovider.version>
@@ -522,22 +521,6 @@
             </dependency>
 
             <!-- Admin console components -->
-            <dependency>
-                <groupId>org.glassfish.jsftemplating</groupId>
-                <artifactId>jsftemplating</artifactId>
-                <version>${jsftemplating.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.servlet</groupId>
-                        <artifactId>jakarta.servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jsftemplating</groupId>
-                <artifactId>jsftemplating-dt</artifactId>
-                <version>${jsftemplating.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.glassfish.woodstock</groupId>
                 <artifactId>woodstock-webui-jsf</artifactId>

--- a/appserver/tests/embedded/ejb/remoteejb/pom.xml
+++ b/appserver/tests/embedded/ejb/remoteejb/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -41,11 +41,12 @@
 
     <build>
         <finalName>remoteejb</finalName>
+
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <parallel>method</parallel>
+                    <parallel>methods</parallel>
                     <threadCount>1</threadCount>
                     <skip>true</skip>
                 </configuration>
@@ -56,7 +57,7 @@
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <parallel>method</parallel>
+                            <parallel>methods</parallel>
                             <threadCount>1</threadCount>
                             <skip>false</skip>
                         </configuration>
@@ -65,6 +66,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>run-with-uber-jar</id>
@@ -78,6 +80,7 @@
                 </dependency>
             </dependencies>
         </profile>
+
         <profile>
             <id>run-with-uber-jar-web</id>
             <activation>
@@ -93,6 +96,7 @@
                 </dependency>
             </dependencies>
         </profile>
+
         <profile>
             <id>run-with-shell-jar</id>
             <activation>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -143,8 +143,8 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-        <eclipselink.version>5.0.0</eclipselink.version>
-        <eclipselink.asm.version>9.9.0</eclipselink.asm.version>
+        <eclipselink.version>5.0.1-RC2</eclipselink.version>
+        <eclipselink.asm.version>9.10.0</eclipselink.asm.version>
 
         <!-- Jakarta Mail -->
         <jakarta.mail-api.version>2.2.0-M1</jakarta.mail-api.version>
@@ -189,9 +189,9 @@
         <!-- Jakarta Data / NoSQL -->
         <jakarta.data-api.version>1.1.0-M3</jakarta.data-api.version>
         <jakarta.data.spec.version>1.1</jakarta.data.spec.version>
-        <jakarta.nosql-api.version>1.1.0-M2</jakarta.nosql-api.version>
+        <jakarta.nosql-api.version>1.1.0-M3</jakarta.nosql-api.version>
         <jakarta.nosql.spec.version>1.1.0</jakarta.nosql.spec.version>
-        <jnosql.version>1.2.0-SNAPSHOT</jnosql.version>
+        <jnosql.version>1.2.0-M1</jnosql.version>
 
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
@@ -210,16 +210,16 @@
         <jakarta.jsonp-api.version>2.1.3</jakarta.jsonp-api.version>
         <parsson.version>1.1.9</parsson.version>
         <parsson-media.version>1.1.9</parsson-media.version>
-        <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
+        <jakarta.json.bind-api.version>3.1.0-M1</jakarta.json.bind-api.version>
         <yasson.version>3.0.4</yasson.version>
 
         <!-- Jakarta Pages and Jakarta Standard Tag Library -->
         <jakarta.pages-api.version>4.1.0-M2</jakarta.pages-api.version>
-        <jstl-api.version>3.0.2</jstl-api.version>
+        <jstl-api.version>3.1.0-SNAPSHOT</jstl-api.version>
         <wasp.version>4.0.0</wasp.version>
 
         <!-- Jakarta MVC -->
-        <jakarta.mvc-api.version>3.0.0</jakarta.mvc-api.version>
+        <jakarta.mvc-api.version>3.0.1</jakarta.mvc-api.version>
         <krazo.version>4.0.2</krazo.version>
 
         <!-- Jakarta SOAP (XML Web Services) -->
@@ -266,7 +266,7 @@
         <jettison.version>1.5.5</jettison.version>
         <mimepull.version>1.11.0</mimepull.version>
         <jna.version>5.19.1</jna.version>
-        <jline.version>4.1.0</jline.version>
+        <jline.version>4.1.3</jline.version>
 
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
@@ -275,10 +275,10 @@
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <shrinkwrap.version>3.3.5</shrinkwrap.version>
+        <shrinkwrap.version>3.3.7</shrinkwrap.version>
         <testcontainers.version>2.0.5</testcontainers.version>
 
-        <surefire.version>3.5.5</surefire.version>
+        <surefire.version>3.6.0-M1</surefire.version>
         <junit5-surefire-tree-reporter.version>1.5.1</junit5-surefire-tree-reporter.version>
 
         <file.executable.suffix></file.executable.suffix>
@@ -1200,7 +1200,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>13.4.0</version>
+                            <version>13.6.0</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1915,20 +1915,6 @@
                                                 <ignoreVersion>
                                                     <type>range</type>
                                                     <version>[3.2.0,)</version>
-                                                </ignoreVersion>
-                                                <ignoreVersion>
-                                                    <type>regex</type>
-                                                    <version>.*-M.*</version>
-                                                </ignoreVersion>
-                                            </ignoreVersions>
-                                        </rule>
-
-                                        <rule>
-                                            <groupId>org.glassfish.jsftemplating</groupId>
-                                            <ignoreVersions>
-                                                <ignoreVersion>
-                                                    <type>range</type>
-                                                    <version>[4.1.0,)</version>
                                                 </ignoreVersion>
                                                 <ignoreVersion>
                                                     <type>regex</type>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -215,7 +215,7 @@
 
         <!-- Jakarta Pages and Jakarta Standard Tag Library -->
         <jakarta.pages-api.version>4.1.0-M2</jakarta.pages-api.version>
-        <jstl-api.version>3.1.0-SNAPSHOT</jstl-api.version>
+        <jstl-api.version>3.0.2</jstl-api.version>
         <wasp.version>4.0.0</wasp.version>
 
         <!-- Jakarta MVC -->
@@ -260,7 +260,7 @@
         <ant.version>1.10.17</ant.version>
         <ant-osgi.version>1.10.17</ant-osgi.version>
         <jackson.version>2.22.0</jackson.version>
-        <jackson-annotations.version>2.21</jackson-annotations.version>
+        <jackson-annotations.version>2.22</jackson-annotations.version>
         <fasterxml.classmate.version>1.7.3</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
         <jettison.version>1.5.5</jettison.version>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -33,7 +33,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.5</version>
+                    <version>3.6.0-M1</version>
                     <executions>
                         <execution>
                             <id>default-test</id>


### PR DESCRIPTION
JSFTemplate is exclusively used by the AdminUI in GlassFish, and therefor should be bundled with it as a private internal dependency.
