### PR TITLE
Upgrade Jackson 2.22.0 -> 2.22.1

### DIFF
--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -239,7 +239,7 @@
         <!-- Keep Ant versions in separated properties to be able to test snapshot while keeping antrun runnable -->
         <ant.version>1.10.17</ant.version>
         <ant-osgi.version>1.10.17</ant-osgi.version>
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <jackson-annotations.version>2.22</jackson-annotations.version>
         <fasterxml.classmate.version>1.7.3</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>


### PR DESCRIPTION
Jackson 2.22.1 release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.22.1