### PR TITLE
Fix JNDI validation failure for app-scoped resources on server restart

### DIFF
--- a/appserver/deployment/jakartaee-core/src/main/java/org/glassfish/javaee/core/deployment/DolProvider.java
+++ b/appserver/deployment/jakartaee-core/src/main/java/org/glassfish/javaee/core/deployment/DolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, 2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/deployment/jakartaee-core/src/main/java/org/glassfish/javaee/core/deployment/DolProvider.java
+++ b/appserver/deployment/jakartaee-core/src/main/java/org/glassfish/javaee/core/deployment/DolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -31,6 +31,7 @@ import com.sun.enterprise.deployment.archivist.DescriptorArchivist;
 import com.sun.enterprise.deployment.deploy.shared.DeploymentPlanArchive;
 import com.sun.enterprise.deployment.deploy.shared.InputJarArchive;
 import com.sun.enterprise.deployment.deploy.shared.Util;
+import com.sun.enterprise.deployment.util.ResourceValidator;
 import com.sun.enterprise.util.LocalStringManagerImpl;
 import com.sun.enterprise.util.io.FileUtils;
 import com.sun.enterprise.v3.common.HTMLActionReporter;
@@ -109,6 +110,14 @@ public class DolProvider implements ApplicationMetaDataProvider<Application>,
 
     @Inject
     Provider<ClassLoaderHierarchy> clhProvider;
+
+    /**
+     * Never read, but must not be removed: this injection is what instantiates the validator, whose
+     * postConstruct registers it as a deployment event listener. Nothing else references its contract,
+     * so without it resource validation never runs.
+     */
+    @Inject
+    private ResourceValidator resourceValidator;
 
     private static final String WRITEOUT_XML = System.getProperty("writeout.xml");
 

--- a/appserver/resources/resources-runtime/pom.xml
+++ b/appserver/resources/resources-runtime/pom.xml
@@ -89,6 +89,10 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/appserver/resources/resources-runtime/pom.xml
+++ b/appserver/resources/resources-runtime/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -78,6 +79,15 @@
             <groupId>org.glassfish.main.deployment</groupId>
             <artifactId>deployment-jakartaee-core</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
+++ b/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, 2026 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
+++ b/appserver/resources/resources-runtime/src/main/java/org/glassfish/resources/module/ResourcesDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -408,6 +408,59 @@ public class ResourcesDeployer extends JavaEEDeployer<ResourcesContainer, Resour
                     }
                 }
             }
+            populateAppScopedResourcesJndiNames(dc, application, appName);
+        }
+    }
+
+    /**
+     * Publish the JNDI names of the application/module scoped resources into the deployment context.
+     * <p>
+     * Unlike the deploy path (see {@link #processArchive(DeploymentContext)}), the load path (server
+     * restart, application/application-ref enable) reads the resource configuration from domain.xml and
+     * does not produce this metadata. Without it, {@code ResourceValidator} cannot resolve app-scoped JNDI
+     * names (e.g. {@code java:app/jdbc/mydb}) from its in-memory namespace and instead falls back to a live
+     * JNDI lookup. During restart that lookup runs before the resources are bound to naming, so it fails
+     * and the application is not deployed. Populating the names here lets the validator recognize them as
+     * legitimately declared, the same way it does on a fresh deploy.
+     */
+    private void populateAppScopedResourcesJndiNames(DeploymentContext dc, Application application, String appName) {
+        Map<String, List<SimpleJndiName>> jndiNames = collectAppScopedResourceJndiNames(application, appName);
+        if (!jndiNames.isEmpty()) {
+            dc.addTransientAppMetaData(APP_SCOPED_RESOURCES_JNDI_NAMES, jndiNames);
+        }
+    }
+
+    /**
+     * Collect the JNDI names of bindable application/module scoped resources from the application
+     * configuration, keyed by scope (application name for app-scoped resources, module name for
+     * module-scoped ones), matching the layout produced on the deploy path.
+     */
+    static Map<String, List<SimpleJndiName>> collectAppScopedResourceJndiNames(Application application, String appName) {
+        Map<String, List<SimpleJndiName>> jndiNames = new HashMap<>();
+        addBindableJndiNames(jndiNames, appName, application.getResources());
+        List<Module> modules = application.getModule();
+        if (modules != null) {
+            for (Module module : modules) {
+                addBindableJndiNames(jndiNames, getActualModuleNameWithExtension(module.getName()),
+                        module.getResources());
+            }
+        }
+        return jndiNames;
+    }
+
+    private static void addBindableJndiNames(Map<String, List<SimpleJndiName>> jndiNames, String scopeName,
+            Resources resources) {
+        if (resources == null) {
+            return;
+        }
+        List<SimpleJndiName> names = new ArrayList<>();
+        for (Resource resource : resources.getResources()) {
+            if (resource instanceof BindableResource) {
+                names.add(new SimpleJndiName(((BindableResource) resource).getJndiName()));
+            }
+        }
+        if (!names.isEmpty()) {
+            jndiNames.put(scopeName, names);
         }
     }
 

