### PR TITLE
Fixed pattern for hostname - unit test failed in docker container

### DIFF
--- a/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/net/NetUtilsTest.java
+++ b/nucleus/common/common-util/src/test/java/com/sun/enterprise/util/net/NetUtilsTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetUtilsTest {
     private static final Logger LOG = System.getLogger(NetUtilsTest.class.getName());
-    private static final Pattern PATTERN_HOSTNAME = Pattern.compile("^[a-zA-Z][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})*$");
+    private static final Pattern PATTERN_HOSTNAME = Pattern.compile("^[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})*$");
 
     @Test
     void getFreePort() throws Exception {


### PR DESCRIPTION
- 0c5849191f89 is a valid hostname (test failed in docker container)

