### PR TITLE
Template current-release versions in download pages

### DIFF
--- a/docs/website/src/main/resources/download.md
+++ b/docs/website/src/main/resources/download.md
@@ -1,10 +1,10 @@
 # Eclipse GlassFish Downloads
 
-## Eclipse GlassFish 8.0.2
+## Eclipse GlassFish ${glassfish.version.8x}
 
 Eclipse GlassFish is an application server, implementing Jakarta EE. This release is corresponding with the [Jakarta EE 11](https://jakarta.ee/release/11) specification, which is a major new feature release. Eclipse GlassFish 8 requires JDK 21 or higher.
 
-### Breaking Changes Compared to 7.1.0
+### Breaking Changes Compared to ${glassfish.version.71x}
 
 * Compliance with Jakarta EE 11
 * Minimal supported version is Java 21
@@ -17,14 +17,14 @@ Eclipse GlassFish is an application server, implementing Jakarta EE. This releas
 
 ### Download
 
-* [Eclipse GlassFish 8.0.2, Jakarta EE Platform 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-8.0.2.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/8.0.2)
-* [Eclipse GlassFish 8.0.2, Jakarta EE Web Profile 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-8.0.2.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/8.0.2)
-* [Eclipse GlassFish Embedded 8.0.2, Jakarta EE Platform 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/8.0.2/glassfish-embedded-all-8.0.2.jar) (jar) — run with `java -jar glassfish-embedded-all-8.0.2.jar`, no installation required
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/8.0.2)
-* [Eclipse GlassFish Embedded 8.0.2, Jakarta EE Web Profile 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/8.0.2/glassfish-embedded-web-8.0.2.jar) (jar) — run with `java -jar glassfish-embedded-web-8.0.2.jar`, no installation required
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/8.0.2)
+* [Eclipse GlassFish ${glassfish.version.8x}, Jakarta EE Platform 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-${glassfish.version.8x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/${glassfish.version.8x})
+* [Eclipse GlassFish ${glassfish.version.8x}, Jakarta EE Web Profile 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-${glassfish.version.8x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/${glassfish.version.8x})
+* [Eclipse GlassFish Embedded ${glassfish.version.8x}, Jakarta EE Platform 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/${glassfish.version.8x}/glassfish-embedded-all-${glassfish.version.8x}.jar) (jar) — run with `java -jar glassfish-embedded-all-${glassfish.version.8x}.jar`, no installation required
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/${glassfish.version.8x})
+* [Eclipse GlassFish Embedded ${glassfish.version.8x}, Jakarta EE Web Profile 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/${glassfish.version.8x}/glassfish-embedded-web-${glassfish.version.8x}.jar) (jar) — run with `java -jar glassfish-embedded-web-${glassfish.version.8x}.jar`, no installation required
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/${glassfish.version.8x})
 
 More details:
 
