### PR TITLE
Updated parent, plugins and dependencies

### DIFF
--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -75,14 +75,14 @@
 
         <!-- MicroProfile Config -->
         <microprofile.config-api.version>3.1.1</microprofile.config-api.version>
-        <helidon-config.version>4.4.1</helidon-config.version>
+        <helidon-config.version>4.5.1</helidon-config.version>
 
 
         <!-- MicroProfile Health -->
         <microprofile.health-api.version>4.0.1</microprofile.health-api.version>
 
         <!-- MicroProfile JWT / JWT Authentication Mechanism for Jakarta Security -->
-        <microprofile-jwt-auth-api.version>2.1</microprofile-jwt-auth-api.version>
+        <microprofile-jwt-auth-api.version>2.2</microprofile-jwt-auth-api.version>
         <omnifaces-jwt-auth.version>3.0.1</omnifaces-jwt-auth.version>
 
         <!-- MicroProfile REST Client -->
@@ -428,7 +428,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.22.0</version>
+                <version>1.22.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/appserver/tests/application-tests/pom.xml
+++ b/appserver/tests/application-tests/pom.xml
@@ -43,8 +43,6 @@
         <glassfish.home>${glassfish.root}/${glassfish.directoryName}</glassfish.home>
 
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>
-
-        <omnifish.arquillian.version>2.2.0</omnifish.arquillian.version>
     </properties>
 
     <dependencyManagement>
