### PR TITLE
Document that add/remove-library for domain/lib doesn't require restart

### DIFF
--- a/docs/administration-guide/src/main/asciidoc/jdbc.adoc
+++ b/docs/administration-guide/src/main/asciidoc/jdbc.adoc
@@ -1056,15 +1056,17 @@ the latest database support information.
 ===== Making the JDBC Driver JAR Files Accessible
 
 To integrate the JDBC driver into a {productName} domain, copy the
-JAR files into the domain-dir``/lib`` directory, then restart the server.
+JAR files into the domain-dir``/lib`` directory.
+Since GlassFish 7.0.18, restarting the server is not required for the
+runtime to pick up these libraries.
 This makes classes accessible to all applications or modules deployed on
 servers that share the same configuration. For more information about
 {productName} class loaders, see "xref:application-development-guide.adoc#class-loaders[Class Loaders]" in
 {productName} Application Development Guide.
 
 If you are using an Oracle database with EclipseLink extensions, copy
-the JAR files into the domain-dir``/lib/ext`` directory, then restart the
-server. For details, see "xref:application-development-guide.adoc#oracle-database-enhancements[Oracle Database
+the JAR files into the domain-dir``/lib/ext`` directory, then restart the server.
+For details, see "xref:application-development-guide.adoc#oracle-database-enhancements[Oracle Database
 Enhancements]" in {productName} Application
 Development Guide.
 

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/add-library.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/add-library.1
@@ -20,19 +20,17 @@ DESCRIPTION
        multiple paths separated by spaces.
 
            Note
-           +----------------------------------------+
-           |           The library archive file is  |
-           |           added to the DAS. For common |
-           |           and extension libraries, you |
-           |           must restart the DAS so the  |
-           |           libraries are picked up by   |
-           |           the server runtime. To add   |
-           |           the libraries to other       |
-           |           server instances,            |
-           |           synchronize the instances    |
-           |           with the DAS by restarting   |
-           |           them.                        |
-           +----------------------------------------+
+           +-----------------------------------------+
+           |           The library archive file is   |
+           |           added to the DAS. Since       |
+           |           GlassFish 7.0.18, common      |
+           |           libraries are picked up by    |
+           |           the runtime without           |
+           |           restarting the DAS or server  |
+           |           instances. Extension          |
+           |           libraries (lib/ext) still     |
+           |           require a restart.            |
+           +-----------------------------------------+
 
        This subcommand is supported in remote mode only.
 

--- a/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/remove-library.1
+++ b/nucleus/deployment/admin/src/main/manpages/org/glassfish/deployment/admin/remove-library.1
@@ -21,23 +21,20 @@ DESCRIPTION
        names separated by spaces.
 
            Note
-           +---------------------------------------+
-           |           The library archive file is |
-           |           removed from the DAS. For   |
-           |           common and extension        |
-           |           libraries, you must restart |
-           |           the DAS so the library      |
-           |           removals are picked up by   |
-           |           the server runtime. To      |
-           |           remove the libraries from   |
-           |           other server instances,     |
-           |           synchronize the instances   |
-           |           with the DAS by restarting  |
-           |           them.                       |
-           |           This command is not         |
-           |           supported on the Windows    |
-           |           operating system.           |
-           +---------------------------------------+
+           +----------------------------------------+
+           |           The library archive file is  |
+           |           removed from the DAS. Since  |
+           |           GlassFish 7.0.18, common     |
+           |           library removals are picked  |
+           |           up by the runtime without    |
+           |           restarting the DAS or server |
+           |           instances. Extension         |
+           |           libraries (lib/ext) still    |
+           |           require a restart.           |
+           |           This command is not          |
+           |           supported on the Windows     |
+           |           operating system.            |
+           +----------------------------------------+
 
        This subcommand is supported in remote mode only.
 


### PR DESCRIPTION
- Update add-library.1 and remove-library.1 manpage notes
- Update jdbc.adoc (domain/lib: no restart; domain/lib/ext: still needs restart)
- Add integration test verifying no-restart behavior in SQLTraceListenerTest