@@ -37,37 +37,37 @@ Download all GlassFish 8.x releases at the [Eclipse GlassFish 8.x Downloads](dow
 
 ----
 
-## Eclipse GlassFish 7.1.0
+## Eclipse GlassFish ${glassfish.version.71x}
 
 Eclipse GlassFish is an application server, implementing [Jakarta EE](https://jakarta.ee/about).
 This release is corresponding with the [Jakarta EE 10](https://jakarta.ee/specifications/platform/10) specification, which is a major feature release.
 
-GlassFish 7.1.0 is a final release, containing final Jakarta EE 10 APIs.
+GlassFish ${glassfish.version.71x} is a final release, containing final Jakarta EE 10 APIs.
 It is tested with Java 17, 21 and 25 experimentally can be used also with newer or non LTS version.
 
 This is the first release after several months of intensive work on fixes and feature upgrades.
 
 The release marks the transition to the latest version of the Java Platform, so we dropped support for Java 11, and are now supporting Java 25 instead.
-GlassFish 7.1.0 introduces support for Microprofile Health, switches keystores from JKS to PKCS12, the current industry standard, and adapted server bootstrap to JPMS.
+GlassFish ${glassfish.version.71x} introduces support for Microprofile Health, switches keystores from JKS to PKCS12, the current industry standard, and adapted server bootstrap to JPMS.
 
 We also implemented more user friendly interactive asadmin, improved user communication on server startups, etc. The complete list of changes is available on GitHub.
 
-This is a step of gradual modernization while it did not slow down the development of GlassFish 8, based on Jakarta EE 11, while GlassFish 7.1.0 still supports Jakarta EE 10.
+This is a step of gradual modernization while it did not slow down the development of GlassFish 8, based on Jakarta EE 11, while GlassFish ${glassfish.version.71x} still supports Jakarta EE 10.
 
 Download:
 
-* [Eclipse GlassFish 7.1.0, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-7.1.0.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/7.1.0)
-* [Eclipse GlassFish 7.1.0, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-7.1.0.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/7.1.0)
-* [Eclipse GlassFish Embedded 7.1.0, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/7.1.0/glassfish-embedded-all-7.1.0.jar) (jar) — run with `java -jar glassfish-embedded-all-7.1.0.jar`, no installation required
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/7.1.0)
-* [Eclipse GlassFish Embedded 7.1.0, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/7.1.0/glassfish-embedded-web-7.1.0.jar) (jar) — run with `java -jar glassfish-embedded-web-7.1.0.jar`, no installation required
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/7.1.0)
+* [Eclipse GlassFish ${glassfish.version.71x}, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-${glassfish.version.71x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/${glassfish.version.71x})
+* [Eclipse GlassFish ${glassfish.version.71x}, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-${glassfish.version.71x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/${glassfish.version.71x})
+* [Eclipse GlassFish Embedded ${glassfish.version.71x}, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/${glassfish.version.71x}/glassfish-embedded-all-${glassfish.version.71x}.jar) (jar) — run with `java -jar glassfish-embedded-all-${glassfish.version.71x}.jar`, no installation required
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/${glassfish.version.71x})
+* [Eclipse GlassFish Embedded ${glassfish.version.71x}, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/${glassfish.version.71x}/glassfish-embedded-web-${glassfish.version.71x}.jar) (jar) — run with `java -jar glassfish-embedded-web-${glassfish.version.71x}.jar`, no installation required
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/${glassfish.version.71x})
 
 More details:
 
-* [Eclipse GlassFish 7.1.0 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.1.0)
+* [Eclipse GlassFish ${glassfish.version.71x} Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/${glassfish.version.71x})
 * [Jakarte EE Specifications](https://jakarta.ee/specifications/) for more info about Jakarta EE
 
 ### All Eclipse GlassFish 7.x Downloads

--- a/docs/website/src/main/resources/download_gf7.md
+++ b/docs/website/src/main/resources/download_gf7.md
@@ -1,63 +1,63 @@
 # Eclipse GlassFish 7.x Downloads
 
-## Eclipse GlassFish 7.1.0
+## Eclipse GlassFish ${glassfish.version.71x}
 
 Eclipse GlassFish is an application server, implementing [Jakarta EE](https://jakarta.ee/about).
 This release is corresponding with the [Jakarta EE 10](https://jakarta.ee/specifications/platform/10) specification, which is a major feature release.
 
-GlassFish 7.1.0 is a final release, containing final Jakarta EE 10 APIs.
+GlassFish ${glassfish.version.71x} is a final release, containing final Jakarta EE 10 APIs.
 It is tested with Java 17, 21 and 25 experimentally can be used also with newer or non LTS version.
 
 This is the first release after several months of intensive work on fixes and feature upgrades.
 
 The release marks the transition to the latest version of the Java Platform, so we dropped support for Java 11, and are now supporting Java 25 instead.
-GlassFish 7.1.0 introduces support for Microprofile Health, switches keystores from JKS to PKCS12, the current industry standard, and adapted server bootstrap to JPMS.
+GlassFish ${glassfish.version.71x} introduces support for Microprofile Health, switches keystores from JKS to PKCS12, the current industry standard, and adapted server bootstrap to JPMS.
 
 We also implemented more user friendly interactive asadmin, improved user communication on server startups, etc. The complete list of changes is available on GitHub.
 
-This is a step of gradual modernization while it did not slow down the development of GlassFish 8, based on Jakarta EE 11, while GlassFish 7.1.0 still supports Jakarta EE 10.
+This is a step of gradual modernization while it did not slow down the development of GlassFish 8, based on Jakarta EE 11, while GlassFish ${glassfish.version.71x} still supports Jakarta EE 10.
 
 Download:
 
-* [Eclipse GlassFish 7.1.0, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-7.1.0.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/7.1.0)
-* [Eclipse GlassFish 7.1.0, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-7.1.0.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/7.1.0)
-* [Eclipse GlassFish Embedded 7.1.0, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/7.1.0/glassfish-embedded-all-7.1.0.jar) (jar)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/7.1.0)
-* [Eclipse GlassFish Embedded 7.1.0, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/7.1.0/glassfish-embedded-web-7.1.0.jar) (jar)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/7.1.0)
+* [Eclipse GlassFish ${glassfish.version.71x}, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-${glassfish.version.71x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/${glassfish.version.71x})
+* [Eclipse GlassFish ${glassfish.version.71x}, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-${glassfish.version.71x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/${glassfish.version.71x})
+* [Eclipse GlassFish Embedded ${glassfish.version.71x}, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/${glassfish.version.71x}/glassfish-embedded-all-${glassfish.version.71x}.jar) (jar)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/${glassfish.version.71x})
+* [Eclipse GlassFish Embedded ${glassfish.version.71x}, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/${glassfish.version.71x}/glassfish-embedded-web-${glassfish.version.71x}.jar) (jar)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/${glassfish.version.71x})
 
 More details:
 
-* [Eclipse GlassFish 7.1.0 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.1.0)
+* [Eclipse GlassFish ${glassfish.version.71x} Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/${glassfish.version.71x})
 * [Jakarte EE Specifications](https://jakarta.ee/specifications/) for more info about Jakarta EE
 
-## Eclipse GlassFish 7.0.25
+## Eclipse GlassFish ${glassfish.version.7x}
 
 Eclipse GlassFish is an application server, implementing [Jakarta EE](https://jakarta.ee/about).
 This release is corresponding with the [Jakarta EE 10](https://jakarta.ee/specifications/platform/10) specification, which is a major feature release.
 
-GlassFish 7.0.25 is a final release, containing final Jakarta EE 10 APIs.
+GlassFish ${glassfish.version.7x} is a final release, containing final Jakarta EE 10 APIs.
 It is tested with Java 11, 17 and 21, experimentally can be used also with newer or non LTS version.
 MicroProfile support requires JDK 17 or higher.
 
-This update emphasizes major cleanups, system optimizations, and prepares the codebase for easier future maintenance, notably in anticipation of the upcoming 7.1.0 release.
+This update emphasizes major cleanups, system optimizations, and prepares the codebase for easier future maintenance, notably in anticipation of the upcoming ${glassfish.version.71x} release.
 
 Download:
 
-* [Eclipse GlassFish 7.0.25, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-7.0.25.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/7.0.25)
-* [Eclipse GlassFish 7.0.25, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-7.0.25.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/7.0.25)
-* [Eclipse GlassFish Embedded 7.0.25, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/7.0.25/glassfish-embedded-all-7.0.25.jar) (jar)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/7.0.25)
-* [Eclipse GlassFish Embedded 7.0.25, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/7.0.25/glassfish-embedded-web-7.0.25.jar) (jar)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/7.0.25)
+* [Eclipse GlassFish ${glassfish.version.7x}, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-${glassfish.version.7x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/${glassfish.version.7x})
+* [Eclipse GlassFish ${glassfish.version.7x}, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-${glassfish.version.7x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/${glassfish.version.7x})
+* [Eclipse GlassFish Embedded ${glassfish.version.7x}, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/${glassfish.version.7x}/glassfish-embedded-all-${glassfish.version.7x}.jar) (jar)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/${glassfish.version.7x})
+* [Eclipse GlassFish Embedded ${glassfish.version.7x}, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/${glassfish.version.7x}/glassfish-embedded-web-${glassfish.version.7x}.jar) (jar)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/${glassfish.version.7x})
 
 More details:
 
-* [Eclipse GlassFish 7.0.25 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.25)
+* [Eclipse GlassFish ${glassfish.version.7x} Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/${glassfish.version.7x})
 * [Jakarte EE Specifications](https://jakarta.ee/specifications/) for more info about Jakarta EE
 
 ## Eclipse GlassFish 7.0.24
@@ -155,7 +155,7 @@ Eclipse GlassFish is an application server, implementing Jakarta EE. This releas
 
 GlassFish 7.0.20 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 23. MicroProfile support requires JDK 17 or higher.
 
-While working on GlassFish 7.1.0 and GlassFish 8, we didn't leave the stable 7.0.x series in the dark. In this release we updated a lot of our dependencies to their latest versions and did a large amount of testing to ensure everything worked as required. We also improved stability again by squashing a number of outstanding bugs.
+While working on GlassFish ${glassfish.version.71x} and GlassFish 8, we didn't leave the stable 7.0.x series in the dark. In this release we updated a lot of our dependencies to their latest versions and did a large amount of testing to ensure everything worked as required. We also improved stability again by squashing a number of outstanding bugs.
 
 Download:
 

--- a/docs/website/src/main/resources/download_gf8.md
+++ b/docs/website/src/main/resources/download_gf8.md
@@ -3,9 +3,9 @@
 Eclipse GlassFish is an application server, implementing Jakarta EE.
 This release is corresponding with the [Jakarta EE 11](https://jakarta.ee/release/11) specification, which is a major new feature release. Eclipse GlassFish 8 requires JDK 21 or higher.
 
-## Eclipse GlassFish 8.0.2
+## Eclipse GlassFish ${glassfish.version.8x}
 
-This release focused on dependencies - see [release notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/8.0.2) for details.
+This release focused on dependencies - see [release notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/${glassfish.version.8x}) for details.
 
 ### Main Changes
 
@@ -15,18 +15,18 @@ This release focused on dependencies - see [release notes](https://github.com/ec
 
 ### Download
 
-* [Eclipse GlassFish 8.0.2, Jakarta EE Platform 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-8.0.2.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/8.0.2)
-* [Eclipse GlassFish 8.0.2, Jakarta EE Web Profile 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-8.0.2.zip) (zip)
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/8.0.2)
-* [Eclipse GlassFish Embedded 8.0.2, Jakarta EE Platform 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/8.0.2/glassfish-embedded-all-8.0.2.jar) (jar) — run with `java -jar glassfish-embedded-all-8.0.2.jar`, no installation required
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/8.0.2)
-* [Eclipse GlassFish Embedded 8.0.2, Jakarta EE Web Profile 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/8.0.2/glassfish-embedded-web-8.0.2.jar) (jar) — run with `java -jar glassfish-embedded-web-8.0.2.jar`, no installation required
-  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/8.0.2)
+* [Eclipse GlassFish ${glassfish.version.8x}, Jakarta EE Platform 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-${glassfish.version.8x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/${glassfish.version.8x})
+* [Eclipse GlassFish ${glassfish.version.8x}, Jakarta EE Web Profile 11](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-${glassfish.version.8x}.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/${glassfish.version.8x})
+* [Eclipse GlassFish Embedded ${glassfish.version.8x}, Jakarta EE Platform 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/${glassfish.version.8x}/glassfish-embedded-all-${glassfish.version.8x}.jar) (jar) — run with `java -jar glassfish-embedded-all-${glassfish.version.8x}.jar`, no installation required
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/${glassfish.version.8x})
+* [Eclipse GlassFish Embedded ${glassfish.version.8x}, Jakarta EE Web Profile 11](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/${glassfish.version.8x}/glassfish-embedded-web-${glassfish.version.8x}.jar) (jar) — run with `java -jar glassfish-embedded-web-${glassfish.version.8x}.jar`, no installation required
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/${glassfish.version.8x})
 
 More details:
 
-* [Eclipse GlassFish 8.0.2 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/8.0.2)
+* [Eclipse GlassFish ${glassfish.version.8x} Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/${glassfish.version.8x})
 * [Jakarte EE Specifications](https://jakarta.ee/specifications/) for more info about Jakarta EE
 
 ## Eclipse GlassFish 8.0.1


### PR DESCRIPTION
## Summary

Phase 1 of #25503. Replaces the hardcoded *current-release* version literals in the download pages with the existing `${glassfish.version.*}` properties from `docs/pom.xml`, which are already resolved by the website module's resource filtering. This removes the per-release copy&paste for the latest 7.x, 7.1.x and 8.x entries.

- `download.md`: `8.0.2` → `${glassfish.version.8x}`, `7.1.0` → `${glassfish.version.71x}`
- `download_gf7.md`: `7.1.0` → `${glassfish.version.71x}`, `7.0.25` → `${glassfish.version.7x}`
- `download_gf8.md`: `8.0.2` → `${glassfish.version.8x}`

Rendered output is unchanged: the properties already resolve to these exact values in the build (the existing `target/classes/docs/README.md` confirms `${glassfish.version.71x}` → `7.1.0`).

## Scope / why this is only Phase 1

Older release blocks (`8.0.1`, `8.0.0`, `7.0.24` and below) are left as literals **on purpose**. Maven property filtering is global/static, so a property can only carry the *current* value of each series — only the latest entry per series maps to a property. The repeated historical blocks need a real templating engine with per-block variable reassignment (Velocity/FreeMarker, as discussed in the issue), which is left for a follow-up. Hence `Refs` rather than `Fixes`.

## Notes for reviewers

- Opened as **draft** to coordinate with the mentored work already in progress on #25503 (cc @OndroMih / @Ariho-Seth) — happy to defer, hand off, or fold this in as a starting point.
- No copyright headers were added to these `.md` files: they currently carry none and render directly into the published website HTML, so a header would leak into the page. Please confirm website content `.md` is treated like `.adoc` (exempt).

Refs #25503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
