### PR TITLE
Resolving problems with Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -454,10 +454,6 @@ pipeline {
    }
 
    post {
-      // Some files allocate a lot of disk space, but when the build succeeded, we often don't need them any more.'
-      always {
-         cleanWs()
-      }
       success {
          // Overwrite stashes with empty content
          stash includes: 'nothing', name: 'appserv-tests', allowEmpty: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@
 * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 */
 
-def mvnVersion = '3.9.11'
+def mvnVersion = '3.9.16'
 def javaVersion = '21'
 def jdkTool = "temurin-jdk${javaVersion}-latest"
 def mvnTool = "apache-maven-${mvnVersion}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ def generateMvnTestPodTemplate(job, nodeCfg) {
                               tar -xzf ${BUNDLES_DIR}/maven-repo.tar.gz --overwrite -m -p -C /home/jenkins/.m2/repository
                               '''
                               sh """
-                              mvn -B -e clean verify -Psnapshots -pl :${job} -amd
+                              mvn -V -B -e clean verify -Psnapshots -pl :${job} -amd
                               """
                            }
                         } finally {

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/pom.xml
@@ -50,10 +50,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.70.0</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/pom.xml
@@ -34,13 +34,24 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.authentication</groupId>
+            <artifactId>jakarta.authentication-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.3</version>
+            <version>1.22.2</version>
         </dependency>
 
         <dependency>

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/ArquillianBase.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/ArquillianBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,14 +17,13 @@
 
 package org.glassfish.jaccApi.common;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.WebClient;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.logging.Logger;
 
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/JaspicUtils.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/JaspicUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestServerAuthContext.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/common/src/main/java/org/glassfish/jaccApi/common/TestServerAuthContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -44,7 +44,7 @@ public class TestServerAuthContext implements ServerAuthContext {
 
     public TestServerAuthContext(CallbackHandler handler, ServerAuthModule serverAuthModule) throws AuthException {
         this.serverAuthModule = serverAuthModule;
-        serverAuthModule.initialize(null, null, handler, Collections.<String, String> emptyMap());
+        serverAuthModule.initialize(null, null, handler, Collections.<String, Object> emptyMap());
     }
 
     @Override

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.6.0.Final</version>
+                <version>1.10.2.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -61,31 +61,16 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>2.58.0</version>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>arquillian-glassfish-server-remote</artifactId>
+            <version>2.2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-api</artifactId>
-            <version>9.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-glassfish-remote-3.1</artifactId>
-            <version>1.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.ejte.ccl.reporter</groupId>
-            <artifactId>SimpleReporterAdapter</artifactId>
-            <version>1.0</version>
-            <scope>system</scope>
-            <systemPath>${APS_HOME}/lib/target/reporter.jar</systemPath>
+            <groupId>org.glassfish.main.tests</groupId>
+            <artifactId>reporter</artifactId>
+            <version>${glassfish.version}</version>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/pom.xml
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/pom.xml
@@ -39,5 +39,26 @@
             <artifactId>jaccApi-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.authentication</groupId>
+            <artifactId>jakarta.authentication-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.authorization</groupId>
+            <artifactId>jakarta.authorization-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/src/main/java/org/glassfish/jaccApi/programmaticauthentication/sam/TestServerAuthModule.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/src/main/java/org/glassfish/jaccApi/programmaticauthentication/sam/TestServerAuthModule.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,17 +17,6 @@
 
 package org.glassfish.jaccApi.programmaticauthentication.sam;
 
-import static jakarta.security.auth.message.AuthStatus.SEND_SUCCESS;
-import static jakarta.security.auth.message.AuthStatus.SUCCESS;
-
-import java.io.IOException;
-import java.security.Principal;
-import java.util.Map;
-
-import javax.security.auth.Subject;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.AuthStatus;
 import jakarta.security.auth.message.MessageInfo;
@@ -36,6 +26,18 @@ import jakarta.security.auth.message.callback.GroupPrincipalCallback;
 import jakarta.security.auth.message.module.ServerAuthModule;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import static jakarta.security.auth.message.AuthStatus.SEND_SUCCESS;
+import static jakarta.security.auth.message.AuthStatus.SUCCESS;
 
 /**
  * Very basic SAM that returns a single hardcoded user named "test" with role "architect" when the request *attribute*

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/src/main/java/org/glassfish/jaccApi/programmaticauthentication/servlet/AuthenticateServlet.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/src/main/java/org/glassfish/jaccApi/programmaticauthentication/servlet/AuthenticateServlet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,19 +17,20 @@
 
 package org.glassfish.jaccApi.programmaticauthentication.servlet;
 
-import java.io.IOException;
-
+import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PolicyContextException;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import javax.security.auth.Subject;
-import jakarta.security.jacc.PolicyContext;
-import jakarta.security.jacc.PolicyContextException;
+
+import java.io.IOException;
 import java.security.Principal;
-import java.util.stream.Collectors;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.security.auth.Subject;
 
 @WebServlet(urlPatterns = "/public/authenticate")
 public class AuthenticateServlet extends HttpServlet {
@@ -51,16 +53,13 @@ public class AuthenticateServlet extends HttpServlet {
             if (subject != null) {
                 response.getWriter().write(subject.toString());
                 Set<Principal> principalsSet = subject.getPrincipals();
-//                String princiaplsInSubject = "";
-                String princiaplsInSubject = principalsSet.stream()
-                                                          .map(e -> e.getName())
-                                                          .collect(Collectors.joining(", "));
-                response.getWriter().write("Principals: " + princiaplsInSubject);
-//            response.getWriter().write("Principals in subject are :" + subject.getPrincipals().stream().map(Principal::getName()).collect(Collectors.join(",")));
+                response.getWriter().write("Principals in subject are: " + subject.getPrincipals().stream()
+                    .map(Principal::getName).distinct().collect(Collectors.joining(", ")));
             }
-        }catch (PolicyContextException e){
+        } catch (PolicyContextException e) {
             response.getWriter().write("ERROR while getting Subject");
             e.printStackTrace(response.getWriter());
+            response.getWriter().flush();
         }
 
     }

--- a/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/src/test/java/org/glassfish/jaccApi/programmaticauthentication/ProgrammaticAuthenticationIT.java
+++ b/appserver/tests/appserv-tests/devtests/security/jaccApi/prog-auth/programmatic-authentication/src/test/java/org/glassfish/jaccApi/programmaticauthentication/ProgrammaticAuthenticationIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,18 +17,18 @@
 
 package org.glassfish.jaccApi.programmaticauthentication;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 
 import org.glassfish.jaccApi.common.ArquillianBase;
-import static org.glassfish.jaccApi.common.ArquillianBase.mavenWar;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
+
+import static org.glassfish.jaccApi.common.ArquillianBase.mavenWar;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This tests that a call from a Servlet to HttpServletRequest#authenticate can result
@@ -47,7 +48,8 @@ public class ProgrammaticAuthenticationIT extends ArquillianBase {
     @Test
     public void testSubjectPrincipals() throws IOException, SAXException {
         String response = getFromServerPath("public/authenticate");
-        assertTrue("Should contain web user test and architect in subject principals", response.contains("Principals: test, architect"));
+        assertTrue("Should contain web user test and architect in subject principals",
+            response.contains("Principals in subject are: test, architect"));
     }
 
 

--- a/appserver/tests/embedded/inplanted/pom.xml
+++ b/appserver/tests/embedded/inplanted/pom.xml
@@ -57,7 +57,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.4.2</version>
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
@@ -117,9 +116,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.70.0</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.tests.embedded</groupId>

--- a/appserver/tests/embedded/maven-plugin/jsftest/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/jsftest/pom.xml
@@ -70,14 +70,27 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.faces</groupId>
             <artifactId>jakarta.faces-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/appserver/tests/embedded/maven-plugin/jsftest/src/main/java/org/glassfish/tests/embedded/jsftest/JSFTestBean.java
+++ b/appserver/tests/embedded/maven-plugin/jsftest/src/main/java/org/glassfish/tests/embedded/jsftest/JSFTestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,8 +17,8 @@
 
 package org.glassfish.tests.embedded.jsftest;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Named;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Named;
 
 /**
  * @author bhavanishankar@java.net

--- a/appserver/tests/embedded/maven-plugin/jsptest/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
+++ b/appserver/tests/embedded/maven-plugin/jsptest/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,11 +24,13 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -42,13 +44,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JspTest {
 
-    private static final int EXPECTED_COUNT = 3;
+    // FIXME: read certificate from truststore.
+    private static final TrustManager[] naiveTrustManager = new TrustManager[]{new X509TrustManager() {
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
 
-    private String contextPath = "test";
+        @Override
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+            return;
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+            return;
+        }
+    }};
 
     @BeforeAll
     public static void createKeyStore() throws Exception {
         // Path matches javax.net.ssl.keyStore in src/test/resources/system.properties.
+        // FIXME: This should be done BEFORE the server started
         File keystore = JUnitSystem.detectBasedir().resolve(Path.of("target", "testkeystore.p12")).toFile();
         KeyTool keyTool = new KeyTool(keystore, KEYSTORE_PASSWORD_DEFAULT.toCharArray());
         keyTool.generateKeyPair("s1as", "CN=localhost", "RSA", 1);
@@ -66,60 +83,48 @@ public class JspTest {
     }
 
     private static void goGet(String url, String result) throws Exception {
-            disableCertValidation();
-            URL servlet = URI.create(url).toURL();
-            HttpURLConnection uc = (HttpURLConnection)servlet.openConnection();
-            try {
-                System.out.println("\nURLConnection = " + uc + " : ");
-                if (uc.getResponseCode() != 200) {
-                    throw new Exception("Servlet did not return 200 OK response code");
-                }
-                try (BufferedReader in = new BufferedReader(new InputStreamReader(uc.getInputStream()))) {
-                    String line = null;
-                    boolean found = false;
-                    int index;
-                    while ((line = in.readLine()) != null) {
-                        System.out.println(line);
-                        index = line.indexOf(result);
-                        if (index != -1) {
-                            found = true;
-                        }
-                    }
-                    assertTrue(found);
-                    System.out.println("\n***** SUCCESS **** Found [" + result + "] in the response.*****\n");
-                }
-            } finally {
-                uc.disconnect();
-            }
-        }
-
-    public static void disableCertValidation() {
-        // Create a trust manager that does not validate certificate chains
-        TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return null;
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                return;
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                return;
-            }
-        }};
-
+        boolean secure = url.startsWith("https");
+        URL servlet = URI.create(url).toURL();
+        HttpURLConnection uc = secure ? openHttpsConnection(servlet) : openHttpConnection(servlet);
         try {
-            SSLContext sc = SSLContext.getInstance("TLS");
-            sc.init(null, trustAllCerts, new SecureRandom());
-            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        } catch (Exception e) {
-            return;
+            System.out.println("\nURLConnection = " + uc + " : ");
+            if (uc.getResponseCode() != 200) {
+                throw new Exception("Servlet did not return 200 OK response code");
+            }
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(uc.getInputStream()))) {
+                String line = null;
+                boolean found = false;
+                int index;
+                while ((line = in.readLine()) != null) {
+                    System.out.println(line);
+                    index = line.indexOf(result);
+                    if (index != -1) {
+                        found = true;
+                    }
+                }
+                assertTrue(found);
+                System.out.println("\n***** SUCCESS **** Found [" + result + "] in the response.*****\n");
+            }
+        } finally {
+            uc.disconnect();
         }
     }
 
+    private static HttpURLConnection openHttpConnection(URL endpoint) throws Exception {
+        return (HttpURLConnection) endpoint.openConnection();
+    }
 
+    private static HttpsURLConnection openHttpsConnection(URL endpoint) throws Exception {
+        HttpsURLConnection uc = (HttpsURLConnection) endpoint.openConnection();
+        uc.setHostnameVerifier((hostname, session) -> true);
+        uc.setSSLSocketFactory(createSocketFactory());
+
+        return uc;
+    }
+
+    private static SSLSocketFactory createSocketFactory() throws GeneralSecurityException {
+        SSLContext sc = SSLContext.getInstance("TLS");
+        sc.init(null, naiveTrustManager, new SecureRandom());
+        return sc.getSocketFactory();
+    }
 }

--- a/appserver/tests/embedded/maven-plugin/localejbs/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/localejbs/pom.xml
@@ -85,5 +85,11 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/embedded/maven-plugin/localejbs/src/main/java/org/glassfish/tests/embedded/localejbs/LocalEjbTest.java
+++ b/appserver/tests/embedded/maven-plugin/localejbs/src/main/java/org/glassfish/tests/embedded/localejbs/LocalEjbTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,30 +19,24 @@ package org.glassfish.tests.embedded.localejbs;
 
 import javax.naming.InitialContext;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author bhavanishankar@dev.java.net
  */
-
 public class LocalEjbTest {
 
-    @Test
+    @org.junit.Test
     public void testTimer() throws Exception {
-        try {
-            InitialContext ic = new InitialContext();
-            TimerEjb ejb = (TimerEjb) ic.lookup("java:global/localejbs/TimerEjb");
-            System.out.println("Looked up [" + ejb + "]");
-            ejb.createTimer();
-            System.out.println("createTimer called");
-            Thread.sleep(4000);
-            boolean result = ejb.verifyTimer();
-            System.out.println("EJB timer called: " + result);
-            Assertions.assertTrue(result);
-            System.err.println("TimerEJB successful.");
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
+        InitialContext ic = new InitialContext();
+        TimerEjb ejb = (TimerEjb) ic.lookup("java:global/localejbs/TimerEjb");
+        System.out.println("Looked up [" + ejb + "]");
+        ejb.createTimer();
+        System.out.println("createTimer called");
+        Thread.sleep(4000);
+        boolean result = ejb.verifyTimer();
+        System.out.println("EJB timer called: " + result);
+        assertTrue(result);
+        System.err.println("TimerEJB successful.");
     }
 }

--- a/appserver/tests/embedded/maven-plugin/localejbs/src/main/java/org/glassfish/tests/embedded/localejbs/TesterServlet.java
+++ b/appserver/tests/embedded/maven-plugin/localejbs/src/main/java/org/glassfish/tests/embedded/localejbs/TesterServlet.java
@@ -25,6 +25,9 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+
 /**
  * @author bhavanishankar@dev.java.net
  */

--- a/appserver/tests/embedded/maven-plugin/multipleApps/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
+++ b/appserver/tests/embedded/maven-plugin/multipleApps/src/test/java/org/glassfish/tests/embedded/jsptest/JspTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,11 +24,13 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -42,13 +44,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JspTest {
 
-    private static final int EXPECTED_COUNT = 3;
+    // FIXME: read certificate from truststore.
+    private static final TrustManager[] naiveTrustManager = new TrustManager[]{new X509TrustManager() {
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
 
-    private String contextPath = "test";
+        @Override
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+            return;
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+            return;
+        }
+    }};
 
     @BeforeAll
     public static void createKeyStore() throws Exception {
         // Path matches javax.net.ssl.keyStore in src/test/resources/system.properties.
+        // FIXME: This should be done BEFORE the server started
         File keystore = JUnitSystem.detectBasedir().resolve(Path.of("target", "testkeystore.p12")).toFile();
         KeyTool keyTool = new KeyTool(keystore, KEYSTORE_PASSWORD_DEFAULT.toCharArray());
         keyTool.generateKeyPair("s1as", "CN=localhost", "RSA", 1);
@@ -70,9 +87,9 @@ public class JspTest {
     }
 
     private static void goGet(String url, String result) throws Exception {
-        disableCertValidation();
+        boolean secure = url.startsWith("https");
         URL servlet = URI.create(url).toURL();
-        HttpURLConnection uc = (HttpURLConnection) servlet.openConnection();
+        HttpURLConnection uc = secure ? openHttpsConnection(servlet) : openHttpConnection(servlet);
         try {
             System.out.println("\nURLConnection = " + uc + " : ");
             if (uc.getResponseCode() != 200) {
@@ -97,33 +114,21 @@ public class JspTest {
         }
     }
 
-    public static void disableCertValidation() {
-        // Create a trust manager that does not validate certificate chains
-        TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return null;
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                return;
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                return;
-            }
-        }};
-
-        try {
-            SSLContext sc = SSLContext.getInstance("TLS");
-            sc.init(null, trustAllCerts, new SecureRandom());
-            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-        } catch (Exception e) {
-            return;
-        }
+    private static HttpURLConnection openHttpConnection(URL endpoint) throws Exception {
+        return (HttpURLConnection) endpoint.openConnection();
     }
 
+    private static HttpsURLConnection openHttpsConnection(URL endpoint) throws Exception {
+        HttpsURLConnection uc = (HttpsURLConnection) endpoint.openConnection();
+        uc.setHostnameVerifier((hostname, session) -> true);
+        uc.setSSLSocketFactory(createSocketFactory());
 
+        return uc;
+    }
+
+    private static SSLSocketFactory createSocketFactory() throws GeneralSecurityException {
+        SSLContext sc = SSLContext.getInstance("TLS");
+        sc.init(null, naiveTrustManager, new SecureRandom());
+        return sc.getSocketFactory();
+    }
 }

--- a/appserver/tests/embedded/maven-plugin/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Contributors to the Eclipse Foundation.
+    Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -53,18 +53,15 @@
                 <module>queryString</module>
                 <module>sessionDestroyed</module>
                 <module>standalonewar</module>
-                <!--<module>websockets</module>-->
-                <!--<module>webservice</module>-->
+                <module>websockets</module>
+                <module>webservice</module>
                 <module>secureWebApp</module>
                 <module>jsptest</module>
 
-                <!-- jsftest fails because CDI not available - fixed by adding beans.xml.
-                  Then fails on something else
-                -->
+                <!-- needs add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
 <!--                <module>jsftest</module>-->
-
-                <!-- localejbs only need add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
-                <!--<module>localejbs</module>-->
+                <!-- needs add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
+<!--                <module>localejbs</module>-->
                 <module>multipleApps</module>
             </modules>
         </profile>
@@ -87,12 +84,14 @@
                 <module>queryString</module>
                 <module>sessionDestroyed</module>
                 <module>standalonewar</module>
-                <!--<module>websockets</module>-->
-                <!--<module>webservice</module>-->
+                <module>websockets</module>
+                <module>webservice</module>
                 <module>secureWebApp</module>
                 <module>jsptest</module>
+                <!-- needs add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
 <!--                <module>jsftest</module>-->
-                <module>localejbs</module>
+                <!-- needs add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
+<!--                <module>localejbs</module>-->
                 <module>multipleApps</module>
             </modules>
         </profile>
@@ -115,12 +114,14 @@
                 <module>queryString</module>
                 <module>sessionDestroyed</module>
                 <module>standalonewar</module>
-                <!--<module>websockets</module>-->
-                <!--<module>webservice</module>-->
+                <module>websockets</module>
+                <module>webservice</module>
                 <module>secureWebApp</module>
                 <module>jsptest</module>
+                <!-- needs add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
 <!--                <module>jsftest</module>-->
-                <module>localejbs</module>
+                <!-- needs add-opens=java.base/java.lang=ALL-UNNAMED set in MAVEN_OPTS to pass -->
+<!--                <module>localejbs</module>-->
                 <module>multipleApps</module>
             </modules>
         </profile>

--- a/appserver/tests/embedded/maven-plugin/secureWebApp/src/test/java/org/glassfish/tests/embedded/securewebapp/SecureWebAppTest.java
+++ b/appserver/tests/embedded/maven-plugin/secureWebApp/src/test/java/org/glassfish/tests/embedded/securewebapp/SecureWebAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2025 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -66,6 +66,7 @@ public class SecureWebAppTest {
     @BeforeAll
     public static void createKeyStore() throws Exception {
         // The file is set also in system.properties file
+        // FIXME: This should be done BEFORE the server started
         File keystore = JUnitSystem.detectBasedir().resolve(Path.of("target", "testkeystore.p12")).toFile();
         KeyTool keyTool = new KeyTool(keystore, KEYSTORE_PASSWORD_DEFAULT.toCharArray());
         keyTool.generateKeyPair("s1as", "CN=localhost", "RSA", 1);

--- a/appserver/tests/embedded/maven-plugin/webservice/src/main/java/test/SimpleWebService.java
+++ b/appserver/tests/embedded/maven-plugin/webservice/src/main/java/test/SimpleWebService.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,7 +17,8 @@
 
 package test;
 
-import jakarta.jws.*;
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
 
 @WebService
 public class SimpleWebService {

--- a/appserver/tests/embedded/maven-plugin/webservice/src/test/java/org/glassfish/tests/webservice/WebTest.java
+++ b/appserver/tests/embedded/maven-plugin/webservice/src/test/java/org/glassfish/tests/webservice/WebTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,62 +17,42 @@
 
 package org.glassfish.tests.webservice;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLConnection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class WebTest {
 
-    private static int count = 0;
-    private static int EXPECTED_COUNT = 3;
-
-    private String contextPath = "test";
-
-    @BeforeAll
-    public static void setup() throws IOException {
-    }
-
     @Test
     public void testWeb() throws Exception {
-        goGet("localhost", 8080, "SimpleWebServicePort", contextPath);
+        Assertions.assertTrue(goGet());
     }
 
-    private static void goGet(String host, int port,
-                              String result, String contextPath) throws Exception {
+    private static boolean goGet() throws Exception {
+        URL servlet = URI.create("http://localhost:8080/test/SimpleWebServiceService?wsdl").toURL();
+        HttpURLConnection uc = (HttpURLConnection) servlet.openConnection();
         try {
-            URL servlet = URI.create("http://localhost:8080/test/SimpleWebServiceService?wsdl").toURL();
-            URLConnection yc = servlet.openConnection();
-            BufferedReader in = new BufferedReader(new InputStreamReader(
-                    yc.getInputStream()));
-            String line = null;
-            int index;
-            while ((line = in.readLine()) != null) {
-                System.out.println(line);
-                index = line.indexOf(result);
-                if (index != -1) {
-                    index = line.indexOf(":");
-                    String status = line.substring(index+1);
-
-                    if (status.equalsIgnoreCase("PASS")){
-                        count++;
-                    } else {
-                        return;
+            System.out.println("\nURLConnection = " + uc + " : ");
+            if (uc.getResponseCode() != 200) {
+                throw new Exception("Servlet did not return 200 OK response code");
+            }
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(uc.getInputStream()))) {
+                String line = null;
+                while ((line = in.readLine()) != null) {
+                    System.err.println("RESPONSE LINE: " + line);
+                    if (line.contains("SimpleWebServicePort")) {
+                        return true;
                     }
                 }
             }
-            Assertions.assertTrue(count==3);
-
-        } catch(Exception e) {
-            e.printStackTrace();
-            throw e;
+            return false;
+        } finally {
+            uc.disconnect();
         }
-   }
-
+    }
 }

--- a/appserver/tests/embedded/maven-plugin/websockets/pom.xml
+++ b/appserver/tests/embedded/maven-plugin/websockets/pom.xml
@@ -93,6 +93,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.glassfish.main</groupId>
+            <artifactId>glassfish-jul-extension</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
         </dependency>

--- a/appserver/tests/embedded/maven-plugin/websockets/src/main/java/com/sun/grizzly/samples/websockets/ChatApplication.java
+++ b/appserver/tests/embedded/maven-plugin/websockets/src/main/java/com/sun/grizzly/samples/websockets/ChatApplication.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -11,6 +12,7 @@
 package com.sun.grizzly.samples.websockets;
 
 import java.util.logging.Level;
+
 import org.glassfish.grizzly.http.HttpRequestPacket;
 import org.glassfish.grizzly.websockets.DataFrame;
 import org.glassfish.grizzly.websockets.ProtocolHandler;

--- a/appserver/tests/embedded/maven-plugin/websockets/src/main/java/com/sun/grizzly/samples/websockets/ChatWebSocket.java
+++ b/appserver/tests/embedded/maven-plugin/websockets/src/main/java/com/sun/grizzly/samples/websockets/ChatWebSocket.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -10,12 +11,12 @@
 
 package com.sun.grizzly.samples.websockets;
 
-import org.glassfish.grizzly.websockets.DefaultWebSocket;
-import org.glassfish.grizzly.websockets.WebSocketException;
-
 import java.util.logging.Level;
+
 import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.websockets.DefaultWebSocket;
 import org.glassfish.grizzly.websockets.ProtocolHandler;
+import org.glassfish.grizzly.websockets.WebSocketException;
 import org.glassfish.grizzly.websockets.WebSocketListener;
 
 public class ChatWebSocket extends DefaultWebSocket {

--- a/appserver/tests/embedded/maven-plugin/websockets/src/main/java/com/sun/grizzly/samples/websockets/WebSocketsServlet.java
+++ b/appserver/tests/embedded/maven-plugin/websockets/src/main/java/com/sun/grizzly/samples/websockets/WebSocketsServlet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -10,12 +11,13 @@
 
 package com.sun.grizzly.samples.websockets;
 
-import org.glassfish.grizzly.websockets.WebSocketEngine;
-
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
+
 import java.util.logging.Logger;
+
+import org.glassfish.grizzly.websockets.WebSocketEngine;
 
 public class WebSocketsServlet extends HttpServlet {
     static final Logger logger = Logger.getLogger(WebSocketsServlet.class.getName());

--- a/appserver/tests/embedded/maven-plugin/websockets/src/test/java/org/glassfish/tests/standalonewar/WebTest.java
+++ b/appserver/tests/embedded/maven-plugin/websockets/src/test/java/org/glassfish/tests/standalonewar/WebTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2023, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,17 +19,16 @@ package org.glassfish.tests.standalonewar;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLConnection;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class WebTest {
 
-    private static int count = 0;
     private static int EXPECTED_COUNT = 3;
 
     private String contextPath = "test";
@@ -40,31 +39,26 @@ public class WebTest {
 
     @Test
     public void testWeb() throws Exception {
-        goGet("localhost", 8080, "Please input your name", contextPath);
+        Assertions.assertTrue(goGet());
     }
 
-    private static void goGet(String host, int port,
-            String result, String contextPath) throws Exception {
+    private static boolean goGet() throws Exception {
         URL servlet = URI.create("http://localhost:8080/test").toURL();
-        URLConnection yc = servlet.openConnection();
-        BufferedReader in = new BufferedReader(new InputStreamReader(
-                yc.getInputStream()));
-        String line = null;
-        int index;
-        while ((line = in.readLine()) != null) {
-            index = line.indexOf(result);
-            if (index != -1) {
-                index = line.indexOf(":");
-                String status = line.substring(index + 1);
-
-                if (status.equalsIgnoreCase("PASS")) {
-                    count++;
-                } else {
-                    break;
+        HttpURLConnection uc = (HttpURLConnection) servlet.openConnection();
+        try {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(uc.getInputStream()))) {
+                String line = null;
+                int index;
+                while ((line = in.readLine()) != null) {
+                    System.err.println("RESPONSE LINE: " + line);
+                    if (line.contains("Please input your name:")) {
+                        return true;
+                    }
                 }
             }
+            return false;
+        } finally {
+            uc.disconnect();
         }
-        MatcherAssert.assertThat(count, CoreMatchers.is(3));
     }
-
 }

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -94,5 +94,66 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <!-- FIXME: The egf plugin doesn't do a proper cleanup, so we have to do that manually -->
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>5.1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                        <version>5.0.7</version>
+                        <scope>runtime</scope>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <!-- To download the plugin before the usage + to log current state. -->
+                    <execution>
+                        <id>list-properties</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <includeClasspath>PLUGIN_ONLY</includeClasspath>
+                            <scripts>
+                                <script>
+                                System.getProperties().sort().each { key, value -> println "${key} = ${value}" }
+                                </script>
+                            </scripts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>clear-properties</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <scripts>
+                                <script>
+                                System.getProperties().sort().each { key, value -> println "${key} = ${value}" }
+                                System.clearProperty('catalina.home')
+                                System.clearProperty('catalina.base')
+                                System.clearProperty('com.sun.aas.instanceRoot')
+                                System.clearProperty('com.sun.aas.instanceRootURI')
+                                System.clearProperty('com.sun.aas.installRoot')
+                                System.clearProperty('com.sun.aas.installRootURI')
+                                System.clearProperty('javax.net.ssl.keyStore')
+                                System.clearProperty('javax.net.ssl.trustStore')
+                                System.clearProperty('javax.net.ssl.keyStoreType')
+                                System.clearProperty('javax.net.ssl.trustStoreType')
+                                System.clearProperty('javax.net.ssl.keyStoreProvider')
+                                System.clearProperty('javax.net.ssl.trustStoreProvider')
+                                System.clearProperty('org.glassfish.embedded.greeting')
+                                </script>
+                            </scripts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/appserver/tests/embedded/web/autodelete/pom.xml
+++ b/appserver/tests/embedded/web/autodelete/pom.xml
@@ -73,10 +73,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.70.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/appserver/tests/embedded/web/pom.xml
+++ b/appserver/tests/embedded/web/pom.xml
@@ -36,14 +36,4 @@
         <module>web-api</module>
         <module>servlet</module>
     </modules>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>3.0</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/appserver/tests/embedded/web/servlet/pom.xml
+++ b/appserver/tests/embedded/web/servlet/pom.xml
@@ -70,10 +70,8 @@
             <artifactId>hamcrest</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.70.0</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/appserver/tests/embedded/web/servlet/src/test/java/org/glassfish/tests/embedded/web/servlet/WebClientITest.java
+++ b/appserver/tests/embedded/web/servlet/src/test/java/org/glassfish/tests/embedded/web/servlet/WebClientITest.java
@@ -17,9 +17,8 @@
 
 package org.glassfish.tests.embedded.web.servlet;
 
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.WebClient;
-
+import org.htmlunit.Page;
+import org.htmlunit.WebClient;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.startsWith;

--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -36,10 +36,7 @@
         <maven.executable>${maven.home}/bin/mvn</maven.executable>
         <maven.settings.xml>${user.home}/.m2/settings.xml</maven.settings.xml>
 
-        <!-- FIXME:
-        https://github.com/jakartaee/authentication/pull/242
-        -->
-        <tck.version>3.1.0-SNAPSHOT</tck.version>
+        <tck.version>3.1.2</tck.version>
         <tck.artifactId>tck-authentication-download</tck.artifactId>
         <tck.home>${project.build.directory}/authentication-tck-${tck.version}</tck.home>
         <tck.parentPomFile>${tck.home}/tck/pom.xml</tck.parentPomFile>

--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -152,7 +152,6 @@
         <dependency>
             <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>4.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/tck-download/authentication/pom.xml
+++ b/appserver/tests/tck/tck-download/authentication/pom.xml
@@ -32,7 +32,7 @@
     <name>TCK Download: Install Jakarta Authentication</name>
 
     <properties>
-        <tck.artifactFileName>jakarta-authentication-tck-3.1.1.zip</tck.artifactFileName>
+        <tck.artifactFileName>jakarta-authentication-tck-3.1.2.zip</tck.artifactFileName>
         <tck.artifactUrl>https://download.eclipse.org/jakartaee/authentication/3.1/${tck.artifactFileName}</tck.artifactUrl>
     </properties>
 

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -824,6 +824,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+                <version>5.3.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
                 <version>${easymock.version}</version>


### PR DESCRIPTION
Jenkins now blocks merging PRs, doing releases, etc. It fails to upload results for unknown reason.

### Cause

* Embedded GlassFish doesn't do cleanup of JVM options and global classes. 
* Embedded GlassFish Maven Plugin 5.1 runs inside Maven's JVM, including Embedded GlassFish.
* When some module tried to download anything from Eclipse Maven Central Mirror using https, it failed, because the EGF truststore set by tests was not useful for this purpose.
* When we started having issues with Jenkins, I deleted the maven cache.

### Changes

* Added printing system properties before and after the test (just in embedded-tests)
* Added clearing of some limited set of properties added by tests or embedded gf.
* Updated html unit
* Updated Maven used in Jenkinsfile
* Removed CleanWs call from Jenkinsfile
* Fixed prog-auth tests (executed by Ant which ignores failures)
* Fixed few commented out tests

### See Also
* https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/work_items/7610
* #26146 
