### PR TITLE
Fix upgrade if the domain contains a cluster

### DIFF
--- a/nucleus/cluster/gms-adapter/pom.xml
+++ b/nucleus/cluster/gms-adapter/pom.xml
@@ -80,6 +80,28 @@
             <artifactId>logging-annotation-processor</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/GMSConfigUpgrade.java
+++ b/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/GMSConfigUpgrade.java
@@ -135,7 +135,7 @@ public class GMSConfigUpgrade implements ConfigurationUpgrade, PostConstruct {
 
             }
 
-            //gms-bind-interface is an attribute of cluster in 3.1
+            //gms-bind-interface is an a            ttribute of cluster in 3.1
             Property prop  = cluster.getProperty("gms-bind-interface-address");
             if (prop != null && prop.getValue() != null) {
                 cluster.setGmsBindInterfaceAddress(prop.getValue());
@@ -149,10 +149,12 @@ public class GMSConfigUpgrade implements ConfigurationUpgrade, PostConstruct {
                             cluster.getName()));
                 }
             }
-            Property gmsListenerPort = cluster.createChild(Property.class);
-            gmsListenerPort.setName("GMS_LISTENER_PORT");
-            gmsListenerPort.setValue(String.format("${GMS_LISTENER_PORT-%s}", cluster.getName()));
-            cluster.getProperty().add(gmsListenerPort);
+            if (cluster.getProperty("GMS_LISTENER_PORT") == null) {
+                Property gmsListenerPort = cluster.createChild(Property.class);
+                gmsListenerPort.setName("GMS_LISTENER_PORT");
+                gmsListenerPort.setValue(String.format("${GMS_LISTENER_PORT-%s}", cluster.getName()));
+                cluster.getProperty().add(gmsListenerPort);
+            }
             return cluster;
         }
     }

--- a/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/GMSConfigUpgrade.java
+++ b/nucleus/cluster/gms-adapter/src/main/java/org/glassfish/gms/GMSConfigUpgrade.java
@@ -135,7 +135,7 @@ public class GMSConfigUpgrade implements ConfigurationUpgrade, PostConstruct {
 
             }
 
