### PR TITLE
Honor key-store, trust-store and classname of the ssl element

### DIFF
--- a/appserver/tests/embedded/web/web-api/src/test/java/org/glassfish/tests/embedded/web/EmbeddedAddHttpsListenerTest.java
+++ b/appserver/tests/embedded/web/web-api/src/test/java/org/glassfish/tests/embedded/web/EmbeddedAddHttpsListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -95,8 +95,7 @@ public class EmbeddedAddHttpsListenerTest {
         listener.setPort(port);
         listener.setId(name);
 
-        String keyStorePath = root.getAbsolutePath() + keystore;
-        SslConfig sslConfig = new SslConfig(keyStorePath, null);
+        SslConfig sslConfig = new SslConfig(keystore.getAbsolutePath(), null);
         sslConfig.setKeyPassword(password.toCharArray());
         if (certname != null) {
             sslConfig.setCertNickname(certname);

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to Eclipse Foundation.
  * Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -62,6 +62,7 @@ import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_TRUSTSTORE
 public class SSLConfigurator extends SSLEngineConfigurator {
 
     private static final String PLAIN_PASSWORD_PROVIDER_NAME = "plain";
+    private static final String DEFAULT_SSL_IMPLEMENTATION = "com.sun.enterprise.security.ssl.GlassfishSSLImpl";
     private static final Logger LOG = System.getLogger(SSLConfigurator.class.getName());
 
     /**
@@ -87,21 +88,28 @@ public class SSLConfigurator extends SSLEngineConfigurator {
     }
 
     /**
+     * The {@code classname} attribute of the {@code ssl} element is honored first, so a custom
+     * implementation configured in the domain.xml is not silently ignored. The implementation
+     * registered in the {@link ServiceLocator} is used when the attribute is not set or when it
+     * names exactly that implementation.
+     *
      * @return the {@link SSLImplementation}
      */
     private SSLImplementation getSslImplementation() {
+        final String classname = ssl == null || ssl.getClassname() == null || ssl.getClassname().isBlank()
+            ? null
+            : ssl.getClassname().trim();
         final SSLImplementation implementation = serviceLocator.getService(SSLImplementation.class);
-        if (implementation != null) {
+        if (implementation != null && (classname == null || classname.equals(implementation.getClass().getName()))) {
             LOG.log(DEBUG, () -> "Found SSL implementation: " + implementation);
             return implementation;
         }
-        final String classname = ssl.getClassname() == null ? "com.sun.enterprise.security.ssl.GlassfishSSLImpl"
-            : ssl.getClassname();
-        LOG.log(DEBUG, () -> "Creating SSL implementation: " + classname);
+        final String implementationClass = classname == null ? DEFAULT_SSL_IMPLEMENTATION : classname;
+        LOG.log(DEBUG, () -> "Creating SSL implementation: " + implementationClass);
         try {
-            return (SSLImplementation) Class.forName(classname).getDeclaredConstructor().newInstance();
+            return (SSLImplementation) Utils.loadClass(implementationClass).getDeclaredConstructor().newInstance();
         } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException("Failed to create SSL implementation: " + classname, e);
+            throw new IllegalStateException("Failed to create SSL implementation: " + implementationClass, e);
         }
     }
 

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/SSLConfigurator.java
@@ -53,6 +53,8 @@ import static org.glassfish.embeddable.GlassFishVariable.KEYSTORE_TYPE;
 import static org.glassfish.embeddable.GlassFishVariable.TRUSTSTORE_FILE;
 import static org.glassfish.embeddable.GlassFishVariable.TRUSTSTORE_PASSWORD;
 import static org.glassfish.embeddable.GlassFishVariable.TRUSTSTORE_TYPE;
+import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_KEYSTORE_CONFIGURED;
+import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_TRUSTSTORE_CONFIGURED;
 
 /**
  * @author oleksiys
@@ -157,6 +159,7 @@ public class SSLConfigurator extends SSLEngineConfigurator {
             // Key store settings
             setAttribute(sslContextFactory, "keystore", ssl == null ? null : ssl.getKeyStore(),
                 KEYSTORE_FILE.getSystemPropertyName(), null);
+            markConfiguredStore(sslContextFactory, ATTR_KEYSTORE_CONFIGURED, ssl == null ? null : ssl.getKeyStore());
             setAttribute(sslContextFactory, "keystoreType", ssl == null ? null : ssl.getKeyStoreType(),
                 KEYSTORE_TYPE.getSystemPropertyName(), KEYSTORE_TYPE_DEFAULT);
             setAttribute(sslContextFactory, "keystorePass", ssl == null ? null : getKeyStorePassword(ssl),
@@ -165,6 +168,7 @@ public class SSLConfigurator extends SSLEngineConfigurator {
             // Trust store settings
             setAttribute(sslContextFactory, "truststore", ssl == null ? null : ssl.getTrustStore(),
                 TRUSTSTORE_FILE.getSystemPropertyName(), null);
+            markConfiguredStore(sslContextFactory, ATTR_TRUSTSTORE_CONFIGURED, ssl == null ? null : ssl.getTrustStore());
             setAttribute(sslContextFactory, "truststoreType", ssl == null ? null : ssl.getTrustStoreType(),
                 TRUSTSTORE_TYPE.getSystemPropertyName(), KEYSTORE_TYPE_DEFAULT);
             setAttribute(sslContextFactory, "truststorePass", ssl == null ? null : getTrustStorePassword(ssl),
@@ -284,6 +288,21 @@ public class SSLConfigurator extends SSLEngineConfigurator {
     private static void setAttribute(final SSLContextFactory sslContextFactory, final String name, final String value,
         final String property, final String defaultValue) {
         sslContextFactory.setAttribute(name, value == null ? System.getProperty(property, defaultValue) : value);
+    }
+
+    /**
+     * Records that the store is the one of the listener and not the one of the server, because the
+     * store attributes themselves are merged with the system properties of the server.
+     *
+     * @param sslContextFactory the factory which will create the {@link SSLContext}.
+     * @param name the name of the marking attribute.
+     * @param configuredStore the store configured in the ssl element, may be null.
+     */
+    private static void markConfiguredStore(final SSLContextFactory sslContextFactory, final String name,
+        final String configuredStore) {
+        if (configuredStore != null && !configuredStore.isBlank()) {
+            sslContextFactory.setAttribute(name, Boolean.TRUE.toString());
+        }
     }
 
     private static boolean isWantClientAuth(final Ssl ssl) {

--- a/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/SSLContextFactory.java
+++ b/nucleus/grizzly/config/src/main/java/org/glassfish/grizzly/config/ssl/SSLContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -72,6 +72,22 @@ import static com.sun.enterprise.util.SystemPropertyConstants.KEYSTORE_PASSWORD_
  * @author Jan Luehe
  */
 public class SSLContextFactory implements Cloneable {
+
+    /**
+     * Name of the attribute set when the keystore is configured in the {@code ssl} element of the
+     * listener. The {@code keystore} attribute alone cannot tell that, because it is merged with
+     * the keystore of the server coming from the system properties.
+     */
+    public static final String ATTR_KEYSTORE_CONFIGURED = "keystoreConfigured";
+
+    /**
+     * Name of the attribute set when the truststore is configured in the {@code ssl} element of the
+     * listener.
+     *
+     * @see #ATTR_KEYSTORE_CONFIGURED
+     */
+    public static final String ATTR_TRUSTSTORE_CONFIGURED = "truststoreConfigured";
+
     private static final StringManager sm = StringManager.getManager(
             SSLContextFactory.class.getPackage().getName(),
             SSLContextFactory.class.getClassLoader());

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/GrizzlyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -27,6 +27,7 @@ import org.glassfish.grizzly.Transport;
 import org.glassfish.grizzly.config.dom.NetworkAddressValidator;
 import org.glassfish.grizzly.config.dom.NetworkListener;
 import org.glassfish.grizzly.config.dom.ThreadPool;
+import org.glassfish.grizzly.config.test.ConfiguredSSLImplementation;
 import org.glassfish.grizzly.config.test.GrizzlyConfigTestHelper;
 import org.glassfish.grizzly.config.test.example.DummySelectionKeyHandler;
 import org.glassfish.grizzly.http.server.HttpHandler;
@@ -254,6 +255,36 @@ public class GrizzlyConfigTest {
                 helper.getContent(URI.create("https://localhost:38084").toURL()));
             assertEquals("<html><body>You've found the server on port 38085</body></html>",
                 helper.getContent(URI.create("https://localhost:38085").toURL()));
+        } finally {
+            if (grizzlyConfig != null) {
+                grizzlyConfig.shutdown();
+            }
+        }
+    }
+
+    /**
+     * The {@code classname} attribute of the {@code ssl} element must be honored even if another
+     * {@link org.glassfish.grizzly.config.ssl.SSLImplementation} is registered in the locator.
+     *
+     * @see <a href="https://github.com/eclipse-ee4j/glassfish/issues/18175">Issue 18175</a>
+     */
+    @Test
+    public void sslWithConfiguredImplementation() throws URISyntaxException, IOException {
+        GrizzlyConfig grizzlyConfig = null;
+        ConfiguredSSLImplementation.resetUsageCount();
+        try {
+            configure();
+            grizzlyConfig = new GrizzlyConfig("grizzly-config-ssl-classname.xml");
+            grizzlyConfig.setupNetwork();
+            int count = 0;
+            for (GrizzlyListener listener : grizzlyConfig.getListeners()) {
+                helper.addStaticHttpHandler((GenericGrizzlyListener) listener, count++);
+            }
+
+            assertEquals("<html><body>You've found the server on port 38086</body></html>",
+                helper.getContent(URI.create("https://localhost:38086").toURL()));
+            assertEquals(1, ConfiguredSSLImplementation.getUsageCount(),
+                "Usages of the SSLImplementation configured by the classname attribute");
         } finally {
             if (grizzlyConfig != null) {
                 grizzlyConfig.shutdown();

--- a/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/test/ConfiguredSSLImplementation.java
+++ b/nucleus/grizzly/config/src/test/java/org/glassfish/grizzly/config/test/ConfiguredSSLImplementation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.grizzly.config.test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.glassfish.grizzly.config.ssl.SSLContextFactory;
+import org.glassfish.grizzly.config.ssl.SSLImplementation;
+
+/**
+ * Implementation used just by tests to verify that the {@code classname} attribute of the
+ * {@code ssl} element is honored. It is intentionally not a HK2 service, so it can be found only
+ * through the configured class name.
+ */
+public class ConfiguredSSLImplementation implements SSLImplementation {
+
+    private static final AtomicInteger USAGE_COUNTER = new AtomicInteger();
+
+    public ConfiguredSSLImplementation() {
+        USAGE_COUNTER.incrementAndGet();
+    }
+
+    @Override
+    public SSLContextFactory getSSLContextFactory() {
+        return new SSLContextFactory();
+    }
+
+    public static int getUsageCount() {
+        return USAGE_COUNTER.get();
+    }
+
+    public static void resetUsageCount() {
+        USAGE_COUNTER.set(0);
+    }
+}

--- a/nucleus/grizzly/config/src/test/resources/grizzly-config-ssl-classname.xml
+++ b/nucleus/grizzly/config/src/test/resources/grizzly-config-ssl-classname.xml
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<network-config>
+    <transports>
+        <transport name="tcp"/>
+    </transports>
+    <protocols>
+        <protocol name="https-configured-impl" security-enabled="true">
+            <http/>
+            <ssl cert-nickname="s1as" allow-lazy-init="false"
+                 classname="org.glassfish.grizzly.config.test.ConfiguredSSLImplementation"/>
+        </protocol>
+    </protocols>
+    <network-listeners>
+        <thread-pool name="defaultThreadPool"/>
+        <network-listener name="https-configured-impl-listener" port="38086" transport="tcp"
+                          protocol="https-configured-impl" thread-pool="defaultThreadPool"/>
+    </network-listeners>
+</network-config>

--- a/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassFishSSLContextFactory.java
+++ b/nucleus/security/core/src/main/java/com/sun/enterprise/security/ssl/GlassFishSSLContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,7 +30,18 @@ import javax.net.ssl.X509KeyManager;
 import org.glassfish.grizzly.config.ssl.SSLContextFactory;
 import org.glassfish.hk2.api.ServiceLocator;
 
+import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_KEYSTORE_CONFIGURED;
+import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_TRUSTSTORE_CONFIGURED;
+
 /**
+ * The {@link SSLContextFactory} used by {@link GlassfishSSLImpl}.
+ * <p>
+ * The server keystore and truststore are managed by {@link SSLUtils}; they are opened once with the
+ * domain master password and shared by all listeners. A listener which configures its own store in
+ * the {@code ssl} element of the domain.xml is served by the generic {@link SSLContextFactory}
+ * instead, so that {@code key-store}, {@code trust-store}, their types and their passwords are
+ * honored.
+ *
  * @author Sudarsan Sridhar
  */
 public class GlassFishSSLContextFactory extends SSLContextFactory {
@@ -54,11 +65,12 @@ public class GlassFishSSLContextFactory extends SSLContextFactory {
 
     @Override
     protected KeyManager[] getKeyManagers(String algorithm, String keyAlias) throws Exception {
-        String keystoreFile = getAttribute("keystore");
-        LOG.log(Level.DEBUG, "Keystore file = {0}", keystoreFile);
+        LOG.log(Level.DEBUG, "Keystore file = {0}, type = {1}", getAttribute("keystore"),
+            getAttribute("keystoreType"));
+        if (isConfiguredForListener(ATTR_KEYSTORE_CONFIGURED)) {
+            return super.getKeyManagers(algorithm, keyAlias);
+        }
 
-        String keystoreType = getAttribute("keystoreType");
-        LOG.log(Level.DEBUG, "Keystore type = {0}", keystoreType);
         KeyManager[] kMgrs = sslUtils.getKeyManagers(algorithm);
         if (keyAlias != null && keyAlias.length() > 0 && kMgrs != null) {
             for (int i = 0; i < kMgrs.length; i++) {
@@ -71,6 +83,24 @@ public class GlassFishSSLContextFactory extends SSLContextFactory {
 
     @Override
     protected KeyStore getTrustStore() throws IOException {
+        LOG.log(Level.DEBUG, "Truststore file = {0}, type = {1}", getAttribute("truststore"),
+            getAttribute("truststoreType"));
+        if (isConfiguredForListener(ATTR_TRUSTSTORE_CONFIGURED)) {
+            return super.getTrustStore();
+        }
         return sslUtils.getTrustStore();
+    }
+
+
+    /**
+     * The store attributes themselves cannot tell that, because the {@code SSLConfigurator} merges
+     * them with the system properties of the server; it marks the stores which come from the
+     * {@code ssl} element of the listener.
+     *
+     * @param attribute the name of the marking attribute.
+     * @return true if the listener configured its own store.
+     */
+    private boolean isConfiguredForListener(String attribute) {
+        return Boolean.parseBoolean(getAttribute(attribute));
     }
 }

--- a/nucleus/security/core/src/test/java/com/sun/enterprise/security/ssl/GlassFishSSLContextFactoryTest.java
+++ b/nucleus/security/core/src/test/java/com/sun/enterprise/security/ssl/GlassFishSSLContextFactoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.security.ssl;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.net.ssl.SSLContext;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.main.jdke.security.KeyTool;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_KEYSTORE_CONFIGURED;
+import static org.glassfish.grizzly.config.ssl.SSLContextFactory.ATTR_TRUSTSTORE_CONFIGURED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that the {@code key-store} and {@code trust-store} attributes of the {@code ssl} element
+ * of the domain.xml are honored instead of being silently replaced by the server stores.
+ *
+ * @see <a href="https://github.com/eclipse-ee4j/glassfish/issues/18175">Issue 18175</a>
+ */
+public class GlassFishSSLContextFactoryTest {
+
+    private static final String LISTENER_ALIAS = "listener-cert";
+    private static final String LISTENER_PASSWORD = "listenerpassword";
+
+    /** The locator is intentionally empty - the {@link SSLUtils} service must not be needed. */
+    private static final ServiceLocator EMPTY_LOCATOR = ServiceLocatorFactory.getInstance()
+        .create(GlassFishSSLContextFactoryTest.class.getName());
+
+    @TempDir
+    private static File tempDir;
+
+    private static File listenerKeyStore;
+    private static File listenerTrustStore;
+
+    @BeforeAll
+    static void createListenerStores() throws Exception {
+        listenerKeyStore = new File(tempDir, "listener-keystore.p12");
+        KeyTool keyTool = new KeyTool(listenerKeyStore, LISTENER_PASSWORD.toCharArray());
+        keyTool.generateKeyPair(LISTENER_ALIAS, "CN=listener", "RSA", 1);
+        listenerTrustStore = new File(tempDir, "listener-truststore.p12");
+        keyTool.copyCertificate(LISTENER_ALIAS, listenerTrustStore);
+    }
+
+
+    /**
+     * The listener configured its own stores, therefore they must be used even if the server stores
+     * managed by the {@link SSLUtils} singleton are not available at all.
+     */
+    @Test
+    public void listenerOwnStores() throws Exception {
+        GlassFishSSLContextFactory factory = createFactory(LISTENER_ALIAS);
+        SSLContext context = factory.create();
+        assertNotNull(context, "SSLContext created from the stores of the listener");
+    }
+
+
+    /**
+     * Proves that the keystore of the listener is really the one which is opened - the alias comes
+     * from the server keystore and does not exist in the keystore of the listener.
+     */
+    @Test
+    public void listenerOwnKeyStoreWithoutRequestedAlias() throws Exception {
+        GlassFishSSLContextFactory factory = createFactory("s1as");
+        IOException e = assertThrows(IOException.class, factory::create);
+        assertThat(e.getMessage(), containsString("s1as"));
+    }
+
+
+    private static GlassFishSSLContextFactory createFactory(String keyAlias) {
+        GlassFishSSLContextFactory factory = new GlassFishSSLContextFactory(EMPTY_LOCATOR);
+        factory.setAttribute("keystore", listenerKeyStore.getAbsolutePath());
+        factory.setAttribute("keystoreType", "PKCS12");
+        factory.setAttribute("keystorePass", LISTENER_PASSWORD);
+        factory.setAttribute(ATTR_KEYSTORE_CONFIGURED, "true");
+        factory.setAttribute("truststore", listenerTrustStore.getAbsolutePath());
+        factory.setAttribute("truststoreType", "PKCS12");
+        factory.setAttribute("truststorePass", LISTENER_PASSWORD);
+        factory.setAttribute(ATTR_TRUSTSTORE_CONFIGURED, "true");
+        factory.setAttribute("keyAlias", keyAlias);
+        return factory;
+    }
+}


### PR DESCRIPTION
Fixes #18175

## Problem

`key-store` and `trust-store` configured in the `ssl` element of a protocol have never had any effect:

```xml
<protocol security-enabled="true" name="ssl-listener">
    <http default-virtual-server="server"><file-cache/></http>
    <ssl key-store="/opt/security/keystore.p12" trust-store="/opt/security/truststore.p12"
         cert-nickname="s1as" classname="com.sun.enterprise.security.ssl.GlassfishSSLImpl"/>
</protocol>
```

`GlassFishSSLContextFactory` read the `keystore` and `keystoreType` attributes only to log them and
then built the key managers, as well as the trust store, from `SSLUtils`. `SSLUtils` delegates to the
`SecuritySupport` singleton, which opens a single pair of stores in its `@PostConstruct` from the
`javax.net.ssl.keyStore` / `javax.net.ssl.trustStore` system properties and the domain master
password. The store location, type and password of a listener were therefore silently ignored, while
the admin console offers them as editable fields and the config model and `asadmin set` accept them.

While fixing that I found a second, newer defect. Since `SSLImplementation` became a HK2 contract,
`SSLConfigurator.getSslImplementation()` resolves it from the service locator unconditionally and
uses the `classname` attribute only when no service is registered. `GlassfishSSLImpl` is a service
and the only implementation on the server classpath, so the attribute is never used. That silently
disables the pluggability documented in `http_https.adoc` and it also removed the workaround for
this very issue that was suggested in 2012 (clearing `classname` so that the generic Grizzly
implementation, which does honor the stores, is used).

## Solution

**Per listener stores.** A listener which configures its own store is served by the generic
`SSLContextFactory`, which loads the store from the configured path, with the configured type and
password. Listeners without their own store keep using the server stores managed by `SSLUtils`, so
the stores protected by the master password stay the default and nothing changes for a default
domain. The keystore and the truststore are decided independently, so overriding only one of them
works. The store paths themselves cannot carry that decision, because `SSLConfigurator` merges them
with the system properties of the server before the factory sees them; it therefore marks the stores
which come from the `ssl` element with the new `keystoreConfigured` and `truststoreConfigured`
attributes, and the factory reads that mark.

**The classname attribute.** It is honored again. The implementation registered in the service
locator is used when the attribute is not set or when it names exactly that implementation, which is
the case of every default domain, so this is not a behaviour change for stock configurations. The
class is loaded by `Utils.loadClass`, which tries the thread context class loader first.

## Tests

`GlassFishSSLContextFactoryTest` (new; the module had no test sources yet) creates a keystore and a
truststore with `KeyTool` and configures them as the stores of the listener. The factory is created
with an intentionally empty `ServiceLocator`, so any fall back to the server stores fails. One of the
tests asks for the `s1as` alias, which exists only in a server keystore, and asserts that the
resulting `IOException` names it - that proves the keystore of the listener is really the one which
is opened.

`GrizzlyConfigTest.sslWithConfiguredImplementation` serves HTTPS from a configuration whose `ssl`
element names `ConfiguredSSLImplementation`, a test implementation which is intentionally not a HK2
service and counts its usages.

Both reproducers were verified to fail without the fixes.

`EmbeddedAddHttpsListenerTest` concatenated the absolute path of the docroot with the absolute path
of the keystore file, so its listener was configured with a `key-store` which cannot exist. It went
unnoticed because the attribute was ignored; now the listener really tries to open that path and the
client sees a terminated handshake. The listener is configured with the keystore of the test, which
is also the server keystore, as it is in a default domain - the test now covers the configured store
path end to end.

## Not included

- A store of a listener configured without `key-store-password` still falls back to
  `javax.net.ssl.keyStorePassword` and then to the default password, which is the existing behaviour
  of `SSLConfigurator`. Falling back to the master password instead may be more useful, but it would
  mean reaching the security services from `grizzly-config`, so I left it for a follow up if you
  consider it right.
- `create-ssl` still has no parameters for the stores and the documentation describes only the
  `classname` attribute. Happy to add both once the approach here is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