--- a/appserver/resources/resources-runtime/src/test/java/org/glassfish/resources/module/ResourcesDeployerTest.java
+++ b/appserver/resources/resources-runtime/src/test/java/org/glassfish/resources/module/ResourcesDeployerTest.java
@@ -23,15 +23,15 @@ import com.sun.enterprise.config.serverbeans.Resource;
 import com.sun.enterprise.config.serverbeans.ResourcePool;
 import com.sun.enterprise.config.serverbeans.Resources;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Proxy;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.glassfish.api.naming.SimpleJndiName;
 import org.junit.jupiter.api.Test;
 
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -107,37 +107,42 @@ public class ResourcesDeployerTest {
         assertThat(result, not(hasKey("web.war")));
     }
 
-    // --- config-bean proxies (no Mockito available in this module) ---
+    // --- config-bean mocks ---
 
     private static Application application(Resources appResources, Module... modules) {
-        Map<String, Object> values = new HashMap<>();
-        values.put("getResources", appResources);
-        values.put("getModule", List.of(modules));
-        return proxy(Application.class, values);
+        Application app = createNiceMock(Application.class);
+        expect(app.getResources()).andReturn(appResources).anyTimes();
+        expect(app.getModule()).andReturn(List.of(modules)).anyTimes();
+        replay(app);
+        return app;
     }
 
     private static Module module(String name, Resources moduleResources) {
-        Map<String, Object> values = new HashMap<>();
-        values.put("getName", name);
-        values.put("getResources", moduleResources);
-        return proxy(Module.class, values);
+        Module module = createNiceMock(Module.class);
+        expect(module.getName()).andReturn(name).anyTimes();
+        expect(module.getResources()).andReturn(moduleResources).anyTimes();
+        replay(module);
+        return module;
     }
 
     private static Resources resources(Resource... resources) {
-        return proxy(Resources.class, Map.of("getResources", List.of(resources)));
+        Resources mock = createNiceMock(Resources.class);
+        expect(mock.getResources()).andReturn(List.of(resources)).anyTimes();
+        replay(mock);
+        return mock;
     }
 
     private static BindableResource jdbcResource(String jndiName) {
-        return proxy(BindableResource.class, Map.of("getJndiName", jndiName));
+        BindableResource resource = createNiceMock(BindableResource.class);
+        expect(resource.getJndiName()).andReturn(jndiName).anyTimes();
+        replay(resource);
+        return resource;
     }
 
     private static ResourcePool pool(String name) {
-        return proxy(ResourcePool.class, Map.of("getName", name));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> T proxy(Class<T> type, Map<String, Object> values) {
-        InvocationHandler handler = (p, method, args) -> values.get(method.getName());
-        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, handler);
+        ResourcePool pool = createNiceMock(ResourcePool.class);
+        expect(pool.getName()).andReturn(name).anyTimes();
+        replay(pool);
+        return pool;
     }
 }

