### PR TITLE
Fixed #26004 - Felix plugin knows well what to do

### DIFF
--- a/appserver/grizzly/glassfish-grizzly-extra-all/pom.xml
+++ b/appserver/grizzly/glassfish-grizzly-extra-all/pom.xml
@@ -112,12 +112,12 @@
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            org.glassfish.grizzly.comet.*;version=${grizzly.version},
-                            org.glassfish.grizzly.websockets.*;version=${grizzly.version},
-                            org.glassfish.grizzly.http.ajp.*;version=${grizzly.version},
-                            org.glassfish.grizzly.servlet.*;version=${grizzly.version},
-                            org.glassfish.grizzly.extras.*;version=${project.version},
-                            org.glassfish.extras.grizzly.*;version=${project.version}
+                            org.glassfish.grizzly.comet.*,
+                            org.glassfish.grizzly.websockets.*,
+                            org.glassfish.grizzly.http.ajp.*,
+                            org.glassfish.grizzly.servlet.*,
+                            org.glassfish.grizzly.extras.*,
+                            org.glassfish.extras.grizzly.*
                         </Export-Package>
                         <Import-Package>*</Import-Package>
                         <Include-Resource>META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/</Include-Resource>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -2423,6 +2423,7 @@
                         <_include>-osgi.bundle</_include>
                         <_noimportjava>true</_noimportjava>
                         <_runee>JavaSE-21</_runee>
+                        <_fixupmessages>"Version for package * is set to different values in the source *";restrict:=warning;is:=error</_fixupmessages>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- original state had problems with -Dgrizzly.version=5.0.3-SNAPSHOT and also for own project used 8.0.4.SNAPSHOT
- second commit requalifies this bnd warning to an error which fails the build then.

Closes #26004 

Test of the validation - when I revert the first commit:
```
mvn clean install -pl :glassfish-grizzly-extra-all -Dgrizzly.version=5.0.3-SNAPSHOT
[INFO] Scanning for projects...
...
[INFO] --- bundle:6.0.2:bundle (bundle) @ glassfish-grizzly-extra-all ---
[WARNING] Include-Resource: overriding META-INF/LICENSE.md=target/common-resources/legal/LICENSE.md,META-INF/NOTICE.md=target/common-resources/legal/NOTICE.md with META-INF/hk2-locator/=target/classes/META-INF/hk2-locator/ (add {maven-resources} if you want to include the maven resources)
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.comet is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.comet.concurrent is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.websockets is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.websockets.frametypes is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.websockets.glassfish is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.websockets.rfc6455 is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.http.ajp is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.grizzly.servlet is set to different values in the source (5.0.3-SNAPSHOT) and in the manifest (5.0.3). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Bundle org.glassfish.main.grizzly:glassfish-grizzly-extra-all:jar:8.0.4-SNAPSHOT : Version for package org.glassfish.extras.grizzly is set to different values in the source (8.0.4-SNAPSHOT) and in the manifest (8.0.4). The version in the manifest is not picked up by an other sibling bundles in this project or projects that directly depend on this project
[ERROR] Error(s) found in bundle configuration
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.646 s
[INFO] Finished at: 2026-08-02T22:49:19+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.felix:maven-bundle-plugin:6.0.2:bundle (bundle) on project glassfish-grizzly-extra-all: Error(s) found in bundle configuration -> [Help 1]
```

