### PR TITLE
Allocate ServletRequestAttributeEvent lazily in Request

### DIFF
--- a/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
+++ b/appserver/web/web-core/src/main/java/org/apache/catalina/connector/Request.java
@@ -1643,7 +1643,9 @@ public class Request implements HttpRequest, HttpServletRequest {
         if (listeners.isEmpty()) {
             return;
         }
-        ServletRequestAttributeEvent event = new ServletRequestAttributeEvent(servletContext, getRequest(), name, value);
+        // Build the event lazily: allocating it up front is wasteful when no
+        // ServletRequestAttributeListener is registered (the common case).
+        ServletRequestAttributeEvent event = null;
         Iterator<EventListener> iter = listeners.iterator();
         while (iter.hasNext()) {
             EventListener eventListener = iter.next();
@@ -1652,6 +1654,9 @@ public class Request implements HttpRequest, HttpServletRequest {
             }
 
             ServletRequestAttributeListener listener = (ServletRequestAttributeListener) eventListener;
+            if (event == null) {
+                event = new ServletRequestAttributeEvent(servletContext, getRequest(), name, value);
+            }
             try {
                 listener.attributeRemoved(event);
             } catch (Throwable t) {
@@ -1707,13 +1712,9 @@ public class Request implements HttpRequest, HttpServletRequest {
             return;
         }
 
+        // Build the event lazily: allocating it up front is wasteful when no
+        // ServletRequestAttributeListener is registered (the common case).
         ServletRequestAttributeEvent event = null;
-        if (replaced) {
-            event = new ServletRequestAttributeEvent(servletContext, getRequest(), name, oldValue);
-        } else {
-            event = new ServletRequestAttributeEvent(servletContext, getRequest(), name, value);
-        }
-
         Iterator<EventListener> iter = listeners.iterator();
         while (iter.hasNext()) {
             EventListener eventListener = iter.next();
@@ -1721,6 +1722,13 @@ public class Request implements HttpRequest, HttpServletRequest {
                 continue;
             }
             ServletRequestAttributeListener listener = (ServletRequestAttributeListener) eventListener;
+            if (event == null) {
+                if (replaced) {
+                    event = new ServletRequestAttributeEvent(servletContext, getRequest(), name, oldValue);
+                } else {
+                    event = new ServletRequestAttributeEvent(servletContext, getRequest(), name, value);
+                }
+            }
             try {
                 if (replaced) {
                     listener.attributeReplaced(event);


### PR DESCRIPTION
## Problem

`Request.setAttribute` / `removeAttribute` construct a `ServletRequestAttributeEvent` on **every** call whenever the context has any application event listener registered — regardless of whether a `ServletRequestAttributeListener` is actually present to consume it.

In any Faces/CDI application `getApplicationEventListeners()` is non-empty (Weld and Faces register `ServletRequestListener`s), but those apps register **no** `ServletRequestAttributeListener`. So the event is allocated and immediately discarded. And these methods are called many times per request — e.g. Faces row-variable iteration over `UIData`/`UIRepeat`, and EL implicit objects exposed via the request map — turning a hot path into a steady source of short-lived garbage.

## Fix

Build the event lazily, on the first matching `ServletRequestAttributeListener`. When none is registered (the common case) it is never allocated. Behavior is otherwise identical — the original iteration, `instanceof` filtering and listener dispatch are unchanged.

## Measurement

JFR recording of the GlassFish server JVM under a Jakarta Faces microbenchmark (server-side state saving, 32 scenarios × 1000 postbacks):

| | before | after |
|---|---|---|
| `ServletRequestAttributeEvent` allocations / run | 186 | 0 |
| `Request.setAttribute` self-time samples | 49 | 18 (−63%) |

This is an allocation-hygiene change (reduced GC pressure), so the benefit shows under concurrency rather than as single-request latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