@@ -61,14 +59,14 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.10.2.Final</version>
+                <version>${jboss.arquillian.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.junit5</groupId>
                 <artifactId>arquillian-junit5-container</artifactId>
-                <version>1.10.2.Final</version>
+                <version>${jboss.arquillian.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/appserver/tests/application/pom.xml
+++ b/appserver/tests/application/pom.xml
@@ -159,7 +159,7 @@
             <plugin>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-maven-plugin</artifactId>
-                <version>4.0.4</version>
+                <version>4.0.5</version>
                 <executions>
                     <execution>
                         <id>jaxws-generate</id>

--- a/appserver/tests/appserv-tests/lib/pom.xml
+++ b/appserver/tests/appserv-tests/lib/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.3.6</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/appserver/tests/jdbc/pom.xml
+++ b/appserver/tests/jdbc/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.dbunit</groupId>
             <artifactId>dbunit</artifactId>
-            <version>3.2.0</version>
+            <version>3.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.11</version>
+            <version>42.7.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/appserver/tests/pom.xml
+++ b/appserver/tests/pom.xml
@@ -34,6 +34,12 @@
 
     <name>GlassFish Tests</name>
 
+    <properties>
+        <omnifish.arquillian.version>2.2.1</omnifish.arquillian.version>
+        <jboss.arquillian.version>1.10.2.Final</jboss.arquillian.version>
+        <jakarta.arquillian.version>10.0.0.Final</jakarta.arquillian.version>
+    </properties>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -105,7 +111,7 @@
                     <dependency>
                         <groupId>org.apache.groovy</groupId>
                         <artifactId>groovy</artifactId>
-                        <version>5.0.7</version>
+                        <version>5.0.8</version>
                         <scope>runtime</scope>
                     </dependency>
                 </dependencies>

--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -206,7 +206,7 @@
                     <dependency>
                         <groupId>com.beust</groupId>
                         <artifactId>jcommander</artifactId>
-                        <version>1.72</version>
+                        <version>1.82</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/appserver/tests/quicklook/pom.xml
+++ b/appserver/tests/quicklook/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
         <relativePath />
     </parent>
 

--- a/appserver/tests/tck/authentication/pom.xml
+++ b/appserver/tests/tck/authentication/pom.xml
@@ -131,7 +131,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -143,7 +142,7 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-legacy</artifactId>
-            <version>2.10.3</version>
+            <version>2.13.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/authorization/pom.xml
+++ b/appserver/tests/tck/authorization/pom.xml
@@ -125,12 +125,11 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.21.1</version>
+            <version>1.23.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.6</version>
         </dependency>
     </dependencies>
 

--- a/appserver/tests/tck/cdi/cdi-full/pom.xml
+++ b/appserver/tests/tck/cdi/cdi-full/pom.xml
@@ -228,7 +228,7 @@
         <dependency>
             <groupId>org.jcommander</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.83</version>
+            <version>1.85</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/concurrency/pom.xml
+++ b/appserver/tests/tck/concurrency/pom.xml
@@ -56,13 +56,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/connectors/pom.xml
+++ b/appserver/tests/tck/connectors/pom.xml
@@ -36,8 +36,9 @@
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         <whitebox.directory>${project.build.directory}/whiteboxes</whitebox.directory>
 
-        <tck.version>11.0.1</tck.version>
-        <tck.arquillian.version>11.1.0</tck.arquillian.version>
+        <tck.version>11.0.3</tck.version>
+        <tck.common.version>11.1.1</tck.common.version>
+        <tck.arquillian.version>11.1.3</tck.arquillian.version>
         <tck.test.user1>j2ee</tck.test.user1>
         <tck.test.user2>javajoe</tck.test.user2>
         <tck.reportDirectory>${project.build.directory}/report</tck.reportDirectory>
@@ -69,7 +70,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${tck.arquillian.version}</version>
+            <version>${tck.common.version}</version>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>
@@ -123,7 +124,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/data/pom.xml
+++ b/appserver/tests/tck/data/pom.xml
@@ -76,13 +76,6 @@
                 <version>${jakarta.data.tck.version}</version>
             </dependency>
 
-            <!-- Signature Test Plugin -->
-            <dependency>
-                <groupId>jakarta.tck</groupId>
-                <artifactId>sigtest-maven-plugin</artifactId>
-                <version>2.6</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>

--- a/appserver/tests/tck/enterprise-beans/pom.xml
+++ b/appserver/tests/tck/enterprise-beans/pom.xml
@@ -39,7 +39,8 @@
         <derby.lib>${glassfish.home}/javadb/lib</derby.lib>
 
         <tck.version>11.0.1</tck.version>
-        <tck.arquillian.version>11.1.0</tck.arquillian.version>
+        <tck.common.version>11.1.1</tck.common.version>
+        <tck.arquillian.version>11.1.3</tck.arquillian.version>
         <tck.test.user1>j2ee</tck.test.user1>
         <tck.test.user2>javajoe</tck.test.user2>
         <tck.certificatesDirectory>${project.build.directory}/certificates</tck.certificatesDirectory>
@@ -103,7 +104,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${tck.arquillian.version}</version>
+            <version>${tck.common.version}</version>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>

--- a/appserver/tests/tck/expression-language/pom.xml
+++ b/appserver/tests/tck/expression-language/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/faces/pom.xml
+++ b/appserver/tests/tck/faces/pom.xml
@@ -38,7 +38,7 @@
         <faces.tck.version>4.1.1</faces.tck.version>
         <tck.root>${project.build.directory}</tck.root>
         <tck.parentPomFile>${tck.root}/faces-tck-${faces.tck.version}/tck/pom.xml</tck.parentPomFile>
-        <selenium.version>4.20.0</selenium.version>
+        <selenium.version>4.22.0</selenium.version>
     </properties>
 
     <dependencyManagement>

--- a/appserver/tests/tck/glassfish-runner/pom.xml
+++ b/appserver/tests/tck/glassfish-runner/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>11.1.0</version>
+            <version>11.1.3</version>
         </dependency>
 
         <dependency>

--- a/appserver/tests/tck/jsonp/pom.xml
+++ b/appserver/tests/tck/jsonp/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main</groupId>

--- a/appserver/tests/tck/microprofile/config/pom.xml
+++ b/appserver/tests/tck/microprofile/config/pom.xml
@@ -28,12 +28,12 @@
 
     <artifactId>glassfish-external-tck-microprofile-config</artifactId>
     <name>TCK: MicroProfile Config</name>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-tck</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/appserver/tests/tck/microprofile/health/pom.xml
+++ b/appserver/tests/tck/microprofile/health/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.19.2</version>
+            <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/tck/microprofile/jwt/pom.xml
+++ b/appserver/tests/tck/microprofile/jwt/pom.xml
@@ -30,7 +30,7 @@
     <artifactId>glassfish-external-tck-microprofile-jwt</artifactId>
     <name>TCK: MicroProfile JWT</name>
     <description>Aggregates dependencies and runs the MicroProfile JWT TCK</description>
-    
+
     <properties>
         <!-- Needed in PublicKeyAsJWKLocationURLTest.createLocationURLDeployment() which cannot use regular injection -->
         <glassfish.httpPort>8080</glassfish.httpPort>
@@ -42,14 +42,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <!-- This is the actual MP-JWT TCK test classes archive -->
         <dependency>
             <groupId>org.eclipse.microprofile.jwt</groupId>
             <artifactId>microprofile-jwt-auth-tck</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <classifier>tests</classifier>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/microprofile/rest-client/pom.xml
+++ b/appserver/tests/tck/microprofile/rest-client/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.13.1</version>
+            <version>3.13.2</version>
             <!-- Requirement of the wiremock plugin -->
             <scope>compile</scope>
         </dependency>
@@ -156,7 +156,7 @@
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
                     </dependenciesToScan>
-                
+
                     <systemPropertyVariables>
                         <!-- A workaround for the ConfigKeyForMultipleInterfacesTest -->
                         <ee.omnifish.arquillian.prependDeploySequence>true</ee.omnifish.arquillian.prependDeploySequence>

--- a/appserver/tests/tck/mvc/pom.xml
+++ b/appserver/tests/tck/mvc/pom.xml
@@ -19,7 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
- 
+
     <parent>
         <groupId>org.glassfish.main.tests.tck</groupId>
         <artifactId>tck</artifactId>
@@ -55,14 +55,14 @@
         <dependency>
             <groupId>jakarta.mvc.tck</groupId>
             <artifactId>mvc-tck-api</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.mvc.tck</groupId>
             <artifactId>mvc-tck-tests</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -71,12 +71,12 @@
             <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.glassfish.main</groupId>
             <artifactId>glassfish-jul-extension</artifactId>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-depchain</artifactId>
-            <version>3.3.4</version>
+            <version>3.3.7</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>

--- a/appserver/tests/tck/pages/pom.xml
+++ b/appserver/tests/tck/pages/pom.xml
@@ -104,7 +104,6 @@ mvn clean install -Ptck -pl :jakarta-pages-tck,:javatest,:glassfish-external-tck
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/pom.xml
+++ b/appserver/tests/tck/pom.xml
@@ -85,8 +85,6 @@
         <port.orb.mutual>13920</port.orb.mutual>
         <port.orb.ssl>13820</port.orb.ssl>
         <port.harness.log>12000</port.harness.log>
-
-        <omnifish.arquillian.version>2.1.3</omnifish.arquillian.version>
     </properties>
 
     <dependencyManagement>
@@ -96,6 +94,12 @@
                 <artifactId>glassfish</artifactId>
                 <version>${glassfish.version}</version>
                 <type>zip</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>2.7</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -138,13 +142,13 @@
             <dependency>
                 <groupId>org.jboss.arquillian.protocol</groupId>
                 <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-                <version>10.0.0.Final</version>
+                <version>${jakarta.arquillian.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian.junit5</groupId>
                 <artifactId>arquillian-junit5-container</artifactId>
-                <version>1.10.1.Final</version>
+                <version>${jboss.arquillian.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -161,7 +165,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.10.1.Final</version>
+                <version>${jboss.arquillian.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/appserver/tests/tck/rest/pom.xml
+++ b/appserver/tests/tck/rest/pom.xml
@@ -67,7 +67,7 @@ mvn clean install -Dgroups=security
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <tck.version>4.0.0</tck.version>
+        <tck.version>4.0.1</tck.version>
 
         <glassfish.version>${project.version}</glassfish.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
@@ -94,9 +94,8 @@ mvn clean install -Dgroups=security
             <artifactId>arquillian-junit5-container</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/appserver/tests/tck/servlet/pom.xml
+++ b/appserver/tests/tck/servlet/pom.xml
@@ -86,7 +86,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appserver/tests/tck/websocket/pom.xml
+++ b/appserver/tests/tck/websocket/pom.xml
@@ -105,9 +105,8 @@ mvn clean install -Drun.test="WebSocketSigTestIT#signatureTest" -Dglassfish.susp
         </dependency>
 
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
 
         <dependency>

--- a/appserver/tests/v2-tests/appserv-tests/util/reportbuilder/pom.xml
+++ b/appserver/tests/v2-tests/appserv-tests/util/reportbuilder/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.devtests</groupId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -101,7 +101,7 @@
         <jakarta.xml.ws-api.version>4.0.3</jakarta.xml.ws-api.version>
 
         <!-- Jakarta SOAP (with Attachments) -->
-        <webservices.version>4.0.6</webservices.version>
+        <webservices.version>4.0.7</webservices.version>
 
         <!-- Jakarta Inject -->
         <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
@@ -123,7 +123,7 @@
 
         <!-- Jakarta Persistence -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-        <eclipselink.version>5.0.0</eclipselink.version>
+        <eclipselink.version>5.0.1</eclipselink.version>
         <eclipselink.asm.version>9.10.0</eclipselink.asm.version>
 
         <!-- Jakarta Mail -->
@@ -139,7 +139,7 @@
 
         <!-- Jakarta Faces -->
         <jakarta.faces-api.version>4.1.2</jakarta.faces-api.version>
-        <mojarra.version>4.1.9</mojarra.version>
+        <mojarra.version>4.1.12</mojarra.version>
 
         <!-- Jakarta WebSocket -->
         <jakarta.websocket-api.version>2.2.0</jakarta.websocket-api.version>
@@ -171,7 +171,7 @@
         <jakarta.data.spec.version>1.0</jakarta.data.spec.version>
         <jakarta.nosql-api.version>1.0.1</jakarta.nosql-api.version>
         <jakarta.nosql.spec.version>1.0.1</jakarta.nosql.spec.version>
-        <jnosql.version>1.1.14</jnosql.version>
+        <jnosql.version>1.1.15</jnosql.version>
 
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
@@ -204,7 +204,7 @@
 
         <!-- Jakarta SOAP (XML Web Services) -->
         <xmlsec.version>4.0.4</xmlsec.version>
-        <woodstox.version>7.2.0</woodstox.version>
+        <woodstox.version>7.2.1</woodstox.version>
         <stax2-api.version>4.3.0</stax2-api.version>
 
         <!-- GlassFish Components -->
@@ -230,9 +230,9 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <jboss.logging.annotation.version>3.0.4.Final</jboss.logging.annotation.version>
         <jboss.logging.version>3.6.3.Final</jboss.logging.version>
-        <javassist.version>3.31.0-GA</javassist.version>
+        <javassist.version>3.32.0-GA</javassist.version>
         <asm.version>9.10.1</asm.version>
-        <jsch.version>2.28.2</jsch.version>
+        <jsch.version>2.28.6</jsch.version>
         <antlr2.version>2.7.7</antlr2.version>
         <antlr2-repackaged.version>2.7.8</antlr2-repackaged.version>
         <antlr4.version>4.13.2</antlr4.version>
@@ -243,15 +243,15 @@
         <jackson-annotations.version>2.22</jackson-annotations.version>
         <fasterxml.classmate.version>1.7.3</fasterxml.classmate.version>
         <stax-api.version>1.0-2</stax-api.version>
-        <jettison.version>1.5.5</jettison.version>
+        <jettison.version>1.5.7</jettison.version>
         <mimepull.version>1.11.0</mimepull.version>
-        <jna.version>5.19.0</jna.version>
-        <jline.version>4.1.3</jline.version>
+        <jna.version>5.19.1</jna.version>
+        <jline.version>4.3.1</jline.version>
 
         <replacer.plugin.version>1.5.3</replacer.plugin.version>
 
         <easymock.version>5.6.0</easymock.version>
-        <junit.version>6.1.0</junit.version>
+        <junit.version>6.1.2</junit.version>
         <jmh.version>1.37</jmh.version>
         <osgi-resource-locator.version>3.0.0</osgi-resource-locator.version>
         <slf4j.version>2.0.18</slf4j.version>
@@ -1192,7 +1192,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>13.5.0</version>
+                            <version>13.9.0</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -1986,6 +1986,10 @@
                                                 <ignoreVersion>
                                                     <type>regex</type>
                                                     <version>.*-M.*</version>
+                                                </ignoreVersion>
+                                                <ignoreVersion>
+                                                    <type>regex</type>
+                                                    <version>.*payara.*</version>
                                                 </ignoreVersion>
                                             </ignoreVersions>
                                         </rule>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -1001,7 +1001,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>6.1.0</version>
+                    <version>6.0.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
         <relativePath />
     </parent>
 
@@ -266,7 +266,6 @@
         <project.build.commonResourcesDirectory>${project.build.directory}/common-resources</project.build.commonResourcesDirectory>
         <legal.doc.source>${project.build.commonResourcesDirectory}/legal</legal.doc.source>
         <nucleus.install.dir.name>nucleus</nucleus.install.dir.name>
-        <cyclonedx.skip>true</cyclonedx.skip>
         <javadoc.skip>false</javadoc.skip>
         <deploy.skip>false</deploy.skip>
 
@@ -1002,7 +1001,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>6.0.2</version>
+                    <version>6.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
@@ -1233,7 +1232,7 @@
                 <plugin>
                     <groupId>org.cyclonedx</groupId>
                     <artifactId>cyclonedx-maven-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>2.9.3</version>
                 </plugin>
                 <plugin>
                     <groupId>io.github.download-maven-plugin</groupId>
@@ -1269,7 +1268,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.7.3</version>
+                    <version>1.8.0</version>
                     <configuration>
                         <updatePomFile>true</updatePomFile>
                         <flattenedPomFilename>${project.build.directory}/flattened-pom.xml</flattenedPomFilename>
@@ -1332,7 +1331,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -2511,7 +2510,6 @@
                 <release.projectName>Eclipse GlassFish</release.projectName>
                 <release.autoPublish>false</release.autoPublish>
                 <release.waitUntil>published</release.waitUntil>
-                <cyclonedx.skip>false</cyclonedx.skip>
             </properties>
         </profile>
         <profile>
@@ -2552,7 +2550,7 @@
             <id>jacoco</id>
             <properties>
                 <jacoco.report.outputDirectory>${project.build.directory}/jacoco</jacoco.report.outputDirectory>
-                <jacoco.version>0.8.14</jacoco.version>
+                <jacoco.version>0.8.15</jacoco.version>
                 <maven.test.failure.ignore>true</maven.test.failure.ignore>
                 <surefire.argLine>${maven.test.jvmoptions} @{argLine}</surefire.argLine>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
         <relativePath />
     </parent>
 
@@ -76,7 +76,7 @@
                 <plugin>
                     <groupId>org.cyclonedx</groupId>
                     <artifactId>cyclonedx-maven-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>2.9.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -173,22 +173,6 @@
         </profile>
 
         <!--
-        Override cyclonedx skip
-        -->
-        <profile>
-            <id>oss-release</id>
-            <properties>
-                <cyclonedx.skip>false</cyclonedx.skip>
-            </properties>
-            <modules>
-                <module>qa</module>
-                <module>nucleus</module>
-                <module>appserver</module>
-                <module>docs</module>
-            </modules>
-        </profile>
-
-        <!--
         Merges all exec files in the directory tree - useful when you want to se the code coverage
         produced by integration tests executed by different modules, or exactly opposite - to see
         not covered by tests at all.
@@ -200,7 +184,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.14</version>
+                        <version>0.8.15</version>
                         <executions>
                             <execution>
                                 <id>jacoco-merge</id>

--- a/qa/src/main/resources/org/glassfish/qa/config/checkstyle/checkstyle.xml
+++ b/qa/src/main/resources/org/glassfish/qa/config/checkstyle/checkstyle.xml
@@ -63,10 +63,6 @@
             <property name="severity" value="warning" />
             <property name="accessModifiers" value="public, protected" />
         </module>
-        <module name="JavadocStyle">
-            <property name="checkFirstSentence" value="false" />
-            <property name="severity" value="warning" />
-        </module>
         <module name="JavadocType">
             <property name="severity" value="warning" />
         </module>


### PR DESCRIPTION
Links to release notes:

* https://checkstyle.org/releasenotes.html
* https://github.com/eclipse-ee4j/metro-wsit/releases/tag/4.0.7
* https://github.com/eclipse-ee4j/ee4j/compare/2.0.4...2.0.5
* https://github.com/helidon-io/helidon/releases/tag/4.5.1
* https://commons.apache.org/proper/commons-codec/changes.html#a1.22.1
* https://github.com/eclipse-ee4j/eclipselink/releases/tag/5.0.1
* https://github.com/eclipse-ee4j/mojarra/releases (4.1.9 -> 4.1.12)
* https://github.com/eclipse-jnosql/jnosql/releases/tag/1.1.15
* https://github.com/FasterXML/woodstox/compare/woodstox-core-7.2.0...woodstox-core-7.2.1
* https://github.com/jboss-javassist/javassist/releases/tag/rel_3_32_0_ga
* https://github.com/mwiede/jsch/releases (2.28.2 -> 2.28.6)
* https://github.com/jettison-json/jettison/releases (1.5.5 -> 1.5.7)
* https://github.com/java-native-access/jna/compare/5.19.0...5.19.1
* JLine
  * https://github.com/jline/jline3/releases#release-4.3.0
  * https://github.com/jline/jline3/releases#release-4.3.1
  * https://github.com/jline/jline3/releases#release-4.2.1
  * https://github.com/jline/jline3/releases#release-4.2.0
* https://github.com/CycloneDX/cyclonedx-maven-plugin/releases (2.9.1 -> 2.9.3)

Test Dependencies:

* https://github.com/jacoco/jacoco/releases/tag/v0.8.15
* https://docs.junit.org/6.1.2/release-notes.html (6.1.0 -> 6.1.2)
* Small sync in TCK dependencies, I will not elaborate here as it needs to be finished via #25896

Maven Plugins:

* https://github.com/mojohaus/flatten-maven-plugin/releases/tag/1.8.0
* https://github.com/apache/maven-jar-plugin/releases/tag/maven-jar-plugin-3.5.1

Not updated:

* hibernate-validator after 7.0.0 cause race conditions in initialization with random exceptions, usually missing osgi or jakarta el. See https://github.com/eclipse-ee4j/glassfish/issues/26160 .