### PR TITLE
Bump yasson from 3.0.4 to 3.0.5

### DIFF
--- a/appserver/appclient/client/acc/pom.xml
+++ b/appserver/appclient/client/acc/pom.xml
@@ -345,7 +345,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse</groupId>
+            <groupId>org.eclipse.yasson</groupId>
             <artifactId>yasson</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/appserver/featuresets/embedded-web/pom.xml
+++ b/appserver/featuresets/embedded-web/pom.xml
@@ -1263,7 +1263,7 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
+            <groupId>org.eclipse.yasson</groupId>
             <artifactId>yasson</artifactId>
         </dependency>
         <!-- derby -->

--- a/appserver/featuresets/web/pom.xml
+++ b/appserver/featuresets/web/pom.xml
@@ -1797,7 +1797,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.eclipse</groupId>
+            <groupId>org.eclipse.yasson</groupId>
             <artifactId>yasson</artifactId>
             <exclusions>
                 <exclusion>

--- a/appserver/pom.xml
+++ b/appserver/pom.xml
@@ -385,7 +385,7 @@
                 <version>${parsson-media.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse</groupId>
+                <groupId>org.eclipse.yasson</groupId>
                 <artifactId>yasson</artifactId>
                 <version>${yasson.version}</version>
             </dependency>
@@ -748,7 +748,7 @@
                         </spec>
                         <spec>
                             <artifact>
-                                <groupId>org.eclipse</groupId>
+                                <groupId>org.eclipse.yasson</groupId>
                                 <artifactId>yasson</artifactId>
                                 <version>${yasson.version}</version>
                             </artifact>

--- a/nucleus/parent/pom.xml
+++ b/nucleus/parent/pom.xml
@@ -191,7 +191,7 @@
         <parsson.version>1.1.9</parsson.version>
         <parsson-media.version>1.1.9</parsson-media.version>
         <jakarta.json.bind-api.version>3.0.2</jakarta.json.bind-api.version>
-        <yasson.version>3.0.4</yasson.version>
+        <yasson.version>3.0.5</yasson.version>
 
         <!-- Jakarta Pages and Jakarta Standard Tag Library -->
         <jakarta.pages-api.version>4.0.0</jakarta.pages-api.version>


### PR DESCRIPTION
- https://repo.maven.apache.org/maven2/org/eclipse/yasson/3.0.5/yasson-3.0.5.pom
```xml
    <distributionManagement>
        <relocation>
            <groupId>org.eclipse.yasson</groupId>
            <artifactId>yasson</artifactId>
            <message>
                The groupId has changed from org.eclipse to org.eclipse.yasson.
                Update your dependency to org.eclipse.yasson:yasson.
            </message>
        </relocation>
    </distributionManagement>
```

- https://github.com/eclipse-ee4j/yasson/releases/tag/3.0.5
> Yasson is the last eclipse project to directly publish to the `org.eclipse` namespace. All other projects use their own namespace. We will publish to the `org.eclipse.yasson` namespace going forward and the Eclipse Foundation will work with Sonatype to publish a relocation pom to the old group:archive location.