### PR TITLE
Add Zip file Extra field headers: Header ID & Data Size.

### DIFF
--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
@@ -22,6 +22,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -315,6 +318,8 @@ class ZipPayloadImpl extends PayloadImpl {
      */
     private static class Extra {
         private static final String CONTENT_TYPE_NAME = "Content-Type";
+        private static final short EXTID = (short) 0xFFFF;       // Extra field Header ID
+        private static final short EXT_HEADER_SZIE = 4;   // Extra field header size (2 bytes for Header ID, 2 bytes for Data Size)
 
         private String contentType;
         private Properties props;
@@ -322,7 +327,9 @@ class ZipPayloadImpl extends PayloadImpl {
         private Extra(final byte[] extra) {
             try {
                 props = new Properties();
-                ByteArrayInputStream bais = new ByteArrayInputStream(extra);
+                // skip the header (first 4 bytes).
+                byte[] extraData = Arrays.copyOfRange(extra, EXT_HEADER_SZIE, extra.length);
+                ByteArrayInputStream bais = new ByteArrayInputStream(extraData);
                 props.load(bais);
                 contentType = props.getProperty(CONTENT_TYPE_NAME);
                 props.remove(CONTENT_TYPE_NAME);
@@ -345,7 +352,15 @@ class ZipPayloadImpl extends PayloadImpl {
             fullProps.setProperty(CONTENT_TYPE_NAME, contentType);
             try {
                 fullProps.store(baos, null);
-                return baos.toByteArray();
+                byte[] bytes = baos.toByteArray();
+                int length = bytes.length;
+                ByteBuffer bb = ByteBuffer.allocate(EXT_HEADER_SZIE + length).order(ByteOrder.LITTLE_ENDIAN);
+                // add Header ID
+                bb.putShort(EXTID);
+                // add Data Size
+                bb.putShort((short) length);
+                bb.put(bytes);
+                return bb.array();
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
@@ -319,7 +319,7 @@ class ZipPayloadImpl extends PayloadImpl {
     private static class Extra {
         private static final String CONTENT_TYPE_NAME = "Content-Type";
         private static final short EXTID = (short) 0xFFFF;       // Extra field Header ID
-        private static final short EXT_HEADER_SZIE = 4;   // Extra field header size (2 bytes for Header ID, 2 bytes for Data Size)
+        private static final short EXT_HEADER_SIZE = 4;   // Extra field header size (2 bytes for Header ID, 2 bytes for Data Size)
 
         private String contentType;
         private Properties props;
@@ -328,7 +328,7 @@ class ZipPayloadImpl extends PayloadImpl {
             try {
                 props = new Properties();
                 // skip the header (first 4 bytes).
-                byte[] extraData = Arrays.copyOfRange(extra, EXT_HEADER_SZIE, extra.length);
+                byte[] extraData = Arrays.copyOfRange(extra, EXT_HEADER_SIZE, extra.length);
                 ByteArrayInputStream bais = new ByteArrayInputStream(extraData);
                 props.load(bais);
                 contentType = props.getProperty(CONTENT_TYPE_NAME);
@@ -354,7 +354,7 @@ class ZipPayloadImpl extends PayloadImpl {
                 fullProps.store(baos, null);
                 byte[] bytes = baos.toByteArray();
                 int length = bytes.length;
-                ByteBuffer bb = ByteBuffer.allocate(EXT_HEADER_SZIE + length).order(ByteOrder.LITTLE_ENDIAN);
+                ByteBuffer bb = ByteBuffer.allocate(EXT_HEADER_SIZE + length).order(ByteOrder.LITTLE_ENDIAN);
                 // add Header ID
                 bb.putShort(EXTID);
                 // add Data Size

--- a/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
+++ b/nucleus/common/common-util/src/main/java/org/glassfish/admin/payload/ZipPayloadImpl.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -328,8 +327,7 @@ class ZipPayloadImpl extends PayloadImpl {
             try {
                 props = new Properties();
                 // skip the header (first 4 bytes).
-                byte[] extraData = Arrays.copyOfRange(extra, EXT_HEADER_SIZE, extra.length);
-                ByteArrayInputStream bais = new ByteArrayInputStream(extraData);
+                ByteArrayInputStream bais = new ByteArrayInputStream(extra, EXT_HEADER_SIZE, extra.length);
                 props.load(bais);
                 contentType = props.getProperty(CONTENT_TYPE_NAME);
                 props.remove(CONTENT_TYPE_NAME);


### PR DESCRIPTION
The improved validation of the ZIP64 Extra Fields (JDK-8302483) mentioned that each Extra Header Must consist of `Header ID` (2 bytes) and `Data Size` (2 bytes). (from the comments in `java.util.zip.ZipFile`)
Such header is absent in the current extra data bytes, causing "Invalid CEN header" errors when reading zip files exported by `ZipPayloadImpl.java`.

For example, `export-sync-bundle`, then `import-sync-bundle` the exported zip file.
The import command fails if system property `jdk.util.zip.disableZip64ExtraFieldValidation` not set to `true`.
And if using `zipinfo -v` to inspect the exported zip file, errors about the extra fields would also be found.

Using `0xFFFF` as the `Header ID` to avoid any [Known Types of Extra fields](https://libzip.org/specifications/extrafld.txt).
If a better value is suggested, please change it directly.