### PR TITLE
Fix metadata parser in RemoteAdminCommand.java

### DIFF
--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteAdminCommand.java
@@ -77,6 +77,7 @@ import org.glassfish.common.util.HttpParser;
 import org.glassfish.common.util.admin.AuthTokenManager;
 import org.glassfish.main.jdke.i18n.LocalStringsImpl;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -1172,9 +1173,19 @@ public class RemoteAdminCommand {
                 if (ok(cause)) {
                     errors.append(cause);
                 } else {
-                    Node mp = report.getFirstChild(); // message-part
-                    if (mp != null) {
-                        cause = getAttr(mp.getAttributes(), "message");
+                    // Node mp = report.getFirstChild(); // message-part
+                    // Because of the OutputKeys.INDENT has been set to "yes" in the XMLContentActionReporter,
+                    // (commit:c65c777ea244516e1ed5e3163332457820a3a938)
+                    // message-part cannot be fetched by simply call "getFirstChild()" method,
+                    // that would be a text node with blank content as node value now.
+                    // and its attributes would be null, then result in the NPE in "getAttr" method.
+                    // so we need to find the message-part element.
+                    NodeList children = report.getChildNodes();
+                    for (int i = 0; i < children.getLength(); i++) {
+                        Node mp = children.item(i);
+                        if (mp instanceof Element el && "message-part".equals(el.getTagName())) {
+                            cause = getAttr(mp.getAttributes(), "message");
+                        }
                     }
                     if (ok(cause)) {
                         errors.append(cause);

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteAdminCommand.java
@@ -1179,12 +1179,13 @@ public class RemoteAdminCommand {
                     // message-part cannot be fetched by simply call "getFirstChild()" method,
                     // that would be a text node with blank content as node value now.
                     // and its attributes would be null, then result in the NPE in "getAttr" method.
-                    // so we need to find the message-part element.
+                    // so we need to find the first message-part element.
                     NodeList children = report.getChildNodes();
                     for (int i = 0; i < children.getLength(); i++) {
                         Node mp = children.item(i);
                         if (mp instanceof Element el && "message-part".equals(el.getTagName())) {
                             cause = getAttr(mp.getAttributes(), "message");
+                            break;
                         }
                     }
                     if (ok(cause)) {

--- a/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteAdminCommand.java
+++ b/nucleus/admin/util/src/main/java/com/sun/enterprise/admin/remote/RemoteAdminCommand.java
@@ -1173,9 +1173,7 @@ public class RemoteAdminCommand {
                 if (ok(cause)) {
                     errors.append(cause);
                 } else {
-                    // Node mp = report.getFirstChild(); // message-part
                     // Because of the OutputKeys.INDENT has been set to "yes" in the XMLContentActionReporter,
-                    // (commit:c65c777ea244516e1ed5e3163332457820a3a938)
                     // message-part cannot be fetched by simply call "getFirstChild()" method,
                     // that would be a text node with blank content as node value now.
                     // and its attributes would be null, then result in the NPE in "getAttr" method.


### PR DESCRIPTION
Because of the `OutputKeys.INDENT` has been set to "yes" in the `XMLContentActionReporter`,
(commit: c65c777ea244516e1ed5e3163332457820a3a938, released with 7.0.18, PR #25149 )
message-part cannot be fetched by simply call `getFirstChild()` method,
that would be a text node with blank content as node value now.
and its attributes would be null, then result in the NPE inside `getAttr(mp.getAttributes(), "message")`.
I think it would be safer to actually find THE first message-part element, rather than `getFirstChild()`.