### PR TITLE
Include Jakarta Data/NoSQL implementation in embedded web feature set 

### DIFF
--- a/appserver/featuresets/embedded-web/pom.xml
+++ b/appserver/featuresets/embedded-web/pom.xml
@@ -650,6 +650,19 @@
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
+
+        <!-- Jakarta Data / NoSQL -->
+        <dependency>
+            <groupId>org.glassfish.main.persistence</groupId>
+            <artifactId>jnosql-integration</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jnosql.mapping</groupId>
+            <artifactId>jnosql-jakarta-persistence</artifactId>
+            <version>${jnosql.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>

--- a/appserver/tests/embedded/data/pom.xml
+++ b/appserver/tests/embedded/data/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.tests</groupId>
+        <artifactId>embedded-tests</artifactId>
+        <version>8.0.5-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.tests.embedded</groupId>
+    <artifactId>data</artifactId>
+    <name>Jakarta Data integration test</name>
+
+    <build>
+        <finalName>data</finalName>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>embedded-all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-all</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>embedded-web</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-web</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/data/DataSampleDataInitializer.java
+++ b/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/data/DataSampleDataInitializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.data.data;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Startup;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.glassfish.tests.embedded.data.domain.Todo;
+
+/**
+ * Seeds sample todos on application startup.
+ */
+@ApplicationScoped
+@Transactional
+public class DataSampleDataInitializer {
+    private static final Logger LOG = Logger.getLogger(DataSampleDataInitializer.class.getName());
+
+    @Inject
+    DataTodoRepository todoRepository;
+
+    public void init(@Observes Startup event) {
+        LOG.log(Level.INFO, "initializing sample data: {0}", event);
+        todoRepository.saveAll(List.of(
+                Todo.of("Say Hello to Jakarta EE 11"),
+                Todo.of("Upgrade to Jakarta EE 11")
+        ));
+        LOG.log(Level.INFO, "initializing sample data is done: {0}", event);
+    }
+}

--- a/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/data/DataTodoRepository.java
+++ b/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/data/DataTodoRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.data.data;
+
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+import jakarta.transaction.Transactional;
+
+import org.glassfish.tests.embedded.data.domain.Todo;
+
+/**
+ * Jakarta Data repository backed by the JPA implementation.
+ */
+@Repository
+@Transactional
+public interface DataTodoRepository extends CrudRepository<Todo, Long> {
+}

--- a/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/domain/Todo.java
+++ b/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/domain/Todo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.data.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * A simple JPA entity managed through a Jakarta Data repository.
+ */
+@Entity
+@Table(name = "todos")
+public class Todo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    public Todo() {
+    }
+
+    public static Todo of(String title) {
+        Todo todo = new Todo();
+        todo.setTitle(title);
+        return todo;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/rest/DataTodoResource.java
+++ b/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/rest/DataTodoResource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.data.rest;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.glassfish.tests.embedded.data.data.DataTodoRepository;
+
+/**
+ * REST endpoint backed by a Jakarta Data repository.
+ */
+@RequestScoped
+@Path("datatodos")
+@Produces(MediaType.APPLICATION_JSON)
+public class DataTodoResource {
+
+    @Inject
+    DataTodoRepository todoRepository;
+
+    @GET
+    public Response getAll() {
+        return Response.ok(todoRepository.findAll().toList()).build();
+    }
+}

--- a/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/rest/RestActivator.java
+++ b/appserver/tests/embedded/data/src/main/java/org/glassfish/tests/embedded/data/rest/RestActivator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.data.rest;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * JAX-RS application exposing the Jakarta Data REST endpoints.
+ */
+@ApplicationPath("/")
+public class RestActivator extends Application {
+}

--- a/appserver/tests/embedded/data/src/main/resources/META-INF/persistence.xml
+++ b/appserver/tests/embedded/data/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="3.2" xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd">
+    <persistence-unit name="defaultPU" transaction-type="JTA">
+        <jta-data-source>java:comp/DefaultDataSource</jta-data-source>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/appserver/tests/embedded/data/src/main/webapp/WEB-INF/beans.xml
+++ b/appserver/tests/embedded/data/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+        version="4.1">
+</beans>

--- a/appserver/tests/embedded/data/src/test/java/org/glassfish/tests/embedded/data/JakartaDataIT.java
+++ b/appserver/tests/embedded/data/src/test/java/org/glassfish/tests/embedded/data/JakartaDataIT.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.tests.embedded.data;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Path;
+
+import org.glassfish.embeddable.Deployer;
+import org.glassfish.embeddable.GlassFish;
+import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
+import org.glassfish.embeddable.archive.ScatteredArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test Jakarta Data support in embedded GlassFish.
+ */
+public class JakartaDataIT {
+
+    private static final Path PROJECT_DIR = detectBasedir();
+    private static final int HTTP_PORT = 8080;
+    private static final String APP_NAME = "data";
+
+    static GlassFish glassfish;
+    static String appName;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        GlassFishProperties props = new GlassFishProperties();
+        props.setPort("http-listener", HTTP_PORT);
+        glassfish = GlassFishRuntime.bootstrap().newGlassFish(props);
+        glassfish.start();
+
+        ScatteredArchive sa = new ScatteredArchive(APP_NAME, ScatteredArchive.Type.WAR,
+                PROJECT_DIR.resolve(Path.of("src", "main", "webapp")).toFile());
+        sa.addClassPath(PROJECT_DIR.resolve(Path.of("target", "classes")).toFile());
+        sa.addClassPath(PROJECT_DIR.resolve(Path.of("src", "main", "resources")).toFile());
+        URI warURI = sa.toURI();
+
+        Deployer deployer = glassfish.getDeployer();
+        appName = deployer.deploy(warURI);
+    }
+
+    @Test
+    void testGetAllTodos() throws Exception {
+        URL url = URI.create("http://localhost:" + HTTP_PORT + "/" + APP_NAME + "/datatodos").toURL();
+        URLConnection connection = url.openConnection();
+        StringBuilder response = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                response.append(line);
+            }
+        }
+        assertTrue(response.toString().contains("Say Hello to Jakarta EE 11"));
+        assertTrue(response.toString().contains("Upgrade to Jakarta EE 11"));
+    }
+
+    @AfterAll
+    static void shutdownServer() throws Exception {
+        if (appName != null) {
+            glassfish.getDeployer().undeploy(appName);
+        }
+        if (glassfish != null) {
+            glassfish.dispose();
+        }
+    }
+
+    private static Path detectBasedir() {
+        // Maven would set this property.
+        final String basedir = System.getProperty("basedir");
+        if (basedir != null) {
+            return new File(basedir).toPath().toAbsolutePath();
+        }
+        // Maybe we are standing in the basedir.
+        final File target = new File("target");
+        if (target.exists()) {
+            return target.toPath().toAbsolutePath().getParent();
+        }
+        // Eclipse IDE sometimes uses target as the current dir.
+        return new File(".").toPath().toAbsolutePath().getParent();
+    }
+}

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -44,6 +44,7 @@
         <module>basic</module>
         <module>cdi_basic</module>
         <module>cdi_ejb_jpa</module>
