### PR TITLE
Fix JMS support in glassfish-embedded-all and add embedded JMS test

### DIFF
--- a/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorsClassLoaderUtil.java
+++ b/appserver/connectors/connectors-internal-api/src/main/java/com/sun/appserv/connectors/internal/api/ConnectorsClassLoaderUtil.java
@@ -21,6 +21,7 @@ import com.sun.enterprise.loader.ASURLClassLoader;
 import com.sun.logging.LogDomains;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 
 import java.io.File;
@@ -43,6 +44,7 @@ import org.jvnet.hk2.annotations.Service;
 import static com.sun.appserv.connectors.internal.api.ConnectorsUtil.belongsToSystemRA;
 import static java.util.logging.Level.WARNING;
 import static org.glassfish.api.event.EventTypes.PREPARE_SHUTDOWN;
+import static org.glassfish.api.event.EventTypes.SERVER_SHUTDOWN;
 import static org.glassfish.embeddable.GlassFishVariable.INSTALL_ROOT;
 
 
@@ -69,8 +71,13 @@ public class ConnectorsClassLoaderUtil {
     @Inject
     private Events events;
 
+    @Inject
+    private Provider<ConnectorRuntime> connectorRuntimeProvider;
+
 
     private volatile boolean rarsInitializedInEmbeddedServerMode;
+
+    private volatile boolean prepareShutdownHandled;
 
     public ConnectorClassFinder createRARClassLoader(String moduleDir, ClassLoader deploymentParent, String moduleName, List<URI> appLibs) throws ConnectorRuntimeException {
 
@@ -108,9 +115,30 @@ public class ConnectorsClassLoaderUtil {
             final DelegatingClassLoader.ClassFinder librariesCL = getLibrariesClassLoader(appLibs);
             final ConnectorClassFinder ccf = new ConnectorClassFinder(parent, moduleName, librariesCL);
 
+            // In embedded mode, stop the active resource adapters (including the
+            // JMS RA's embedded broker) during PREPARE_SHUTDOWN and release the
+            // RAR classloader's jar handles on SERVER_SHUTDOWN so the embedded
+            // instance root can be cleaned up afterwards.
+            // AppServerStartup.stop() sends PREPARE_SHUTDOWN before proceedTo(VAL);
+            // the RA shutdown inside proceedTo(VAL) (ResourceManager preDestroy ->
+            // stopAllActiveResourceAdapters) lazily resolves classes such as
+            // BrokerStateHandler$ShutdownRunnable through this loader. Stopping the
+            // RAs during PREPARE_SHUTDOWN - while this loader is still open - makes
+            // that lazy resolution succeed, and the later ResourceManager shutdown
+            // re-runs stopAllActiveResourceAdapters(), which is idempotent and
+            // becomes a no-op. The classloader close itself stays on
+            // SERVER_SHUTDOWN, after the RAs are already stopped.
             if (processEnvironment.getProcessType().isEmbedded()) {
                 events.register(event -> {
                     if (event.is(PREPARE_SHUTDOWN)) {
+                        if (!prepareShutdownHandled) {
+                            prepareShutdownHandled = true;
+                            ConnectorRuntime runtime = connectorRuntimeProvider.get();
+                            if (runtime != null) {
+                                runtime.shutdownAllActiveResourceAdapters();
+                            }
+                        }
+                    } else if (event.is(SERVER_SHUTDOWN)) {
                         try {
                             ccf.close();
                         } catch (IOException ioe) {

--- a/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ActiveRAFactory.java
+++ b/appserver/connectors/connectors-runtime/src/main/java/com/sun/enterprise/connectors/ActiveRAFactory.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.glassfish.api.admin.ProcessEnvironment;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.annotations.Service;
 
@@ -63,7 +62,6 @@ public class ActiveRAFactory {
         ActiveResourceAdapter activeResourceAdapter = null;
         ClassLoader originalContextClassLoader = null;
 
-        ProcessEnvironment.ProcessType processType = ConnectorRuntime.getRuntime().getEnvironment();
         ResourceAdapter ra = null;
         String raClass = cd.getResourceAdapterClass();
 
@@ -72,14 +70,18 @@ public class ActiveRAFactory {
             // If raClass is available, load it...
 
             if (raClass != null && !raClass.equals("")) {
-                if (processType == ProcessEnvironment.ProcessType.Server) {
-                    ra = (ResourceAdapter)
-                            loader.loadClass(raClass).newInstance();
-                } else {
-                    //ra = (ResourceAdapter) Class.forName(raClass).newInstance();
-                    ra = (ResourceAdapter)
-                            Thread.currentThread().getContextClassLoader().loadClass(raClass).newInstance();
-                }
+                // Load the RA bean through the resource adapter's own classloader
+                // whenever it is available, regardless of the process type. Only
+                // fall back to the thread context classloader when no RAR
+                // classloader was provided. Loading the RA bean from a different
+                // classloader than the rest of the RAR (e.g. from the thread
+                // context classloader in embedded mode) produces a different
+                // Class identity and breaks instanceof checks inside the RA,
+                // such as MQJMSRA_AS4001 in the OpenMQ JMS resource adapter.
+                ClassLoader raClassLoader = loader != null
+                        ? loader
+                        : Thread.currentThread().getContextClassLoader();
+                ra = (ResourceAdapter) raClassLoader.loadClass(raClass).newInstance();
             }
 
             originalContextClassLoader = Utility.setContextClassLoader(loader);

--- a/appserver/extras/embedded/all/pom.xml
+++ b/appserver/extras/embedded/all/pom.xml
@@ -115,7 +115,11 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <outputDirectory>${artifact-collection.directory}</outputDirectory>
-                            <excludeTransitive>true</excludeTransitive>
+                            <!-- mq-distribution is declared in the embedded-all featureset pom, so it is
+                                 a transitive dependency here; transitive unpacking must stay enabled or
+                                 the broker props never reach the RAR and the embedded broker fails
+                                 (Unable to load default property file .../props/broker/default.properties). -->
+                            <excludeTransitive>false</excludeTransitive>
                             <includeTypes>zip</includeTypes>
                             <includeArtifactIds>mq-distribution</includeArtifactIds>
                             <includes>**/props/broker/**</includes>

--- a/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
+++ b/appserver/jms/jms-core/src/main/java/com/sun/enterprise/connectors/jms/system/ActiveJmsResourceAdapter.java
@@ -304,7 +304,11 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
      */
     @Override
     protected void loadRAConfiguration() throws ConnectorRuntimeException{
-        if (connectorRuntime.isServer()) {
+        // In embedded mode the server also manages the JMS broker lifecycle, so
+        // the full server-side RA configuration (broker type, port, credentials,
+        // etc.) must be applied there too. Without this, embedded falls through
+        // to the appclient branch which forces BrokerType=REMOTE.
+        if (connectorRuntime.isServer() || connectorRuntime.isEmbedded()) {
             // Check whether MQ has started up or not.
             try {
                 setLifecycleProperties();
@@ -433,7 +437,7 @@ public class ActiveJmsResourceAdapter extends ActiveInboundResourceAdapterImpl i
     protected Set<ConnectorConfigProperty> mergeRAConfiguration(ResourceAdapterConfig raConfig,
         List<Property> raConfigProps) {
         Set<ConnectorConfigProperty> mergedProps = super.mergeRAConfiguration(raConfig, raConfigProps);
-        if (!connectorRuntime.isServer()) {
+        if (!connectorRuntime.isServer() && !connectorRuntime.isEmbedded()) {
             return mergedProps;
         }
 

--- a/appserver/tests/embedded/jms/pom.xml
+++ b/appserver/tests/embedded/jms/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.tests</groupId>
+        <artifactId>embedded-tests</artifactId>
+        <version>8.0.5-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.glassfish.tests.embedded.jms</groupId>
+    <artifactId>jms-test</artifactId>
+    <name>Test JMS in embedded GlassFish</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.jms</groupId>
+            <artifactId>jakarta.jms-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>embedded-all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.main.extras</groupId>
+                    <artifactId>glassfish-embedded-all</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloConsumer.java
+++ b/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloConsumer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import jakarta.ejb.ActivationConfigProperty;
+import jakarta.ejb.MessageDriven;
+import jakarta.inject.Inject;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@MessageDriven(
+        activationConfig = {
+                @ActivationConfigProperty(
+                        propertyName = "destinationType",
+                        propertyValue = "jakarta.jms.Queue"),
+                @ActivationConfigProperty(
+                        propertyName = "destinationLookup",
+                        propertyValue = "java:comp/jms/HelloQueue")
+        }
+)
+public class HelloConsumer implements MessageListener {
+
+    private static final Logger LOGGER = Logger.getLogger(HelloConsumer.class.getName());
+
+    @Inject
+    HelloHandler handler;
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            String body = message.getBody(String.class);
+            LOGGER.log(Level.INFO, "received message: {0}", body);
+            handler.handle(body);
+        } catch (JMSException e) {
+            LOGGER.log(Level.SEVERE, "Error handling JMS message", e);
+        }
+    }
+}

--- a/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloHandler.java
+++ b/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class HelloHandler {
+
+    private static final Logger LOGGER = Logger.getLogger(HelloHandler.class.getName());
+
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    public void handle(String message) {
+        LOGGER.log(Level.INFO, "handling message: {0}", message);
+        messages.add(message);
+    }
+
+    public void clear() {
+        this.messages.clear();
+    }
+
+    public List<String> getMessages() {
+        return this.messages;
+    }
+}

--- a/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloJmsResource.java
+++ b/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloJmsResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@RequestScoped
+@Path("hellojms")
+public class HelloJmsResource {
+
+    private static final Logger LOGGER = Logger.getLogger(HelloJmsResource.class.getName());
+
+    @Inject
+    private HelloSender sender;
+
+    @Inject
+    private HelloHandler handler;
+
+    @GET
+    public String sayHello() {
+        LOGGER.log(Level.INFO, "sayHello from HelloJmsResource");
+        sender.sayHelloFromJms();
+        return "sent";
+    }
+
+    @GET
+    @Path("messages")
+    public String getMessages() {
+        return String.join(",", handler.getMessages());
+    }
+}

--- a/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloSender.java
+++ b/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/HelloSender.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSContext;
+
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+public class HelloSender {
+
+    private static final Logger LOGGER = Logger.getLogger(HelloSender.class.getName());
+
+    @Inject
+    JMSContext context;
+
+    @Resource(lookup = "java:comp/jms/HelloQueue")
+    private Destination helloQueue;
+
+    public void sayHelloFromJms() {
+        String msg = "Hello JMS at " + Instant.now();
+        LOGGER.log(Level.INFO, "sending message from HelloSender: {0}", msg);
+        context.createProducer().send(helloQueue, msg);
+    }
+}

--- a/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/JmsResourcesSetup.java
+++ b/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/JmsResourcesSetup.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.jms.JMSDestinationDefinition;
+
+// JMSDestinationDefinition is repeatable, so no @JMSDestinationDefinitions wrapper is needed.
+@JMSDestinationDefinition(
+        name = "java:comp/jms/HelloQueue",
+        interfaceName = "jakarta.jms.Queue",
+        destinationName = "HelloQueue"
+)
+@ApplicationScoped
+public class JmsResourcesSetup {
+}

--- a/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/RestActivator.java
+++ b/appserver/tests/embedded/jms/src/main/java/org/glassfish/tests/embedded/jms/RestActivator.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/api")
+public class RestActivator extends Application {
+}

--- a/appserver/tests/embedded/jms/src/main/webapp/WEB-INF/beans.xml
+++ b/appserver/tests/embedded/jms/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+        version="4.1">
+</beans>

--- a/appserver/tests/embedded/jms/src/test/java/org/glassfish/tests/embedded/jms/HelloJmsIT.java
+++ b/appserver/tests/embedded/jms/src/test/java/org/glassfish/tests/embedded/jms/HelloJmsIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.tests.embedded.jms;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Path;
+
+import org.glassfish.embeddable.Deployer;
+import org.glassfish.embeddable.GlassFish;
+import org.glassfish.embeddable.GlassFishProperties;
+import org.glassfish.embeddable.GlassFishRuntime;
+import org.glassfish.embeddable.archive.ScatteredArchive;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test JMS functionality in embedded GlassFish.
+ */
+public class HelloJmsIT {
+
+    private static final Path PROJECT_DIR = detectBasedir();
+    private static final int HTTP_PORT = 8080;
+    private static final String APP_NAME = "hellojms";
+
+    static GlassFish glassfish;
+    static String appName;
+
+    @BeforeAll
+    static void setupServer() throws Exception {
+        GlassFishProperties props = new GlassFishProperties();
+        props.setPort("http-listener", HTTP_PORT);
+        glassfish = GlassFishRuntime.bootstrap().newGlassFish(props);
+        glassfish.start();
+
+        ScatteredArchive sa = new ScatteredArchive(APP_NAME, ScatteredArchive.Type.WAR,
+                PROJECT_DIR.resolve(Path.of("src", "main", "webapp")).toFile());
+        sa.addClassPath(PROJECT_DIR.resolve(Path.of("target", "classes")).toFile());
+        URI warURI = sa.toURI();
+
+        Deployer deployer = glassfish.getDeployer();
+        appName = deployer.deploy(warURI);
+    }
+
+    @Test
+    void testJmsSendAndReceive() throws Exception {
+        URL sendUrl = URI.create("http://localhost:" + HTTP_PORT + "/" + APP_NAME + "/api/hellojms").toURL();
+        String response = read(sendUrl);
+        assertEquals("sent", response);
+
+        // The MDB consumes the message asynchronously, poll until it shows up.
+        URL messagesUrl = URI.create("http://localhost:" + HTTP_PORT + "/" + APP_NAME + "/api/hellojms/messages").toURL();
+        String messages = "";
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                messages = read(messagesUrl);
+            } catch (IOException e) {
+                // Message not available yet, retry.
+            }
+            if (messages != null && messages.contains("Hello JMS")) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+        assertTrue(messages != null && messages.contains("Hello JMS"), "MDB did not receive the message: " + messages);
+    }
+
+    @AfterAll
+    static void shutdownServer() throws Exception {
+        if (appName != null) {
+            glassfish.getDeployer().undeploy(appName);
+        }
+        if (glassfish != null) {
+            glassfish.dispose();
+        }
+    }
+
+    private static String read(URL url) throws IOException {
+        URLConnection connection = url.openConnection();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            return reader.readLine();
+        }
+    }
+
+    private static Path detectBasedir() {
+        // Maven would set this property.
+        final String basedir = System.getProperty("basedir");
+        if (basedir != null) {
+            return new File(basedir).toPath().toAbsolutePath();
+        }
+        // Maybe we are standing in the basedir.
+        final File target = new File("target");
+        if (target.exists()) {
+            return target.toPath().toAbsolutePath().getParent();
+        }
+        // Eclipse IDE sometimes uses target as the current dir.
+        return new File(".").toPath().toAbsolutePath().getParent();
+    }
+}

--- a/appserver/tests/embedded/pom.xml
+++ b/appserver/tests/embedded/pom.xml
@@ -46,6 +46,7 @@
         <module>cdi_ejb_jpa</module>
         <module>ejb</module>
         <module>glassfish_resources_xml</module>
+        <module>jms</module>
         <module>maven-plugin</module>
         <module>microprofile</module>
         <module>runnable</module>

--- a/nucleus/core/kernel/src/main/resources/org/glassfish/embed/domain.xml
+++ b/nucleus/core/kernel/src/main/resources/org/glassfish/embed/domain.xml
@@ -37,11 +37,22 @@
       <property name="databaseName" value="${com.sun.aas.instanceRoot}/lib/databases/embedded_default" />
       <property name="connectionAttributes" value=";create=true" />
     </jdbc-connection-pool>
+    <!--
+      Default JMS connection factory. In a full GlassFish distribution these
+      resources are added by the gf-jms-connector module config bundle
+      (jms-module-conf.xml), which is not applied in embedded mode. Without them
+      the java:comp/DefaultJMSConnectionFactory logical JNDI name cannot resolve
+      to the physical jms/__defaultConnectionFactory resource.
+    -->
+    <connector-connection-pool name="jms/__defaultConnectionFactory-Connection-Pool" max-pool-size="250" steady-pool-size="1" resource-adapter-name="jmsra" connection-definition-name="jakarta.jms.ConnectionFactory">
+    </connector-connection-pool>
+    <connector-resource pool-name="jms/__defaultConnectionFactory-Connection-Pool" jndi-name="jms/__defaultConnectionFactory" object-type="system-all-req"></connector-resource>
   </resources>
   <servers>
     <server name="server" config-ref="server-config">
       <resource-ref ref="jdbc/__TimerPool" />
       <resource-ref ref="jdbc/__default" />
+      <resource-ref ref="jms/__defaultConnectionFactory" />
     </server>
   </servers>
  <configs>
@@ -77,6 +88,13 @@
       <jms-service type="EMBEDDED" default-jms-host="default_JMS_host">
         <jms-host name="default_JMS_host" host="localhost" port="7676" admin-user-name="admin" admin-password="admin" lazy-init="false"/>
       </jms-service>
+      <!--
+        Run the JMS Resource Adapter in EMBEDDED mode (in-JVM OpenMQ broker).
+        RevertToEmbedded keeps GlassFish from converting EMBEDDED to DIRECT and
+        imq.jmsra.direct=false keeps the RA from forcing DIRECT mode.
+      -->
+      <system-property name="com.sun.enterprise.connectors.system.RevertToEmbedded" value="true"/>
+      <system-property name="imq.jmsra.direct" value="false"/>
       <log-service file="${com.sun.aas.instanceRoot}/logs/server.log" log-rotation-limit-in-bytes="2000000">
         <module-log-levels />
       </log-service>


### PR DESCRIPTION
## Summary

Fixes JMS support in the embedded GlassFish uber jar (`glassfish-embedded-all`). The JMS resource adapter could not run in embedded mode: the RA bean was loaded from the wrong classloader (`MQJMSRA_AS4001`), the broker stayed in REMOTE mode, the default JMS connection factory was never registered in JNDI, the embedded `jmsra.rar` was missing OpenMQ runtime jars, and — once the embedded broker was functional — shutdown failed with `NoClassDefFoundError: BrokerStateHandler$ShutdownRunnable` because the RAR classloader was closed before the resource adapters were stopped.

## Changes

- **ActiveRAFactory** (connectors-runtime): load the RA bean through the provided RAR classloader for all process types, falling back to the thread context classloader only when no loader is available. Resolves `MQJMSRA_AS4001` classloader mismatch.
- **ActiveJmsResourceAdapter** (jms-core): treat embedded as server for RA configuration so the embedded broker lifecycle (EMBEDDED/LOCAL/DIRECT) is applied instead of hardcoded REMOTE.
- **embedded domain.xml** (kernel): add the default JMS connector-connection-pool, connector-resource `jms/__defaultConnectionFactory`, server resource-ref (mirroring `jms-module-conf.xml`, which is only applied at domain creation in the full distribution), plus system properties `com.sun.enterprise.connectors.system.RevertToEmbedded=true` and `imq.jmsra.direct=false`. This makes ResourceManager bind the connection factory in JNDI in embedded mode.
- **embedded-all packaging** (`pom.xml`): unpack the OpenMQ broker properties (`**/props/broker/**`) from `mq-distribution` with `excludeTransitive=false` so the broker props reach the RAR and the embedded broker starts cleanly. `imqutil.jar` is not bundled in `jmsra.rar` — every class it provides already exists in the other bundled jars, so it is redundant.
- **ConnectorsClassLoaderUtil** (connectors-internal-api): in embedded mode, stop the active resource adapters during `PREPARE_SHUTDOWN` while the RAR classloader is still open (so the embedded broker's lazy class resolution such as `BrokerStateHandler$ShutdownRunnable` succeeds), and close the RAR classloaders on `SERVER_SHUTDOWN` to release the jar handles. The later ResourceManager shutdown re-runs `stopAllActiveResourceAdapters()`, which is idempotent. Embedded-only.
- **appserver/tests/embedded/jms**: a flat embedded test module that deploys a JAX-RS + JMS app (sender, MDB consumer, destination definition) on embedded GlassFish and verifies the send/receive round trip via the default connection factory, including a clean shutdown.

## Verification

Embedded integration test (`HelloJmsIT` against the rebuilt `glassfish-embedded-all`): `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`. Log shows `broker is EMBEDDED, connection mode is TCP` and `Started:EMBEDDED`, the send/receive round trip works (`sending message from HelloSender` → `received message: Hello JMS`), and shutdown is clean — the RA stop completes (`MQJMSRA_RA1101 ... stopping...` → `stopped.`) with no `BrokerStateHandler` / `ShutdownRunnable` / `NoClassDefFoundError` / `ClassNotFoundException` / `Could not close the`.

Embedded mode (minimal JMS-only Jakarta EE 11 app, `mvn clean package embedded-glassfish:run -Pglassfish-embedded`):

- No `MQJMSRA_AS4001`
- No `NameNotFoundException: jms` — `jms/__defaultConnectionFactory` resolves
- `GET /api/hellojms` returns 200 `sent`, MDB logs `received message: Hello JMS at ...`

Normal distribution regression (Arquillian managed test against the stock unpatched `glassfish-8.0.4.zip`): `HelloJmsResourceTest` passes — `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`. The patch does not affect the full distribution (the classloader/RA-stop change is embedded-only).

Rebased on upstream `main` and squashed into a single commit.

Related upstream issue: eclipse-ee4j/glassfish#24842

Original PR and discussion: https://github.com/hantsy/glassfish/pull/1