### PR TITLE
Use default value for `.publish`

### DIFF
--- a/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/CommonWorkManager.java
+++ b/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/CommonWorkManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -71,8 +72,7 @@ public final class CommonWorkManager implements WorkManager {
             comment = "Failed to find thread pool",
             level = "SEVERE",
             cause = "Could not find a thread pool according to the pool ID.",
-            action = "Check the thread-pool-id property in Resource Adapter Config.",
-            publish = true)
+            action = "Check the thread-pool-id property in Resource Adapter Config.")
     private static final String RAR_THREAD_POOL_NOT_FOUND = "AS-RAR-05001";
 
     @LogMessageInfo(
@@ -80,8 +80,7 @@ public final class CommonWorkManager implements WorkManager {
             comment = "Failed to find the default thread pool.",
             level = "SEVERE",
             cause = "Could not find the default thread pool for resource adatper.",
-            action = "Check the thread-pool-id property in Resource Adapter Config.",
-            publish = true)
+            action = "Check the thread-pool-id property in Resource Adapter Config.")
     private static final String RAR_DEFAULT_THREAD_POOL_NOT_FOUND = "AS-RAR-05002";
 
     /**

--- a/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/WorkCoordinator.java
+++ b/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/WorkCoordinator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -56,8 +57,7 @@ public final class WorkCoordinator {
             level = "SEVERE",
             cause = "Resource Adapter throws exception during ManagedConnectionFactory.setResourceAdapter().",
             action = "[1] If you are using third party resource adapter, contact resource adapter vendor." +
-                     "[2] If you are a resource adapter developer, please check the resource adapter code.",
-            publish = true)
+                     "[2] If you are a resource adapter developer, please check the resource adapter code.")
     private static final String RAR_RA_ASSOCIATE_ERROR = "AS-RAR-05005";
 
     static final int WAIT_UNTIL_START = 1;

--- a/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/WorkManagerFactoryImpl.java
+++ b/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/WorkManagerFactoryImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -80,8 +81,7 @@ public final class WorkManagerFactoryImpl implements WorkManagerFactory {
             comment = "Failed to create Work Manager instance.",
             level = "SEVERE",
             cause = "Can not initiate the Work Manager class.",
-            action = "Check the Work Manager class type.",
-            publish = true)
+            action = "Check the Work Manager class type.")
     private static final String RAR_INIT_WORK_MANAGER_ERR = "AS-RAR-05003";
 
     /**

--- a/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/context/ConnectorCallbackHandler.java
+++ b/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/context/ConnectorCallbackHandler.java
@@ -68,8 +68,7 @@ public class ConnectorCallbackHandler implements CallbackHandler {
         comment = "Unsupported callback class.",
         level = "WARNING",
         cause = "Resource adapter has used a callback that is not supported by application server.",
-        action = "Check whether the callback in question is supported by application server.",
-        publish = true)
+        action = "Check whether the callback in question is supported by application server.")
     private static final String RAR_UNSUPPORT_CALLBACK = "AS-RAR-05012";
 
     private final CallbackHandler handler;

--- a/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/context/WorkContextHandlerImpl.java
+++ b/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/context/WorkContextHandlerImpl.java
@@ -96,8 +96,7 @@ public class WorkContextHandlerImpl implements WorkContextHandler {
             comment = "ExecutionContext conflict.",
             level = "WARNING",
             cause = "Submitted Work has Transaction Context as well it is a Work Context Provider which is specification violation.",
-            action = "Make sure that either Execution Context or Work Context Provider with Transaction Context is passed, but not both.",
-            publish = true)
+            action = "Make sure that either Execution Context or Work Context Provider with Transaction Context is passed, but not both.")
     private static final String RAR_EXECUTION_CONTEXT_CONFLICT = "AS-RAR-05007";
 
     @LogMessageInfo(
@@ -105,8 +104,7 @@ public class WorkContextHandlerImpl implements WorkContextHandler {
             comment = "Duplicate Work Context.",
             level = "WARNING",
             cause = "Multiple Work Contexts of same type submitted.",
-            action = "Make sure that same context type is not submitted multiple times in the Work Context.",
-            publish = true)
+            action = "Make sure that same context type is not submitted multiple times in the Work Context.")
     private static final String RAR_EXECUTION_CONTEXT_DUPLICATE = "AS-RAR-05008";
 
     @LogMessageInfo(
@@ -114,8 +112,7 @@ public class WorkContextHandlerImpl implements WorkContextHandler {
             comment = "Unsupported Work Context.",
             level = "WARNING",
             cause = "Work Context in question is not supported by application server.",
-            action = "Check the application server documentation for supported Work Contexts.",
-            publish = true)
+            action = "Check the application server documentation for supported Work Contexts.")
     private static final String RAR_EXECUTION_CONTEXT_NOT_SUPPORT = "AS-RAR-05009";
 
     @LogMessageInfo(
@@ -123,8 +120,7 @@ public class WorkContextHandlerImpl implements WorkContextHandler {
             comment = "Handle custom Work Context.",
             level = "INFO",
             cause = "Requested Work Context is not supported, but a super type of the context is supported.",
-            action = "",
-            publish = true)
+            action = "")
     private static final String RAR_USE_SUPER_WORK_CONTEXT = "AS-RAR-05010";
 
     @LogMessageInfo(
@@ -132,16 +128,14 @@ public class WorkContextHandlerImpl implements WorkContextHandler {
             comment = "Can not find Work Context class.",
             level = "WARNING",
             cause = "Work Context class is not available to application server.",
-            action = "Make sure that the Work Context class is available to server.",
-            publish = true)
+            action = "Make sure that the Work Context class is available to server.")
     private static final String RAR_LOAD_WORK_CONTEXT_ERROR = "AS-RAR-05006";
 
     @LogMessageInfo(
             message = "Unable to set Security Context.",
             comment = "Unable to set Security Context.",
             level = "WARNING", cause = "Unable to set Security Context.",
-            action = "Check the server.log for exceptions",
-            publish = true)
+            action = "Check the server.log for exceptions")
     private static final String RAR_SETUP_SECURITY_CONTEXT_ERROR = "AS-RAR-05011";
 
     @Inject


### PR DESCRIPTION
The only other explicit `publish` I've found is (setting to the non-default): https://github.com/eclipse-ee4j/glassfish/blob/a51f9c4ed6b024223737c7d39b975151d8007837/appserver/connectors/work-management/src/main/java/com/sun/enterprise/connectors/work/OneWork.java#L33-L37

OTOH - this `publish` flag does not seem to be used by GF at all.

Maybe it _could be used_ or - dropped from `@LogMessageInfo`? :thinking: 