### PR TITLE
Update website for 7.0.26

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -61,7 +61,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <glassfish.version.5x>5.1.0</glassfish.version.5x>
         <glassfish.version.6x>6.2.5</glassfish.version.6x>
-        <glassfish.version.7x>7.0.25</glassfish.version.7x>
+        <glassfish.version.7x>7.0.26</glassfish.version.7x>
         <glassfish.version.71x>7.1.0</glassfish.version.71x>
         <glassfish.version.8x>8.0.3</glassfish.version.8x>
         <glassfish.version.7x.artifact>${glassfish.version.7x}</glassfish.version.7x.artifact>

--- a/docs/website/src/main/resources/download_gf7.md
+++ b/docs/website/src/main/resources/download_gf7.md
@@ -33,6 +33,32 @@ More details:
 * [Eclipse GlassFish 7.1.0 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.1.0)
 * [Jakarte EE Specifications](https://jakarta.ee/specifications/) for more info about Jakarta EE
 
+## Eclipse GlassFish 7.0.26
+
+Eclipse GlassFish is an application server, implementing [Jakarta EE](https://jakarta.ee/about). This release is corresponding with the [Jakarta EE 10](https://jakarta.ee/specifications/platform/10) specification, which is a major feature release. Jakarta EE 10 requires JDK 11 as a minimum, but also officially works on JDK 17 and JDK 21.
+
+GlassFish 7.0.26 is a final release, containing final Jakarta EE 10 APIs. It compiles and runs on JDK 11 to JDK 24. MicroProfile support requires JDK 17 or higher.
+
+Since 7.0.26, the GlassFish 7.0.x branch is in maintenance mode with focus on security and stability. It mainly receives security fixes and important patches.
+
+This update brings security fixes, a fix of memory leak in Jersey, and a few other small improvements and fixes. Mojarra is upgraded to 4.0.15, which proved to be a stable release without any regressions or known issues.
+
+Download:
+
+* [Eclipse GlassFish 7.0.26, Jakarta EE Platform, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/glassfish-7.0.26.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/glassfish/7.0.26)
+* [Eclipse GlassFish 7.0.26, Jakarta EE Web Profile, 10](https://www.eclipse.org/downloads/download.php?file=/ee4j/glassfish/web-7.0.26.zip) (zip)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.distributions/web/7.0.26)
+* [Eclipse GlassFish Embedded 7.0.26, Jakarta EE Platform, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-all/7.0.26/glassfish-embedded-all-7.0.26.jar) (jar)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-all/7.0.26)
+* [Eclipse GlassFish Embedded 7.0.26, Jakarta EE Web Profile, 10](https://repo1.maven.org/maven2/org/glassfish/main/extras/glassfish-embedded-web/7.0.26/glassfish-embedded-web-7.0.26.jar) (jar)
+  * [Maven coordinates](https://central.sonatype.com/artifact/org.glassfish.main.extras/glassfish-embedded-web/7.0.26)
+
+More details:
+
+* [Eclipse GlassFish 7.0.26 Release Notes](https://github.com/eclipse-ee4j/glassfish/releases/tag/7.0.26)
+* [Jakarte EE Specifications](https://jakarta.ee/specifications/) for more info about Jakarta EE
+
 ## Eclipse GlassFish 7.0.25
 
 Eclipse GlassFish is an application server, implementing [Jakarta EE](https://jakarta.ee/about).


### PR DESCRIPTION
No news piece, just release info in the GlassFish 7 download page, and GF 7.0 docs moved to 7.0.26.