+        <module>data</module>
         <module>ejb</module>
         <module>glassfish_resources_xml</module>
         <module>maven-plugin</module>


### PR DESCRIPTION
## Problem

The embedded distributions (`org.glassfish.main.extras:glassfish-embedded-all` and the embedded web distribution built from the `embedded-web` feature set) ship the `jakarta.data` API classes but omit the Jakarta Data implementation that the full GlassFish distribution provides via JNoSQL. As a result, a `@Repository` interface cannot be resolved on embedded GlassFish — deployment fails with `WELD-001408 Unsatisfied dependencies` at the injection point.

The root cause is that the `embedded-web` feature set (`appserver/featuresets/embedded-web/pom.xml`) does not declare the Jakarta Data/NoSQL modules, while the full-dist feature set (`appserver/featuresets/web/pom.xml`) does.

## Fix

Add exactly two dependencies to the `embedded-web` feature set (`appserver/featuresets/embedded-web/pom.xml`), both without exclusions:

- `org.glassfish.main.persistence:jnosql-integration` — GlassFish's CDI integration (the `JakartaPersistenceIntegrationExtension` / `JNoSqlIntegrationExtension` CDI `Extension` service entries).
- `org.eclipse.jnosql.mapping:jnosql-jakarta-persistence` — the Eclipse JNoSQL Jakarta Data implementation.

`embedded-all` depends on `embedded-web` (pom type), so declaring them in `embedded-web` covers both the embedded web and embedded all distributions. The flat embedded uber jar assembly unpacks every compile-scope jar into the jar root and merges `META-INF/services`, so the implementation classes and the CDI Extension registrations land in the jar without needing the OSGi bundle wrapper used by the full distribution.

`jakarta.data-api`, `jakarta.nosql-api`, and `antlr4-runtime` arrive transitively (`jnosql-jakarta-persistence:1.1.15` pulls `jakarta.data-api:1.0.1`, `jakarta.nosql-api`, and `antlr4-runtime:4.13.2` via `jnosql-communication-query`), so no extra declarations are needed.

## Verification

Built `glassfish-embedded-all` from source with this change and verified the resulting jar:

- `org/eclipse/jnosql/**` (542 entries), `org/glassfish/main/jnosql/**` (51), `jakarta/nosql/**` (31), `org/antlr/v4/**` (223) present.
- `META-INF/services/jakarta.enterprise.inject.spi.Extension` contains the JNoSQL entries (`JakartaPersistenceIntegrationExtension`, `JNoSqlIntegrationExtension`, `JakartaPersistenceExtension`, `DocumentExtension`, `ReflectionEntityMetadataExtension`).

Then ran the minimal Jakarta Data demo against embedded GlassFish:

```
mvn clean package embedded-glassfish:run -Pglassfish-embedded
GET http://localhost:8080/jakarta-data/api/datatodos
```

Results:

- `GET /api/datatodos` → `HTTP 200` with the two seeded todos:

```json
[
  {"id":2,"title":"Upgrade to Jakarta EE 11(DataSampleDataInitializer)","status":"PENDING"},
  {"id":1,"title":"Say Hello to Jakarta EE 11(DataSampleDataInitializer)","status":"PENDING"}
]
```

- `GET /api/datatodos/1` → `HTTP 200` with the seeded todo.
- `POST /api/datatodos` → `HTTP 201` (created todo).

## Regression test

Added `appserver/tests/embedded/data`, a new embedded GlassFish test module modeled after the existing `microprofile`/`cdi_ejb_jpa` modules. It deploys a scattered WAR with a minimal Jakarta Data repository (`@Repository` extending `CrudRepository`) backed by JPA on the embedded `DefaultDataSource`, and `JakartaDataIT` asserts that `GET /data/datatodos` returns HTTP 200 with the two seeded todos.

Verified with `mvn -f appserver/tests/embedded/pom.xml -pl data -am verify` — Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 (BUILD SUCCESS).