New exports in the manifest file:
```
Export-Package
org.glassfish.extras.grizzly;version="8.0.4";uses:="org.glassfish.api.container,org.glassfish.api.deployment,org.glassfish.api.deployment.archive,org.glassfish.grizzly.http.server,org.glassfish.internal.deployment,org.jvnet.hk2.annotations"
org.glassfish.grizzly.comet.concurrent;version="5.0.3";uses:="org.glassfish.grizzly.comet,org.glassfish.grizzly.http.server"
org.glassfish.grizzly.comet;version="5.0.3";uses:="org.glassfish.grizzly.filterchain,org.glassfish.grizzly.http.server"
org.glassfish.grizzly.extras.addons;uses:="org.glassfish.grizzly.comet,org.glassfish.grizzly.config,org.glassfish.grizzly.config.dom,org.glassfish.grizzly.http.ajp,org.glassfish.grizzly.http.server,org.glassfish.grizzly.websockets,org.glassfish.hk2.api,org.jvnet.hk2.annotations,org.jvnet.hk2.config";version="8.0.4"
org.glassfish.grizzly.http.ajp;version="5.0.3";uses:="org.glassfish.grizzly,org.glassfish.grizzly.filterchain,org.glassfish.grizzly.http,org.glassfish.grizzly.http.server,org.glassfish.grizzly.http.util"
org.glassfish.grizzly.servlet;version="5.0.3";uses:="jakarta.servlet,jakarta.servlet.descriptor,jakarta.servlet.http,org.glassfish.grizzly.http,org.glassfish.grizzly.http.server,org.glassfish.grizzly.http.server.util,org.glassfish.grizzly.utils"
org.glassfish.grizzly.websockets.frametypes;version="5.0.3";uses:="org.glassfish.grizzly.websockets"
org.glassfish.grizzly.websockets.glassfish;version="5.0.3";uses:="jakarta.servlet.http,org.glassfish.grizzly.http.server"
org.glassfish.grizzly.websockets.rfc6455;version="5.0.3";uses:="org.glassfish.grizzly,org.glassfish.grizzly.http,org.glassfish.grizzly.websockets"
org.glassfish.grizzly.websockets;version="5.0.3";uses:="jakarta.servlet.http,org.glassfish.grizzly,org.glassfish.grizzly.filterchain,org.glassfish.grizzly.http,org.glassfish.grizzly.http.server,org.glassfish.grizzly.http.server.util,org.glassfish.grizzly.http.util"
```

Old version:
```
Export-Package
org.glassfish.extras.grizzly;version="8.0.4.SNAPSHOT";uses:="org.glassfish.api.container,org.glassfish.api.deployment,org.glassfish.api.deployment.archive,org.glassfish.grizzly.http.server,org.glassfish.internal.deployment,org.jvnet.hk2.annotations"
org.glassfish.grizzly.comet.concurrent;version="5.0.3.SNAPSHOT";uses:="org.glassfish.grizzly.comet,org.glassfish.grizzly.http.server"
org.glassfish.grizzly.comet;version="5.0.3.SNAPSHOT";uses:="org.glassfish.grizzly.filterchain,org.glassfish.grizzly.http.server"
org.glassfish.grizzly.extras.addons;version="8.0.4.SNAPSHOT";uses:="org.glassfish.grizzly.comet,org.glassfish.grizzly.config,org.glassfish.grizzly.config.dom,org.glassfish.grizzly.http.ajp,org.glassfish.grizzly.http.server,org.glassfish.grizzly.websockets,org.glassfish.hk2.api,org.jvnet.hk2.annotations,org.jvnet.hk2.config"
org.glassfish.grizzly.http.ajp;version="5.0.3.SNAPSHOT";uses:="org.glassfish.grizzly,org.glassfish.grizzly.filterchain,org.glassfish.grizzly.http,org.glassfish.grizzly.http.server,org.glassfish.grizzly.http.util"
org.glassfish.grizzly.servlet;version="5.0.3.SNAPSHOT";uses:="jakarta.servlet,jakarta.servlet.descriptor,jakarta.servlet.http,org.glassfish.grizzly.http,org.glassfish.grizzly.http.server,org.glassfish.grizzly.http.server.util,org.glassfish.grizzly.utils"
org.glassfish.grizzly.websockets.frametypes;version="5.0.3.SNAPSHOT";uses:="org.glassfish.grizzly.websockets"
org.glassfish.grizzly.websockets.glassfish;version="5.0.3.SNAPSHOT";uses:="jakarta.servlet.http,org.glassfish.grizzly.http.server"
org.glassfish.grizzly.websockets.rfc6455;version="5.0.3.SNAPSHOT";uses:="org.glassfish.grizzly,org.glassfish.grizzly.http,org.glassfish.grizzly.websockets"
org.glassfish.grizzly.websockets;version="5.0.3.SNAPSHOT";uses:="jakarta.servlet.http,org.glassfish.grizzly,org.glassfish.grizzly.filterchain,org.glassfish.grizzly.http,org.glassfish.grizzly.http.server,org.glassfish.grizzly.http.server.util,org.glassfish.grizzly.http.util"
```