--- a/appserver/resources/resources-runtime/src/test/java/org/glassfish/resources/module/ResourcesDeployerTest.java
+++ b/appserver/resources/resources-runtime/src/test/java/org/glassfish/resources/module/ResourcesDeployerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.resources.module;
+
+import com.sun.enterprise.config.serverbeans.Application;
+import com.sun.enterprise.config.serverbeans.BindableResource;
+import com.sun.enterprise.config.serverbeans.Module;
+import com.sun.enterprise.config.serverbeans.Resource;
+import com.sun.enterprise.config.serverbeans.ResourcePool;
+import com.sun.enterprise.config.serverbeans.Resources;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.glassfish.api.naming.SimpleJndiName;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tests for {@link ResourcesDeployer#collectAppScopedResourceJndiNames(Application, String)}, which feeds
+ * the resource validator on the load (server restart) path so that app-scoped resources declared in
+ * {@code glassfish-resources.xml} (e.g. {@code java:app/jdbc/mydb}) are recognized as legitimately declared
+ * instead of failing a premature live JNDI lookup. Regression test for issue #25961.
+ */
+public class ResourcesDeployerTest {
+
+    private static final String APP_NAME = "sample";
+
+    @Test
+    public void appScopedBindableResourcesAreCollectedUnderAppName() {
+        Application app = application(
+            resources(pool("dbPool"), jdbcResource("java:app/jdbc/mydb")));
+
+        Map<String, List<SimpleJndiName>> result =
+            ResourcesDeployer.collectAppScopedResourceJndiNames(app, APP_NAME);
+
+        assertThat(result, hasKey(APP_NAME));
+        assertThat(result.get(APP_NAME), contains(new SimpleJndiName("java:app/jdbc/mydb")));
+    }
+
+    @Test
+    public void connectionPoolsAreNotTreatedAsBindableNames() {
+        // A connection pool is not bindable and has no JNDI name; only the jdbc-resource must be collected.
+        Application app = application(
+            resources(pool("dbPool"), jdbcResource("java:app/jdbc/mydb")));
+
+        Map<String, List<SimpleJndiName>> result =
+            ResourcesDeployer.collectAppScopedResourceJndiNames(app, APP_NAME);
+
+        assertThat(result.get(APP_NAME).size(), is(1));
+    }
+
+    @Test
+    public void moduleScopedResourcesAreKeyedByModuleName() {
+        Application app = application(
+            resources(jdbcResource("java:app/jdbc/mydb")),
+            module("web_war", resources(jdbcResource("java:module/jdbc/local"))));
+
+        Map<String, List<SimpleJndiName>> result =
+            ResourcesDeployer.collectAppScopedResourceJndiNames(app, APP_NAME);
+
+        assertThat(result, hasKey(APP_NAME));
+        // "web_war" is normalized back to the archive name "web.war".
+        assertThat(result, hasKey("web.war"));
+        assertThat(result.get("web.war"), contains(new SimpleJndiName("java:module/jdbc/local")));
+    }
+
+    @Test
+    public void noResourcesYieldsEmptyMap() {
+        Application app = application(null);
+        assertThat(ResourcesDeployer.collectAppScopedResourceJndiNames(app, APP_NAME).isEmpty(), is(true));
+    }
+
+    @Test
+    public void multipleAppScopedResourcesAreAllCollected() {
+        Application app = application(
+            resources(jdbcResource("java:app/jdbc/mydb"), jdbcResource("java:app/jdbc/other")));
+
+        Map<String, List<SimpleJndiName>> result =
+            ResourcesDeployer.collectAppScopedResourceJndiNames(app, APP_NAME);
+
+        assertThat(result.get(APP_NAME), containsInAnyOrder(
+            new SimpleJndiName("java:app/jdbc/mydb"), new SimpleJndiName("java:app/jdbc/other")));
+        assertThat(result, not(hasKey("web.war")));
+    }
+
+    // --- config-bean proxies (no Mockito available in this module) ---
+
+    private static Application application(Resources appResources, Module... modules) {
+        Map<String, Object> values = new HashMap<>();
+        values.put("getResources", appResources);
+        values.put("getModule", List.of(modules));
+        return proxy(Application.class, values);
+    }
+
+    private static Module module(String name, Resources moduleResources) {
+        Map<String, Object> values = new HashMap<>();
+        values.put("getName", name);
+        values.put("getResources", moduleResources);
+        return proxy(Module.class, values);
+    }
+
+    private static Resources resources(Resource... resources) {
+        return proxy(Resources.class, Map.of("getResources", List.of(resources)));
+    }
+
+    private static BindableResource jdbcResource(String jndiName) {
+        return proxy(BindableResource.class, Map.of("getJndiName", jndiName));
+    }
+
+    private static ResourcePool pool(String name) {
+        return proxy(ResourcePool.class, Map.of("getName", name));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, Map<String, Object> values) {
+        InvocationHandler handler = (p, method, args) -> values.get(method.getName());
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, handler);
+    }
+}


