### PR TITLE
Answer a malformed request URI with 400 instead of 500

### DIFF
--- a/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JdbcITest.java
+++ b/appserver/tests/admin/tests/src/test/java/org/glassfish/main/admin/test/rest/JdbcITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -86,16 +86,18 @@ public class JdbcITest extends RestTestBase {
         Response response = managementClient.post(URL_JDBC_RESOURCE, params);
         assertEquals(500, response.getStatus());
 
+        // The encoded backslash makes the request URI undecodable, so every request carrying it is
+        // rejected as a malformed request before it reaches the resource itself.
         Response responseGet = managementClient.get(URL_JDBC_CONNECTION_POOL + "/" + encodedPoolName);
-        assertEquals(500, response.getStatus());
+        assertEquals(400, responseGet.getStatus());
         Map<String, String> entity = getEntityValues(responseGet);
         assertNull(entity);
 
         response = managementClient.delete("/" + encodedPoolName, Map.of());
-        assertEquals(500, response.getStatus());
+        assertEquals(400, response.getStatus());
 
         response = managementClient.get(URL_JDBC_CONNECTION_POOL + "/" + encodedPoolName);
-        assertEquals(500, response.getStatus());
+        assertEquals(400, response.getStatus());
     }
 
 

--- a/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/ContainerMapper.java
+++ b/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/services/impl/ContainerMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -140,9 +140,27 @@ public class ContainerMapper extends ADBAwareHttpHandler {
         try {
             request.addAfterServiceListener(afterServiceListener);
             lookupHandler(request, response).call();
+        } catch (UndecodableRequestURIException ex) {
+            logAndSendBadRequest(request, response, ex.getCause());
         } catch (Exception ex) {
             logAndSendError(request, response, ex);
         }
+    }
+
+    /**
+     * The client sent a request URI we are not able to decode. That is a malformed request, not a
+     * server failure, so it is answered with 400 and logged at {@link java.util.logging.Level#FINE}
+     * without a stack trace - any client can produce it by sending arbitrary bytes to the listener,
+     * so reporting it as a server error would let anybody flood the server log.
+     */
+    private void logAndSendBadRequest(final Request request, final Response response, final Throwable cause) {
+        if (LOGGER.isLoggable(FINE)) {
+            // Deliberately without the URI itself - it is the undecodable garbage we are rejecting.
+            LOGGER.log(FINE, "Cannot decode the request URI received from {0}, responding 400. Cause: {1}",
+                new Object[] { request.getRemoteAddr(), cause });
+        }
+
+        sendError(response, 400);
     }
 
     private void logAndSendError(final Request request, final Response response, Exception ex) {
@@ -150,13 +168,17 @@ public class ContainerMapper extends ADBAwareHttpHandler {
             LogHelper.log(LOGGER, WARNING, exceptionMapper, ex, toUrlForLogging(request));
         }
 
+        sendError(response, 500);
+    }
+
+    private void sendError(final Response response, final int status) {
         if (response.getResponse() == null) {
             LOGGER.log(WARNING, "Response is not set in {0}, there's nothing we can do now.", response);
             return;
         }
 
         try {
-            response.sendError(500);
+            response.sendError(status);
         } catch (Exception ex2) {
             LOGGER.log(WARNING, exceptionMapper2, ex2);
         }
@@ -170,7 +192,7 @@ public class ContainerMapper extends ADBAwareHttpHandler {
         }
     }
 
