### PR TITLE
Render the admin console tree when no configuration can be read

### DIFF
--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/GuiUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/GuiUtil.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -310,9 +311,14 @@ public class GuiUtil {
      *     '_'.  This method will also ensure an alpha character (or '_') is
      *     the first character in the id.</p>
      *
-     * @param        uid        A non-null String.
+     * @param        uid        A non-null, non-empty String.
+     * @throws IllegalArgumentException if the given String is null or empty;
+     *     there is no id which can be generated from it.
      */
     public static String genId(String uid) {
+        if (isEmpty(uid)) {
+            throw new IllegalArgumentException("Cannot generate a component id from an empty value.");
+        }
         char[] chArr = uid.toCharArray();
         int len = chArr.length;
         int newIdx = 0;

--- a/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
+++ b/appserver/admingui/common/src/main/java/org/glassfish/admingui/common/util/TargetUtil.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -109,10 +110,15 @@ public class TargetUtil {
         try{
             config.addAll(RestUtil.getChildMap(GuiUtil.getSessionValue("REST_URL") + "/configs/config").keySet());
         }catch (Exception ex){
-            GuiUtil.getLogger().info(GuiUtil.getCommonMessage("log.error.getClusters") + ex.getLocalizedMessage());
+            GuiUtil.getLogger().info(GuiUtil.getCommonMessage("log.error.getConfigs") + ex.getLocalizedMessage());
             if (GuiUtil.getLogger().isLoggable(Level.FINE)){
                 ex.printStackTrace();
             }
+        }
+        if (config.isEmpty()) {
+            // A domain always has at least the server-config; an empty list
+            // means the configurations could not be read.
+            GuiUtil.getLogger().warning(GuiUtil.getCommonMessage("log.warning.noConfigs"));
         }
         return config;
     }

--- a/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
+++ b/appserver/admingui/common/src/main/resources/org/glassfish/common/admingui/Strings.properties
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2021 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -940,6 +940,8 @@ log.error.initSession=Exception in InitSessionAttributes():
 log.error.prepareAlert=Exception in prepareAlert():
 log.error.getClusters=Exception in getClusters().
 log.error.getInstances=Exception in getInstances().
+log.error.getConfigs=Exception in getConfigs().
+log.warning.noConfigs=No configuration could be read from the domain; the navigation tree will be incomplete.
 log.error.getTargetEndpoint=Exception in getTargetEndpoint().
 log.error.getDeployedAppsInfo=Exception in getDeployedAppsInfo().
 log.error.getSubComponents=Exception in getSubComponents().

--- a/appserver/admingui/common/src/main/resources/peTree.inc
+++ b/appserver/admingui/common/src/main/resources/peTree.inc
@@ -1,7 +1,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2026 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,8 +53,12 @@ monitoring     web  800
   <sun:form id="treeForm">
     <!beforeCreate
       gf.listConfigs(configs="#{pageSession.configsList}");
-      setAttribute(key="configName" value="#{pageSession.configsList[0]}");
-      gf.encodeId(id="${configName}" result="#{requestScope.configNameId}");
+      // The list is empty when the configurations cannot be read; the tree
+      // must still be rendered, so don't generate an id for a missing config.
+      if ("#{pageSession.configsList[0]}") {
+          setAttribute(key="configName" value="#{pageSession.configsList[0]}");
+          gf.encodeId(id="${configName}" result="#{requestScope.configNameId}");
+      }
     />
     <h:commandButton id="update" style="display: none;">
         <!command

--- a/appserver/admingui/common/src/main/resources/pluginTreeNodeConfigurations.jsf
+++ b/appserver/admingui/common/src/main/resources/pluginTreeNodeConfigurations.jsf
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,13 +27,16 @@
     <!afterCreate
         setAttribute(key="configsTreeNode" value="$this{component}");
     />
-    <sun:treeNode id="${configNameId}" 
-            text="${configName}"
-            url="#{request.contextPath}/common/configuration/configuration.jsf?configName=${configName}"
-            imageURL="/resource/common/images/configurations.gif"
-            expanded="false">
-        <!afterCreate
-            setAttribute(key="configTreeNodeLE" value="$this{layoutElement}");
-        />
-    </sun:treeNode>
+    <!-- Without any configuration there is no child node to create. -->
+    <!if "$attribute{configName}">
+        <sun:treeNode id="${configNameId}"
+                text="${configName}"
+                url="#{request.contextPath}/common/configuration/configuration.jsf?configName=${configName}"
+                imageURL="/resource/common/images/configurations.gif"
+                expanded="false">
+            <!afterCreate
+                setAttribute(key="configTreeNodeLE" value="$this{layoutElement}");
+            />
+        </sun:treeNode>
+    </if>
 </sun:treeNode>


### PR DESCRIPTION
Fixes #26182

Reloading the admin console front page answers HTTP 500 and keeps doing so for
every following reload of that browser session:

```
java.lang.NullPointerException: Cannot invoke "String.toCharArray()" because "uid" is null
        at org.glassfish.admingui.common.util.GuiUtil.genId(GuiUtil.java:316)
        at org.glassfish.admingui.common.handlers.UtilHandlers.encodeId(UtilHandlers.java:985)
        ...
        at com.sun.jsftemplating.layout.descriptors.LayoutComponent.beforeCreate(LayoutComponent.java:357)
```

`peTree.inc` takes the first element of the configuration list without checking
that the list has one:

```
gf.listConfigs(configs="#{pageSession.configsList}");
setAttribute(key="configName" value="#{pageSession.configsList[0]}");
gf.encodeId(id="${configName}" result="#{requestScope.configNameId}");
```

The list is empty whenever the REST call behind `gf.listConfigs` fails, because
`RestUtil.doesProxyExist()` catches every exception and returns `false` and
`TargetUtil.getConfigs()` swallows the rest. `#{pageSession.configsList[0]}`
then evaluates to `null`, `GuiUtil.genId(null)` throws, and the exception
escapes the `beforeCreate` event of `treeForm`, so the whole page fails instead
of the tree simply missing its Configurations subtree.

In the reported case the REST calls failed because the console's REST token had
been purged after 30 minutes of inactivity (`session-token-timeout`) while its
HTTP session was still valid (`admin-session-timeout-in-minutes` defaults to 60),
so the auth module kept letting the request through. That part is not addressed
here - see #24982 and #26092, which align the two lifetimes. This PR makes the
console survive an unreadable configuration list, whatever the reason for it.

## Changes

* `peTree.inc` generates the id only when a configuration was returned, and
  `pluginTreeNodeConfigurations.jsf` builds the per-configuration node only when
  there is a name for it.
* `GuiUtil.genId()` rejects an empty value with a message naming the cause
  instead of a `NullPointerException`, and no longer fails with
  `ArrayIndexOutOfBoundsException` on an empty `String`.
* `TargetUtil.getConfigs()` logged its exceptions under the message key of
  `getClusters()` and said nothing when the list came back empty. A domain
  always has at least `server-config`, so an empty list is now logged as a
  warning; without it the 500 leaves no trace at all in `server.log`, since
  `RestUtil.get()` does not pass through `parseResponse()` and the
  `LOG_REQUEST_RESULT` message is never written.

## Testing

`mvn -pl appserver/admingui/common -am install` passes. The templates are parsed
at runtime rather than at build time, so the edited
`pluginTreeNodeConfigurations.jsf` was additionally run through jsftemplating's
`TemplateReader`, which resolves it to
`LayoutComponent(configurations) -> LayoutIf -> LayoutComponent(${configNameId})`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
