### PR TITLE
Fix download instance log file

### DIFF
--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
@@ -94,7 +94,7 @@ public class LogFilterForInstance {
 
             // creating local file name on DAS
             long instanceLogFileSize = 0;
-            File instanceLogFile = SFTPPath.of(logFileDirectoryOnServer.toPath()).resolve(loggingFile.getFileName()).toFile();
+            File instanceLogFile = logFileDirectoryOnServer.toPath().resolve(loggingFile.getFileName()).toFile();
 
             // getting size of the file on DAS
             if (instanceLogFile.exists()) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
@@ -94,7 +94,7 @@ public class LogFilterForInstance {
 
             // creating local file name on DAS
             long instanceLogFileSize = 0;
-            File instanceLogFile = logFileDirectoryOnServer.toPath().resolve(loggingFile.getFileName()).toFile();
+            File instanceLogFile = logFileDirectoryOnServer.toPath().resolve(loggingFile.getFileName().toString()).toFile();
 
             // getting size of the file on DAS
             if (instanceLogFile.exists()) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
@@ -27,6 +27,7 @@ import com.sun.enterprise.util.cluster.RemoteType;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,6 +108,8 @@ public class LogFilterForInstance {
 
             // if differ both size then downloading
             if (instanceLogFileSize != fileSizeOnNode) {
+                // Delete the local file if exists before sftp downloading
+                Files.deleteIfExists(instanceLogFile.toPath());
                 sftpClient.download(loggingFile, instanceLogFile.toPath());
             }
             return instanceLogFile;
@@ -160,7 +163,10 @@ public class LogFilterForInstance {
                 }
 
                 for (String fileName : allInstanceLogFileNames) {
-                    sftpClient.download(sourceDir.resolve(fileName), tempDirectoryOnServer.resolve(fileName));
+                    Path instanceLogFile = tempDirectoryOnServer.resolve(fileName);
+                    // Delete the local file if exists before sftp downloading
+                    Files.deleteIfExists(instanceLogFile);
+                    sftpClient.download(sourceDir.resolve(fileName), instanceLogFile);
                 }
             }
         } catch (Exception e) {

--- a/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
+++ b/nucleus/core/logging/src/main/java/com/sun/enterprise/server/logging/logviewer/backend/LogFilterForInstance.java
@@ -94,7 +94,7 @@ public class LogFilterForInstance {
 
             // creating local file name on DAS
             long instanceLogFileSize = 0;
-            File instanceLogFile = logFileDirectoryOnServer.toPath().resolve(loggingFile.getFileName()).toFile();
+            File instanceLogFile = SFTPPath.of(logFileDirectoryOnServer.toPath()).resolve(loggingFile.getFileName()).toFile();
 
             // getting size of the file on DAS
             if (instanceLogFile.exists()) {


### PR DESCRIPTION
Cannot download log file from ssh instance.
A `ProviderMismatchException` thrown when `logFileDirectoryOnServer.toPath().resolve(loggingFile.getFileName())`, because a `SFTPPath` is not a `UnixPath` or `WindowsPath`.

And also, `SFTPClient.download(..)` requires that local file does not exist, so the local log file needs to be deleted before download a new one.