-    private Callable lookupHandler(final Request request, final Response response) throws CharConversionException, Exception {
+    private Callable lookupHandler(final Request request, final Response response) throws Exception {
 
         MappingData mappingData;
         mapperLock.readLock().lock();
@@ -187,10 +209,7 @@ public class ContainerMapper extends ADBAwareHttpHandler {
                 }
             }
 
-            final DataChunk decodedURI =
-                request.getRequest()
-                       .getRequestURIRef()
-                       .getDecodedRequestURIBC(isAllowEncodedSlash());
+            final DataChunk decodedURI = decodeRequestURI(request);
 
             mappingData = request.getNote(MAPPING_DATA);
             if (mappingData == null) {
@@ -238,6 +257,24 @@ public class ContainerMapper extends ADBAwareHttpHandler {
 
         } finally {
             mapperLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Decodes the request URI sent by the client.
+     *
+     * @param request
+     * @return the decoded request URI, never null
+     * @throws UndecodableRequestURIException if the URI sent by the client cannot be decoded
+     */
+    private DataChunk decodeRequestURI(final Request request) throws UndecodableRequestURIException {
+        try {
+            return request.getRequest().getRequestURIRef().getDecodedRequestURIBC(isAllowEncodedSlash());
+        } catch (CharConversionException | IllegalArgumentException | IndexOutOfBoundsException e) {
+            // Bytes which are not valid in the URI encoding are reported as CharConversionException,
+            // a truncated percent escape as IndexOutOfBoundsException and a non-hexadecimal one as
+            // NumberFormatException. All of them mean the same thing: the client sent us garbage.
+            throw new UndecodableRequestURIException(e);
         }
     }
 
@@ -409,6 +446,20 @@ public class ContainerMapper extends ADBAwareHttpHandler {
 
     protected static MappingData getNote(Request request) {
         return request.getNote(MAPPING_DATA);
+    }
+
+    /**
+     * Signals that the request URI sent by the client cannot be decoded, so the request is
+     * malformed and has to be answered with 400. Used just to tell this client error apart from
+     * server failures; it is never propagated out of {@link #service(Request, Response)}.
+     */
+    private static final class UndecodableRequestURIException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        UndecodableRequestURIException(final Throwable cause) {
+            super(cause);
+        }
     }
 
     private final static class HttpHandlerCallable implements Callable<Object> {

--- a/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/services/impl/ContainerMapperTest.java
+++ b/nucleus/core/kernel/src/test/java/com/sun/enterprise/v3/services/impl/ContainerMapperTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.enterprise.v3.services.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.glassfish.grizzly.config.GrizzlyListener;
+import org.glassfish.grizzly.http.HttpRequestPacket;
+import org.glassfish.grizzly.http.HttpResponsePacket;
+import org.glassfish.grizzly.http.Protocol;
+import org.glassfish.grizzly.http.server.HttpHandler;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.glassfish.internal.grizzly.ContextMapper;
+import org.glassfish.kernel.KernelLoggerInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies how {@link ContainerMapper} reacts to a request URI it is not able to decode.
+ * <p>
+ * Such a request is malformed - the client sent garbage - so it has to be answered with 400 and it
+ * must not be reported as an internal server error. Anybody can trigger it by sending arbitrary
+ * bytes to an HTTP listener (a TLS handshake arriving at a plain HTTP listener is the usual source),
+ * so a stack trace at WARNING would let any client flood the server log.
+ *
+ * @author Renat R. Safiullin
+ */
+public class ContainerMapperTest {
+
+    private static final Logger LOGGER = KernelLoggerInfo.getLogger();
+
+    private final List<LogRecord> logRecords = new ArrayList<>();
+
+    private Handler logCollector;
+    private Level originalLevel;
+    private ContainerMapper mapper;
+    private ContextMapper contextMapper;
+
+    @BeforeEach
+    public void prepare() {
+        originalLevel = LOGGER.getLevel();
+        LOGGER.setLevel(Level.ALL);
+        logCollector = new Handler() {
+
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
+
+
+            @Override
+            public void flush() {
+                // nothing to do
+            }
+
+
+            @Override
+            public void close() {
+                // nothing to do
+            }
+        };
+        logCollector.setLevel(Level.ALL);
+        LOGGER.addHandler(logCollector);
+
+        GrizzlyService service = createNiceMock(GrizzlyService.class);
+        expect(service.obtainMapperLock()).andStubReturn(new ReentrantReadWriteLock());
+        replay(service);
+
+        contextMapper = createNiceMock(ContextMapper.class);
+
+        mapper = new ContainerMapper(service, createNiceMock(GrizzlyListener.class));
+        mapper.setMapper(contextMapper);
+    }
+
+
+    @AfterEach
+    public void cleanup() {
+        LOGGER.removeHandler(logCollector);
+        LOGGER.setLevel(originalLevel);
+        logRecords.clear();
+    }
+
+
+    /**
+     * Raw bytes which are not valid in the URI encoding end up as a CharConversionException,
+     * a truncated percent escape as an IndexOutOfBoundsException and a non-hexadecimal one as
+     * a NumberFormatException - all of them are the client's fault, all of them must give 400.
+     */
+    @ParameterizedTest(name = "request URI: {0}")
+    @ValueSource(strings = {"Ýõf­", "/%", "/%ZZ", "/%E0%A4%A"})
+    public void undecodableRequestUriIsAnsweredWithBadRequest(String requestURI) throws Exception {
+        expect(contextMapper.getHttpHandler()).andStubReturn(null);
+        replay(contextMapper);
+
+        Response response = createMock(Response.class);
+        expect(response.getResponse()).andReturn(createNiceMock(HttpResponsePacket.class));
+        response.sendError(400);
+        expectLastCall();
+        replay(response);
+
+        mapper.service(mockRequest(requestURI), response);
+
+        verify(response);
+    }
+
+
+    @Test
+    public void undecodableRequestUriIsNotLoggedAsServerError() throws Exception {
+        expect(contextMapper.getHttpHandler()).andStubReturn(null);
+        replay(contextMapper);
+
+        mapper.service(mockRequest("Ýõf­"), niceResponse());
+
+        assertThat("Records logged at WARNING or higher", recordsAtLeast(Level.WARNING), empty());
+        assertThat("Records logged at FINE", recordsAtLeast(Level.FINE), hasSize(1));
+
+        LogRecord record = recordsAtLeast(Level.FINE).get(0);
+        assertEquals(Level.FINE, record.getLevel());
+        assertThat("Message parameters", List.of(record.getParameters()),
+            contains(instanceOf(String.class), instanceOf(Throwable.class)));
+    }
+
+
+    /**
+     * A failure of the mapped handler is a genuine server error and must keep its previous
+     * behaviour - 500 and a WARNING with the exception.
+     */
+    @Test
+    public void handlerFailureIsStillAnsweredWithInternalServerError() throws Exception {
+        HttpHandler failingHandler = new HttpHandler() {
+
+            @Override
+            public void service(Request request, Response response) throws Exception {
+                throw new IllegalStateException("Deployed application failed");
+            }
+        };
+        expect(contextMapper.getHttpHandler()).andStubReturn(failingHandler);
+        replay(contextMapper);
+
+        Response response = createMock(Response.class);
+        expect(response.getResponse()).andReturn(createNiceMock(HttpResponsePacket.class));
+        response.sendError(500);
+        expectLastCall();
+        replay(response);
+
+        mapper.service(mockRequest("/anything"), response);
+
+        verify(response);
+        List<LogRecord> warnings = recordsAtLeast(Level.WARNING);
+        assertThat("Records logged at WARNING or higher", warnings, hasSize(1));
+        assertThat("Logged exception", warnings.get(0).getThrown(), instanceOf(IllegalStateException.class));
+    }
+
+
+    private Request mockRequest(String requestURI) {
+        HttpRequestPacket packet = HttpRequestPacket.builder()
+            .method("GET")
+            .uri(requestURI)
+            .protocol(Protocol.HTTP_1_1)
+            .build();
+
+        Request request = createNiceMock(Request.class);
+        request.addAfterServiceListener(anyObject());
+        expectLastCall().asStub();
+        expect(request.getRequest()).andStubReturn(packet);
+        expect(request.getRemoteAddr()).andStubReturn("192.0.2.10");
+        replay(request);
+        return request;
+    }
+
+
+    private Response niceResponse() throws Exception {
+        Response response = createNiceMock(Response.class);
+        expect(response.getResponse()).andStubReturn(createNiceMock(HttpResponsePacket.class));
+        replay(response);
+        return response;
+    }
+
+
+    private List<LogRecord> recordsAtLeast(Level level) {
+        return logRecords.stream().filter(record -> record.getLevel().intValue() >= level.intValue()).toList();
+    }
+}


### PR DESCRIPTION
- Fixes #26163

## Problem

`ContainerMapper.service()` routes every failure through a single `catch (Exception)` that unconditionally logs a stack trace at WARNING under `NCLS-CORE-00090 Internal Server error: {0}` and answers 500.

An undecodable request URI does not belong in that path. It is malformed input, not a server failure, and since any client able to reach an HTTP listener can produce one, the current behaviour permits unauthenticated appending of stack traces to `server.log`. The URI in the logged message is always `null` in this case, that value being precisely what failed to decode.

Reproducer, no TLS and no deployed application required:

```bash
printf 'GET /\xdd\xf5\x66\xad HTTP/1.1\r\nHost: localhost\r\n\r\n' | nc localhost 8080   # invalid bytes
printf 'GET /%% HTTP/1.1\r\nHost: localhost\r\n\r\n'               | nc localhost 8080   # truncated escape
printf 'GET /%%ZZ HTTP/1.1\r\nHost: localhost\r\n\r\n'             | nc localhost 8080   # non-hex escape
```

Originally observed on an admin listener running without secure-admin, where a browser request to `https://<host>:4848/` put a TLS ClientHello through the HTTP request-line parser; one page load produced six records across `admin-listener(1)`, `(4)`, `(19)`, `(24)`, `(50)`.

## Change

URI decoding moves into `decodeRequestURI()`, the single point at which this client error is recognised and wrapped in a private `UndecodableRequestURIException`. Classifying there rather than in the `catch` of `service()` keeps a failure thrown by a deployed application from being misclassified.

Such a request is answered with **400** and logged at **FINE** without a stack trace and without the URI, the URI being the undecodable input under rejection; the remote address and the cause are logged instead. All other failures retain the existing 500 at WARNING.

The decoder reports malformed input with three distinct exception types, not only the `CharConversionException` visible in the reported stack trace. Verified against Grizzly 5.0.2:

| Input | Exception |
| --- | --- |
| `/%` | `java.lang.StringIndexOutOfBoundsException: Range [2, 4) out of bounds for length 2` |
| `/%ZZ` | `java.lang.NumberFormatException: For input string: "ZZ" under radix 16` |
| `/%E0%A4%A` | `java.lang.StringIndexOutOfBoundsException: Range [8, 10) out of bounds for length 9` |
| raw non-UTF-8 bytes | `java.io.CharConversionException: Invalid URI character encoding` |

Catching only `CharConversionException` would therefore cover one case of three. Hence `IllegalArgumentException | IndexOutOfBoundsException` alongside it: both are bad-input families, and neither is plausible as a genuine server-side failure at that one call site.

## Externally visible change

`JdbcITest.testBackslashValidation` asserted 500 for requests whose URI contains an encoded backslash and now asserts 400. This is the intended effect of the change rather than an incidental adjustment.

Grizzly rejects `%5C` outright - `getDecodedRequestURIBC` throws `CharConversionException: Invalid URI character encoding` for it irrespective of `allowEncodedSlash`, unlike `%2F` which is accepted when encoded slashes are permitted:

```
allowEncodedSlash=false   /TestPool%5Cabc -> CharConversionException: Invalid URI character encoding
allowEncodedSlash=true    /TestPool%5Cabc -> CharConversionException: Invalid URI character encoding
allowEncodedSlash=false   /TestPool%2Fabc -> CharConversionException: Encoded slashes are not allowed
allowEncodedSlash=true    /TestPool%2Fabc -> /TestPool/abc
```

Such a request is refused before it reaches the resource, on the basis of the URI the client sent. Per RFC 9110 that is 400; 500 asserts a server failure that did not occur. The previous assertion encoded the defect this PR fixes.

The same commit corrects an assertion in that test which checked the status of the preceding POST response rather than the GET it belongs to, and so verified nothing about the GET.

## Tests

`ContainerMapperTest`, EasyMock as elsewhere in the module:

- `undecodableRequestUriIsAnsweredWithBadRequest` - parameterized over the four URIs above, asserts `sendError(400)`.
- `undecodableRequestUriIsNotLoggedAsServerError` - asserts no record at WARNING or higher and exactly one FINE record.
- `handlerFailureIsStillAnsweredWithInternalServerError` - a throwing handler still produces `sendError(500)` and a WARNING carrying the exception, guarding the behaviour that must not change.

Against the unpatched code 5 of the 6 test executions fail; the sixth is the guard on the unchanged 500 path.

`mvn -pl nucleus/core/kernel test` reports 64 tests with 2 failures, both in `CommonClassLoaderServiceImplTest`. Those two are pre-existing: they reproduce on unmodified `main` at ed65d94252 and are unrelated to this change. The six tests added here pass.

The first CI run of this PR failed on Ubuntu and Windows with a single assertion, `JdbcITest:95 expected: <500> but was: <400>`, addressed by the second commit. MacOS passed, running `-Pfastest`, which excludes the admin integration tests. Since the build carries no `--fail-at-end`, modules ordered after `appserver/tests/admin` did not run in that first attempt.

## Out of scope

A related defect sits one layer lower, in Grizzly. When the request line leaves a non-empty protocol token that Grizzly does not recognise and the header block then fails to parse, `HttpServerFilter.onHttpHeaderError()` -> `sendBadRequestResponse()` -> `prepareResponse()` -> `HttpHeader.getProtocol()` throws `IllegalStateException: Unknown protocol <token>`. The 400 Grizzly meant to send is never written, the client gets a bare connection close, and a WARNING stack trace is logged for each such request. `prepareRequest()` already repairs that state for the 505 it answers, but it runs only once the whole header block has parsed, so a header-parse failure bypasses the repair.

Reported as eclipse-ee4j/glassfish-grizzly#2301, with a reproducer and a candidate fix. Nothing in this PR depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

