### PR TITLE
Fixed NPE when check 'behind-proxy' is enabled or not on an ssh node.

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
@@ -323,14 +323,8 @@ public class GenericAdminAuthenticator implements AdminAccessController, JMXAuth
      * When enabled, the server trusts X-Real-IP and X-Forwarded-For headers.
      */
     private boolean isBehindProxyEnabled() {
-        // When this method is executed on a remote node instance,
-        // for example, execute the start-instance command on das, and the target is an instance on an ssh node,
-        // a <server> element named "server" cannot be found in the instance's domain.xml.
-        // would result in NPE when call "getConfig()" method.
-
-        // Config config = domain.getServerNamed("server").getConfig();
-
-        // it would be better to find the <server> element of the current instance.
+        // find the <server> element of the current instance. Needed if executed on non-DAS instances,
+        // e.g. when calling admin commands against a remote instance
         Server server = domain.getServerNamed(serverEnv.getInstanceName());
         Config config;
         if (server == null || (config = server.getConfig()) == null) {

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/util/GenericAdminAuthenticator.java
@@ -23,6 +23,7 @@ import com.sun.enterprise.config.serverbeans.Config;
 import com.sun.enterprise.config.serverbeans.Domain;
 import com.sun.enterprise.config.serverbeans.SecureAdmin;
 import com.sun.enterprise.config.serverbeans.SecurityService;
+import com.sun.enterprise.config.serverbeans.Server;
 import com.sun.enterprise.security.SecurityContext;
 import com.sun.enterprise.security.auth.realm.Realm;
 import com.sun.enterprise.security.auth.realm.exceptions.NoSuchUserException;
@@ -322,7 +323,20 @@ public class GenericAdminAuthenticator implements AdminAccessController, JMXAuth
      * When enabled, the server trusts X-Real-IP and X-Forwarded-For headers.
      */
     private boolean isBehindProxyEnabled() {
-        Config config = domain.getServerNamed("server").getConfig();
+        // When this method is executed on a remote node instance,
+        // for example, execute the start-instance command on das, and the target is an instance on an ssh node,
+        // a <server> element named "server" cannot be found in the instance's domain.xml.
+        // would result in NPE when call "getConfig()" method.
+
+        // Config config = domain.getServerNamed("server").getConfig();
+
+        // it would be better to find the <server> element of the current instance.
+        Server server = domain.getServerNamed(serverEnv.getInstanceName());
+        Config config;
+        if (server == null || (config = server.getConfig()) == null) {
+            // seems not possible.
+            throw new IllegalStateException("Can't find the config of the server.");
+        }
         Protocol protocol = config.getAdminListener().findHttpProtocol();
         Http http = protocol != null ? protocol.getHttp() : null;
         return http != null && http.isBehindProxy();


### PR DESCRIPTION
When `isBehindProxyEnabled()` method is executed on a remote node instance,
for example, execute the `start-instance` command on das, and the target is an instance on an ssh node,
a server element named "server" cannot be found in the instance's `domain.xml`.

So `domain.getServerNamed("server")` here returns null, resulting in NPE when call `getConfig()`.
It would be better to find the server element of the current instance.

With this issue, `start-instance` command targeting on ssh instances would succeed, but `list-instance` cannot get the correct running status of target instances. It would always be "stopped".
Then `stop-instance` command on the target instances always timeout.
The only temporary workaround I found for now, is to ssh to the remote instance server and execute `stop-local-instance`.