### PR DESCRIPTION
Fixes #25961

Applications with app-scoped resources defined in `glassfish-resources.xml` (e.g. `java:app/jdbc/mydb`) deployed fine but failed to load after `asadmin restart-domain` with:

```
DeploymentException: JNDI lookup failed for the resource: Name: my_persistence_unit, Lookup: java:app/jdbc/mydb, Type: javax.sql.DataSource
```

leaving the application inaccessible (404) until manual redeploy.

## Root cause

The deploy path (`ResourcesDeployer.processArchive`) parses `glassfish-resources.xml` and publishes the declared JNDI names into the deployment context as `APP_SCOPED_RESOURCES_JNDI_NAMES` transient metadata, which `ResourceValidator` loads into its in-memory namespace — so validation passes without a live JNDI lookup.

The load path (server restart, app/app-ref enable) reads the resource config from domain.xml via `populateResourceConfigInAppInfo()` but never produced this metadata. The validator then fell back to a live `InitialContext.doLookup()`, which runs before the app-scoped resources are bound to naming (and without a component invocation context for `java:app`), so it always failed and aborted the deployment.

## Changes

- **Commit 1**: `ResourcesDeployer.populateResourceConfigInAppInfo()` now also publishes `APP_SCOPED_RESOURCES_JNDI_NAMES` built from the domain.xml config beans, keyed identically to the deploy path (app name / module name). Includes unit tests.
- **Commit 2**: Restores `ResourceValidator` activation. Commit 6f269c13a0 removed the seemingly unused `ResourceValidator` injection from `DolProvider`, but that injection was the only thing instantiating the validator (whose `postConstruct` registers it as a deployment event listener — nothing else references its `ResourceValidatorVisitor` contract). Since then resource validation never ran at all on 8.0.3+, which also masked this issue there: invalid resource references were no longer rejected at deployment time and surfaced later with less helpful errors (e.g. from JPA prepare). Re-added with a comment explaining the injection is load-bearing.

## Verification

Using the reporter's Derby-based reproducer from the issue (deploy → visit → `restart-domain` → visit), on Windows 11 / JDK 25:

| Build | Restart result |
|---|---|
| 8.0.0 release, stock | 404, exception from the issue |
| 8.0.0 release + patched `resources-runtime.jar` | 200 across two restart cycles |
| current main, stock | 200, but only because validation never runs |
| current main + commit 2 only | 404 — the bug resurfaces once validation is restored |
| current main + both commits | 200 |

Negative control on both fixed builds: an app referencing a nonexistent datasource (`java:app/jdbc/DOESNOTEXIST`) is still rejected at deploy time with the validator's error, so validation is not weakened — the load path now only recognizes names that are genuinely declared in the application's resource configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)