-            //gms-bind-interface is an a            ttribute of cluster in 3.1
+            //gms-bind-interface is an attribute of cluster in 3.1
             Property prop  = cluster.getProperty("gms-bind-interface-address");
             if (prop != null && prop.getValue() != null) {
                 cluster.setGmsBindInterfaceAddress(prop.getValue());

--- a/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/GmsUpgradePropertyAlreadyExistsTest.java
+++ b/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/GmsUpgradePropertyAlreadyExistsTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.gms;
+
+import org.glassfish.tests.utils.junit.DomainXml;
+
+@DomainXml(value = "GmsUpgradePropertyAlreadyExistsTest.xml")
+public class GmsUpgradePropertyAlreadyExistsTest extends GmsUpgradeTestBase {
+
+}

--- a/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/GmsUpgradeTestBase.java
+++ b/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/GmsUpgradeTestBase.java
@@ -23,16 +23,14 @@ import com.sun.enterprise.config.serverbeans.Domain;
 import jakarta.inject.Inject;
 
 import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.tests.utils.junit.DomainXml;
 import org.glassfish.tests.utils.junit.HK2JUnit5Extension;
-import org.jvnet.hk2.config.types.Property;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.jvnet.hk2.config.types.Property;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(HK2JUnit5Extension.class)
 public class GmsUpgradeTestBase {

--- a/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/GmsUpgradeTestBase.java
+++ b/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/GmsUpgradeTestBase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.gms;
+
+import com.sun.enterprise.config.serverbeans.Cluster;
+import com.sun.enterprise.config.serverbeans.Clusters;
+import com.sun.enterprise.config.serverbeans.Domain;
+
+import jakarta.inject.Inject;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.tests.utils.junit.DomainXml;
+import org.glassfish.tests.utils.junit.HK2JUnit5Extension;
+import org.jvnet.hk2.config.types.Property;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(HK2JUnit5Extension.class)
+public class GmsUpgradeTestBase {
+
+    @Inject
+    private ServiceLocator locator;
+
+    @BeforeEach
+    public void runUpgrades() {
+        Domain domain = locator.getService(Domain.class);
+        assertNotNull(domain);
+
+        assertNotNull(locator.getService(GMSConfigUpgrade.class), "GMSConfigUpgrade is missing");
+    }
+
+    @Test
+    public void gmsListenerPortCorrectlyUpdated() {
+        Clusters clusters = locator.getService(Clusters.class);
+        assertNotNull(clusters);
+
+        Cluster cluster = clusters.getCluster().stream()
+            .filter(c -> "cluster1".equals(c.getName()))
+            .findFirst()
+            .orElseThrow();
+
+        long gmsListenerPortCount = cluster.getProperty().stream()
+            .map(Property::getName)
+            .filter("GMS_LISTENER_PORT"::equals)
+            .count();
+        assertEquals(1L, gmsListenerPortCount);
+
+        Property gmsListenerPort = cluster.getProperty("GMS_LISTENER_PORT");
+        assertNotNull(gmsListenerPort);
+        assertEquals("${GMS_LISTENER_PORT-cluster1}", gmsListenerPort.getValue());
+    }
+}

--- a/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/UpgradeGmsClusterTest.java
+++ b/nucleus/cluster/gms-adapter/src/test/java/org/glassfish/gms/UpgradeGmsClusterTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.gms;
+
+import org.glassfish.tests.utils.junit.DomainXml;
+
+@DomainXml(value = "UpgradeGmsClusterTest.xml")
+public class UpgradeGmsClusterTest extends GmsUpgradeTestBase {
+
+}

--- a/nucleus/cluster/gms-adapter/src/test/resources/GmsUpgradePropertyAlreadyExistsTest.xml
+++ b/nucleus/cluster/gms-adapter/src/test/resources/GmsUpgradePropertyAlreadyExistsTest.xml
@@ -1,0 +1,221 @@
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+  <system-applications>
+    <application enabled="true" context-root="" location="${com.sun.aas.installRootURI}/lib/install/applications/__admingui" name="__admingui" directory-deployed="true" object-type="system-admin">
+      <engine sniffer="web"></engine>
+      <engine sniffer="security"></engine>
+    </application>
+  </system-applications>
+  <applications>
+    <application enabled="true" context-root="/simple" location="${com.sun.aas.instanceRootURI}/applications/simple/" directory-deployed="false" name="simple" object-type="user">
+      <engine sniffer="web"></engine>
+      <engine sniffer="security"></engine>
+    </application>
+  </applications>
+  <j2ee-application location="/foo/bar">
+  </j2ee-application>
+    <something-weird>
+        <foo>
+            <something-weird>
+                <again>
+                    <something-weird>
+                        <notagain>
+                            <ohno>
+                                <stopthis></stopthis>
+                            </ohno>
+                        </notagain>
+                    </something-weird>
+                </again>
+            </something-weird>
+        </foo>
+    </something-weird>
+    <something-weirder>
+        <foo>
+            <bar></bar>
+        </foo>
+    </something-weirder>
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin"></jdbc-resource>
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default"></jdbc-resource>
+    <jdbc-connection-pool datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource" name="__TimerPool">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer"></property>
+      <property name="connectionAttributes" value=";create=true"></property>
+    </jdbc-connection-pool>
+    <jdbc-connection-pool datasource-classname="org.apache.derby.jdbc.ClientDataSource" is-isolation-level-guaranteed="false" res-type="javax.sql.DataSource" name="DerbyPool">
+      <property name="PortNumber" value="1527"></property>
+      <property name="Password" value="APP"></property>
+      <property name="User" value="APP"></property>
+      <property name="serverName" value="localhost"></property>
+      <property name="DatabaseName" value="sun-appserv-samples"></property>
+      <property name="connectionAttributes" value=";create=true"></property>
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="server" config-ref="server-config">
+      <application-ref ref="__admingui" virtual-servers="__asadmin"></application-ref>
+      <application-ref ref="simple" virtual-servers="server"></application-ref>
+      <resource-ref ref="jdbc/__TimerPool"></resource-ref>
+      <resource-ref ref="jdbc/__default"></resource-ref>
+    </server>
+  </servers>
+  <configs>
+    <config name="server-config">
+      <http-service>
+        <access-log rotation-suffix="yyyy-MM-dd" rotation-interval-in-minutes="15"></access-log>
+        <http-listener id="http-listener-1" port="8080" address="0.0.0.0" default-virtual-server="server" server-name=""></http-listener>
+        <http-listener id="http-listener-2" port="8181" enabled="false" address="0.0.0.0" security-enabled="true" default-virtual-server="server" server-name="">
+          <ssl ssl3-enabled="false" cert-nickname="s1as"></ssl>
+        </http-listener>
+        <http-listener id="admin-listener" port="4848" address="0.0.0.0" default-virtual-server="__asadmin" server-name=""></http-listener>
+        <virtual-server id="server" http-listeners="http-listener-1, http-listener-2">
+          <property name="docroot" value="${com.sun.aas.instanceRoot}/docroot"></property>
+          <property name="accesslog" value="${com.sun.aas.instanceRoot}/logs/access"></property>
+          <property name="sso-enabled" value="false"></property>
+        </virtual-server>
+        <virtual-server id="__asadmin" http-listeners="admin-listener">
+          <property name="docroot" value="${com.sun.aas.instanceRoot}/docroot"></property>
+          <property name="accesslog" value="${com.sun.aas.instanceRoot}/logs/access"></property>
+          <property name="sso-enabled" value="false"></property>
+        </virtual-server>
+        <request-processing thread-count="20" header-buffer-length-in-bytes="8192" initial-thread-count="2" thread-increment="1"></request-processing>
+        <keep-alive max-connections="250"></keep-alive>
+        <connection-pool></connection-pool>
+        <http-protocol forced-response-type="text/plain; charset=iso-8859-1" default-response-type="text/plain; charset=iso-8859-1"></http-protocol>
+        <http-file-cache globally-enabled="false" file-caching-enabled="false"></http-file-cache>
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1"></orb>
+        <iiop-listener id="orb-listener-1" port="3700" address="0.0.0.0"></iiop-listener>
+        <iiop-listener id="SSL" port="3820" address="0.0.0.0" security-enabled="true">
+          <ssl cert-nickname="s1as"></ssl>
+        </iiop-listener>
+        <iiop-listener id="SSL_MUTUALAUTH" port="3920" address="0.0.0.0" security-enabled="true">
+          <ssl cert-nickname="s1as" client-auth-enabled="true"></ssl>
+        </iiop-listener>
+      </iiop-service>
+      <admin-service system-jmx-connector-name="system" type="das-and-server">
+        <jmx-connector port="8686" address="0.0.0.0" security-enabled="false" name="system" auth-realm-name="admin-realm"></jmx-connector>
+        <das-config dynamic-reload-enabled="true" deploy-xml-validation="full" autodeploy-dir="${com.sun.aas.instanceRoot}/autodeploy" autodeploy-enabled="true"></das-config>
+        <property name="adminConsoleContextRoot" value="/admin"></property>
+        <property name="adminConsoleDownloadLocation" value="glassfish/lib/install/applications/admingui.war"></property>
+        <property name="ipsRoot" value="${com.sun.aas.installRoot}/.."></property>
+        <property name="adminConsoleVersion" value=""></property>
+      </admin-service>
+      <web-container>
+        <session-config>
+          <session-manager>
+            <manager-properties></manager-properties>
+            <store-properties></store-properties>
+          </session-manager>
+          <session-properties></session-properties>
+        </session-config>
+      </web-container>
+      <ejb-container pool-resize-quantity="8" max-pool-size="32" steady-pool-size="0" session-store="${com.sun.aas.instanceRoot}/session-store">
+        <ejb-timer-service></ejb-timer-service>
+      </ejb-container>
+      <mdb-container pool-resize-quantity="8" max-pool-size="32" steady-pool-size="0"></mdb-container>
+      <jms-service default-jms-host="default_JMS_host" type="EMBEDDED">
+        <jms-host host="localhost" name="default_JMS_host"></jms-host>
+      </jms-service>
+      <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+        <module-log-levels></module-log-levels>
+      </log-service>
+      <security-service>
+        <auth-realm name="admin-realm" classname="com.sun.enterprise.security.auth.realm.file.FileRealm">
+          <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile"></property>
+          <property name="jaas-context" value="fileRealm"></property>
+        </auth-realm>
+        <auth-realm name="file" classname="com.sun.enterprise.security.auth.realm.file.FileRealm">
+          <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile"></property>
+          <property name="jaas-context" value="fileRealm"></property>
+        </auth-realm>
+        <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
+        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory">
+          <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy"></property>
+        </jacc-provider>
+        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <audit-module name="default" classname="com.sun.enterprise.security.ee.audit.Audit">
+          <property name="auditOn" value="false"></property>
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="dynamic.username.password" value="false"></property>
+            <property name="debug" value="false"></property>
+          </provider-config>
+          <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="dynamic.username.password" value="false"></property>
+            <property name="debug" value="false"></property>
+            <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml"></property>
+          </provider-config>
+          <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="debug" value="false"></property>
+          </provider-config>
+          <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="debug" value="false"></property>
+            <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml"></property>
+          </provider-config>
+        </message-security-config>
+      </security-service>
+      <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs"></transaction-service>
+      <monitoring-service>
+        <module-monitoring-levels></module-monitoring-levels>
+      </monitoring-service>
+      <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
+        <jvm-options>-client</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-XX:+LogVMOutput</jvm-options>
+        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Xmx512m</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.p12</jvm-options>
+        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext${path.separator}${com.sun.aas.derbyRoot}/lib</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <jvm-options>-XX:NewRatio=2</jvm-options>
+      </java-config>
+      <thread-pools>
+        <thread-pool thread-pool-id="thread-pool-1"></thread-pool>
+      </thread-pools>
+    </config>
+  </configs>
+  <clusters>
+    <cluster name="cluster1" config-ref="server-config" gms-enabled="true" gms-multicast-address="228.9.62.245" gms-multicast-port="18706" gms-bind-interface-address="${GMS-BIND-INTERFACE-ADDRESS-cluster1}">
+      <property name="GMS_LISTENER_PORT" value="${GMS_LISTENER_PORT-cluster1}"></property>
+    </cluster>
+  </clusters>
+  <property name="administrative.domain.name" value="domain1"></property>
+</domain>

--- a/nucleus/cluster/gms-adapter/src/test/resources/UpgradeGmsClusterTest.xml
+++ b/nucleus/cluster/gms-adapter/src/test/resources/UpgradeGmsClusterTest.xml
@@ -1,0 +1,220 @@
+<!--
+
+    Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<domain log-root="${com.sun.aas.instanceRoot}/logs" application-root="${com.sun.aas.instanceRoot}/applications" version="10.0">
+  <system-applications>
+    <application enabled="true" context-root="" location="${com.sun.aas.installRootURI}/lib/install/applications/__admingui" name="__admingui" directory-deployed="true" object-type="system-admin">
+      <engine sniffer="web"></engine>
+      <engine sniffer="security"></engine>
+    </application>
+  </system-applications>
+  <applications>
+    <application enabled="true" context-root="/simple" location="${com.sun.aas.instanceRootURI}/applications/simple/" directory-deployed="false" name="simple" object-type="user">
+      <engine sniffer="web"></engine>
+      <engine sniffer="security"></engine>
+    </application>
+  </applications>
+  <j2ee-application location="/foo/bar">
+  </j2ee-application>
+    <something-weird>
+        <foo>
+            <something-weird>
+                <again>
+                    <something-weird>
+                        <notagain>
+                            <ohno>
+                                <stopthis></stopthis>
+                            </ohno>
+                        </notagain>
+                    </something-weird>
+                </again>
+            </something-weird>
+        </foo>
+    </something-weird>
+    <something-weirder>
+        <foo>
+            <bar></bar>
+        </foo>
+    </something-weirder>
+  <resources>
+    <jdbc-resource pool-name="__TimerPool" jndi-name="jdbc/__TimerPool" object-type="system-admin"></jdbc-resource>
+    <jdbc-resource pool-name="DerbyPool" jndi-name="jdbc/__default"></jdbc-resource>
+    <jdbc-connection-pool datasource-classname="org.apache.derby.jdbc.EmbeddedXADataSource" res-type="javax.sql.XADataSource" name="__TimerPool">
+      <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/ejbtimer"></property>
+      <property name="connectionAttributes" value=";create=true"></property>
+    </jdbc-connection-pool>
+    <jdbc-connection-pool datasource-classname="org.apache.derby.jdbc.ClientDataSource" is-isolation-level-guaranteed="false" res-type="javax.sql.DataSource" name="DerbyPool">
+      <property name="PortNumber" value="1527"></property>
+      <property name="Password" value="APP"></property>
+      <property name="User" value="APP"></property>
+      <property name="serverName" value="localhost"></property>
+      <property name="DatabaseName" value="sun-appserv-samples"></property>
+      <property name="connectionAttributes" value=";create=true"></property>
+    </jdbc-connection-pool>
+  </resources>
+  <servers>
+    <server name="server" config-ref="server-config">
+      <application-ref ref="__admingui" virtual-servers="__asadmin"></application-ref>
+      <application-ref ref="simple" virtual-servers="server"></application-ref>
+      <resource-ref ref="jdbc/__TimerPool"></resource-ref>
+      <resource-ref ref="jdbc/__default"></resource-ref>
+    </server>
+  </servers>
+  <configs>
+    <config name="server-config">
+      <http-service>
+        <access-log rotation-suffix="yyyy-MM-dd" rotation-interval-in-minutes="15"></access-log>
+        <http-listener id="http-listener-1" port="8080" address="0.0.0.0" default-virtual-server="server" server-name=""></http-listener>
+        <http-listener id="http-listener-2" port="8181" enabled="false" address="0.0.0.0" security-enabled="true" default-virtual-server="server" server-name="">
+          <ssl ssl3-enabled="false" cert-nickname="s1as"></ssl>
+        </http-listener>
+        <http-listener id="admin-listener" port="4848" address="0.0.0.0" default-virtual-server="__asadmin" server-name=""></http-listener>
+        <virtual-server id="server" http-listeners="http-listener-1, http-listener-2">
+          <property name="docroot" value="${com.sun.aas.instanceRoot}/docroot"></property>
+          <property name="accesslog" value="${com.sun.aas.instanceRoot}/logs/access"></property>
+          <property name="sso-enabled" value="false"></property>
+        </virtual-server>
+        <virtual-server id="__asadmin" http-listeners="admin-listener">
+          <property name="docroot" value="${com.sun.aas.instanceRoot}/docroot"></property>
+          <property name="accesslog" value="${com.sun.aas.instanceRoot}/logs/access"></property>
+          <property name="sso-enabled" value="false"></property>
+        </virtual-server>
+        <request-processing thread-count="20" header-buffer-length-in-bytes="8192" initial-thread-count="2" thread-increment="1"></request-processing>
+        <keep-alive max-connections="250"></keep-alive>
+        <connection-pool></connection-pool>
+        <http-protocol forced-response-type="text/plain; charset=iso-8859-1" default-response-type="text/plain; charset=iso-8859-1"></http-protocol>
+        <http-file-cache globally-enabled="false" file-caching-enabled="false"></http-file-cache>
+      </http-service>
+      <iiop-service>
+        <orb use-thread-pool-ids="thread-pool-1"></orb>
+        <iiop-listener id="orb-listener-1" port="3700" address="0.0.0.0"></iiop-listener>
+        <iiop-listener id="SSL" port="3820" address="0.0.0.0" security-enabled="true">
+          <ssl cert-nickname="s1as"></ssl>
+        </iiop-listener>
+        <iiop-listener id="SSL_MUTUALAUTH" port="3920" address="0.0.0.0" security-enabled="true">
+          <ssl cert-nickname="s1as" client-auth-enabled="true"></ssl>
+        </iiop-listener>
+      </iiop-service>
+      <admin-service system-jmx-connector-name="system" type="das-and-server">
+        <jmx-connector port="8686" address="0.0.0.0" security-enabled="false" name="system" auth-realm-name="admin-realm"></jmx-connector>
+        <das-config dynamic-reload-enabled="true" deploy-xml-validation="full" autodeploy-dir="${com.sun.aas.instanceRoot}/autodeploy" autodeploy-enabled="true"></das-config>
+        <property name="adminConsoleContextRoot" value="/admin"></property>
+        <property name="adminConsoleDownloadLocation" value="glassfish/lib/install/applications/admingui.war"></property>
+        <property name="ipsRoot" value="${com.sun.aas.installRoot}/.."></property>
+        <property name="adminConsoleVersion" value=""></property>
+      </admin-service>
+      <web-container>
+        <session-config>
+          <session-manager>
+            <manager-properties></manager-properties>
+            <store-properties></store-properties>
+          </session-manager>
+          <session-properties></session-properties>
+        </session-config>
+      </web-container>
+      <ejb-container pool-resize-quantity="8" max-pool-size="32" steady-pool-size="0" session-store="${com.sun.aas.instanceRoot}/session-store">
+        <ejb-timer-service></ejb-timer-service>
+      </ejb-container>
+      <mdb-container pool-resize-quantity="8" max-pool-size="32" steady-pool-size="0"></mdb-container>
+      <jms-service default-jms-host="default_JMS_host" type="EMBEDDED">
+        <jms-host host="localhost" name="default_JMS_host"></jms-host>
+      </jms-service>
+      <log-service log-rotation-limit-in-bytes="2000000" file="${com.sun.aas.instanceRoot}/logs/server.log">
+        <module-log-levels></module-log-levels>
+      </log-service>
+      <security-service>
+        <auth-realm name="admin-realm" classname="com.sun.enterprise.security.auth.realm.file.FileRealm">
+          <property name="file" value="${com.sun.aas.instanceRoot}/config/admin-keyfile"></property>
+          <property name="jaas-context" value="fileRealm"></property>
+        </auth-realm>
+        <auth-realm name="file" classname="com.sun.enterprise.security.auth.realm.file.FileRealm">
+          <property name="file" value="${com.sun.aas.instanceRoot}/config/keyfile"></property>
+          <property name="jaas-context" value="fileRealm"></property>
+        </auth-realm>
+        <auth-realm name="certificate" classname="com.sun.enterprise.security.auth.realm.certificate.CertificateRealm"></auth-realm>
+        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="default" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory">
+          <property name="repository" value="${com.sun.aas.instanceRoot}/generated/policy"></property>
+        </jacc-provider>
+        <jacc-provider policy-provider="org.glassfish.exousia.modules.locked.SimplePolicyProvider" name="simple" policy-configuration-factory-provider="org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"></jacc-provider>
+        <audit-module name="default" classname="com.sun.enterprise.security.ee.audit.Audit">
+          <property name="auditOn" value="false"></property>
+        </audit-module>
+        <message-security-config auth-layer="SOAP">
+          <provider-config provider-type="client" provider-id="XWS_ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="dynamic.username.password" value="false"></property>
+            <property name="debug" value="false"></property>
+          </provider-config>
+          <provider-config provider-type="client" provider-id="ClientProvider" class-name="com.sun.xml.wss.provider.ClientSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="dynamic.username.password" value="false"></property>
+            <property name="debug" value="false"></property>
+            <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml"></property>
+          </provider-config>
+          <provider-config provider-type="server" provider-id="XWS_ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="debug" value="false"></property>
+          </provider-config>
+          <provider-config provider-type="server" provider-id="ServerProvider" class-name="com.sun.xml.wss.provider.ServerSecurityAuthModule">
+            <request-policy auth-source="content"></request-policy>
+            <response-policy auth-source="content"></response-policy>
+            <property name="encryption.key.alias" value="s1as"></property>
+            <property name="signature.key.alias" value="s1as"></property>
+            <property name="debug" value="false"></property>
+            <property name="security.config" value="${com.sun.aas.instanceRoot}/config/wss-server-config-1.0.xml"></property>
+          </provider-config>
+        </message-security-config>
+      </security-service>
+      <transaction-service tx-log-dir="${com.sun.aas.instanceRoot}/logs"></transaction-service>
+      <monitoring-service>
+        <module-monitoring-levels></module-monitoring-levels>
+      </monitoring-service>
+      <java-config debug-options="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9009" system-classpath="" classpath-suffix="">
+        <jvm-options>-client</jvm-options>
+        <jvm-options>-XX:+UnlockDiagnosticVMOptions</jvm-options>
+        <jvm-options>-XX:+LogVMOutput</jvm-options>
+        <jvm-options>-XX:LogFile=${com.sun.aas.instanceRoot}/logs/jvm.log</jvm-options>
+        <jvm-options>-Djava.security.auth.login.config=${com.sun.aas.instanceRoot}/config/login.conf</jvm-options>
+        <jvm-options>-Xmx512m</jvm-options>
+        <jvm-options>-Djavax.net.ssl.keyStore=${com.sun.aas.instanceRoot}/config/keystore.p12</jvm-options>
+        <jvm-options>-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.p12</jvm-options>
+        <jvm-options>-Djava.ext.dirs=${com.sun.aas.javaRoot}/lib/ext${path.separator}${com.sun.aas.javaRoot}/jre/lib/ext${path.separator}${com.sun.aas.instanceRoot}/lib/ext${path.separator}${com.sun.aas.derbyRoot}/lib</jvm-options>
+        <jvm-options>-Djdbc.drivers=org.apache.derby.jdbc.ClientDriver</jvm-options>
+        <jvm-options>-Dcom.sun.enterprise.config.config_environment_factory_class=com.sun.enterprise.config.serverbeans.AppserverConfigEnvironmentFactory</jvm-options>
+        <jvm-options>-XX:NewRatio=2</jvm-options>
+      </java-config>
+      <thread-pools>
+        <thread-pool thread-pool-id="thread-pool-1"></thread-pool>
+      </thread-pools>
+    </config>
+  </configs>
+  <clusters>
+    <cluster name="cluster1" config-ref="server-config" gms-enabled="true" gms-multicast-address="228.9.62.245" gms-multicast-port="18706" gms-bind-interface-address="${GMS-BIND-INTERFACE-ADDRESS-cluster1}">
+    </cluster>
+  </clusters>
+  <property name="administrative.domain.name" value="domain1"></property>
+</domain>

--- a/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/osgi/GlassFishOsgiLauncher.java
+++ b/nucleus/core/bootstrap-osgi/src/main/java/org/glassfish/main/boot/osgi/GlassFishOsgiLauncher.java
@@ -41,6 +41,9 @@ public class GlassFishOsgiLauncher implements Launcher {
     // logging system may override original output streams.
     private static final PrintStream STDOUT = System.out;
     private static final PrintStream STDERR = System.err;
+    private static final String UPGRADE_STATUS_PROPERTY = "glassfish.upgrade.status";
+    private static final String UPGRADE_STATUS_SUCCEEDED = "succeeded";
+    private static final String UPGRADE_STATUS_FAILED = "failed";
 
     private volatile GlassFish gf;
     private volatile GlassFishRuntime gfr;
@@ -149,6 +152,7 @@ public class GlassFishOsgiLauncher implements Launcher {
                     if (gfr != null) {
                         gfr.shutdown();
                     }
+                    printUpgradeStatus();
                 }
                 catch (final Exception ex) {
                     STDERR.println("Error stopping framework: " + ex);
@@ -157,6 +161,15 @@ public class GlassFishOsgiLauncher implements Launcher {
             }
         });
 
+    }
+
+    private void printUpgradeStatus() {
+        final String upgradeStatus = System.getProperty(UPGRADE_STATUS_PROPERTY);
+        if (UPGRADE_STATUS_SUCCEEDED.equals(upgradeStatus)) {
+            STDOUT.println("Upgrade succeeded");
+        } else if (UPGRADE_STATUS_FAILED.equals(upgradeStatus)) {
+            STDOUT.println("Upgrade failed");
+        }
     }
 
     private void runCommand(final CommandRunner cmdRunner, final String command) {

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/UpgradeStartup.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/UpgradeStartup.java
@@ -126,6 +126,10 @@ public class UpgradeStartup implements ModuleStartup {
 
     private final static String SIGNATURE_TYPES_PARAM = "-signatureTypes";
 
+    private final static String UPGRADE_STATUS_PROPERTY = "glassfish.upgrade.status";
+    private final static String UPGRADE_STATUS_FAILED = "failed";
+    private final static String UPGRADE_STATUS_SUCCEEDED = "succeeded";
+
     private List<String> sigTypeList = new ArrayList<>();
 
     @Override
@@ -137,6 +141,7 @@ public class UpgradeStartup implements ModuleStartup {
     // run correctly.
     @Override
     public void start() {
+        System.setProperty(UPGRADE_STATUS_PROPERTY, UPGRADE_STATUS_FAILED);
 
         // we need to disable all the applications before starting server
         // so the applications will not get loaded before redeployment
@@ -225,13 +230,20 @@ public class UpgradeStartup implements ModuleStartup {
         KernelLoggerInfo.getLogger().info(KernelLoggerInfo.exitUpgrade);
         try {
             Thread.sleep(3000);
-            if (runner!=null) {
+            System.setProperty(UPGRADE_STATUS_PROPERTY, UPGRADE_STATUS_SUCCEEDED);
+            if (runner != null) {
                 runner.getCommandInvocation("stop-domain", new DoNothingActionReporter(), kernelIdentity.getSubject())
                     .execute();
             }
 
         } catch (InterruptedException e) {
             KernelLoggerInfo.getLogger().log(Level.SEVERE, KernelLoggerInfo.exceptionUpgrade, e);
+            System.setProperty(UPGRADE_STATUS_PROPERTY, UPGRADE_STATUS_FAILED);
+            Thread.currentThread().interrupt();
+        } catch (RuntimeException e) {
+            System.setProperty(UPGRADE_STATUS_PROPERTY, UPGRADE_STATUS_FAILED);
+            KernelLoggerInfo.getLogger().log(Level.SEVERE, KernelLoggerInfo.exceptionUpgrade, e);
+            throw e;
         }
 
     }
@@ -252,7 +264,7 @@ public class UpgradeStartup implements ModuleStartup {
 
         // 2. remove generated/xml/j2ee-apps(modules) directory
         File oldJ2eeAppsGeneratedXMLDir = new File(
-           env.getApplicationGeneratedXMLPath(), J2EE_APPS);
+              env.getApplicationGeneratedXMLPath(), J2EE_APPS);
         FileUtils.whack(oldJ2eeAppsGeneratedXMLDir);
         File oldJ2eeModulesGeneratedXMLDir = new File(
            env.getApplicationGeneratedXMLPath(), J2EE_MODULES);
@@ -260,7 +272,7 @@ public class UpgradeStartup implements ModuleStartup {
 
         // 3. remove generated/ejb/j2ee-apps(modules) directory
         File oldJ2eeAppsEJBStubDir = new File(
-           env.getApplicationEJBStubPath(), J2EE_APPS);
+              env.getApplicationEJBStubPath(), J2EE_APPS);
         FileUtils.whack(oldJ2eeAppsEJBStubDir);
         File oldJ2eeModulesEJBStubDir = new File(
            env.getApplicationEJBStubPath(), J2EE_MODULES);

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityUpgradeService.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/SecurityUpgradeService.java
@@ -94,6 +94,11 @@ public class SecurityUpgradeService implements ConfigurationUpgrade, PostConstru
     private static final String BAK_SUFFIX = ".bak";
 
     private static final String JDBC_REALM_CLASSNAME = "com.sun.enterprise.security.ee.auth.realm.jdbc.JDBCRealm";
+        private static final String SIMPLE_JACC_PROVIDER_NAME = "simple";
+        private static final String SIMPLE_POLICY_CONFIGURATION_FACTORY =
+            "org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory";
+        private static final String SIMPLE_POLICY_PROVIDER =
+            "org.glassfish.exousia.modules.locked.SimplePolicyProvider";
     public static final String PARAM_DIGEST_ALGORITHM = "digest-algorithm";
     private static final Logger _logger = SecurityLoggerInfo.getLogger();
 
@@ -355,31 +360,52 @@ public class SecurityUpgradeService implements ConfigurationUpgrade, PostConstru
 
     private void upgradeJACCProvider(SecurityService securityService) {
         try {
-            List<JaccProvider> jaccProviders = securityService.getJaccProvider();
-            for (JaccProvider jacc : jaccProviders) {
-                if ("org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory"
-                    .equals(jacc.getPolicyConfigurationFactoryProvider())) {
-                    //simple policy provider already present
-                    return;
-                }
-            }
             ConfigSupport.apply(new SingleConfigCode<SecurityService>() {
                 @Override
                 public Object run(SecurityService secServ) throws PropertyVetoException, TransactionFailure {
+                    JaccProvider existing = findJaccProvider(secServ, SIMPLE_JACC_PROVIDER_NAME);
+                    if (existing != null) {
+                        if (!SIMPLE_POLICY_CONFIGURATION_FACTORY.equals(existing.getPolicyConfigurationFactoryProvider())) {
+                            existing.setPolicyConfigurationFactoryProvider(SIMPLE_POLICY_CONFIGURATION_FACTORY);
+                        }
+                        if (!SIMPLE_POLICY_PROVIDER.equals(existing.getPolicyProvider())) {
+                            existing.setPolicyProvider(SIMPLE_POLICY_PROVIDER);
+                        }
+                        return secServ;
+                    }
+
+                    for (JaccProvider jacc : secServ.getJaccProvider()) {
+                        if (SIMPLE_POLICY_CONFIGURATION_FACTORY.equals(jacc.getPolicyConfigurationFactoryProvider())) {
+                            return secServ;
+                        }
+                    }
+
                     JaccProvider jacc = secServ.createChild(JaccProvider.class);
                     //add the simple provider to the domain's security service
-                    jacc.setName("simple");
-                    jacc.setPolicyConfigurationFactoryProvider("org.glassfish.exousia.modules.locked.SimplePolicyConfigurationFactory");
-                    jacc.setPolicyProvider("org.glassfish.exousia.modules.locked.SimplePolicyProvider");
+                    jacc.setName(SIMPLE_JACC_PROVIDER_NAME);
+                    jacc.setPolicyConfigurationFactoryProvider(SIMPLE_POLICY_CONFIGURATION_FACTORY);
+                    jacc.setPolicyProvider(SIMPLE_POLICY_PROVIDER);
                     secServ.getJaccProvider().add(jacc);
                     return secServ;
                 }
             }, securityService);
         } catch (TransactionFailure ex) {
+            if (findJaccProvider(securityService, SIMPLE_JACC_PROVIDER_NAME) != null) {
+                return;
+            }
             Logger.getAnonymousLogger().log(Level.SEVERE, null, ex);
             throw new RuntimeException(ex);
         }
 
+    }
+
+    private JaccProvider findJaccProvider(SecurityService securityService, String jaccProviderName) {
+        for (JaccProvider jaccProvider : securityService.getJaccProvider()) {
+            if (jaccProviderName.equals(jaccProvider.getName())) {
+                return jaccProvider;
+            }
+        }
+        return null;
     }
 
     private boolean deleteFile(File path) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish/issues/26068 - doesn't add the GMS property if it already exists.

Also adjusts the start-domain --upgrade command to report an error or failure as the last log message when it terminates.