### PR TITLE
Upgrade Nimbus 9.47 -> 10.4.2

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -99,10 +99,10 @@
         <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
 
         <!-- Jakarta Security + Authentication/Authorization -->
-        <soteria.version>3.0.3</soteria.version>
+        <soteria.version>3.0.4</soteria.version>
         <exousia.version>2.1.3</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>10.0.2</nimbus.version>
+        <nimbus.version>10.4.2</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->
@@ -159,7 +159,7 @@
 
         <!-- MicroProfile JWT / JWT Authentication Mechanism for Jakarta Security -->
         <microprofile-jwt-auth-api.version>2.1</microprofile-jwt-auth-api.version>
-        <omnifaces-jwt-auth.version>2.0.2</omnifaces-jwt-auth.version>
+        <omnifaces-jwt-auth.version>2.0.3</omnifaces-jwt-auth.version>
 
         <!-- MicroProfile REST Client -->
         <microprofile.rest-client.version>3.0.1</microprofile.rest-client.version>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -102,7 +102,7 @@
         <soteria.version>3.0.3</soteria.version>
         <exousia.version>2.1.3</exousia.version>
         <epicyro.version>3.0.0</epicyro.version>
-        <nimbus.version>9.47</nimbus.version>
+        <nimbus.version>10.0.2</nimbus.version>
         <jcip.version>1.0.2</jcip.version>
 
         <!-- Jakarta Messaging -->

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -39,7 +39,7 @@
             <groupId>org.glassfish.main.distributions</groupId>
             <artifactId>glassfish</artifactId>
             <type>zip</type>
-            <version>${project.version}</version>
+            <version>${glassfish.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
To fix CVE-2025-53864

Nimbus 10.4.2 is the oldest version with the fix that is compatible with Soteria and Omni-JWT.

Nimbus changelog: https://bitbucket.org/connect2id/nimbus-jose-jwt/src/master/CHANGELOG.txt

Newer versions already have a newer Nimbus and aren't impacted.
